### PR TITLE
chore(ci): allow docker workflow actions for each commit

### DIFF
--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -147,29 +147,24 @@ jobs:
         if: ${{ matrix.platform.cross }}
 
       - name: Set up Docker
-        if: ${{ needs.tag.outputs.tag_created }}
         uses: crazy-max/ghaction-setup-docker@v4
 
       - name: Set up Docker Buildx
-        if: ${{ needs.tag.outputs.tag_created }}
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        if: ${{ needs.tag.outputs.tag_created }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
-        if: ${{ needs.tag.outputs.tag_created }}
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_REGISTRY_NAME }}
 
       - name: Build and push by digest
-        if: ${{ needs.tag.outputs.tag_created }}
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -183,14 +178,12 @@ jobs:
             IGGY_SERVER_PATH=target/${{ matrix.platform.target }}/release/iggy-server
 
       - name: Export digest
-        if: ${{ needs.tag.outputs.tag_created }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: ${{ needs.tag.outputs.tag_created }}
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ matrix.platform.os_name }}
@@ -199,14 +192,13 @@ jobs:
           retention-days: 1
 
   merge_docker_manifest:
-    if: ${{ needs.tag.outputs.tag_created }}
     runs-on: ubuntu-latest
     needs:
       - release_and_publish
       - tag
     steps:
       - name: Download digests
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
+        uses: actions/download-artifact@v4
         with:
           pattern: 'digests-*'
           merge-multiple: true
@@ -236,7 +228,7 @@ jobs:
         with:
           images: ${{ env.DOCKERHUB_REGISTRY_NAME }}
           tags: |
-            latest
+            edge
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
Skip release conditions for docker steps in publish_server workflow in order to allow iggy docker image preparation for each merged commit under edge tag in dockerhub repo.