### PR TITLE
chore(ci): update envs for docker image release

### DIFF
--- a/.github/workflows/post_publish_server.yml
+++ b/.github/workflows/post_publish_server.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: addnab/docker-run-action@v3
         name: Spin up Docker Container
         with:
-          image: iggyrs/iggy:latest
+          image: apache/iggy:latest
           options: -d -p 8090:8090
           run: /iggy/iggy-server
 

--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -158,8 +158,8 @@ jobs:
         if: ${{ needs.tag.outputs.tag_created }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         if: ${{ needs.tag.outputs.tag_created }}
@@ -215,8 +215,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Fix the names of envs used in workflow to publish the iggy server image to DockerHub.