### PR TITLE
fix(ci): pass DockerHub secrets to Rust production workflow

### DIFF
--- a/.github/workflows/ci-prod-rust.yml
+++ b/.github/workflows/ci-prod-rust.yml
@@ -31,6 +31,11 @@ name: ci-prod-rust
 
 on:
   workflow_call:
+    secretes:
+      DOCKERHUB_USER:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 env:
   DOCKERHUB_REGISTRY_NAME: apache/iggy

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -60,6 +60,9 @@ jobs:
     needs: merge-file-changes
     if: ${{ needs.merge-file-changes.outputs.trigger-rust == 'true' }}
     uses: ./.github/workflows/ci-prod-rust.yml
+    secrets:
+      DOCKERHUB_USER: ${{ secretes.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secretes.DOCKERHUB_TOKEN }}
 
   finalize-prod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pass DockerHub secrets from main production (on push) workflow
to Rust workflow for creating images with iggy server.
