### PR TITLE
feat(io_uring): add configurable CPU sharding with validation

### DIFF
--- a/core/configs/server.toml
+++ b/core/configs/server.toml
@@ -541,3 +541,12 @@ size = "4 GiB"
 # and holds different buffer sizes, from 256 B to 512 MiB.
 # Note: This number has to be a power of 2. Minimum value is 128 due to internal implementation details.
 bucket_capacity = 8192
+
+# Sharding configuration
+[system.sharding]
+# CPU allocation - controls the number of shards and their CPU affinity.
+# Possible values:
+# - "all": Use all available CPU cores (default)
+# - numeric value (e.g. 4): Use 4 shards (4 threads pinned to cores 0, 1, 2, 3)
+# - range (e.g. "5..8"): Use 3 shards with affinity to cores 5, 6, 7
+cpu_allocation = "all"

--- a/core/server/src/binary/handlers/topics/update_topic_handler.rs
+++ b/core/server/src/binary/handlers/topics/update_topic_handler.rs
@@ -19,8 +19,8 @@
 use crate::binary::command::{BinaryServerCommand, ServerCommand, ServerCommandHandler};
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::{handlers::topics::COMPONENT, sender::SenderKind};
-use crate::shard::transmission::event::ShardEvent;
 use crate::shard::IggyShard;
+use crate::shard::transmission::event::ShardEvent;
 use crate::state::command::EntryCommand;
 use crate::streaming::session::Session;
 use anyhow::Result;

--- a/core/server/src/bootstrap.rs
+++ b/core/server/src/bootstrap.rs
@@ -23,13 +23,16 @@ use crate::{
         utils::file::overwrite,
     },
 };
