### PR TITLE
perf(sdk): replace Box<dyn Client> with ClientWrapper enum

### DIFF
--- a/core/integration/src/http_client.rs
+++ b/core/integration/src/http_client.rs
@@ -19,7 +19,7 @@
 use crate::test_server::{ClientFactory, Transport};
 use async_trait::async_trait;
 use iggy::http::http_client::HttpClient;
-use iggy::prelude::{Client, HttpClientConfig};
+use iggy::prelude::{ClientWrapper, HttpClientConfig};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -29,13 +29,13 @@ pub struct HttpClientFactory {
 
 #[async_trait]
 impl ClientFactory for HttpClientFactory {
-    async fn create_client(&self) -> Box<dyn Client> {
+    async fn create_client(&self) -> ClientWrapper {
         let config = HttpClientConfig {
             api_url: format!("http://{}", self.server_addr.clone()),
             ..HttpClientConfig::default()
         };
         let client = HttpClient::create(Arc::new(config)).unwrap();
-        Box::new(client)
+        ClientWrapper::Http(client)
     }
 
     fn transport(&self) -> Transport {

--- a/core/integration/src/quic_client.rs
+++ b/core/integration/src/quic_client.rs
@@ -18,7 +18,7 @@
 
 use crate::test_server::{ClientFactory, Transport};
 use async_trait::async_trait;
-use iggy::prelude::{Client, QuicClientConfig};
+use iggy::prelude::{Client, ClientWrapper, QuicClientConfig};
 use iggy::quic::quick_client::QuicClient;
 use std::sync::Arc;
 
@@ -29,14 +29,14 @@ pub struct QuicClientFactory {
 
 #[async_trait]
 impl ClientFactory for QuicClientFactory {
-    async fn create_client(&self) -> Box<dyn Client> {
+    async fn create_client(&self) -> ClientWrapper {
         let config = QuicClientConfig {
             server_address: self.server_addr.clone(),
             ..QuicClientConfig::default()
         };
         let client = QuicClient::create(Arc::new(config)).unwrap();
         Client::connect(&client).await.unwrap();
-        Box::new(client)
+        ClientWrapper::Quic(client)
     }
 
     fn transport(&self) -> Transport {

--- a/core/integration/src/tcp_client.rs
+++ b/core/integration/src/tcp_client.rs
@@ -18,7 +18,7 @@
 
 use crate::test_server::{ClientFactory, Transport};
 use async_trait::async_trait;
-use iggy::prelude::{Client, TcpClient, TcpClientConfig};
+use iggy::prelude::{Client, ClientWrapper, TcpClient, TcpClientConfig};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Default)]
@@ -33,7 +33,7 @@ pub struct TcpClientFactory {
 
 #[async_trait]
 impl ClientFactory for TcpClientFactory {
-    async fn create_client(&self) -> Box<dyn Client> {
+    async fn create_client(&self) -> ClientWrapper {
         let config = TcpClientConfig {
             server_address: self.server_addr.clone(),
             nodelay: self.nodelay,
@@ -65,7 +65,7 @@ impl ClientFactory for TcpClientFactory {
                 )
             }
         });
-        Box::new(client)
+        ClientWrapper::Tcp(client)
     }
 
     fn transport(&self) -> Transport {

--- a/core/integration/src/test_server.rs
+++ b/core/integration/src/test_server.rs
@@ -53,7 +53,7 @@ pub enum IpAddrKind {
 
 #[async_trait]
 pub trait ClientFactory: Sync + Send {
-    async fn create_client(&self) -> Box<dyn Client>;
+    async fn create_client(&self) -> ClientWrapper;
     fn transport(&self) -> Transport;
     fn server_addr(&self) -> String;
 }

--- a/core/integration/tests/cli/common/mod.rs
+++ b/core/integration/tests/cli/common/mod.rs
@@ -24,10 +24,8 @@ use assert_cmd::assert::{Assert, OutputAssertExt};
 use assert_cmd::prelude::CommandCargoExt;
 use async_trait::async_trait;
 use iggy::clients::client::IggyClient;
-use iggy::prelude::TcpClient;
-use iggy::prelude::TcpClientConfig;
 use iggy::prelude::defaults::*;
-use iggy::prelude::{Client, SystemClient, UserClient};
+use iggy::prelude::{Client, ClientWrapper, SystemClient, TcpClient, TcpClientConfig, UserClient};
 use integration::test_server::TestServer;
 use std::fmt::{Display, Formatter, Result};
 use std::io::Write;
@@ -107,7 +105,7 @@ impl IggyCmdTest {
             server_address: server.get_raw_tcp_addr().unwrap(),
             ..TcpClientConfig::default()
         };
-        let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
+        let client = ClientWrapper::Tcp(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
         let client = IggyClient::create(client, None, None);
 
         Self { server, client }

--- a/core/integration/tests/sdk/producer/background.rs
+++ b/core/integration/tests/sdk/producer/background.rs
@@ -40,7 +40,7 @@ async fn background_send_receive_ok() {
         server_address: test_server.get_raw_tcp_addr().unwrap(),
         ..TcpClientConfig::default()
     };
-    let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
+    let client = ClientWrapper::Tcp(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
     let client = IggyClient::create(client, None, None);
 
     client.connect().await.unwrap();
@@ -106,7 +106,7 @@ async fn background_buffer_overflow_immediate() {
         server_address: test_server.get_raw_tcp_addr().unwrap(),
         ..TcpClientConfig::default()
     };
-    let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
+    let client = ClientWrapper::Tcp(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
     let client = IggyClient::create(client, None, None);
 
     client.connect().await.unwrap();
@@ -157,7 +157,7 @@ async fn background_block_with_timeout() {
         server_address: test_server.get_raw_tcp_addr().unwrap(),
         ..TcpClientConfig::default()
     };
-    let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
+    let client = ClientWrapper::Tcp(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
     let client = IggyClient::create(client, None, None);
 
     client.connect().await.unwrap();
@@ -215,7 +215,7 @@ async fn background_block_waits_then_succeeds() {
         server_address: test_server.get_raw_tcp_addr().unwrap(),
         ..TcpClientConfig::default()
     };
-    let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
+    let client = ClientWrapper::Tcp(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
     let client = IggyClient::create(client, None, None);
 
     client.connect().await.unwrap();
@@ -271,7 +271,7 @@ async fn background_graceful_shutdown() {
         server_address: test_server.get_raw_tcp_addr().unwrap(),
         ..TcpClientConfig::default()
     };
-    let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
+    let client = ClientWrapper::Tcp(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
     let client = IggyClient::create(client, None, None);
 
     client.connect().await.unwrap();
@@ -349,7 +349,7 @@ async fn background_many_parallel_producers() {
         server_address: test_server.get_raw_tcp_addr().unwrap(),
         ..TcpClientConfig::default()
     };
-    let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
+    let client = ClientWrapper::Tcp(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
     let client = Arc::new(IggyClient::create(client, None, None));
 
     client.connect().await.unwrap();

--- a/core/integration/tests/server/specific.rs
+++ b/core/integration/tests/server/specific.rs
@@ -88,7 +88,7 @@ async fn tcp_tls_scenario_should_be_valid() {
         .await
         .expect("Failed to connect TLS client");
 
-    let client = IggyClient::create(Box::new(client), None, None);
+    let client = IggyClient::create(ClientWrapper::Iggy(client), None, None);
 
     tcp_tls_scenario::run(&client).await;
 }
@@ -123,7 +123,7 @@ async fn tcp_tls_self_signed_scenario_should_be_valid() {
         .await
         .expect("Failed to connect TLS client with self-signed cert");
 
-    let client = iggy::clients::client::IggyClient::create(Box::new(client), None, None);
+    let client = iggy::clients::client::IggyClient::create(ClientWrapper::Iggy(client), None, None);
 
     tcp_tls_scenario::run(&client).await;
 }

--- a/core/sdk/src/client_wrappers/binary_client.rs
+++ b/core/sdk/src/client_wrappers/binary_client.rs
@@ -1,0 +1,62 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_broadcast::Receiver;
+use async_trait::async_trait;
+use iggy_binary_protocol::Client;
+use iggy_common::{DiagnosticEvent, IggyError};
+
+#[async_trait]
+impl Client for ClientWrapper {
+    async fn connect(&self) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.connect().await,
+            ClientWrapper::Http(client) => client.connect().await,
+            ClientWrapper::Tcp(client) => client.connect().await,
+            ClientWrapper::Quic(client) => client.connect().await,
+        }
+    }
+
+    async fn disconnect(&self) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.disconnect().await,
+            ClientWrapper::Http(client) => client.disconnect().await,
+            ClientWrapper::Tcp(client) => client.disconnect().await,
+            ClientWrapper::Quic(client) => client.disconnect().await,
+        }
+    }
+
+    async fn shutdown(&self) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.shutdown().await,
+            ClientWrapper::Http(client) => client.shutdown().await,
+            ClientWrapper::Tcp(client) => client.shutdown().await,
+            ClientWrapper::Quic(client) => client.shutdown().await,
+        }
+    }
+
+    async fn subscribe_events(&self) -> Receiver<DiagnosticEvent> {
+        match self {
+            ClientWrapper::Iggy(client) => client.subscribe_events().await,
+            ClientWrapper::Http(client) => client.subscribe_events().await,
+            ClientWrapper::Tcp(client) => client.subscribe_events().await,
+            ClientWrapper::Quic(client) => client.subscribe_events().await,
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_consumer_group_client.rs
+++ b/core/sdk/src/client_wrappers/binary_consumer_group_client.rs
@@ -1,0 +1,210 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_dropper::AsyncDrop;
+use async_trait::async_trait;
+use iggy_binary_protocol::{ConsumerGroupClient, UserClient};
+use iggy_common::{ConsumerGroup, ConsumerGroupDetails, Identifier, IggyError};
+
+#[async_trait]
+impl ConsumerGroupClient for ClientWrapper {
+    async fn get_consumer_group(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        group_id: &Identifier,
+    ) -> Result<Option<ConsumerGroupDetails>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .get_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .get_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .get_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .get_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+        }
+    }
+
+    async fn get_consumer_groups(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+    ) -> Result<Vec<ConsumerGroup>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_consumer_groups(stream_id, topic_id).await,
+            ClientWrapper::Http(client) => client.get_consumer_groups(stream_id, topic_id).await,
+            ClientWrapper::Tcp(client) => client.get_consumer_groups(stream_id, topic_id).await,
+            ClientWrapper::Quic(client) => client.get_consumer_groups(stream_id, topic_id).await,
+        }
+    }
+
+    async fn create_consumer_group(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        name: &str,
+        group_id: Option<u32>,
+    ) -> Result<ConsumerGroupDetails, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .create_consumer_group(stream_id, topic_id, name, group_id)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .create_consumer_group(stream_id, topic_id, name, group_id)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .create_consumer_group(stream_id, topic_id, name, group_id)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .create_consumer_group(stream_id, topic_id, name, group_id)
+                    .await
+            }
+        }
+    }
+
+    async fn delete_consumer_group(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        group_id: &Identifier,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .delete_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .delete_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .delete_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .delete_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+        }
+    }
+
+    async fn join_consumer_group(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        group_id: &Identifier,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .join_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .join_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .join_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .join_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+        }
+    }
+
+    async fn leave_consumer_group(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        group_id: &Identifier,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .leave_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .leave_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .leave_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .leave_consumer_group(stream_id, topic_id, group_id)
+                    .await
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncDrop for ClientWrapper {
+    async fn async_drop(&mut self) {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                let _ = client.logout_user().await;
+            }
+            ClientWrapper::Http(client) => {
+                let _ = client.logout_user().await;
+            }
+            ClientWrapper::Tcp(client) => {
+                let _ = client.logout_user().await;
+            }
+            ClientWrapper::Quic(client) => {
+                let _ = client.logout_user().await;
+            }
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_consumer_offset_client.rs
+++ b/core/sdk/src/client_wrappers/binary_consumer_offset_client.rs
@@ -1,0 +1,119 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::ConsumerOffsetClient;
+use iggy_common::{Consumer, ConsumerOffsetInfo, Identifier, IggyError};
+
+#[async_trait]
+impl ConsumerOffsetClient for ClientWrapper {
+    async fn store_consumer_offset(
+        &self,
+        consumer: &Consumer,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+        offset: u64,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .store_consumer_offset(consumer, stream_id, topic_id, partition_id, offset)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .store_consumer_offset(consumer, stream_id, topic_id, partition_id, offset)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .store_consumer_offset(consumer, stream_id, topic_id, partition_id, offset)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .store_consumer_offset(consumer, stream_id, topic_id, partition_id, offset)
+                    .await
+            }
+        }
+    }
+
+    async fn get_consumer_offset(
+        &self,
+        consumer: &Consumer,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+    ) -> Result<Option<ConsumerOffsetInfo>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .get_consumer_offset(consumer, stream_id, topic_id, partition_id)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .get_consumer_offset(consumer, stream_id, topic_id, partition_id)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .get_consumer_offset(consumer, stream_id, topic_id, partition_id)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .get_consumer_offset(consumer, stream_id, topic_id, partition_id)
+                    .await
+            }
+        }
+    }
+
+    async fn delete_consumer_offset(
+        &self,
+        consumer: &Consumer,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .delete_consumer_offset(consumer, stream_id, topic_id, partition_id)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .delete_consumer_offset(consumer, stream_id, topic_id, partition_id)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .delete_consumer_offset(consumer, stream_id, topic_id, partition_id)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .delete_consumer_offset(consumer, stream_id, topic_id, partition_id)
+                    .await
+            }
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_message_client.rs
+++ b/core/sdk/src/client_wrappers/binary_message_client.rs
@@ -1,0 +1,155 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::MessageClient;
+use iggy_common::{
+    Consumer, Identifier, IggyError, IggyMessage, Partitioning, PolledMessages, PollingStrategy,
+};
+
+#[async_trait]
+impl MessageClient for ClientWrapper {
+    async fn poll_messages(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+        consumer: &Consumer,
+        strategy: &PollingStrategy,
+        count: u32,
+        auto_commit: bool,
+    ) -> Result<PolledMessages, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .poll_messages(
+                        stream_id,
+                        topic_id,
+                        partition_id,
+                        consumer,
+                        strategy,
+                        count,
+                        auto_commit,
+                    )
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .poll_messages(
+                        stream_id,
+                        topic_id,
+                        partition_id,
+                        consumer,
+                        strategy,
+                        count,
+                        auto_commit,
+                    )
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .poll_messages(
+                        stream_id,
+                        topic_id,
+                        partition_id,
+                        consumer,
+                        strategy,
+                        count,
+                        auto_commit,
+                    )
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .poll_messages(
+                        stream_id,
+                        topic_id,
+                        partition_id,
+                        consumer,
+                        strategy,
+                        count,
+                        auto_commit,
+                    )
+                    .await
+            }
+        }
+    }
+
+    async fn send_messages(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partitioning: &Partitioning,
+        messages: &mut [IggyMessage],
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .send_messages(stream_id, topic_id, partitioning, messages)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .send_messages(stream_id, topic_id, partitioning, messages)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .send_messages(stream_id, topic_id, partitioning, messages)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .send_messages(stream_id, topic_id, partitioning, messages)
+                    .await
+            }
+        }
+    }
+
+    async fn flush_unsaved_buffer(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partitioning_id: u32,
+        fsync: bool,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .flush_unsaved_buffer(stream_id, topic_id, partitioning_id, fsync)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .flush_unsaved_buffer(stream_id, topic_id, partitioning_id, fsync)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .flush_unsaved_buffer(stream_id, topic_id, partitioning_id, fsync)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .flush_unsaved_buffer(stream_id, topic_id, partitioning_id, fsync)
+                    .await
+            }
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_partition_client.rs
+++ b/core/sdk/src/client_wrappers/binary_partition_client.rs
@@ -1,0 +1,85 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::PartitionClient;
+use iggy_common::{Identifier, IggyError};
+
+#[async_trait]
+impl PartitionClient for ClientWrapper {
+    async fn create_partitions(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partitions_count: u32,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .create_partitions(stream_id, topic_id, partitions_count)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .create_partitions(stream_id, topic_id, partitions_count)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .create_partitions(stream_id, topic_id, partitions_count)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .create_partitions(stream_id, topic_id, partitions_count)
+                    .await
+            }
+        }
+    }
+
+    async fn delete_partitions(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partitions_count: u32,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .delete_partitions(stream_id, topic_id, partitions_count)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .delete_partitions(stream_id, topic_id, partitions_count)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .delete_partitions(stream_id, topic_id, partitions_count)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .delete_partitions(stream_id, topic_id, partitions_count)
+                    .await
+            }
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_personal_access_token_client.rs
+++ b/core/sdk/src/client_wrappers/binary_personal_access_token_client.rs
@@ -1,0 +1,71 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::PersonalAccessTokenClient;
+use iggy_common::{
+    IdentityInfo, IggyError, PersonalAccessTokenExpiry, PersonalAccessTokenInfo,
+    RawPersonalAccessToken,
+};
+
+#[async_trait]
+impl PersonalAccessTokenClient for ClientWrapper {
+    async fn get_personal_access_tokens(&self) -> Result<Vec<PersonalAccessTokenInfo>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_personal_access_tokens().await,
+            ClientWrapper::Http(client) => client.get_personal_access_tokens().await,
+            ClientWrapper::Tcp(client) => client.get_personal_access_tokens().await,
+            ClientWrapper::Quic(client) => client.get_personal_access_tokens().await,
+        }
+    }
+
+    async fn create_personal_access_token(
+        &self,
+        name: &str,
+        expiry: PersonalAccessTokenExpiry,
+    ) -> Result<RawPersonalAccessToken, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.create_personal_access_token(name, expiry).await,
+            ClientWrapper::Http(client) => client.create_personal_access_token(name, expiry).await,
+            ClientWrapper::Tcp(client) => client.create_personal_access_token(name, expiry).await,
+            ClientWrapper::Quic(client) => client.create_personal_access_token(name, expiry).await,
+        }
+    }
+
+    async fn delete_personal_access_token(&self, name: &str) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.delete_personal_access_token(name).await,
+            ClientWrapper::Http(client) => client.delete_personal_access_token(name).await,
+            ClientWrapper::Tcp(client) => client.delete_personal_access_token(name).await,
+            ClientWrapper::Quic(client) => client.delete_personal_access_token(name).await,
+        }
+    }
+
+    async fn login_with_personal_access_token(
+        &self,
+        token: &str,
+    ) -> Result<IdentityInfo, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.login_with_personal_access_token(token).await,
+            ClientWrapper::Http(client) => client.login_with_personal_access_token(token).await,
+            ClientWrapper::Tcp(client) => client.login_with_personal_access_token(token).await,
+            ClientWrapper::Quic(client) => client.login_with_personal_access_token(token).await,
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_segment_client.rs
+++ b/core/sdk/src/client_wrappers/binary_segment_client.rs
@@ -1,0 +1,56 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::SegmentClient;
+use iggy_common::{Identifier, IggyError};
+
+#[async_trait]
+impl SegmentClient for ClientWrapper {
+    async fn delete_segments(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: u32,
+        segments_count: u32,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .delete_segments(stream_id, topic_id, partition_id, segments_count)
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .delete_segments(stream_id, topic_id, partition_id, segments_count)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .delete_segments(stream_id, topic_id, partition_id, segments_count)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .delete_segments(stream_id, topic_id, partition_id, segments_count)
+                    .await
+            }
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_stream_client.rs
+++ b/core/sdk/src/client_wrappers/binary_stream_client.rs
@@ -1,0 +1,83 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::StreamClient;
+use iggy_common::{Identifier, IggyError, Stream, StreamDetails};
+
+#[async_trait]
+impl StreamClient for ClientWrapper {
+    async fn get_stream(&self, stream_id: &Identifier) -> Result<Option<StreamDetails>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_stream(stream_id).await,
+            ClientWrapper::Http(client) => client.get_stream(stream_id).await,
+            ClientWrapper::Tcp(client) => client.get_stream(stream_id).await,
+            ClientWrapper::Quic(client) => client.get_stream(stream_id).await,
+        }
+    }
+
+    async fn get_streams(&self) -> Result<Vec<Stream>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_streams().await,
+            ClientWrapper::Http(client) => client.get_streams().await,
+            ClientWrapper::Tcp(client) => client.get_streams().await,
+            ClientWrapper::Quic(client) => client.get_streams().await,
+        }
+    }
+
+    async fn create_stream(
+        &self,
+        name: &str,
+        stream_id: Option<u32>,
+    ) -> Result<StreamDetails, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.create_stream(name, stream_id).await,
+            ClientWrapper::Http(client) => client.create_stream(name, stream_id).await,
+            ClientWrapper::Tcp(client) => client.create_stream(name, stream_id).await,
+            ClientWrapper::Quic(client) => client.create_stream(name, stream_id).await,
+        }
+    }
+
+    async fn update_stream(&self, stream_id: &Identifier, name: &str) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.update_stream(stream_id, name).await,
+            ClientWrapper::Http(client) => client.update_stream(stream_id, name).await,
+            ClientWrapper::Tcp(client) => client.update_stream(stream_id, name).await,
+            ClientWrapper::Quic(client) => client.update_stream(stream_id, name).await,
+        }
+    }
+
+    async fn delete_stream(&self, stream_id: &Identifier) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.delete_stream(stream_id).await,
+            ClientWrapper::Http(client) => client.delete_stream(stream_id).await,
+            ClientWrapper::Tcp(client) => client.delete_stream(stream_id).await,
+            ClientWrapper::Quic(client) => client.delete_stream(stream_id).await,
+        }
+    }
+
+    async fn purge_stream(&self, stream_id: &Identifier) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.purge_stream(stream_id).await,
+            ClientWrapper::Http(client) => client.purge_stream(stream_id).await,
+            ClientWrapper::Tcp(client) => client.purge_stream(stream_id).await,
+            ClientWrapper::Quic(client) => client.purge_stream(stream_id).await,
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_system_client.rs
+++ b/core/sdk/src/client_wrappers/binary_system_client.rs
@@ -1,0 +1,95 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::SystemClient;
+use iggy_common::{
+    ClientInfo, ClientInfoDetails, IggyDuration, IggyError, Snapshot, SnapshotCompression, Stats,
+    SystemSnapshotType,
+};
+
+#[async_trait]
+impl SystemClient for ClientWrapper {
+    async fn get_stats(&self) -> Result<Stats, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_stats().await,
+            ClientWrapper::Http(client) => client.get_stats().await,
+            ClientWrapper::Tcp(client) => client.get_stats().await,
+            ClientWrapper::Quic(client) => client.get_stats().await,
+        }
+    }
+
+    async fn get_me(&self) -> Result<ClientInfoDetails, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_me().await,
+            ClientWrapper::Http(client) => client.get_me().await,
+            ClientWrapper::Tcp(client) => client.get_me().await,
+            ClientWrapper::Quic(client) => client.get_me().await,
+        }
+    }
+
+    async fn get_client(&self, client_id: u32) -> Result<Option<ClientInfoDetails>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_client(client_id).await,
+            ClientWrapper::Http(client) => client.get_client(client_id).await,
+            ClientWrapper::Tcp(client) => client.get_client(client_id).await,
+            ClientWrapper::Quic(client) => client.get_client(client_id).await,
+        }
+    }
+
+    async fn get_clients(&self) -> Result<Vec<ClientInfo>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_clients().await,
+            ClientWrapper::Http(client) => client.get_clients().await,
+            ClientWrapper::Tcp(client) => client.get_clients().await,
+            ClientWrapper::Quic(client) => client.get_clients().await,
+        }
+    }
+
+    async fn ping(&self) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.ping().await,
+            ClientWrapper::Http(client) => client.ping().await,
+            ClientWrapper::Tcp(client) => client.ping().await,
+            ClientWrapper::Quic(client) => client.ping().await,
+        }
+    }
+
+    async fn heartbeat_interval(&self) -> IggyDuration {
+        match self {
+            ClientWrapper::Iggy(client) => client.heartbeat_interval().await,
+            ClientWrapper::Http(client) => client.heartbeat_interval().await,
+            ClientWrapper::Tcp(client) => client.heartbeat_interval().await,
+            ClientWrapper::Quic(client) => client.heartbeat_interval().await,
+        }
+    }
+
+    async fn snapshot(
+        &self,
+        compression: SnapshotCompression,
+        snapshot_types: Vec<SystemSnapshotType>,
+    ) -> Result<Snapshot, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.snapshot(compression, snapshot_types).await,
+            ClientWrapper::Http(client) => client.snapshot(compression, snapshot_types).await,
+            ClientWrapper::Tcp(client) => client.snapshot(compression, snapshot_types).await,
+            ClientWrapper::Quic(client) => client.snapshot(compression, snapshot_types).await,
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_topic_client.rs
+++ b/core/sdk/src/client_wrappers/binary_topic_client.rs
@@ -1,0 +1,212 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::TopicClient;
+use iggy_common::{
+    CompressionAlgorithm, Identifier, IggyError, IggyExpiry, MaxTopicSize, Topic, TopicDetails,
+};
+
+#[async_trait]
+impl TopicClient for ClientWrapper {
+    async fn get_topic(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+    ) -> Result<Option<TopicDetails>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_topic(stream_id, topic_id).await,
+            ClientWrapper::Http(client) => client.get_topic(stream_id, topic_id).await,
+            ClientWrapper::Tcp(client) => client.get_topic(stream_id, topic_id).await,
+            ClientWrapper::Quic(client) => client.get_topic(stream_id, topic_id).await,
+        }
+    }
+
+    async fn get_topics(&self, stream_id: &Identifier) -> Result<Vec<Topic>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_topics(stream_id).await,
+            ClientWrapper::Http(client) => client.get_topics(stream_id).await,
+            ClientWrapper::Tcp(client) => client.get_topics(stream_id).await,
+            ClientWrapper::Quic(client) => client.get_topics(stream_id).await,
+        }
+    }
+
+    async fn create_topic(
+        &self,
+        stream_id: &Identifier,
+        name: &str,
+        partitions_count: u32,
+        compression_algorithm: CompressionAlgorithm,
+        replication_factor: Option<u8>,
+        topic_id: Option<u32>,
+        message_expiry: IggyExpiry,
+        max_topic_size: MaxTopicSize,
+    ) -> Result<TopicDetails, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .create_topic(
+                        stream_id,
+                        name,
+                        partitions_count,
+                        compression_algorithm,
+                        replication_factor,
+                        topic_id,
+                        message_expiry,
+                        max_topic_size,
+                    )
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .create_topic(
+                        stream_id,
+                        name,
+                        partitions_count,
+                        compression_algorithm,
+                        replication_factor,
+                        topic_id,
+                        message_expiry,
+                        max_topic_size,
+                    )
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .create_topic(
+                        stream_id,
+                        name,
+                        partitions_count,
+                        compression_algorithm,
+                        replication_factor,
+                        topic_id,
+                        message_expiry,
+                        max_topic_size,
+                    )
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .create_topic(
+                        stream_id,
+                        name,
+                        partitions_count,
+                        compression_algorithm,
+                        replication_factor,
+                        topic_id,
+                        message_expiry,
+                        max_topic_size,
+                    )
+                    .await
+            }
+        }
+    }
+
+    async fn update_topic(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        name: &str,
+        compression_algorithm: CompressionAlgorithm,
+        replication_factor: Option<u8>,
+        message_expiry: IggyExpiry,
+        max_topic_size: MaxTopicSize,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => {
+                client
+                    .update_topic(
+                        stream_id,
+                        topic_id,
+                        name,
+                        compression_algorithm,
+                        replication_factor,
+                        message_expiry,
+                        max_topic_size,
+                    )
+                    .await
+            }
+            ClientWrapper::Http(client) => {
+                client
+                    .update_topic(
+                        stream_id,
+                        topic_id,
+                        name,
+                        compression_algorithm,
+                        replication_factor,
+                        message_expiry,
+                        max_topic_size,
+                    )
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .update_topic(
+                        stream_id,
+                        topic_id,
+                        name,
+                        compression_algorithm,
+                        replication_factor,
+                        message_expiry,
+                        max_topic_size,
+                    )
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .update_topic(
+                        stream_id,
+                        topic_id,
+                        name,
+                        compression_algorithm,
+                        replication_factor,
+                        message_expiry,
+                        max_topic_size,
+                    )
+                    .await
+            }
+        }
+    }
+
+    async fn delete_topic(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.delete_topic(stream_id, topic_id).await,
+            ClientWrapper::Http(client) => client.delete_topic(stream_id, topic_id).await,
+            ClientWrapper::Tcp(client) => client.delete_topic(stream_id, topic_id).await,
+            ClientWrapper::Quic(client) => client.delete_topic(stream_id, topic_id).await,
+        }
+    }
+
+    async fn purge_topic(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.purge_topic(stream_id, topic_id).await,
+            ClientWrapper::Http(client) => client.purge_topic(stream_id, topic_id).await,
+            ClientWrapper::Tcp(client) => client.purge_topic(stream_id, topic_id).await,
+            ClientWrapper::Quic(client) => client.purge_topic(stream_id, topic_id).await,
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/binary_user_client.rs
+++ b/core/sdk/src/client_wrappers/binary_user_client.rs
@@ -1,0 +1,160 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::client_wrappers::client_wrapper::ClientWrapper;
+use async_trait::async_trait;
+use iggy_binary_protocol::UserClient;
+use iggy_common::{
+    Identifier, IdentityInfo, IggyError, Permissions, UserInfo, UserInfoDetails, UserStatus,
+};
+
+#[async_trait]
+impl UserClient for ClientWrapper {
+    async fn get_user(&self, user_id: &Identifier) -> Result<Option<UserInfoDetails>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_user(user_id).await,
+            ClientWrapper::Http(client) => client.get_user(user_id).await,
+            ClientWrapper::Tcp(client) => client.get_user(user_id).await,
+            ClientWrapper::Quic(client) => client.get_user(user_id).await,
+        }
+    }
+
+    async fn get_users(&self) -> Result<Vec<UserInfo>, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.get_users().await,
+            ClientWrapper::Http(client) => client.get_users().await,
+            ClientWrapper::Tcp(client) => client.get_users().await,
+            ClientWrapper::Quic(client) => client.get_users().await,
+        }
+    }
+
+    async fn create_user(
+        &self,
+        username: &str,
+        password: &str,
+        status: UserStatus,
+        permissions: Option<Permissions>,
+    ) -> Result<UserInfoDetails, IggyError> {
+        match self {
+            ClientWrapper::Http(client) => {
+                client
+                    .create_user(username, password, status, permissions)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .create_user(username, password, status, permissions)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .create_user(username, password, status, permissions)
+                    .await
+            }
+            ClientWrapper::Iggy(client) => {
+                client
+                    .create_user(username, password, status, permissions)
+                    .await
+            }
+        }
+    }
+
+    async fn delete_user(&self, user_id: &Identifier) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Http(client) => client.delete_user(user_id).await,
+            ClientWrapper::Tcp(client) => client.delete_user(user_id).await,
+            ClientWrapper::Quic(client) => client.delete_user(user_id).await,
+            ClientWrapper::Iggy(client) => client.delete_user(user_id).await,
+        }
+    }
+
+    async fn update_user(
+        &self,
+        user_id: &Identifier,
+        username: Option<&str>,
+        status: Option<UserStatus>,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Http(client) => client.update_user(user_id, username, status).await,
+            ClientWrapper::Tcp(client) => client.update_user(user_id, username, status).await,
+            ClientWrapper::Quic(client) => client.update_user(user_id, username, status).await,
+            ClientWrapper::Iggy(client) => client.update_user(user_id, username, status).await,
+        }
+    }
+
+    async fn update_permissions(
+        &self,
+        user_id: &Identifier,
+        permissions: Option<Permissions>,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.update_permissions(user_id, permissions).await,
+            ClientWrapper::Http(client) => client.update_permissions(user_id, permissions).await,
+            ClientWrapper::Tcp(client) => client.update_permissions(user_id, permissions).await,
+            ClientWrapper::Quic(client) => client.update_permissions(user_id, permissions).await,
+        }
+    }
+
+    async fn change_password(
+        &self,
+        user_id: &Identifier,
+        current_password: &str,
+        new_password: &str,
+    ) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Http(client) => {
+                client
+                    .change_password(user_id, current_password, new_password)
+                    .await
+            }
+            ClientWrapper::Tcp(client) => {
+                client
+                    .change_password(user_id, current_password, new_password)
+                    .await
+            }
+            ClientWrapper::Quic(client) => {
+                client
+                    .change_password(user_id, current_password, new_password)
+                    .await
+            }
+            ClientWrapper::Iggy(client) => {
+                client
+                    .change_password(user_id, current_password, new_password)
+                    .await
+            }
+        }
+    }
+
+    async fn login_user(&self, username: &str, password: &str) -> Result<IdentityInfo, IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.login_user(username, password).await,
+            ClientWrapper::Http(client) => client.login_user(username, password).await,
+            ClientWrapper::Tcp(client) => client.login_user(username, password).await,
+            ClientWrapper::Quic(client) => client.login_user(username, password).await,
+        }
+    }
+
+    async fn logout_user(&self) -> Result<(), IggyError> {
+        match self {
+            ClientWrapper::Iggy(client) => client.logout_user().await,
+            ClientWrapper::Http(client) => client.logout_user().await,
+            ClientWrapper::Tcp(client) => client.logout_user().await,
+            ClientWrapper::Quic(client) => client.logout_user().await,
+        }
+    }
+}

