### PR TITLE
feat(sdk): use arrayvec for identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -2452,6 +2455,7 @@ dependencies = [
  "aes-gcm",
  "ahash 0.8.11",
  "anyhow",
+ "arrayvec",
  "async-broadcast",
  "async-dropper",
  "async-trait",

--- a/cli/src/args/message.rs
+++ b/cli/src/args/message.rs
@@ -7,6 +7,7 @@ use iggy::models::header::{HeaderKey, HeaderValue};
 use std::str::FromStr;
 
 #[derive(Debug, Clone, Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum MessageAction {
     /// Send messages to given topic ID and given stream ID
     ///

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -15,6 +15,7 @@ readme = "../README.md"
 aes-gcm = "0.10.3"
 ahash = { version = "0.8.11", features = ["serde"] }
 anyhow = "1.0.96"
+arrayvec = { version = "0.7.6", features = ["serde"] }
 async-broadcast = { version = "0.7.2" }
 async-dropper = { version = "0.3.1", features = ["tokio", "simple"] }
 async-trait = "0.1.86"

--- a/sdk/src/clients/consumer.rs
+++ b/sdk/src/clients/consumer.rs
@@ -2,7 +2,7 @@ use crate::client::Client;
 use crate::consumer::{Consumer, ConsumerKind};
 use crate::diagnostic::DiagnosticEvent;
 use crate::error::IggyError;
-use crate::identifier::{IdKind, Identifier};
+use crate::identifier::Identifier;
 use crate::locking::{IggySharedMut, IggySharedMutFn};
 use crate::messages::poll_messages::{PollingKind, PollingStrategy};
 use crate::models::messages::{PolledMessage, PolledMessages};
@@ -743,10 +743,7 @@ impl IggyConsumer {
         }
 
         let client = client.read().await;
-        let (name, id) = match consumer.id.kind {
-            IdKind::Numeric => (consumer_name.to_owned(), Some(consumer.id.get_u32_value()?)),
-            IdKind::String => (consumer.id.get_string_value()?, None),
-        };
+        let (name, id) = consumer.id.extract_name_id(consumer_name.to_owned())?;
 
         let consumer_group_id = name.to_owned().try_into()?;
         trace!("Validating consumer group: {consumer_group_id} for topic: {topic_id}, stream: {stream_id}");

--- a/sdk/src/identifier.rs
+++ b/sdk/src/identifier.rs
@@ -3,70 +3,35 @@ use crate::error::IggyError;
 use crate::utils::byte_size::IggyByteSize;
 use crate::utils::sizeable::Sizeable;
 use crate::validatable::Validatable;
+use arrayvec::ArrayString;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
-use serde_with::base64::Base64;
-use serde_with::serde_as;
 use std::borrow::Cow;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 /// `Identifier` represents the unique identifier of the resources such as stream, topic, partition, user etc.
-/// It consists of the following fields:
-/// - `kind`: the kind of the identifier.
-/// - `length`: the length of the identifier payload.
-/// - `value`: the binary value of the identifier payload.
-#[serde_as]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
-pub struct Identifier {
-    /// The kind of the identifier.
-    pub kind: IdKind,
-    /// The length of the identifier payload.
-    #[serde(skip)]
-    pub length: u8,
-    /// The binary value of the identifier payload, max length is 255 bytes.
-    #[serde_as(as = "Base64")]
-    pub value: Vec<u8>,
-}
-
-/// `IdKind` represents the kind of the identifier.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Default, Copy, Clone, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum IdKind {
-    /// The identifier is numeric.
-    #[default]
-    Numeric,
-    /// The identifier is string.
-    String,
+#[allow(clippy::large_enum_variant)]
+pub enum Identifier {
+    Numeric(u32),
+    String(ArrayString<255>),
 }
 
 impl Default for Identifier {
     fn default() -> Self {
-        Self {
-            kind: IdKind::default(),
-            length: 4,
-            value: 1u32.to_le_bytes().to_vec(),
-        }
+        Self::Numeric(1)
     }
 }
 
 impl Validatable<IggyError> for Identifier {
     fn validate(&self) -> Result<(), IggyError> {
-        if self.length == 0 {
+        if self.length() == 0 {
             return Err(IggyError::InvalidIdentifier);
         }
 
-        if self.value.is_empty() {
-            return Err(IggyError::InvalidIdentifier);
-        }
-
-        #[allow(clippy::cast_possible_truncation)]
-        if self.length != self.value.len() as u8 {
-            return Err(IggyError::InvalidIdentifier);
-        }
-
-        if self.kind == IdKind::Numeric && self.length != 4 {
+        if self.is_empty() {
             return Err(IggyError::InvalidIdentifier);
         }
 
@@ -75,17 +40,19 @@ impl Validatable<IggyError> for Identifier {
 }
 
 impl Identifier {
+    fn is_empty(&self) -> bool {
+        match self {
+            Identifier::Numeric(num) => *num == 0,
+            Identifier::String(array_string) => array_string.is_empty(),
+        }
+    }
+
     /// Returns the numeric value of the identifier.
     pub fn get_u32_value(&self) -> Result<u32, IggyError> {
-        if self.kind != IdKind::Numeric {
-            return Err(IggyError::InvalidIdentifier);
+        match self {
+            Identifier::Numeric(num) => Ok(*num),
+            Identifier::String(_) => Err(IggyError::InvalidIdentifier),
         }
-
-        if self.length != 4 {
-            return Err(IggyError::InvalidIdentifier);
-        }
-
-        Ok(u32::from_le_bytes(self.value.clone().try_into().unwrap()))
     }
 
     /// Returns the string value of the identifier.
@@ -95,11 +62,12 @@ impl Identifier {
 
     /// Returns the Cow<str> value of the identifier.
     pub fn get_cow_str_value(&self) -> Result<Cow<str>, IggyError> {
-        if self.kind != IdKind::String {
-            return Err(IggyError::InvalidIdentifier);
+        match self {
+            Identifier::Numeric(_) => Err(IggyError::InvalidIdentifier),
+            Identifier::String(array_string) => {
+                Ok(String::from_utf8_lossy(array_string.as_bytes()))
+            }
         }
-
-        Ok(String::from_utf8_lossy(&self.value))
     }
 
     /// Returns the string representation of the identifier.
@@ -109,18 +77,17 @@ impl Identifier {
 
     // Returns the Cow<str> representation of the identifier.
     pub fn as_cow_str(&self) -> Cow<str> {
-        match self.kind {
-            IdKind::Numeric => Cow::Owned(self.get_u32_value().unwrap().to_string()),
-            IdKind::String => self.get_cow_str_value().unwrap(),
+        match self {
+            Identifier::Numeric(_) => Cow::Owned(self.get_u32_value().unwrap().to_string()),
+            Identifier::String(_) => self.get_cow_str_value().unwrap(),
         }
     }
 
     /// Creates a new identifier from the given identifier.
     pub fn from_identifier(identifier: &Identifier) -> Self {
-        Self {
-            kind: identifier.kind,
-            length: identifier.length,
-            value: identifier.value.clone(),
+        match identifier {
+            Identifier::Numeric(num) => Identifier::Numeric(*num),
+            Identifier::String(array_string) => Identifier::String(*array_string),
         }
     }
 
@@ -143,11 +110,7 @@ impl Identifier {
             return Err(IggyError::InvalidIdentifier);
         }
 
-        Ok(Self {
-            kind: IdKind::Numeric,
-            length: 4,
-            value: value.to_le_bytes().to_vec(),
-        })
+        Ok(Identifier::Numeric(value))
     }
 
     /// Creates a new identifier from the given string value.
@@ -157,27 +120,52 @@ impl Identifier {
             return Err(IggyError::InvalidIdentifier);
         }
 
-        Ok(Self {
-            kind: IdKind::String,
-            #[allow(clippy::cast_possible_truncation)]
-            length: length as u8,
-            value: value.as_bytes().to_vec(),
-        })
+        Ok(Identifier::String(ArrayString::from(value).unwrap()))
+    }
+
+    /// Length of the identifier, for a string it is the capacity of the underlying array
+    pub fn length(&self) -> usize {
+        match self {
+            Identifier::Numeric(_) => 4,
+            Identifier::String(vec) => vec.len(),
+        }
+    }
+
+    /// Returns the code of the identifier kind.
+    pub fn code(&self) -> u8 {
+        match self {
+            Identifier::Numeric(_) => 1,
+            Identifier::String(_) => 2,
+        }
+    }
+
+    pub fn extract_name_id(
+        &self,
+        fallback_name: String,
+    ) -> Result<(String, Option<u32>), IggyError> {
+        let (name, id) = match self {
+            Identifier::Numeric(id) => (fallback_name, Some(*id)),
+            Identifier::String(_id) => (self.get_string_value()?, None),
+        };
+        Ok((name, id))
     }
 }
 
 impl Sizeable for Identifier {
     fn get_size_bytes(&self) -> IggyByteSize {
-        IggyByteSize::from(u64::from(self.length) + 2)
+        IggyByteSize::from(self.length() as u64 + 2)
     }
 }
 
 impl BytesSerializable for Identifier {
     fn to_bytes(&self) -> Bytes {
-        let mut bytes = BytesMut::with_capacity(2 + self.length as usize);
-        bytes.put_u8(self.kind.as_code());
-        bytes.put_u8(self.length);
-        bytes.put_slice(&self.value);
+        let mut bytes = BytesMut::with_capacity(2 + self.length());
+        bytes.put_u8(self.code());
+        bytes.put_u8(self.length() as u8);
+        match self {
+            Identifier::Numeric(value) => bytes.put_slice(&value.to_le_bytes()),
+            Identifier::String(array_string) => bytes.put_slice(array_string.as_bytes()),
+        }
         bytes.freeze()
     }
 
@@ -189,50 +177,33 @@ impl BytesSerializable for Identifier {
             return Err(IggyError::InvalidIdentifier);
         }
 
-        let kind = IdKind::from_code(bytes[0])?;
-        let length = bytes[1];
-        let value = bytes[2..2 + length as usize].to_vec();
-        if value.len() != length as usize {
-            return Err(IggyError::InvalidIdentifier);
-        }
+        let kind = bytes[0];
+        let length = bytes[1] as usize;
 
-        let identifier = Identifier {
-            kind,
-            length,
-            value,
-        };
-        identifier.validate()?;
-        Ok(identifier)
-    }
-}
-
-impl IdKind {
-    /// Returns the code of the identifier kind.
-    pub fn as_code(&self) -> u8 {
-        match self {
-            IdKind::Numeric => 1,
-            IdKind::String => 2,
-        }
-    }
-
-    /// Returns the identifier kind from the code.
-    pub fn from_code(code: u8) -> Result<Self, IggyError> {
-        match code {
-            1 => Ok(IdKind::Numeric),
-            2 => Ok(IdKind::String),
+        let id = match kind {
+            1 => {
+                if length != 4 {
+                    Err(IggyError::InvalidIdentifier)
+                } else {
+                    let num = u32::from_le_bytes(bytes[2..2 + 4].try_into().unwrap());
+                    Ok(Identifier::Numeric(num))
+                }
+            }
+            2 => {
+                let value = &bytes[2..2 + length];
+                if value.len() != length && length <= 255 {
+                    Err(IggyError::InvalidIdentifier)
+                } else {
+                    let s = std::str::from_utf8(value).map_err(|_| IggyError::InvalidIdentifier)?;
+                    let ar = ArrayString::from(s).unwrap();
+                    Ok(Identifier::String(ar))
+                }
+            }
             _ => Err(IggyError::InvalidIdentifier),
-        }
-    }
-}
+        }?;
 
-impl FromStr for IdKind {
-    type Err = IggyError;
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input {
-            "n" | "numeric" => Ok(IdKind::Numeric),
-            "s" | "string" => Ok(IdKind::String),
-            _ => Err(IggyError::InvalidIdentifier),
-        }
+        id.validate()?;
+        Ok(id)
     }
 }
 
@@ -272,35 +243,20 @@ impl TryFrom<&str> for Identifier {
 
 impl Display for Identifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            IdKind::Numeric => write!(
-                f,
-                "{}",
-                u32::from_le_bytes(self.value.as_slice().try_into().unwrap())
-            ),
-            IdKind::String => write!(f, "{}", String::from_utf8_lossy(&self.value)),
-        }
-    }
-}
-
-impl Display for IdKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IdKind::Numeric => write!(f, "numeric"),
-            IdKind::String => write!(f, "string"),
+            Identifier::Numeric(num) => write!(f, "{num}"),
+            Identifier::String(array_string) => {
+                write!(f, "{}", String::from_utf8_lossy(array_string.as_bytes()))
+            }
         }
     }
 }
 
 impl Hash for Identifier {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        match self.kind {
-            IdKind::Numeric => {
-                self.get_u32_value().unwrap().hash(state);
-            }
-            IdKind::String => {
-                self.get_cow_str_value().unwrap().hash(state);
-            }
+        match self {
+            Identifier::Numeric(_) => self.get_u32_value().unwrap().hash(state),
+            Identifier::String(_) => self.get_cow_str_value().unwrap().hash(state),
         }
     }
 }
@@ -337,18 +293,29 @@ mod tests {
     #[test]
     fn numeric_id_should_be_converted_into_identifier_using_trait() {
         let id = 1;
-        let identifier: Identifier = id.try_into().unwrap();
-        assert_eq!(identifier.kind, IdKind::Numeric);
-        assert_eq!(identifier.length, 4);
-        assert_eq!(identifier.value, id.to_le_bytes().to_vec());
+        if let Identifier::Numeric(num) = id.try_into().unwrap() {
+            assert_eq!(id, num);
+        } else {
+            panic!("identifier not numeric");
+        }
     }
 
     #[test]
     fn string_id_should_be_converted_into_identifier_using_trait() {
         let id = "test";
-        let identifier: Identifier = id.try_into().unwrap();
-        assert_eq!(identifier.kind, IdKind::String);
-        assert_eq!(identifier.length, 4);
-        assert_eq!(identifier.value, id.as_bytes().to_vec());
+        if let Identifier::String(av) = id.try_into().unwrap() {
+            assert_eq!(av.as_bytes(), id.as_bytes());
+        } else {
+            panic!("identifier not string");
+        }
+    }
+
+    #[test]
+    fn string_roundtrip() {
+        let id = Identifier::named("hello there").unwrap();
+        let bytes = id.to_bytes();
+        let from_bytes = Identifier::from_bytes(bytes);
+        assert!(from_bytes.is_ok());
+        assert_eq!(id, from_bytes.unwrap());
     }
 }

--- a/server/src/state/system.rs
+++ b/server/src/state/system.rs
@@ -4,7 +4,7 @@ use ahash::AHashMap;
 use error_set::ErrContext;
 use iggy::compression::compression_algorithm::CompressionAlgorithm;
 use iggy::error::IggyError;
-use iggy::identifier::{IdKind, Identifier};
+use iggy::identifier::Identifier;
 use iggy::models::permissions::Permissions;
 use iggy::models::user_status::UserStatus;
 use iggy::utils::expiry::IggyExpiry;
@@ -380,14 +380,10 @@ impl SystemState {
 }
 
 fn find_stream_id(streams: &AHashMap<u32, StreamState>, stream_id: &Identifier) -> u32 {
-    match stream_id.kind {
-        IdKind::Numeric => stream_id
-            .get_u32_value()
-            .unwrap_or_else(|_| panic!("{}", format!("Invalid stream ID: {stream_id}"))),
-        IdKind::String => {
-            let name = stream_id
-                .get_cow_str_value()
-                .unwrap_or_else(|_| panic!("{}", format!("Invalid stream name: {stream_id}")));
+    match stream_id {
+        Identifier::Numeric(id) => *id,
+        Identifier::String(id) => {
+            let name = String::from_utf8_lossy(id.as_bytes());
             let stream = streams
                 .values()
                 .find(|s| s.name == name)
@@ -398,14 +394,10 @@ fn find_stream_id(streams: &AHashMap<u32, StreamState>, stream_id: &Identifier) 
 }
 
 fn find_topic_id(topics: &AHashMap<u32, TopicState>, topic_id: &Identifier) -> u32 {
-    match topic_id.kind {
-        IdKind::Numeric => topic_id
-            .get_u32_value()
-            .unwrap_or_else(|_| panic!("{}", format!("Invalid topic ID: {topic_id}"))),
-        IdKind::String => {
-            let name = topic_id
-                .get_cow_str_value()
-                .unwrap_or_else(|_| panic!("{}", format!("Invalid topic name: {topic_id}")));
+    match topic_id {
+        Identifier::Numeric(id) => *id,
+        Identifier::String(id) => {
+            let name = String::from_utf8_lossy(id.as_bytes());
             let topic = topics
                 .values()
                 .find(|s| s.name == name)
@@ -419,14 +411,10 @@ fn find_consumer_group_id(
     groups: &AHashMap<u32, ConsumerGroupState>,
     group_id: &Identifier,
 ) -> u32 {
-    match group_id.kind {
-        IdKind::Numeric => group_id
-            .get_u32_value()
-            .unwrap_or_else(|_| panic!("{}", format!("Invalid group ID: {group_id}"))),
-        IdKind::String => {
-            let name = group_id
-                .get_cow_str_value()
-                .unwrap_or_else(|_| panic!("{}", format!("Invalid group name: {group_id}")));
+    match group_id {
+        Identifier::Numeric(id) => *id,
+        Identifier::String(id) => {
+            let name = String::from_utf8_lossy(id.as_bytes());
             let group = groups
                 .values()
                 .find(|s| s.name == name)
@@ -437,14 +425,10 @@ fn find_consumer_group_id(
 }
 
 fn find_user_id(users: &AHashMap<u32, UserState>, user_id: &Identifier) -> u32 {
-    match user_id.kind {
-        IdKind::Numeric => user_id
-            .get_u32_value()
-            .unwrap_or_else(|_| panic!("{}", format!("Invalid user ID: {user_id}"))),
-        IdKind::String => {
-            let username = user_id
-                .get_cow_str_value()
-                .unwrap_or_else(|_| panic!("{}", format!("Invalid username: {user_id}")));
+    match user_id {
+        Identifier::Numeric(id) => *id,
+        Identifier::String(id) => {
+            let username = String::from_utf8_lossy(id.as_bytes());
             let user = users
                 .values()
                 .find(|s| s.username == username)

--- a/server/src/streaming/polling_consumer.rs
+++ b/server/src/streaming/polling_consumer.rs
@@ -1,5 +1,5 @@
 use crate::streaming::utils::hash;
-use iggy::identifier::{IdKind, Identifier};
+use iggy::identifier::Identifier;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -18,9 +18,9 @@ impl PollingConsumer {
     }
 
     pub fn resolve_consumer_id(identifier: &Identifier) -> u32 {
-        match identifier.kind {
-            IdKind::Numeric => identifier.get_u32_value().unwrap(),
-            IdKind::String => hash::calculate_32(&identifier.value),
+        match identifier {
+            Identifier::Numeric(id) => *id,
+            Identifier::String(id) => hash::calculate_32(id.as_bytes()),
         }
     }
 }

--- a/server/src/streaming/streams/topics.rs
+++ b/server/src/streaming/streams/topics.rs
@@ -4,7 +4,7 @@ use crate::streaming::topics::topic::Topic;
 use error_set::ErrContext;
 use iggy::compression::compression_algorithm::CompressionAlgorithm;
 use iggy::error::IggyError;
-use iggy::identifier::{IdKind, Identifier};
+use iggy::identifier::Identifier;
 use iggy::locking::IggySharedMutFn;
 use iggy::utils::expiry::IggyExpiry;
 use iggy::utils::topic_size::MaxTopicSize;
@@ -147,9 +147,11 @@ impl Stream {
     }
 
     pub fn remove_topic(&mut self, identifier: &Identifier) -> Result<Topic, IggyError> {
-        match identifier.kind {
-            IdKind::Numeric => self.remove_topic_by_id(identifier.get_u32_value()?),
-            IdKind::String => self.remove_topic_by_name(&identifier.get_cow_str_value()?),
+        match identifier {
+            Identifier::Numeric(id) => self.remove_topic_by_id(*id),
+            Identifier::String(id) => {
+                self.remove_topic_by_name(&String::from_utf8_lossy(id.as_bytes()))
+            }
         }
     }
 
@@ -158,9 +160,11 @@ impl Stream {
     }
 
     pub fn try_get_topic(&self, identifier: &Identifier) -> Result<Option<&Topic>, IggyError> {
-        match identifier.kind {
-            IdKind::Numeric => Ok(self.topics.get(&identifier.get_u32_value()?)),
-            IdKind::String => Ok(self.try_get_topic_by_name(&identifier.get_cow_str_value()?)),
+        match identifier {
+            Identifier::Numeric(id) => Ok(self.topics.get(id)),
+            Identifier::String(id) => {
+                Ok(self.try_get_topic_by_name(&String::from_utf8_lossy(id.as_bytes())))
+            }
         }
     }
 
@@ -169,16 +173,20 @@ impl Stream {
     }
 
     pub fn get_topic(&self, identifier: &Identifier) -> Result<&Topic, IggyError> {
-        match identifier.kind {
-            IdKind::Numeric => self.get_topic_by_id(identifier.get_u32_value()?),
-            IdKind::String => self.get_topic_by_name(&identifier.get_cow_str_value()?),
+        match identifier {
+            Identifier::Numeric(id) => self.get_topic_by_id(*id),
+            Identifier::String(id) => {
+                self.get_topic_by_name(&String::from_utf8_lossy(id.as_bytes()))
+            }
         }
     }
 
     pub fn get_topic_mut(&mut self, identifier: &Identifier) -> Result<&mut Topic, IggyError> {
-        match identifier.kind {
-            IdKind::Numeric => self.get_topic_by_id_mut(identifier.get_u32_value()?),
-            IdKind::String => self.get_topic_by_name_mut(&identifier.get_cow_str_value()?),
+        match identifier {
+            Identifier::Numeric(id) => self.get_topic_by_id_mut(*id),
+            Identifier::String(id) => {
+                self.get_topic_by_name_mut(&String::from_utf8_lossy(id.as_bytes()))
+            }
         }
     }
 

--- a/server/src/streaming/systems/streams.rs
+++ b/server/src/streaming/systems/streams.rs
@@ -7,7 +7,7 @@ use ahash::{AHashMap, AHashSet};
 use error_set::ErrContext;
 use futures::future::try_join_all;
 use iggy::error::IggyError;
-use iggy::identifier::{IdKind, Identifier};
+use iggy::identifier::Identifier;
 use iggy::locking::IggySharedMutFn;
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -202,9 +202,11 @@ impl System {
     }
 
     pub fn try_get_stream(&self, identifier: &Identifier) -> Result<Option<&Stream>, IggyError> {
-        match identifier.kind {
-            IdKind::Numeric => Ok(self.streams.get(&identifier.get_u32_value()?)),
-            IdKind::String => Ok(self.try_get_stream_by_name(&identifier.get_cow_str_value()?)),
+        match identifier {
+            Identifier::Numeric(id) => Ok(self.streams.get(id)),
+            Identifier::String(id) => {
+                Ok(self.try_get_stream_by_name(&String::from_utf8_lossy(id.as_bytes())))
+            }
         }
     }
 
@@ -215,16 +217,20 @@ impl System {
     }
 
     pub fn get_stream(&self, identifier: &Identifier) -> Result<&Stream, IggyError> {
-        match identifier.kind {
-            IdKind::Numeric => self.get_stream_by_id(identifier.get_u32_value()?),
-            IdKind::String => self.get_stream_by_name(&identifier.get_cow_str_value()?),
+        match identifier {
+            Identifier::Numeric(id) => self.get_stream_by_id(*id),
+            Identifier::String(id) => {
+                self.get_stream_by_name(&String::from_utf8_lossy(id.as_bytes()))
+            }
         }
     }
 
     pub fn get_stream_mut(&mut self, identifier: &Identifier) -> Result<&mut Stream, IggyError> {
-        match identifier.kind {
-            IdKind::Numeric => self.get_stream_by_id_mut(identifier.get_u32_value()?),
-            IdKind::String => self.get_stream_by_name_mut(&identifier.get_cow_str_value()?),
+        match identifier {
+            Identifier::Numeric(id) => self.get_stream_by_id_mut(*id),
+            Identifier::String(id) => {
+                self.get_stream_by_name_mut(&String::from_utf8_lossy(id.as_bytes()))
+            }
         }
     }
 


### PR DESCRIPTION
This is a proof of concept demonstrating the use of [arrayvec](https://github.com/bluss/arrayvec) for identifiers.

For now this just copies the current identifier API to a new one to get a feel of how it would look.

issue: #1594
