### PR TITLE
chore(server): print more detailed error logs

### DIFF
--- a/sdk/src/tcp/client.rs
+++ b/sdk/src/tcp/client.rs
@@ -453,8 +453,10 @@ impl TcpClient {
             let connection = TcpStream::connect(&self.config.server_address).await;
             if connection.is_err() {
                 error!(
-                    "Failed to connect to server: {}",
-                    self.config.server_address
+                    "Failed to connect to server: {}，\
+                     Error: {:?}",
+                    self.config.server_address,
+                    connection.as_ref().err().unwrap().to_string()
                 );
                 if !self.config.reconnection.enabled {
                     warn!("Automatic reconnection is disabled.");


### PR DESCRIPTION
During my debugging process, I found that printing more detailed error logs would help me troubleshoot the problem, but I am not sure if this method is appropriate. The current log is indeed too monotonous.