### PR TITLE
chore(ci): change trigger event for release workflows

### DIFF
--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -17,11 +17,9 @@
 
 name: publish_cli
 on:
-  workflow_dispatch:
-  workflow_run:
-    workflows: [ "publish_sdk" ]
-    types:
-      - completed
+  push:
+    tags:
+      - 'iggy-cli-[0-9]+.[0-9]+.[0-9]+'
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
@@ -36,47 +34,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if cli/Cargo.toml and Cargo.lock are changed
-        uses: tj-actions/changed-files@v45
-        id: all_changed_files
-        with:
-          files: |
-            Cargo.lock
-            cli/Cargo.toml
+      - name: Extract tag name
+        id: extract_tag
+        run: |
+          tag=${GITHUB_REF#refs/tags/}
+          echo "tag_name=$tag" >> "$GITHUB_OUTPUT"
+          echo "::notice ::Tag that triggered the workflow: $tag"
 
       - name: Extract iggy-cli version from Cargo.toml
-        if: ${{ steps.all_changed_files.outputs.all_changed_files == 'Cargo.lock cli/Cargo.toml' }}
         id: extract_version
         run: |
           version=$(cargo pkgid -p iggy-cli | cut -d@ -f2)
           echo "iggy_cli_version=$version" >> "$GITHUB_OUTPUT"
           echo "::notice ::Version from Cargo.toml $version"
 
-      - name: Check if version is a Git tag
-        uses: mukunku/tag-exists-action@v1.6.0
-        if: ${{ steps.all_changed_files.outputs.all_changed_files == 'Cargo.lock cli/Cargo.toml' }}
+      - name: Check if version from Cargo.toml is the same as the tag
         id: check_git_tag
-        with:
-          tag: "iggy-cli-${{ steps.extract_version.outputs.iggy_cli_version }}"
-
-      - name: Print message
-        if: ${{ steps.check_git_tag.outputs.exists == 'true' }}
         run: |
-          echo "::notice ::Tag iggy-cli-${{ steps.extract_version.outputs.iggy_cli_version }} exists, skipping tag creation"
+          if [[ "iggy-cli-${{ steps.extract_version.outputs.iggy_cli_version }}" == "${{ steps.extract_tag.outputs.tag_name }}" ]];
+          then
+            echo "::notice ::Tag ${{ steps.extract_tag.outputs.tag_name }} matches the version in Cargo.toml"
+            echo "tag_matches=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning ::Tag ${{ steps.extract_tag.outputs.tag_name }} does not matche the version from Cargo.toml"
+            echo "tag_matches=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Create tag
-        if: ${{ steps.check_git_tag.outputs.exists == 'false' }}
-        id: tagging
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git tag -a iggy-cli-${{ steps.extract_version.outputs.iggy_cli_version }} -m "iggy-cli-${{ steps.extract_version.outputs.iggy_cli_version }}"
-          git push origin iggy-cli-${{ steps.extract_version.outputs.iggy_cli_version }}
-          echo "::notice ::Created iggy-cli-${{ steps.extract_version.outputs.iggy_cli_version }} tag"
-          echo "tag_created=true" >> "$GITHUB_OUTPUT"
     outputs:
-      iggy_cli_version: ${{ steps.extract_version.outputs.iggy_cli_version }}
-      tag_created: ${{ steps.tagging.outputs.tag_created }}
+      iggy_cli_version: ${{ steps.extract_tag.outputs.tag_name }}
+      tag_created: ${{ steps.check_git_tag.outputs.tag_matches }}
 
   publish:
     name: Publish CLI on crates.io

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -17,10 +17,9 @@
 
 name: publish_sdk
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - master
+    tags:
+      - 'iggy-[0-9]+.[0-9]+.[0-9]+'
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
@@ -35,47 +34,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if sdk/Cargo.toml and Cargo.lock are changed
-        uses: tj-actions/changed-files@v45
-        id: all_changed_files
-        with:
-          files: |
-            Cargo.lock
-            sdk/Cargo.toml
+      - name: Extract tag name
+        id: extract_tag
+        run: |
+          tag=${GITHUB_REF#refs/tags/}
+          echo "tag_name=$tag" >> "$GITHUB_OUTPUT"
+          echo "::notice ::Tag that triggered the workflow: $tag"
 
       - name: Extract iggy version from Cargo.toml
-        if: ${{ steps.all_changed_files.outputs.all_changed_files == 'Cargo.lock sdk/Cargo.toml' }}
         id: extract_version
         run: |
           version=$(cargo pkgid -p iggy | cut -d@ -f2)
           echo "iggy_version=$version" >> "$GITHUB_OUTPUT"
           echo "::notice ::Version from Cargo.toml $version"
 
-      - name: Check if version is a Git tag
-        uses: mukunku/tag-exists-action@v1.6.0
-        if: ${{ steps.all_changed_files.outputs.all_changed_files == 'Cargo.lock sdk/Cargo.toml' }}
+      - name: Check if version from Cargo.toml is the same as the tag
         id: check_git_tag
-        with:
-          tag: "iggy-${{ steps.extract_version.outputs.iggy_version }}"
-
-      - name: Print message
-        if: ${{ steps.check_git_tag.outputs.exists == 'true' }}
         run: |
-          echo "::notice ::Tag iggy-${{ steps.extract_version.outputs.iggy_version }} exists, skipping tag creation"
+          if [[ "iggy-${{ steps.extract_version.outputs.iggy_version }}" == "${{ steps.extract_tag.outputs.tag_name }}" ]];
+          then
+            echo "::notice ::Tag ${{ steps.extract_tag.outputs.tag_name }} matches the version in Cargo.toml"
+            echo "tag_matches=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning ::Tag ${{ steps.extract_tag.outputs.tag_name }} does not matche the version from Cargo.toml"
+            echo "tag_matches=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Create tag
-        if: ${{ steps.check_git_tag.outputs.exists == 'false' }}
-        id: tagging
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git tag -a iggy-${{ steps.extract_version.outputs.iggy_version }} -m "iggy-${{ steps.extract_version.outputs.iggy_version }}"
-          git push origin iggy-${{ steps.extract_version.outputs.iggy_version }}
-          echo "::notice ::Created iggy-${{ steps.extract_version.outputs.iggy_version }} tag"
-          echo "tag_created=true" >> "$GITHUB_OUTPUT"
     outputs:
-      iggy_version: ${{ steps.extract_version.outputs.iggy_version }}
-      tag_created: ${{ steps.tagging.outputs.tag_created }}
+      iggy_version: ${{ steps.extract_tag.outputs.tag_name }}
+      tag_created: ${{ steps.check_git_tag.outputs.tag_matches }}
 
   publish:
     name: Publish SDK on crates.io
@@ -100,7 +87,7 @@ jobs:
     needs: tag
     if: ${{ needs.tag.outputs.tag_created == 'true' }}
     with:
-      tag_name: "iggy-${{ needs.tag.outputs.iggy_version }}"
+      tag_name: "${{ needs.tag.outputs.iggy_version }}"
 
   finalize_sdk:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -16,10 +16,12 @@
 # under the License.
 
 name: publish_server
+
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'server-[0-9]+.[0-9]+.[0-9]+'
+
 env:
   DOCKERHUB_REGISTRY_NAME: apache/iggy
   CRATE_NAME: iggy
@@ -37,44 +39,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if Cargo.toml and Cargo.lock are changed
-        uses: tj-actions/changed-files@v45
-        id: all_changed_files
-        with:
-          files: |
-            Cargo.lock
-            server/Cargo.toml
+      - name: Extract tag name
+        id: extract_tag
+        run: |
+          tag=${GITHUB_REF#refs/tags/}
+          echo "tag_name=$tag" >> "$GITHUB_OUTPUT"
+          echo "::notice ::Tag that triggered the workflow: $tag"
 
       - name: Extract iggy-server version from Cargo.toml
-        if: ${{ steps.all_changed_files.outputs.all_changed_files == 'Cargo.lock server/Cargo.toml' }}
         id: extract_version
         run: |
           version=$(cargo pkgid -p server | cut -d# -f2 | cut -d: -f2)
           echo "server_version=$version" >> "$GITHUB_OUTPUT"
           echo "::notice ::Version from Cargo.toml $version"
 
-      - name: Check if version is a Git tag
-        uses: mukunku/tag-exists-action@v1.6.0
-        if: ${{ steps.all_changed_files.outputs.all_changed_files == 'Cargo.lock server/Cargo.toml' }}
+      - name: Check if version from Cargo.toml is the same as the tag
         id: check_git_tag
-        with:
-          tag: "server-${{ steps.extract_version.outputs.server_version }}"
-
-      - name: Print message
-        if: ${{ steps.check_git_tag.outputs.exists == 'true' }}
         run: |
-          echo "::notice ::Tag server-${{ steps.extract_version.outputs.server_version }} exists, skipping tag creation"
-
-      - name: Create tag
-        if: ${{ steps.check_git_tag.outputs.exists == 'false' }}
-        id: tagging
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git tag -a server-${{ steps.extract_version.outputs.server_version }} -m "server-${{ steps.extract_version.outputs.server_version }}"
-          git push origin server-${{ steps.extract_version.outputs.server_version }}
-          echo "::notice ::Created server-${{ steps.extract_version.outputs.server_version }} tag"
-          echo "tag_created=true" >> "$GITHUB_OUTPUT"
+          if [[ "iggy-${{ steps.extract_version.outputs.server_version }}" == "${{ steps.extract_tag.outputs.tag_name }}" ]];
+          then
+            echo "::notice ::Tag ${{ steps.extract_tag.outputs.tag_name }} matches the version in Cargo.toml"
+            echo "tag_matches=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning ::Tag ${{ steps.extract_tag.outputs.tag_name }} does not matche the version from Cargo.toml"
+            echo "tag_matches=false" >> "$GITHUB_OUTPUT"
+          fi
 
     outputs:
       server_version: ${{ steps.extract_version.outputs.server_version }}
@@ -158,24 +147,29 @@ jobs:
         if: ${{ matrix.platform.cross }}
 
       - name: Set up Docker
+        if: ${{ needs.tag.outputs.tag_created }}
         uses: crazy-max/ghaction-setup-docker@v4
 
       - name: Set up Docker Buildx
+        if: ${{ needs.tag.outputs.tag_created }}
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        if: ${{ needs.tag.outputs.tag_created }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Docker meta
+        if: ${{ needs.tag.outputs.tag_created }}
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_REGISTRY_NAME }}
 
       - name: Build and push by digest
+        if: ${{ needs.tag.outputs.tag_created }}
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -189,12 +183,14 @@ jobs:
             IGGY_SERVER_PATH=target/${{ matrix.platform.target }}/release/iggy-server
 
       - name: Export digest
+        if: ${{ needs.tag.outputs.tag_created }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: ${{ needs.tag.outputs.tag_created }}
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ matrix.platform.os_name }}
@@ -203,6 +199,7 @@ jobs:
           retention-days: 1
 
   merge_docker_manifest:
+    if: ${{ needs.tag.outputs.tag_created }}
     runs-on: ubuntu-latest
     needs:
       - release_and_publish


### PR DESCRIPTION
Replace trigger to tag push and add checks to verify if the tag
name matches version set in corresponding Cargo.toml files.
Skip docker publish steps in server release if not run as release
(tag push) workflow.
