### PR TITLE
chore(ci): update GitHub Actions to use latest versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,9 @@ jobs:
           echo -n "test" | gnome-keyring-daemon --unlock
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
       - name: Build
         run: source <(cargo llvm-cov show-env --export-prefix) && cargo build

--- a/.github/workflows/post_publish_server.yml
+++ b/.github/workflows/post_publish_server.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Something went wrong
         if: ${{ contains(needs.*.result, 'failure') && github.event_name == 'workflow_run' }}
-        uses: JasonEtco/create-an-issue@v2.9.2
+        uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_BOT_CONTEXT_STRING: "post release docker container test"

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -99,7 +99,7 @@ jobs:
         run: exit 0
       - name: Something went wrong
         if: ${{ contains(needs.*.result, 'failure') }}
-        uses: JasonEtco/create-an-issue@v2.9.2
+        uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_BOT_CONTEXT_STRING: "publish to crates.io"

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -98,7 +98,7 @@ jobs:
         run: exit 0
       - name: Something went wrong
         if: ${{ contains(needs.*.result, 'failure') }}
-        uses: JasonEtco/create-an-issue@v2.9.2
+        uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_BOT_CONTEXT_STRING: "publish to crates.io"

--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -107,23 +107,23 @@ jobs:
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
         if: contains(matrix.platform.name, 'musl')
 
-      - name: Build iggy-server release binary
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Prepare ${{ matrix.platform.target }} toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command: "build"
+          toolchain: stable
+          override: true
           target: ${{ matrix.platform.target }}
-          toolchain: ${{ matrix.toolchain }}
-          args: "--verbose --release --bin iggy-server"
-        if: ${{ matrix.toolchain }} == 'stable'
 
-      - name: Build iggy-cli release binary
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Install cross
+        uses: taiki-e/install-action@v2
         with:
-          command: "build"
-          target: ${{ matrix.platform.target }}
-          toolchain: ${{ matrix.toolchain }}
-          args: "--verbose --release --no-default-features --bin iggy"
-        if: ${{ matrix.toolchain }} == 'stable'
+          tool: cross
+
+      - name: Build iggy-server ${{ matrix.platform.target }} release binary
+        run: cross +stable build --verbose --release --target ${{ matrix.platform.target }} --bin iggy-server
+
+      - name: Build iggy-cli ${{ matrix.platform.target }} release binary
+        run: cross +stable build --verbose --release --no-default-features --target ${{ matrix.platform.target }} --bin iggy
 
       - name: Prepare artifacts
         run: |
@@ -141,7 +141,7 @@ jobs:
         if: ${{ matrix.platform.cross }}
 
       - name: Set up Docker
-        uses: crazy-max/ghaction-setup-docker@v3
+        uses: crazy-max/ghaction-setup-docker@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -258,7 +258,7 @@ jobs:
 
       - name: Something went wrong
         if: ${{ contains(needs.*.result, 'failure') && github.event_name != 'workflow_dispatch' }}
-        uses: JasonEtco/create-an-issue@v2.9.2
+        uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_BOT_CONTEXT_STRING: "build and release to dockerhub"

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -61,13 +61,20 @@ jobs:
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
         if: ${{ matrix.platform.target == 'x86_64-unknown-linux-musl' }}
 
-      - name: Build ${{ matrix.platform.target }} release binary
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Prepare ${{ matrix.platform.target }} toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command: "build"
-          target: ${{ matrix.platform.target }}
           toolchain: stable
-          args: "--verbose --release --bin iggy"
+          override: true
+          target: ${{ matrix.platform.target }}
+
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build ${{ matrix.platform.target }} release binary
+        run: cross +stable build --verbose --release --target ${{ matrix.platform.target }}
 
       - name: Collect ${{ matrix.platform.target }} executable
         run: |
@@ -79,7 +86,7 @@ jobs:
         if: ${{ matrix.platform.os == 'ubuntu-latest' }}
 
       - name: Create ${{ matrix.platform.file }} artifact
-        uses: vimtor/action-zip@v1.2
+        uses: vimtor/action-zip@v1
         with:
           files: ${{ matrix.platform.executable }}
           dest: ${{ matrix.platform.file }}

--- a/.github/workflows/release_server.yml
+++ b/.github/workflows/release_server.yml
@@ -27,49 +27,40 @@ jobs:
       - name: Install musl-tools on Linux
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
 
-      - name: Build iggy-server release binary for Linux-x86_64
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Prepare x86_64-unknown-linux-musl toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command: "build"
-          target: x86_64-unknown-linux-musl
           toolchain: stable
-          args: "--verbose --release --bin iggy-server"
+          override: true
+          target: x86_64-unknown-linux-musl
 
-      - name: Build iggy-cli release binary for Linux-x86_64
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Install cross
+        uses: taiki-e/install-action@v2
         with:
