### PR TITLE
fix(ci): fix release when pushing the tags

### DIFF
--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -19,14 +19,32 @@ name: publish_cli
 on:
   push:
     tags:
-      - 'iggy-cli-[0-9]+.[0-9]+.[0-9]+'
+      - 'iggy-cli-*'
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
   CARGO_TERM_COLOR: always
 
 jobs:
+  validate:
+    if: startsWith(github.ref, 'refs/tags/iggy-cli-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract tag name
+        id: extract
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Validate tag format
+        run: |
+          TAG=${TAG}
+          if [[ ! "$TAG" =~ ^iggy-cli-([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
+            echo "Tag $TAG does not match strict semver format (iggy-cli-X.Y.Z where 0 <= X,Y,Z <= 999)"
+            exit 1
+          fi
+          echo "Valid tag: $TAG"
+
   tag:
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -19,14 +19,32 @@ name: publish_sdk
 on:
   push:
     tags:
-      - 'iggy-[0-9]+.[0-9]+.[0-9]+'
+      - 'iggy-*'
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
   CARGO_TERM_COLOR: always
 
 jobs:
+  validate:
+    if: startsWith(github.ref, 'refs/tags/iggy-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract tag name
+        id: extract
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Validate tag format
+        run: |
+          TAG=${TAG}
+          if [[ ! "$TAG" =~ ^iggy-([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
+            echo "Tag $TAG does not match strict semver format (iggy-X.Y.Z where 0 <= X,Y,Z <= 999)"
+            exit 1
+          fi
+          echo "Valid tag: $TAG"
+
   tag:
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -20,7 +20,7 @@ name: publish_server
 on:
   push:
     tags:
-      - 'server-[0-9]+.[0-9]+.[0-9]+'
+      - 'server-*'
 
 env:
   DOCKERHUB_REGISTRY_NAME: apache/iggy
@@ -31,7 +31,25 @@ env:
   IGGY_CI_BUILD: true
 
 jobs:
+  validate:
+    if: startsWith(github.ref, 'refs/tags/server-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract tag name
+        id: extract
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Validate tag format
+        run: |
+          TAG=${TAG}
+          if [[ ! "$TAG" =~ ^server-([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
+            echo "Tag $TAG does not match strict semver format (server-X.Y.Z where 0 <= X,Y,Z <= 999)"
+            exit 1
+          fi
+          echo "Valid tag: $TAG"
+
   tag:
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Since GitHub Actions do not use the regex syntax, but glob patterns instead, the tag-based release trigger needs to be fixed.