### PR TITLE
chore(ci): fix test output capture and rustup command syntax

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add --profile minimal --components clippy stable 
+          rustup toolchain add --profile=minimal --component=clippy stable
           rustup override set stable
 
       - name: Install clippy-sarif sarif-fmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,7 +4109,6 @@ dependencies = [
  "tempfile",
  "test-case",
  "tokio",
- "tracing-subscriber",
  "twox-hash",
  "uuid",
  "zip",

--- a/core/integration/Cargo.toml
+++ b/core/integration/Cargo.toml
@@ -50,7 +50,6 @@ server = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true }
-tracing-subscriber = { workspace = true }
 twox-hash = { workspace = true }
 uuid = { workspace = true }
 zip = { workspace = true }

--- a/core/integration/src/test_server.rs
+++ b/core/integration/src/test_server.rs
@@ -19,7 +19,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -204,16 +204,6 @@ impl TestServer {
 
         let child = command.spawn().unwrap();
         self.child_handle = Some(child);
-
-        if self.child_handle.as_ref().unwrap().stdout.is_some() {
-            let child_stdout = self.child_handle.as_mut().unwrap().stdout.take().unwrap();
-            std::thread::spawn(move || {
-                let reader = BufReader::new(child_stdout);
-                for line in reader.lines() {
-                    println!("{}", line.unwrap());
-                }
-            });
-        }
         self.wait_until_server_has_bound();
     }
 

--- a/core/integration/tests/server/scenarios/stream_size_validation_scenario.rs
+++ b/core/integration/tests/server/scenarios/stream_size_validation_scenario.rs
@@ -21,9 +21,6 @@ use bytes::Bytes;
 use iggy::prelude::*;
 use integration::test_server::{ClientFactory, assert_clean_system, login_root};
 use std::str::FromStr;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Registry};
 
 const S1_NAME: &str = "test-stream-1";
 const T1_NAME: &str = "test-topic-1";
@@ -35,10 +32,6 @@ const MSGS_COUNT: u64 = 117; // number of messages in a single topic after one p
 const MSGS_SIZE: u64 = MSG_SIZE * MSGS_COUNT; // number of bytes in a single topic after one pass of appending
 
 pub async fn run(client_factory: &dyn ClientFactory) {
-    let _ = Registry::default()
-        .with(tracing_subscriber::fmt::layer())
-        .with(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("INFO")))
-        .try_init();
     let client = create_client(client_factory).await;
 
     // 0. Ping server, login as root user and ensure that streams do not exist


### PR DESCRIPTION
Remove explicit tracing initialization from integration tests and
stdout printing thread that were bypassing cargo test's output
capture. Also fix rustup command in security workflow to use
correct --component syntax instead of --components.