-          command: "build"
-          target: x86_64-unknown-linux-musl
-          toolchain: stable
-          args: "--verbose --release --no-default-features --bin iggy"
+          tool: cross
 
-      - name: Prepare Linux-x86_64 artifacts
+      - name: Build iggy-server release binary for x86_64-unknown-linux-musl
+        run: cross +stable build --verbose --target x86_64-unknown-linux-musl --release --bin iggy-server
+
+      - name: Prepare x86_64-unknown-linux-musl artifacts
         run: |
           mkdir -p all_artifacts/Linux-x86_64
           cp target/x86_64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-x86_64/
-          cp target/x86_64-unknown-linux-musl/release/iggy all_artifacts/Linux-x86_64/
 
-      - name: Build iggy-server release binary for Linux-aarch64
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Prepare aarch64-unknown-linux-musl toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command: "build"
-          target: aarch64-unknown-linux-musl
           toolchain: stable
-          args: "--verbose --release --bin iggy-server"
-
-      - name: Build iggy-cli release binary for Linux-aarch64
-        uses: houseabsolute/actions-rust-cross@v0
-        with:
-          command: "build"
+          override: true
           target: aarch64-unknown-linux-musl
-          toolchain: stable
-          args: "--verbose --release --no-default-features --bin iggy"
 
-      - name: Prepare Linux-aarch64 artifacts
+      - name: Build iggy-server release binary for aarch64-unknown-linux-musl
+        run: cross +stable build --verbose --target aarch64-unknown-linux-musl --release --bin iggy-server
+
+      - name: Prepare aarch64-unknown-linux-musl artifacts
         run: |
           mkdir -p all_artifacts/Linux-aarch64
           cp target/aarch64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-aarch64/
-          cp target/aarch64-unknown-linux-musl/release/iggy all_artifacts/Linux-aarch64/
 
       - name: Zip artifacts for each platform
         run: |

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -9,28 +9,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: clechasseur/rs-cargo@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
         with:
           command: check
+
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup component add rustfmt
-      - uses: clechasseur/rs-cargo@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: clechasseur/rs-cargo@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all-targets --all-features -- -D warnings
@@ -40,24 +50,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo install cargo-sort
-      - run: cargo sort --check --workspace
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-sort
+      - uses: actions-rs/cargo@v1
+        with:
+          command: sort
+          args: --check --workspace
 
   doctest:
     name: cargo test docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --doc
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --doc
 
   unused_dependencies:
     name: cargo machete
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bnjbvr/cargo-machete@v0.7.0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+      - uses: actions-rs/cargo@v1
+        with:
+          command: machete
 
   check-commit-message:
     name: commit messages
@@ -74,13 +107,3 @@ jobs:
           accessToken: ${{ secrets.GITHUB_TOKEN }} # needed only when checkAllCommitMessages is true
           pattern: '^.{0,80}(\n.*)*$'
           error: "Subject of all commits in the PR and PR body/title has to be shorter than 80 characters."
-
-# Uncomment this when we have a proper release - 1.0.0
-#   semver-checks:
-#     name: SemVer SDK
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v4
-#       - uses: obi1kenobi/cargo-semver-checks-action@v2
-#         with:
-#           package: iggy

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   clippy:

--- a/.github/workflows/test_daily.yml
+++ b/.github/workflows/test_daily.yml
@@ -73,21 +73,23 @@ jobs:
           cat Cross.toml
         if: ${{ matrix.platform.cross }}
 
-      - name: Build binary
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Prepare ${{ matrix.platform.target }} toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command: "build"
+          toolchain: stable
+          override: true
           target: ${{ matrix.platform.target }}
-          toolchain: ${{ matrix.toolchain }}
-          args: " --features ci-qemu --verbose ${{ matrix.platform.profile == 'release' && '--release' || '' }}"
 
-      - name: Run tests
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Install cross
+        uses: taiki-e/install-action@v2
         with:
-          command: "test"
-          target: ${{ matrix.platform.target }}
-          toolchain: ${{ matrix.toolchain }}
-          args: " --features ci-qemu --verbose ${{ matrix.platform.profile == 'release' && '--release' || '' }}"
+          tool: cross
+
+      - name: Build binary ${{ matrix.platform.target }}
+        run: cross +stable build --features ci-qemu --verbose --target ${{ matrix.platform.target }} ${{ matrix.platform.profile == 'release' && '--release' || '' }}
+
+      - name: Run tests ${{ matrix.platform.target }}
+        run: cross +stable test --features ci-qemu --verbose --target ${{ matrix.platform.target }} ${{ matrix.platform.profile == 'release' && '--release' || '' }}
 
       - name: Check if workspace is clean
         run: git status | grep "working tree clean" || { git status ; exit 1; }
