### PR TITLE
chore(sdk): Refine comments for methods under `IggyClient`

### DIFF
--- a/core/sdk/src/clients/client.rs
+++ b/core/sdk/src/clients/client.rs
@@ -63,7 +63,7 @@ impl IggyClient {
         IggyClientBuilder::new()
     }
 
-    /// Creates a new `IggyClientBuilder`.
+    /// Creates a new `IggyClientBuilder` from the provided connection string.
     pub fn builder_from_connection_string(
         connection_string: &str,
     ) -> Result<IggyClientBuilder, IggyError> {
@@ -80,6 +80,7 @@ impl IggyClient {
         }
     }
 
+    /// Creates a new `IggyClient` from the provided connection string.
     pub fn from_connection_string(connection_string: &str) -> Result<Self, IggyError> {
         match ConnectionStringUtils::parse_protocol(connection_string)? {
             TransportProtocol::Tcp => Ok(IggyClient::new(ClientWrapper::Tcp(

--- a/core/sdk/src/clients/client_builder.rs
+++ b/core/sdk/src/clients/client_builder.rs
@@ -44,6 +44,7 @@ impl IggyClientBuilder {
         IggyClientBuilder::default()
     }
 
+    /// Creates a new `IggyClientBuilder` from the provided connection string.
     pub fn from_connection_string(connection_string: &str) -> Result<Self, IggyError> {
         let mut builder = Self::new();
 

--- a/core/sdk/src/tcp/tcp_client.rs
+++ b/core/sdk/src/tcp/tcp_client.rs
@@ -178,6 +178,7 @@ impl TcpClient {
         }))
     }
 
+    /// Create a new TCP client from the provided connection string.
     pub fn from_connection_string(connection_string: &str) -> Result<Self, IggyError> {
         if ConnectionStringUtils::parse_protocol(connection_string)? != TransportProtocol::Tcp {
             return Err(IggyError::InvalidConnectionString);


### PR DESCRIPTION
## Summary
Currently some comments are missing or repeated for the methods under `IggyClient`.
Make the following changes to make the comments of `IggyClient` more complete.

* Clarify comments for `IggyClient::builder_from_connection_string()`
* Add comment for `IggyClient::from_connection_string()`




