### PR TITLE
Fix property name of partitions_count in Python client

### DIFF
--- a/foreign/python/iggy_py.pyi
+++ b/foreign/python/iggy_py.pyi
@@ -194,7 +194,7 @@ class TopicDetails:
     id: builtins.int
     name: builtins.str
     messages_count: builtins.int
-    topics_count: builtins.int
+    partitions_count: builtins.int
 
 class MessageState(Enum):
     Available = auto()

--- a/foreign/python/src/topic.rs
+++ b/foreign/python/src/topic.rs
@@ -53,7 +53,7 @@ impl TopicDetails {
     }
 
     #[getter]
-    pub fn topics_count(&self) -> u32 {
+    pub fn partitions_count(&self) -> u32 {
         self.inner.partitions_count
     }
 }


### PR DESCRIPTION
Rename `topics_count` to `partitions_count` in `TopicDetails`. This seems to have been a copy paste error.

This fixes #1807