@@ -103,7 +105,7 @@ jobs:
         run: exit 0
       - name: Something went wrong
         if: ${{ contains(needs.*.result, 'failure') && github.event_name != 'workflow_dispatch' }}
-        uses: JasonEtco/create-an-issue@v2.9.2
+        uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_BOT_CONTEXT_STRING: "nightly test suite"

--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -74,21 +74,23 @@ jobs:
           cat Cross.toml
         if: ${{ matrix.platform.cross }}
 
-      - name: Build binary
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Prepare ${{ matrix.platform.target }} toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command: "build"
+          toolchain: stable
+          override: true
           target: ${{ matrix.platform.target }}
-          toolchain: ${{ matrix.toolchain }}
-          args: " --features ci-qemu --verbose ${{ matrix.platform.profile == 'release' && '--release' || '' }}"
 
-      - name: Run tests
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Install cross
+        uses: taiki-e/install-action@v2
         with:
-          command: "test"
-          target: ${{ matrix.platform.target }}
-          toolchain: ${{ matrix.toolchain }}
-          args: " --features ci-qemu --verbose ${{ matrix.platform.profile == 'release' && '--release' || '' }}"
+          tool: cross
+
+      - name: Build binary ${{ matrix.platform.target }}
+        run: cross +stable build --features ci-qemu --verbose --target ${{ matrix.platform.target }} ${{ matrix.platform.profile == 'release' && '--release' || '' }}
+
+      - name: Run tests ${{ matrix.platform.target }}
+        run: cross +stable test --features ci-qemu --verbose --target ${{ matrix.platform.target }} ${{ matrix.platform.profile == 'release' && '--release' || '' }}
 
       - name: Check if workspace is clean
         run: git status | grep "working tree clean" || { git status ; exit 1; }

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -74,21 +74,23 @@ jobs:
           rm -f $HOME/.local/share/keyrings/*
           echo -n "test" | gnome-keyring-daemon --unlock
 
-      - name: Build binary (Linux)
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Prepare x86_64-unknown-linux-musl toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command: "build"
-          target: x86_64-unknown-linux-musl
           toolchain: stable
-          args: "--verbose"
+          override: true
+          target: x86_64-unknown-linux-musl
 
-      - name: Run tests
-        uses: houseabsolute/actions-rust-cross@v0
+      - name: Install cross
+        uses: taiki-e/install-action@v2
         with:
-          command: "test"
-          target: x86_64-unknown-linux-musl
-          toolchain: stable
-          args: "--verbose"
+          tool: cross
+
+      - name: Build binary x86_64-unknown-linux-musl
+        run: cross +stable build --verbose --target x86_64-unknown-linux-musl
+
+      - name: Run tests x86_64-unknown-linux-musl
+        run: cross +stable test --verbose --target x86_64-unknown-linux-musl
 
       - name: Check CLI examples from README
         run: ./scripts/run-examples-from-readme.sh
@@ -106,7 +108,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
 
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
@@ -130,7 +135,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
 
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2

--- a/integration/tests/cli/personal_access_token/mod.rs
+++ b/integration/tests/cli/personal_access_token/mod.rs
@@ -2,6 +2,7 @@ mod test_pat_create_command;
 mod test_pat_delete_command;
 mod test_pat_help_command;
 mod test_pat_list_command;
-// Disable tests due to missing keyring on macOS until #794 is implemented
-#[cfg(not(target_os = "macos"))]
+// Disable tests due to missing keyring on macOS until #794 is implemented and skip for musl targets
+// due to missing keyring support while running tests under cross
+#[cfg(not(any(target_os = "macos", target_env = "musl")))]
 mod test_pat_login_options;

--- a/integration/tests/cli/system/mod.rs
+++ b/integration/tests/cli/system/mod.rs
@@ -1,13 +1,14 @@
-// Disable tests due to missing keyring on macOS until #794 is implemented
-#[cfg(not(target_os = "macos"))]
+// Disable tests due to missing keyring on macOS until #794 is implemented and skip for musl targets
+// due to missing keyring support while running tests under cross
+#[cfg(not(any(target_os = "macos", target_env = "musl")))]
 mod test_cli_session_scenario;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_env = "musl")))]
 mod test_login_cmd;
 mod test_login_command;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_env = "musl")))]
 mod test_logout_cmd;
 mod test_logout_command;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_env = "musl")))]
 mod test_me_command;
 mod test_ping_command;
 mod test_snapshot_cmd;


### PR DESCRIPTION
Update version to major only for all actions with detailed version
specifier. Replaced dtolnay/rust-toolchain with actions-rs/toolchain.
Replaced clechasseur/rs-cargo with actions-rs/cargo.
Replaced bnjbvr/cargo-machete with taiki-e/install-action for
cargo-machete installation.
