### PR TITLE
chore(ci): Remove archived actions-rs/* actions

### DIFF
--- a/.github/workflows/ci-check-common.yml
+++ b/.github/workflows/ci-check-common.yml
@@ -94,8 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - run: scripts/licenses-list.sh --check

--- a/.github/workflows/ci-check-rust.yml
+++ b/.github/workflows/ci-check-rust.yml
@@ -52,9 +52,8 @@ jobs:
            rustup toolchain add --profile=minimal stable
            rustup override set stable
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: |
+          cargo check
 
   fmt:
     name: cargo fmt
@@ -67,10 +66,8 @@ jobs:
            rustup toolchain add --profile=minimal stable
            rustup override set stable
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: |
+          cargo fmt --all -- --check
 
   clippy:
     name: cargo clippy
@@ -83,10 +80,8 @@ jobs:
            rustup toolchain add --profile=minimal stable
            rustup override set stable
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
 
   clippy-macos:
     name: cargo clippy macos
@@ -99,10 +94,8 @@ jobs:
            rustup toolchain add --profile=minimal stable
            rustup override set stable
       - name: Run cargo clippy (macos)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
 
   clippy-windows:
     name: cargo clippy windows
@@ -115,15 +108,11 @@ jobs:
            rustup toolchain add --profile=minimal stable
            rustup override set stable
       - name: Run cargo clippy (windows/sdk)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --package iggy --all-features -- -D warnings
+        run: |
+          cargo clippy --package iggy --all-features -- -D warnings
       - name: Run cargo clippy (windows/cli)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --bin iggy --all-features -- -D warnings
+        run: |
+          cargo clippy --bin iggy --all-features -- -D warnings
 
   sort:
     name: cargo sort
@@ -140,10 +129,8 @@ jobs:
         with:
           tool: cargo-sort
       - name: Run cargo sort
-        uses: actions-rs/cargo@v1
-        with:
-          command: sort
-          args: --check --workspace
+        run: |
+          cargo sort --check --workspace
 
   doctest:
     name: cargo test docs
@@ -156,10 +143,8 @@ jobs:
            rustup toolchain add --profile=minimal stable
            rustup override set stable
       - name: Run cargo test (doc)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc
+        run: |
+          cargo test --doc
 
   unused_dependencies:
     name: cargo machete
@@ -176,7 +161,5 @@ jobs:
         with:
           tool: cargo-machete
       - name: Run cargo machete
-        uses: actions-rs/cargo@v1
-        with:
-          command: machete
-          args: --with-metadata
+        run: |
+          cargo machete --with-metadata

--- a/.github/workflows/ci-check-rust.yml
+++ b/.github/workflows/ci-check-rust.yml
@@ -48,10 +48,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -64,10 +63,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -81,10 +79,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
@@ -98,10 +95,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Run cargo clippy (macos)
         uses: actions-rs/cargo@v1
         with:
@@ -115,10 +111,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Run cargo clippy (windows/sdk)
         uses: actions-rs/cargo@v1
         with:
@@ -137,10 +132,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Install cargo-sort
         uses: taiki-e/install-action@v2
         with:
@@ -158,10 +152,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Run cargo test (doc)
         uses: actions-rs/cargo@v1
         with:
@@ -175,10 +168,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Install cargo-machete
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/ci-prod-rust.yml
+++ b/.github/workflows/ci-prod-rust.yml
@@ -74,11 +74,10 @@ jobs:
           rm -f $HOME/.local/share/keyrings/*
           echo -n "test" | gnome-keyring-daemon --unlock
       - name: Prepare ${{ matrix.platform.target }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.platform.target }}
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable ${{ matrix.platform.target }}
+           rustup override set stable
       - name: Install cross tool
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/ci-test-rust-optional.yml
+++ b/.github/workflows/ci-test-rust-optional.yml
@@ -50,11 +50,10 @@ jobs:
         with:
           key: "aarch64-apple-darwin"
       - name: Prepare aarch64-apple-darwin toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: aarch64-apple-darwin
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable aarch64-apple-darwin
+           rustup override set stable
       - name: Set verbose flag
         shell: bash
         run: echo "VERBOSE_FLAG=$([[ "${RUNNER_DEBUG}" = "1" ]] && echo "--verbose" || echo "")" >> $GITHUB_ENV

--- a/.github/workflows/ci-test-rust.yml
+++ b/.github/workflows/ci-test-rust.yml
@@ -59,11 +59,10 @@ jobs:
           rm -f $HOME/.local/share/keyrings/*
           echo -n "test" | gnome-keyring-daemon --unlock
       - name: Prepare ${{ matrix.target }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.target }}
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable ${{ matrix.target }}
+           rustup override set stable
       - name: Set verbose flag
         shell: bash
         run: echo "VERBOSE_FLAG=$([[ "${RUNNER_DEBUG}" = "1" ]] && echo "--verbose" || echo "")" >> $GITHUB_ENV
@@ -88,11 +87,10 @@ jobs:
         with:
           key: "x86_64-pc-windows-msvc"
       - name: Prepare x86_64-pc-windows-msvc toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: x86_64-pc-windows-msvc
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable x86_64-pc-windows-msvc
+           rustup override set stable
       - name: Set verbose flag
         shell: pwsh
         run: |

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -90,10 +90,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
 
       - name: publish
         run: |

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -90,10 +90,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
 
       - name: publish
         run: |

--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -132,11 +132,10 @@ jobs:
         if: contains(matrix.platform.name, 'musl')
 
       - name: Prepare ${{ matrix.platform.target }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.platform.target }}
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable ${{ matrix.platform.target }}
+           rustup override set stable
 
       - name: Install cross
         uses: taiki-e/install-action@v2

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -79,11 +79,10 @@ jobs:
         if: ${{ matrix.platform.target == 'x86_64-unknown-linux-musl' }}
 
       - name: Prepare ${{ matrix.platform.target }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.platform.target }}
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable ${{ matrix.platform.target }}
+           rustup override set stable
 
       - name: Install cross
         uses: taiki-e/install-action@v2

--- a/.github/workflows/release_server.yml
+++ b/.github/workflows/release_server.yml
@@ -45,11 +45,10 @@ jobs:
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
 
       - name: Prepare x86_64-unknown-linux-musl toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: x86_64-unknown-linux-musl
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable x86_64-unknown-linux-musl
+           rustup override set stable
 
       - name: Install cross
         uses: taiki-e/install-action@v2
@@ -65,11 +64,10 @@ jobs:
           cp target_x86/x86_64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-x86_64/
 
       - name: Prepare aarch64-unknown-linux-musl toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: aarch64-unknown-linux-musl
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable aarch64-unknown-linux-musl
+           rustup override set stable
 
       - name: Build iggy-server release binary for aarch64-unknown-linux-musl
         run: cross +stable build --verbose --target aarch64-unknown-linux-musl --release --bin iggy-server --target-dir target_aarch64

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,12 +41,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: clippy
-          override: true
+        run: |
+          rustup toolchain add --profile minimal --components clippy stable 
+          rustup override set stable
 
       - name: Install clippy-sarif sarif-fmt
         run: cargo install clippy-sarif sarif-fmt

--- a/.github/workflows/test_daily.yml
+++ b/.github/workflows/test_daily.yml
@@ -91,11 +91,10 @@ jobs:
         if: ${{ matrix.platform.cross }}
 
       - name: Prepare ${{ matrix.platform.target }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.platform.target }}
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable ${{ matrix.platform.target }}
+           rustup override set stable
 
       - name: Install cross
         uses: taiki-e/install-action@v2

--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -92,11 +92,10 @@ jobs:
         if: ${{ matrix.platform.cross }}
 
       - name: Prepare ${{ matrix.platform.target }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.platform.target }}
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup target add --toolchain=stable ${{ matrix.platform.target }}
+           rustup override set stable
 
       - name: Install cross
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
The actions-rs org has been archived for years at this point and it doesn't look like it's coming back. For security reasons we are going to remove it from the list of allowed actions in the org soon. (See  https://github.com/apache/infrastructure-actions)

In this PR I have replaced the usage of `actions-rs/cargo` and `actions-rs/toolchain` with bare `rustup` and `cargo` commands.