### PR TITLE
fix(test): Fix error logging in integration sample tests

### DIFF
--- a/core/integration/tests/examples/mod.rs
+++ b/core/integration/tests/examples/mod.rs
@@ -142,7 +142,7 @@ impl<'a> IggyExampleTest<'a> {
     pub(crate) async fn execute_test(&mut self, test_case: impl IggyExampleTestCase) {
         assert!(
             self.server.is_started(),
-            "Server is not running, make sure it has been started with IggyExampleTest::setup()"
+            "Server is not running, make sure it has been started with IggyExampleTest::new()"
         );
         let (producer_stdout, consumer_stdout) = self
             .spawn_executables(test_case.protocol(&self.server))


### PR DESCRIPTION
According to the code, the server should be started in IggyExampleTest::new() instead of setup

<img width="1487" alt="image" src="https://github.com/user-attachments/assets/3732ff21-d4ab-420e-b29e-dea60f7f46e6" />


testing

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/1687e042-8848-4f96-9213-134681a6c5a9" />
