### PR TITLE
feat(bench): add Yew routing for benchmark sharing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "bench-dashboard-frontend"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bench-dashboard-shared",
  "bench-report",
@@ -871,6 +871,7 @@ dependencies = [
  "getrandom 0.3.3",
  "gloo 0.11.0",
  "js-sys",
+ "serde_json",
  "thiserror 2.0.12",
  "urlencoding",
  "uuid",
@@ -883,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "bench-dashboard-server"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/core/bench/dashboard/frontend/Cargo.toml
+++ b/core/bench/dashboard/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bench-dashboard-frontend"
 license = "Apache-2.0"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [package.metadata.cargo-machete]
@@ -14,6 +14,7 @@ charming = { workspace = true, features = ["wasm"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 gloo = "0.11"
 js-sys = "0.3"
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 urlencoding = "2.1.3"
 uuid = { workspace = true, features = ["js"] }

--- a/core/bench/dashboard/frontend/src/api/mod.rs
+++ b/core/bench/dashboard/frontend/src/api/mod.rs
@@ -126,6 +126,42 @@ pub async fn fetch_benchmarks_for_hardware_and_gitref(
         .map_err(|e| IggyBenchDashboardError::Parse(e.to_string()))
 }
 
+pub async fn fetch_benchmark_by_uuid(uuid: &str) -> Result<BenchmarkReportLight> {
+    check_server_health().await?;
+
+    log!(format!("Fetching benchmark for UUID: {}", uuid));
+    let base_url = get_api_base_url();
+    let url = format!("{}/api/benchmark/light/{}", base_url, uuid);
+    let response = Request::get(&url).send().await.map_err(|e| {
+        log!(format!("Network error fetching benchmark: {}", e));
+        IggyBenchDashboardError::Network(e.to_string())
+    })?;
+
+    if response.status() != 200 {
+        return Err(IggyBenchDashboardError::Server(format!(
+            "Failed to fetch benchmark: {}",
+            response.status()
+        )));
+    }
+
+    let text = response.text().await.map_err(|e| {
+        log!(format!("Error getting response text: {}", e));
+        IggyBenchDashboardError::Parse(e.to_string())
+    })?;
+
+    if text.is_empty() {
+        log!("Got empty response body despite 200 status code");
+        return Err(IggyBenchDashboardError::Parse(
+            "Empty response body".to_string(),
+        ));
+    }
+
+    serde_json::from_str::<BenchmarkReportLight>(&text).map_err(|e| {
+        log!(format!("JSON parse error: {}", e));
+        IggyBenchDashboardError::Parse(e.to_string())
+    })
+}
+
 pub async fn fetch_benchmark_report_full(uuid: &Uuid) -> Result<BenchmarkReport> {
     check_server_health().await?;
 

--- a/core/bench/dashboard/frontend/src/components/app_content.rs
+++ b/core/bench/dashboard/frontend/src/components/app_content.rs
@@ -18,6 +18,7 @@
 use crate::{
     api,
     components::layout::{main_content::MainContent, sidebar::Sidebar},
+    router::AppRoute,
     state::{
         benchmark::{use_benchmark, BenchmarkAction, BenchmarkContext},
         gitref::{use_gitref, GitrefAction, GitrefContext},
@@ -28,7 +29,7 @@ use crate::{
 use gloo::console::log;
 use urlencoding::decode;
 use yew::prelude::*;
-use yew_router::hooks::use_location;
+use yew_router::hooks::{use_location, use_route};
 
 // Props definitions
 #[derive(Properties, PartialEq)]
@@ -171,6 +172,63 @@ pub fn app_content() -> Html {
     let is_dark = theme_ctx.0;
     let theme_toggle = theme_ctx.1;
     let location = use_location().expect("Should have <BrowserRouter> in the tree");
+    let route = use_route::<AppRoute>().expect("AppRoute not found");
+
+    let uuid_option = match &route {
+        AppRoute::Benchmark { uuid } => Some(uuid.clone()),
+        _ => None,
+    };
+
+    let benchmark_ctx_clone = benchmark_ctx.clone();
+    let hardware_ctx_clone = hardware_ctx.clone();
+    let gitref_ctx_clone = gitref_ctx.clone();
+
+    use_effect_with(uuid_option.clone(), move |uuid_opt| {
+        if let Some(uuid) = uuid_opt {
+            let uuid = uuid.clone();
+            let benchmark_ctx = benchmark_ctx_clone.clone();
+            let hardware_ctx = hardware_ctx_clone.clone();
+            let gitref_ctx = gitref_ctx_clone.clone();
+
+            log!(format!("Loading benchmark by UUID from URL: {}", uuid));
+
+            let already_loaded = benchmark_ctx
+                .state
+                .selected_benchmark
+                .as_ref()
+                .map(|b| b.uuid.to_string() == uuid)
+                .unwrap_or(false);
+
+            if !already_loaded {
+                yew::platform::spawn_local(async move {
+                    match api::fetch_benchmark_by_uuid(&uuid).await {
+                        Ok(benchmark) => {
+                            log!(format!("Successfully loaded benchmark from URL: {}", uuid));
+
+                            hardware_ctx
+                                .dispatch
+                                .emit(HardwareAction::SelectHardware(Some(
+                                    benchmark.hardware.identifier.clone().unwrap(),
+                                )));
+
+                            if let Some(gr) = &benchmark.params.gitref {
+                                gitref_ctx
+                                    .dispatch
+                                    .emit(GitrefAction::SetSelectedGitref(Some(gr.clone())));
+                            }
+
+                            benchmark_ctx
+                                .dispatch
+                                .emit(BenchmarkAction::SelectBenchmark(Box::new(Some(benchmark))));
+                        }
+                        Err(e) => log!(format!("Error loading benchmark by UUID from URL: {}", e)),
+                    }
+                });
+            }
+        }
+
+        || ()
+    });
 
     use_init_hardware(hardware_ctx.clone());
 
@@ -180,8 +238,16 @@ pub fn app_content() -> Html {
         let benchmark_ctx = benchmark_ctx.clone();
         let ui_state = ui_state.clone();
         let query_str = location.query_str().to_string();
+        let has_uuid = uuid_option.is_some();
 
         use_effect_with((), move |_| {
+            let empty_cleanup = || ();
+
+            if has_uuid {
+                log!("Skipping query param processing because UUID is already in the URL");
+                return empty_cleanup;
+            }
+
             let search = query_str.clone();
             let (hw_opt, gitref_opt, meas_opt, pid_opt) = parse_query_params_from_str(&search);
             if hw_opt.is_none() && gitref_opt.is_none() && meas_opt.is_none() && pid_opt.is_none() {
@@ -232,7 +298,7 @@ pub fn app_content() -> Html {
                 }
             }
 
-            || ()
+            empty_cleanup
         });
     }
 

--- a/core/bench/dashboard/frontend/src/components/chart/single_chart.rs
+++ b/core/bench/dashboard/frontend/src/components/chart/single_chart.rs
@@ -22,6 +22,7 @@ use bench_report::report::BenchmarkReport;
 use charming::theme::Theme;
 use charming::{Echarts, WasmRenderer};
 use gloo::console::log;
+use gloo::history::{BrowserHistory, History};
 use uuid::Uuid;
 use yew::platform::spawn_local;
 use yew::prelude::*;
@@ -52,6 +53,17 @@ pub fn single_chart(props: &SingleChartProps) -> Html {
         use_effect_with(benchmark_uuid, move |benchmark_uuid| {
             let benchmark_uuid = *benchmark_uuid;
             is_loading.set(true);
+
+            let current_location = web_sys::window()
+                .and_then(|w| w.location().pathname().ok())
+                .unwrap_or_default();
+
+            let expected_path = format!("/benchmark/{}", benchmark_uuid);
+
+            if current_location != expected_path {
+                let history = BrowserHistory::new();
+                history.push(expected_path);
+            }
 
             spawn_local(async move {
                 match fetch_benchmark_report_full(&benchmark_uuid).await {

--- a/core/bench/dashboard/frontend/src/main.rs
+++ b/core/bench/dashboard/frontend/src/main.rs
@@ -43,7 +43,7 @@ pub fn app() -> Html {
 
 fn switch(routes: AppRoute) -> Html {
     match routes {
-        AppRoute::Single | AppRoute::Home => html! {
+        AppRoute::Benchmark { .. } | AppRoute::Home => html! {
             <ThemeProvider>
                 <UiProvider>
                     <div class="app-container">

--- a/core/bench/dashboard/frontend/src/router.rs
+++ b/core/bench/dashboard/frontend/src/router.rs
@@ -21,8 +21,8 @@ use yew_router::prelude::*;
 pub enum AppRoute {
     #[at("/")]
     Home,
-    #[at("/single")]
-    Single,
+    #[at("/benchmark/:uuid")]
+    Benchmark { uuid: String },
     #[not_found]
     #[at("/404")]
     NotFound,

--- a/core/bench/dashboard/server/Cargo.toml
+++ b/core/bench/dashboard/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bench-dashboard-server"
 license = "Apache-2.0"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This commit introduces Yew routing to enable sharing links to specific
benchmarks. By adding a UUID to the route, users can directly navigate
to a benchmark's page. This change enhances the user experience by
allowing easy sharing and direct access to benchmarks. The routing
logic has been updated to handle UUIDs, and the application now checks
for existing benchmarks to prevent unnecessary reloads. Additionally,
the URL is updated only when necessary to avoid circular redirects.
