### PR TITLE
chore(server): print more detailed error log when connection fails

### DIFF
--- a/core/sdk/src/tcp/tcp_client.rs
+++ b/core/sdk/src/tcp/tcp_client.rs
@@ -285,10 +285,10 @@ impl TcpClient {
             );
 
             let connection = TcpStream::connect(&self.config.server_address).await;
-            if connection.is_err() {
+            if let Err(err) = &connection {
                 error!(
-                    "Failed to connect to server: {}",
-                    self.config.server_address
+                    "Failed to connect to server: {}. Error: {}",
+                    self.config.server_address, err
                 );
                 if !self.config.reconnection.enabled {
                     warn!("Automatic reconnection is disabled.");


### PR DESCRIPTION
When the connection fails, we can print a more detailed error log to let the user know how to solve it.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/d9c63021-17cc-48f0-ab93-e7706cff007d" />
