### PR TITLE
chore(repo): add .asf for Apache infrastructure

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,7 @@
 # All configurations could be found here: https://github.com/apache/infrastructure-asfyaml/
 
 github:
-  description: "Apache Iggy: Blazingly fast message streaming platform"
+  description: "Apache Iggy: Hyper-Efficient Message Streaming at Laser Speed"
   homepage: https://iggy.apache.org
   labels:
     - rust
@@ -41,7 +41,7 @@ github:
           - "master"
       required_pull_request_reviews:
         dismiss_stale_reviews: true
-        required_approving_review_count: 3
+        required_approving_review_count: 2
       required_conversation_resolution: true
   custom_subjects:
     new_discussion: "{title}"

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# All configurations could be found here: https://github.com/apache/infrastructure-asfyaml/
+
+github:
+  description: "Apache Iggy: Blazingly fast message streaming platform"
+  homepage: https://iggy.apache.org
+  labels:
+    - rust
+    - streaming
+    - messaging
+    - tcp
+    - quic
+    - http
+    - iggy
+    - apache
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
+  protected_branches:
+    master:
+      required_status_checks:
+        strict: true
+        contexts:
+          - "master"
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 3
+      required_conversation_resolution: true
+  custom_subjects:
+    new_discussion: "{title}"
+    edit_discussion: "Re: {title}"
+    close_discussion: "Re: {title}"
+    close_discussion_with_comment: "Re: {title}"
+    reopen_discussion: "Re: {title}"
+    new_comment_discussion: "Re: {title}"
+    edit_comment_discussion: "Re: {title}"
+    delete_comment_discussion: "Re: {title}"
+
+notifications:
+  commits: commits@iggy.apache.org
+  issues: commits@iggy.apache.org
+  pullrequests: commits@iggy.apache.org
+  discussions: dev@iggy.apache.org


### PR DESCRIPTION
Add the initial version of `.asf.yaml` infrastructure config, to define the branch protection rules and integrate the discussions with a mailing list.