--- a/core/sdk/src/client_wrappers/client_wrapper.rs
+++ b/core/sdk/src/client_wrappers/client_wrapper.rs
@@ -16,13 +16,16 @@
  * under the License.
  */
 
-#[allow(deprecated)]
-pub mod client_provider;
-pub mod client_wrappers;
-pub mod clients;
-pub mod consumer_ext;
-pub mod http;
-pub mod prelude;
-pub mod quic;
-pub mod stream_builder;
-pub mod tcp;
+use crate::clients::client::IggyClient;
+use crate::http::http_client::HttpClient;
+use crate::quic::quick_client::QuicClient;
+use crate::tcp::tcp_client::TcpClient;
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum ClientWrapper {
+    Iggy(IggyClient),
+    Http(HttpClient),
+    Tcp(TcpClient),
+    Quic(QuicClient),
+}

--- a/core/sdk/src/client_wrappers/mod.rs
+++ b/core/sdk/src/client_wrappers/mod.rs
@@ -16,13 +16,15 @@
  * under the License.
  */
 
-#[allow(deprecated)]
-pub mod client_provider;
-pub mod client_wrappers;
-pub mod clients;
-pub mod consumer_ext;
-pub mod http;
-pub mod prelude;
-pub mod quic;
-pub mod stream_builder;
-pub mod tcp;
+mod binary_client;
+mod binary_consumer_group_client;
+mod binary_consumer_offset_client;
+mod binary_message_client;
+mod binary_partition_client;
+mod binary_personal_access_token_client;
+mod binary_segment_client;
+mod binary_stream_client;
+mod binary_system_client;
+mod binary_topic_client;
+mod binary_user_client;
+pub mod client_wrapper;

