### PR TITLE
chore(ci): update CI workflows rust-cache version and key

### DIFF
--- a/.github/workflows/backwards_compatibility.yml
+++ b/.github/workflows/backwards_compatibility.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "backwards-compatibility"
 
       - name: Build iggy-server (origin/master)
         run: IGGY_CI_BUILD=true cargo build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "coverage"
 
       - name: Install gnome-keyring and keyutils on Linux
         run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "performance"
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/post_publish_server.yml
+++ b/.github/workflows/post_publish_server.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "post-publish-server"
 
       - name: Build binary
         run: cargo build

--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "publish-server-${{ matrix.platform.target }}"
 
       - name: Install musl-tools on Linux
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "release-cli-${{ matrix.platform.target }}"
 
       - name: Install musl-tools on Linux
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
@@ -113,11 +113,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Cache cargo & target directories
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: "v2"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/test_daily.yml
+++ b/.github/workflows/test_daily.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "test-daily-${{ matrix.platform.target }}"
 
       - name: Configure Git
         run: |

--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "test-nightly-${{ matrix.platform.target }}"
 
       - name: Configure Git
         run: |

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "test-pr-x86_64-unknown-linux-musl"
 
       - name: Install musl-tools, gnome-keyring and keyutils on Linux
         run: |
@@ -116,7 +116,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "test-pr-aarch64-apple-darwin"
 
       - name: Build binary
         run: cargo build --verbose --target aarch64-apple-darwin
@@ -143,7 +143,7 @@ jobs:
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
-          key: "v2"
+          key: "test-pr-x86_64-pc-windows-msvc"
 
       - name: Build iggy package
         run: cargo build --verbose --target x86_64-pc-windows-msvc -p iggy


### PR DESCRIPTION
Modified cache keys in each workflow to be more descriptive and
specific to the job, improving cache management and reducing
potential cache conflicts. Removed redundant cache steps in
release_cli.