### PR TITLE
refactor(sdk): rename sync configuration to direct

### DIFF
--- a/core/common/src/error/iggy_error.rs
+++ b/core/common/src/error/iggy_error.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use strum::{EnumDiscriminants, FromRepr, IntoStaticStr};
 use thiserror::Error;
 
-#[derive(Clone, Debug, Error, EnumDiscriminants, IntoStaticStr, FromRepr)]
+#[derive(Clone, Debug, Error, EnumDiscriminants, IntoStaticStr, FromRepr, Default)]
 #[repr(u32)]
 #[strum(serialize_all = "snake_case")]
 #[strum_discriminants(
@@ -31,6 +31,7 @@ use thiserror::Error;
     strum(serialize_all = "snake_case")
 )]
 pub enum IggyError {
+    #[default]
     #[error("Error")]
     Error = 1,
     #[error("Invalid configuration")]
@@ -375,8 +376,10 @@ pub enum IggyError {
     BackgroundSendBufferOverflow = 4055,
     #[error("Producer send failed")]
     ProducerSendFailed {
-        cause: String,
+        cause: Box<IggyError>,
         failed: Arc<Vec<IggyMessage>>,
+        stream_name: String,
+        topic_name: String,
     } = 4056,
     #[error("Producer closed")]
     ProducerClosed = 4057,

--- a/core/connectors/runtime/src/source.rs
+++ b/core/connectors/runtime/src/source.rs
@@ -20,7 +20,7 @@ use dashmap::DashMap;
 use dlopen2::wrapper::Container;
 use flume::{Receiver, Sender};
 use iggy::prelude::{
-    HeaderKey, HeaderValue, IggyClient, IggyDuration, IggyError, IggyMessage, SyncConfig,
+    DirectConfig, HeaderKey, HeaderValue, IggyClient, IggyDuration, IggyError, IggyMessage,
 };
 use iggy_connector_sdk::{
     DecodedMessage, Error, ProducedMessages, StreamEncoder, TopicMetadata, transforms::Transform,
@@ -120,8 +120,8 @@ pub async fn init(
             let batch_length = stream.batch_length.unwrap_or(1000);
             let producer = iggy_client
                 .producer(&stream.stream, &stream.topic)?
-                .sync(
-                    SyncConfig::builder()
+                .direct(
+                    DirectConfig::builder()
                         .batch_length(batch_length)
                         .linger_time(linger_time)
                         .build(),

--- a/core/examples/src/multi-tenant/producer/main.rs
+++ b/core/examples/src/multi-tenant/producer/main.rs
@@ -262,8 +262,8 @@ async fn create_producers(
         for id in 1..=producers_count {
             let producer = client
                 .producer(stream, topic)?
-                .sync(
-                    SyncConfig::builder()
+                .direct(
+                    DirectConfig::builder()
                         .batch_length(batch_length)
                         .linger_time(IggyDuration::from_str(interval).expect("Invalid duration"))
                         .build(),

--- a/core/examples/src/new-sdk/producer/main.rs
+++ b/core/examples/src/new-sdk/producer/main.rs
@@ -46,8 +46,8 @@ async fn main() -> anyhow::Result<(), Box<dyn Error>> {
     let interval = IggyDuration::from_str(&args.interval)?;
     let producer = client
         .producer(&args.stream_id, &args.topic_id)?
-        .sync(
-            SyncConfig::builder()
+        .direct(
+            DirectConfig::builder()
                 .batch_length(args.messages_per_batch)
                 .linger_time(interval)
                 .build(),

--- a/core/examples/src/sink-data-producer/main.rs
+++ b/core/examples/src/sink-data-producer/main.rs
@@ -20,8 +20,8 @@ use std::{env, str::FromStr, time::Duration};
 
 use chrono::{DateTime, Days, Utc};
 use iggy::prelude::{
-    Client, IggyClient, IggyClientBuilder, IggyDuration, IggyError, IggyMessage, Partitioning,
-    SyncConfig,
+    Client, DirectConfig, IggyClient, IggyClientBuilder, IggyDuration, IggyError, IggyMessage,
+    Partitioning,
 };
 use rand::{
     Rng,
@@ -58,8 +58,8 @@ async fn main() -> Result<(), DataProducerError> {
     let client = create_client(&address, &username, &password).await?;
     let producer = client
         .producer(&stream, &topic)?
-        .sync(
-            SyncConfig::builder()
+        .direct(
+            DirectConfig::builder()
                 .batch_length(1000)
                 .linger_time(IggyDuration::from_str("5ms").unwrap())
                 .build(),

--- a/core/sdk/src/clients/mod.rs
+++ b/core/sdk/src/clients/mod.rs
@@ -39,3 +39,4 @@ pub mod producer_sharding;
 
 const ORDERING: std::sync::atomic::Ordering = std::sync::atomic::Ordering::SeqCst;
 const MAX_BATCH_LENGTH: usize = 1000000;
+const MIB: usize = 1_048_576;

--- a/core/sdk/src/clients/producer_builder.rs
+++ b/core/sdk/src/clients/producer_builder.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::clients::producer_config::{BackgroundConfig, SyncConfig};
+use crate::clients::producer_config::{BackgroundConfig, DirectConfig};
 use crate::prelude::IggyProducer;
 use iggy_binary_protocol::Client;
 use iggy_common::locking::IggySharedMut;
@@ -25,13 +25,13 @@ use iggy_common::{
 use std::sync::Arc;
 
 pub enum SendMode {
-    Sync(SyncConfig),
+    Direct(DirectConfig),
     Background(BackgroundConfig),
 }
 
 impl Default for SendMode {
     fn default() -> Self {
-        SendMode::Sync(SyncConfig::builder().build())
+        SendMode::Direct(DirectConfig::builder().build())
     }
 }
 
@@ -198,15 +198,15 @@ impl IggyProducerBuilder {
         }
     }
 
-    /// Sets the producer to use synchronous (direct) message sending.
+    /// Sets the producer to use direct message sending.
     /// This mode ensures that messages are sent immediately to the server
     /// without being buffered or delayed.
-    pub fn sync(mut self, config: SyncConfig) -> Self {
-        self.mode = SendMode::Sync(config);
+    pub fn direct(mut self, config: DirectConfig) -> Self {
+        self.mode = SendMode::Direct(config);
         self
     }
 
-    /// Sets the producer to use asynchronous (background) message sending.
+    /// Sets the producer to use background message sending.
     /// This mode buffers messages and sends them in the background.
     pub fn background(mut self, config: BackgroundConfig) -> Self {
         self.mode = SendMode::Background(config);

--- a/core/sdk/src/clients/producer_dispatcher.rs
+++ b/core/sdk/src/clients/producer_dispatcher.rs
@@ -425,8 +425,10 @@ mod tests {
             .returning(|_, _, _, _| {
                 Box::pin(async {
                     Err(IggyError::ProducerSendFailed {
-                        cause: "some_error".to_string(),
+                        cause: Box::new(IggyError::Error),
                         failed: Arc::new(vec![dummy_message(10)]),
+                        stream_name: "1".to_string(),
+                        topic_name: "1".to_string(),
                     })
                 })
             });

--- a/core/sdk/src/clients/producer_error_callback.rs
+++ b/core/sdk/src/clients/producer_error_callback.rs
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-use iggy_common::{Identifier, IggyMessage, Partitioning};
+use iggy_common::{Identifier, IggyError, IggyMessage, Partitioning};
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -23,9 +23,11 @@ use tracing::error;
 
 #[derive(Debug)]
 pub struct ErrorCtx {
-    pub cause: String,
+    pub cause: Box<IggyError>,
     pub stream: Arc<Identifier>,
+    pub stream_name: String,
     pub topic: Arc<Identifier>,
+    pub topic_name: String,
     pub partitioning: Option<Arc<Partitioning>>,
     pub messages: Arc<Vec<IggyMessage>>,
 }
@@ -54,9 +56,11 @@ impl ErrorCallback for LogErrorCallback {
                 .unwrap_or_else(|| "None".to_string());
 
             error!(
-                cause = ctx.cause,
+                cause = %ctx.cause,
                 stream = %ctx.stream,
+                stream_name = ctx.stream_name,
                 topic = %ctx.topic,
+                topic_name = ctx.topic_name,
                 partitioning = %partitioning,
                 num_messages = ctx.messages.len(),
                 "Failed to send messages in background task",

--- a/core/sdk/src/prelude.rs
+++ b/core/sdk/src/prelude.rs
@@ -37,7 +37,7 @@ pub use crate::clients::consumer::{
 pub use crate::clients::consumer_builder::IggyConsumerBuilder;
 pub use crate::clients::producer::IggyProducer;
 pub use crate::clients::producer_builder::IggyProducerBuilder;
-pub use crate::clients::producer_config::{BackgroundConfig, SyncConfig};
+pub use crate::clients::producer_config::{BackgroundConfig, DirectConfig};
 pub use crate::consumer_ext::IggyConsumerMessageExt;
 pub use crate::stream_builder::IggyConsumerConfig;
 pub use crate::stream_builder::IggyStreamConsumer;

--- a/core/sdk/src/stream_builder/build/build_iggy_producer.rs
+++ b/core/sdk/src/stream_builder/build/build_iggy_producer.rs
@@ -18,7 +18,7 @@
 
 use crate::clients::client::IggyClient;
 use crate::clients::producer::IggyProducer;
-use crate::clients::producer_config::SyncConfig;
+use crate::clients::producer_config::DirectConfig;
 use crate::prelude::{IggyError, IggyExpiry, MaxTopicSize};
 use crate::stream_builder::IggyProducerConfig;
 use tracing::{error, trace};
@@ -66,8 +66,8 @@ pub(crate) async fn build_iggy_producer(
             IggyExpiry::ServerDefault,
             MaxTopicSize::ServerDefault,
         )
-        .sync(
-            SyncConfig::builder()
+        .direct(
+            DirectConfig::builder()
                 .batch_length(batch_length)
                 .linger_time(linger_time)
                 .build(),


### PR DESCRIPTION
These changes address issues raised during the review https://github.com/apache/iggy/pull/1838#discussion_r2132133626

The following was done:
- Introduced a constant(MIB) for the value `1_048_576`
- Increased the maximum shard count (from 16 to 64)
- Added additional logging when messages are accepted in a shard
- Changed the `cause` type in `ProducerSendFailed` from `String` to `IggyError`
- Renamed the `sync` module to `direct`
- Added extra argument logging in `LogErrorCallback`