### PR TITLE
chore(ci): change dependabot schedule and add grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,24 +17,10 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore(ci): "
-    labels:
-      - "ci-cd"
-    assignees:
-      - "apache/iggy-committers"
-    reviewers:
-      - "apache/iggy-committers"
-
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     rebase-strategy: "disabled"
     commit-message:
       prefix: "chore(deps): "
@@ -42,3 +28,10 @@ updates:
       - "apache/iggy-committers"
     reviewers:
       - "apache/iggy-committers"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Set cargo updates to weekly and add grouping for cargo
updates so that minor and patch updates are grouped
together while for major changes individual pull requests
are created. Dropping GitHub actions updates in order
to align with planned Apache strategy for GitHub actions.