### PR TITLE
chore(ci): update assignees and reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,9 @@ updates:
     labels:
       - "ci-cd"
     assignees:
-      - "iggy-rs/maintainers"
+      - "apache/iggy-committers"
     reviewers:
-      - "iggy-rs/maintainers"
+      - "apache/iggy-committers"
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -22,6 +22,6 @@ updates:
     commit-message:
       prefix: "chore(deps): "
     assignees:
-      - "iggy-rs/maintainers"
+      - "apache/iggy-committers"
     reviewers:
-      - "iggy-rs/maintainers"
+      - "apache/iggy-committers"


### PR DESCRIPTION
Updated the assignees and reviewers in the dependabot configuration
file from "iggy-rs/maintainers" to "apache/iggy-committers" for both
the GitHub Actions and Cargo package ecosystems. This change ensures
that the appropriate team members are notified and can review the
dependency updates.
