### PR TITLE
feat(io_uring): fix metadata crud operations

### DIFF
--- a/core/integration/tests/streaming/stream.rs
+++ b/core/integration/tests/streaming/stream.rs
@@ -132,7 +132,6 @@ async fn should_purge_existing_stream_on_disk() {
                 MaxTopicSize::ServerDefault,
                 1,
             )
-            .await
             .unwrap();
 
         let messages = create_messages();

--- a/core/server/src/shard/mod.rs
+++ b/core/server/src/shard/mod.rs
@@ -400,6 +400,7 @@ impl IggyShard {
             }
         }
 
+        //TODO: Refactor...
         let mut streams_states = streams
             .into_iter()
             .filter(|s| !missing_ids.contains(&s.id))

--- a/core/server/src/shard/system/messages.rs
+++ b/core/server/src/shard/system/messages.rs
@@ -53,12 +53,15 @@ impl IggyShard {
             )
         })?;
         let stream_id = stream.stream_id;
-        let numeric_topic_id = stream.get_topic(topic_id).map(|topic| topic.topic_id).with_error_context(|error| {
-            format!(
-                "Failed to get topic with ID: {} (error: {})",
-                topic_id, error
-            )
-        })?;
+        let numeric_topic_id = stream
+            .get_topic(topic_id)
+            .map(|topic| topic.topic_id)
+            .with_error_context(|error| {
+                format!(
+                    "Failed to get topic with ID: {} (error: {})",
+                    topic_id, error
+                )
+            })?;
         // TODO: We should look into refactoring those permissioners, so they can accept `Identifier` instead of numeric IDs.
         // Validate permissions for given user on stream and topic.
         self.permissioner.borrow().append_messages(

--- a/core/server/src/shard/system/streams.rs
+++ b/core/server/src/shard/system/streams.rs
@@ -298,6 +298,13 @@ impl IggyShard {
             })?;
             old_name = stream.name.clone();
             stream.name = name.to_owned();
+            // Drop the exclusive borrow.
+            drop(stream);
+            // Get it again using inclusive borrow
+            let stream = self.get_stream(id).with_error_context(|error| {
+                format!("{COMPONENT} (error: {error}) - failed to get mutable reference to stream with id: {id}")
+            })?;
+            // Persist it.
             stream.persist().await?;
         }
 


### PR DESCRIPTION
This PR fixes the metadata crud operations, preventing double borrow_mut call on collections across awaits