-use std::{collections::HashSet, env, ops::Range, path::Path, sync::Arc};
+use std::{collections::HashSet, env, path::Path, sync::Arc};
 
 pub fn create_shard_connections(
-    shards_set: Range<usize>,
+    shards_set: &HashSet<usize>,
 ) -> (Vec<ShardConnector<ShardFrame>>, Vec<(u16, StopSender)>) {
     let shards_count = shards_set.len();
-    let connectors: Vec<ShardConnector<ShardFrame>> = shards_set
+    let mut shards_vec: Vec<usize> = shards_set.iter().cloned().collect();
+    shards_vec.sort();
+
+    let connectors: Vec<ShardConnector<ShardFrame>> = shards_vec
         .into_iter()
         .map(|id| ShardConnector::new(id as u16, shards_count))
         .collect();
@@ -122,7 +125,7 @@ pub fn create_root_user() -> User {
 }
 
 pub fn create_shard_executor(cpu_set: HashSet<usize>) -> Runtime {
-    // TODO: The event intererval tick, could be configured based on the fact
+    // TODO: The event interval tick, could be configured based on the fact
     // How many clients we expect to have connected.
     // This roughly estimates the number of tasks we will create.
 

--- a/core/server/src/configs/defaults.rs
+++ b/core/server/src/configs/defaults.rs
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+use super::sharding::ShardingConfig;
 use super::system::MemoryPoolConfig;
 use super::tcp::TcpSocketConfig;
 use crate::configs::http::{
@@ -324,6 +325,7 @@ impl Default for SystemConfig {
             message_deduplication: MessageDeduplicationConfig::default(),
             recovery: RecoveryConfig::default(),
             memory_pool: MemoryPoolConfig::default(),
+            sharding: ShardingConfig::default(),
         }
     }
 }

--- a/core/server/src/configs/mod.rs
+++ b/core/server/src/configs/mod.rs
@@ -23,6 +23,7 @@ pub mod displays;
 pub mod http;
 pub mod quic;
 pub mod server;
+pub mod sharding;
 pub mod system;
 pub mod tcp;
 pub mod validators;

--- a/core/server/src/configs/sharding.rs
+++ b/core/server/src/configs/sharding.rs
@@ -1,0 +1,114 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::thread::available_parallelism;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ShardingConfig {
+    #[serde(default)]
+    pub cpu_allocation: CpuAllocation,
+}
+
+impl Default for ShardingConfig {
+    fn default() -> Self {
+        ShardingConfig {
+            cpu_allocation: CpuAllocation::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum CpuAllocation {
+    All,
+    Count(usize),
+    Range(usize, usize),
+}
+
+impl Default for CpuAllocation {
+    fn default() -> Self {
+        CpuAllocation::All
+    }
+}
+
+impl CpuAllocation {
+    pub fn to_shard_set(&self) -> HashSet<usize> {
+        match self {
+            CpuAllocation::All => {
+                let available_cpus = available_parallelism()
+                    .expect("Failed to get num of cores")
+                    .get();
+                (0..available_cpus).collect()
+            }
+            CpuAllocation::Count(count) => (0..*count).collect(),
+            CpuAllocation::Range(start, end) => (*start..*end).collect(),
+        }
+    }
+}
+
+impl FromStr for CpuAllocation {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(CpuAllocation::All),
+            s if s.contains("..") => {
+                let parts: Vec<&str> = s.split("..").collect();
+                if parts.len() != 2 {
+                    return Err(format!("Invalid range format: {s}. Expected 'start..end'"));
+                }
+                let start = parts[0]
+                    .parse::<usize>()
+                    .map_err(|_| format!("Invalid start value: {}", parts[0]))?;
+                let end = parts[1]
+                    .parse::<usize>()
+                    .map_err(|_| format!("Invalid end value: {}", parts[1]))?;
+                Ok(CpuAllocation::Range(start, end))
+            }
+            s => {
+                let count = s
+                    .parse::<usize>()
+                    .map_err(|_| format!("Invalid shard count: {s}"))?;
+                Ok(CpuAllocation::Count(count))
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CpuAllocation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum CpuAllocationHelper {
+            String(String),
+            Number(usize),
+        }
+
+        match CpuAllocationHelper::deserialize(deserializer)? {
+            CpuAllocationHelper::String(s) => {
+                CpuAllocation::from_str(&s).map_err(serde::de::Error::custom)
+            }
+            CpuAllocationHelper::Number(n) => Ok(CpuAllocation::Count(n)),
+        }
+    }
+}

--- a/core/server/src/configs/system.rs
+++ b/core/server/src/configs/system.rs
@@ -17,6 +17,7 @@
  */
 
 use super::cache_indexes::CacheIndexesConfig;
+use super::sharding::ShardingConfig;
 use iggy_common::IggyByteSize;
 use iggy_common::IggyExpiry;
 use iggy_common::MaxTopicSize;
@@ -41,6 +42,7 @@ pub struct SystemConfig {
     pub message_deduplication: MessageDeduplicationConfig,
     pub recovery: RecoveryConfig,
     pub memory_pool: MemoryPoolConfig,
+    pub sharding: ShardingConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/core/server/src/shard/mod.rs
+++ b/core/server/src/shard/mod.rs
@@ -665,13 +665,10 @@ impl IggyShard {
                 })?;
                 Ok(())
             }
-            ShardEvent::UpdatedStream {
-                stream_id,
-                name,
-            } => {
+            ShardEvent::UpdatedStream { stream_id, name } => {
                 self.update_stream_bypass_auth(stream_id, name)?;
                 Ok(())
-            },
+            }
             ShardEvent::UpdatedTopic {
                 stream_id,
                 topic_id,
@@ -689,9 +686,10 @@ impl IggyShard {
                     *compression_algorithm,
                     *max_topic_size,
                     *replication_factor,
-                ).await?;
+                )
+                .await?;
                 Ok(())
-            },
+            }
             ShardEvent::PurgedStream { stream_id: _ } => todo!(),
             ShardEvent::CreatedConsumerGroup {
                 stream_id: _,

--- a/core/server/src/shard/system/topics.rs
+++ b/core/server/src/shard/system/topics.rs
@@ -239,7 +239,8 @@ impl IggyShard {
             compression_algorithm,
             max_topic_size,
             replication_factor,
-        ).await
+        )
+        .await
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
- Add system.sharding.cpu_allocation config to control thread-to-CPU mapping
- Support "all" (default), numeric (e.g. 4), and range (e.g. "5..8") values
- Always pin threads to specific CPU cores for consistent performance
- Validate configuration against available CPU cores with descriptive errors