--- a/core/sdk/src/clients/binary_consumer_group.rs
+++ b/core/sdk/src/clients/binary_consumer_group.rs
@@ -19,7 +19,7 @@
 use crate::prelude::IggyClient;
 use async_dropper::AsyncDrop;
 use async_trait::async_trait;
-use iggy_binary_protocol::ConsumerGroupClient;
+use iggy_binary_protocol::{ConsumerGroupClient, UserClient};
 use iggy_common::locking::IggySharedMutFn;
 use iggy_common::{ConsumerGroup, ConsumerGroupDetails, Identifier, IggyError};
 

--- a/core/sdk/src/clients/consumer.rs
+++ b/core/sdk/src/clients/consumer.rs
@@ -16,11 +16,14 @@
  * under the License.
  */
 
+use crate::client_wrappers::client_wrapper::ClientWrapper;
 use bytes::Bytes;
 use dashmap::DashMap;
 use futures::Stream;
 use futures_util::{FutureExt, StreamExt};
-use iggy_binary_protocol::Client;
+use iggy_binary_protocol::{
+    Client, ConsumerGroupClient, ConsumerOffsetClient, MessageClient, StreamClient, TopicClient,
+};
 use iggy_common::locking::{IggySharedMut, IggySharedMutFn};
 use iggy_common::{
     Consumer, ConsumerKind, DiagnosticEvent, EncryptorKind, IdKind, Identifier, IggyDuration,
@@ -93,7 +96,7 @@ unsafe impl Sync for IggyConsumer {}
 pub struct IggyConsumer {
     initialized: bool,
     can_poll: Arc<AtomicBool>,
-    client: IggySharedMut<Box<dyn Client>>,
+    client: IggySharedMut<ClientWrapper>,
     consumer_name: String,
     consumer: Arc<Consumer>,
     is_consumer_group: bool,
@@ -129,7 +132,7 @@ pub struct IggyConsumer {
 impl IggyConsumer {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        client: IggySharedMut<Box<dyn Client>>,
+        client: IggySharedMut<ClientWrapper>,
         consumer_name: String,
         consumer: Consumer,
         stream_id: Identifier,
@@ -405,7 +408,7 @@ impl IggyConsumer {
 
     #[allow(clippy::too_many_arguments)]
     async fn store_consumer_offset(
-        client: &IggySharedMut<Box<dyn Client>>,
+        client: &IggySharedMut<ClientWrapper>,
         consumer: &Consumer,
         stream_id: &Identifier,
         topic_id: &Identifier,
@@ -781,7 +784,7 @@ impl IggyConsumer {
     }
 
     async fn initialize_consumer_group(
-        client: IggySharedMut<Box<dyn Client>>,
+        client: IggySharedMut<ClientWrapper>,
         create_consumer_group_if_not_exists: bool,
         stream_id: Arc<Identifier>,
         topic_id: Arc<Identifier>,

--- a/core/sdk/src/clients/consumer_builder.rs
+++ b/core/sdk/src/clients/consumer_builder.rs
@@ -16,15 +16,15 @@
  * under the License.
  */
 
+use crate::client_wrappers::client_wrapper::ClientWrapper;
 use crate::prelude::{AutoCommit, AutoCommitWhen, IggyConsumer};
-use iggy_binary_protocol::Client;
 use iggy_common::locking::IggySharedMut;
 use iggy_common::{Consumer, EncryptorKind, Identifier, IggyDuration, PollingStrategy};
 use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct IggyConsumerBuilder {
-    client: IggySharedMut<Box<dyn Client>>,
+    client: IggySharedMut<ClientWrapper>,
     consumer_name: String,
     consumer: Consumer,
     stream: Identifier,
@@ -46,7 +46,7 @@ pub struct IggyConsumerBuilder {
 impl IggyConsumerBuilder {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        client: IggySharedMut<Box<dyn Client>>,
+        client: IggySharedMut<ClientWrapper>,
         consumer_name: String,
         consumer: Consumer,
         stream_id: Identifier,

--- a/core/sdk/src/clients/producer.rs
+++ b/core/sdk/src/clients/producer.rs
@@ -16,13 +16,14 @@
  * under the License.
  */
 use super::ORDERING;
+use crate::client_wrappers::client_wrapper::ClientWrapper;
 use crate::clients::MAX_BATCH_LENGTH;
 use crate::clients::producer_builder::SendMode;
 use crate::clients::producer_config::DirectConfig;
 use crate::clients::producer_dispatcher::ProducerDispatcher;
 use bytes::Bytes;
 use futures_util::StreamExt;
-use iggy_binary_protocol::Client;
+use iggy_binary_protocol::{Client, MessageClient, StreamClient, TopicClient};
 use iggy_common::locking::{IggySharedMut, IggySharedMutFn};
 use iggy_common::{
     CompressionAlgorithm, DiagnosticEvent, EncryptorKind, IdKind, Identifier, IggyDuration,
@@ -52,7 +53,7 @@ pub trait ProducerCoreBackend: Send + Sync + 'static {
 pub struct ProducerCore {
     initialized: AtomicBool,
     can_send: Arc<AtomicBool>,
-    client: Arc<IggySharedMut<Box<dyn Client>>>,
+    client: Arc<IggySharedMut<ClientWrapper>>,
     stream_id: Arc<Identifier>,
     stream_name: String,
     topic_id: Arc<Identifier>,
@@ -431,7 +432,7 @@ pub struct IggyProducer {
 impl IggyProducer {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        client: IggySharedMut<Box<dyn Client>>,
+        client: IggySharedMut<ClientWrapper>,
         stream: Identifier,
         stream_name: String,
         topic: Identifier,

--- a/core/sdk/src/clients/producer_builder.rs
+++ b/core/sdk/src/clients/producer_builder.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::client_wrappers::client_wrapper::ClientWrapper;
 use crate::clients::producer_config::{BackgroundConfig, DirectConfig};
 use crate::prelude::IggyProducer;
-use iggy_binary_protocol::Client;
 use iggy_common::locking::IggySharedMut;
 use iggy_common::{
     EncryptorKind, Identifier, IggyDuration, IggyExpiry, MaxTopicSize, Partitioner, Partitioning,
@@ -36,7 +36,7 @@ impl Default for SendMode {
 }
 
 pub struct IggyProducerBuilder {
-    client: IggySharedMut<Box<dyn Client>>,
+    client: IggySharedMut<ClientWrapper>,
     stream: Identifier,
     stream_name: String,
     topic: Identifier,
@@ -58,7 +58,7 @@ pub struct IggyProducerBuilder {
 impl IggyProducerBuilder {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        client: IggySharedMut<Box<dyn Client>>,
+        client: IggySharedMut<ClientWrapper>,
         stream: Identifier,
         stream_name: String,
         topic: Identifier,

--- a/core/sdk/src/prelude.rs
+++ b/core/sdk/src/prelude.rs
@@ -29,6 +29,7 @@
 
 pub use crate::client_provider;
 pub use crate::client_provider::ClientProviderConfig;
+pub use crate::client_wrappers::client_wrapper::ClientWrapper;
 pub use crate::clients::client::IggyClient;
 pub use crate::clients::client_builder::IggyClientBuilder;
 pub use crate::clients::consumer::{


### PR DESCRIPTION
## Summary
Replace `Box<dyn Client>` trait objects with a concrete `ClientWrapper` enum to eliminate dynamic dispatch overhead and reduce heap allocations.

By leveraging match-based delegation in `ClientWrapper`, we can eliminate dynamic dispatch and `Box` allocations for client instances. The enum is stack-allocated, compared to heap-allocated Box, saving heap memory.

The `ClientWrapper` enum currently contains Http, Tcp, Quic, and Iggy variants. Future protocol implementations should be added as new variants.

This change serves as a V2 implementation and alternative to the approach in #1912. As discussed, using pure static dispatch would alter too many use case behaviors and require users to have deeper API knowledge. With the enum wrapper, no API changes are needed, benefiting `IggyClient, IggyConsumer, IggyProducer`, and other components without changing how they are used.

Performance improvements:
- `IggyClient::from_connection_string()` execution time reduced by 3.45%
- Average byte allocation reduced from 18,626 to 18,618 bytes
- Allocation speed improved by 3.53%

## Performance test
Simple performance test against `IggyClient::from_connection_string()`. Measured its execution time and heap allocation with the following 2 scripts.
Test platform is Darwin Kernel Version 22.6.0 on arm64 architecture.

Execution time:
```
use criterion::{black_box, criterion_group, criterion_main, Criterion};
use iggy::prelude::{IggyClient};

fn bench_iggy_client_new(c: &mut Criterion) {
    c.bench_function("iggy_client_new", |b| {
        b.iter(|| {
            black_box(IggyClient::from_connection_string("iggy://iggy:iggy@localhost:8090"))
        })
    });
}

criterion_group!(benches, bench_iggy_client_new);
criterion_main!(benches);
```

Heap allocation:
```
use criterion::{black_box, criterion_group, criterion_main, Criterion};
use std::alloc::{GlobalAlloc, Layout, System};
use std::sync::atomic::{AtomicUsize, Ordering};

// Custom allocator that tracks allocations
struct TrackingAllocator;

static ALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
static ALLOCATION_COUNT: AtomicUsize = AtomicUsize::new(0);
static DEALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
static DEALLOCATION_COUNT: AtomicUsize = AtomicUsize::new(0);

unsafe impl GlobalAlloc for TrackingAllocator {
    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
        let ptr = unsafe { System.alloc(layout) };
        if !ptr.is_null() {
            ALLOCATED_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
        }
        ptr
    }

    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
        unsafe {System.dealloc(ptr, layout) };
        DEALLOCATED_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
        DEALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
    }
}

#[global_allocator]
static GLOBAL: TrackingAllocator = TrackingAllocator;

fn reset_allocation_counters() {
    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
    DEALLOCATED_BYTES.store(0, Ordering::Relaxed);
    DEALLOCATION_COUNT.store(0, Ordering::Relaxed);
}

fn get_allocation_stats() -> (usize, usize, usize, usize) {
    (
        ALLOCATED_BYTES.load(Ordering::Relaxed),
        ALLOCATION_COUNT.load(Ordering::Relaxed),
        DEALLOCATED_BYTES.load(Ordering::Relaxed),
        DEALLOCATION_COUNT.load(Ordering::Relaxed),
    )
}

use iggy::prelude::{IggyClient};

fn bench_iggy_client_allocation(c: &mut Criterion) {
    c.bench_function("iggy_client_allocation", |b| {
        b.iter_custom(|iters| {
            reset_allocation_counters();
            
            let start = std::time::Instant::now();
            
            for _ in 0..iters {
                let _ = black_box(IggyClient::from_connection_string("iggy://iggy:iggy@localhost:8090"));
            }
            
            let elapsed = start.elapsed();

            let (allocated, alloc_count, deallocated, dealloc_count) = get_allocation_stats();
            eprintln!("Iterations: {}", iters);
            eprintln!("Allocations per iteration: {:.2}", alloc_count as f64 / iters as f64);
            eprintln!("Bytes per iteration: {:.2}", allocated as f64 / iters as f64);
            eprintln!("---");
            
            elapsed
        })
    });
}

criterion_group!(benches, bench_iggy_client_allocation);
criterion_main!(benches);
```

Result are showned in the following, comparing to older implementation

Execution time:
```
$ cargo bench --bench iggy_client_test
   Compiling iggy v0.7.0 (/Users/vax-r/iggy/core/sdk)
    Finished `bench` profile [optimized] target(s) in 1m 02s
     Running benches/iggy_client_test.rs (/Users/vax-r/iggy/target/release/deps/iggy_client_test-22c1dc27e916a5b5)
iggy_client_new         time:   [1.1030 µs 1.1045 µs 1.1059 µs]
                        change: [-3.6387% -3.4529% -3.2761%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  11 (11.00%) low mild
  1 (1.00%) high severe
```

Heap allocation:
* Old:
```
Iterations: 86300
Allocations per iteration: 24.00
Bytes per iteration: 18626.00
```
* New:
```
Iterations: 86300
Allocations per iteration: 23.00
Bytes per iteration: 18618.00
```

## Related Issue
#1873 
