### PR TITLE
chore(ci): add production workflow with Rust specific flow

### DIFF
--- a/.github/workflows/ci-prod-rust.yml
+++ b/.github/workflows/ci-prod-rust.yml
@@ -1,0 +1,119 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+#
+# CI Production Rust Workflow
+#
+# This workflow runs production actions for Rust code.
+# It is triggered by changes to Rust files. It builds and
+# iggy-server and iggy-cli binaries and creates Docker images
+# for x86_64 and aarch64 architectures, then images are pushed to
+# Docker Hub.
+#
+# This workflow can be triggered only oby other workflows.
+#
+name: ci-prod-rust
+
+on:
+  workflow_call:
+
+env:
+  DOCKERHUB_REGISTRY_NAME: apache/iggy
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  IGGY_CI_BUILD: true
+
+jobs:
+  docker-edge-build:
+    name: ${{ matrix.platform.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        platform:
+          - target: x86_64-unknown-linux-musl
+            docker_arch: linux/amd64
+            qemu: false
+            qemu_arch: ""
+          - target: aarch64-unknown-linux-musl
+            docker_arch: linux/arm64/v8
+            qemu: true
+            qemu_arch: "arm64"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Cache cargo & target directories
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "${{ matrix.platform.target }}"
+      - name: Install musl-tools, gnome-keyring and keyutils
+        run: |
+          sudo apt-get update --yes && sudo apt-get install --yes musl-tools gnome-keyring keyutils
+          rm -f $HOME/.local/share/keyrings/*
+          echo -n "test" | gnome-keyring-daemon --unlock
+      - name: Prepare ${{ matrix.platform.target }} toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          target: ${{ matrix.platform.target }}
+      - name: Install cross tool
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - name: Set verbose flag
+        shell: bash
+        run: echo "VERBOSE_FLAG=$([[ "${RUNNER_DEBUG}" = "1" ]] && echo "--verbose" || echo "")" >> $GITHUB_ENV
+      - name: Build iggy-server ${{ matrix.platform.target }} release binary
+        run: cross +stable build ${{ env.VERBOSE_FLAG }} --release --target ${{ matrix.platform.target }} --bin iggy-server
+      - name: Build iggy-cli ${{ matrix.platform.target }} release binary
+        run: cross +stable build ${{ env.VERBOSE_FLAG }} --release --no-default-features --target ${{ matrix.platform.target }} --bin iggy
+      - name: Print build ready message
+        run: echo "::notice ::Build binary artifacts for ${{ matrix.platform.target }}"
+      - name: Set up QEMU
+        if: ${{ matrix.platform.qemu == true }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.platform.qemu_arch }}
+      - name: Set up Docker
+        uses: crazy-max/ghaction-setup-docker@v4
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_REGISTRY_NAME }}
+      - name: Build and push by digest
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ci
+          platforms: ${{ matrix.platform.docker_arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.DOCKERHUB_REGISTRY_NAME }}:edge
+          outputs: type=image,name=${{ env.DOCKERHUB_REGISTRY_NAME }},push-by-digest=true,name-canonical=true
+          push: true
+          build-args: |
+            IGGY_CMD_PATH=target/${{ matrix.platform.target }}/release/iggy
+            IGGY_SERVER_PATH=target/${{ matrix.platform.target }}/release/iggy-server

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+#
+# CI Production Workflow
+#
+name: ci-prod
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  merge-file-changes:
+    name: merge-file-changes
+    runs-on: ubuntu-latest
+    outputs:
+      trigger-rust: ${{ steps.changed-files-yaml.outputs.rust_any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check changed files
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - Cargo.toml
+              - Cargo.lock
+              - Dockerfile
+              - Dockerfile.*
+              - .github/workflows/ci-prod-rust.yml
+      - name: List all changed files
+        run: |
+          if [ "${{ steps.changed-files-yaml.outputs.rust_any_changed }}" == "true" ]; then
+            echo "One or more rust file(s) has changed."
+            echo "List all the files that have changed: ${{ steps.changed-files-yaml.outputs.rust_all_changed_files }}"
+          fi
+
+  ci-prod-rust:
+    name: ci-prod-rust
+    needs: merge-file-changes
+    if: ${{ needs.merge-file-changes.outputs.trigger-rust == 'true' }}
+    uses: ./.github/workflows/ci-prod-rust.yml
+
+  finalize-prod:
+    runs-on: ubuntu-latest
+    needs:
+      - ci-prod-rust
+    if: always()
+    steps:
+      - name: Everything is fine
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
Add production flow triggered on push to master branch with new Rust specific flow which triggers Docker image creation for x86_64 and aarch64 architectures with edge tag release to Docker Hub.
