### PR TITLE
chore(python): fix links on PYPI

### DIFF
--- a/foreign/python/README.md
+++ b/foreign/python/README.md
@@ -64,12 +64,12 @@ pytest tests/ -v
 
 ## Examples
 
-Refer to the [python_examples/](python_examples/) directory for usage examples.
+Refer to the [python_examples/](https://github.com/apache/iggy/tree/master/foreign/python/python_examples) directory for usage examples.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+See [CONTRIBUTING.md](https://github.com/apache/iggy/blob/master/foreign/python/CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 
-Licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.
+Licensed under the Apache License 2.0. See [LICENSE](https://github.com/apache/iggy/blob/master/foreign/python/LICENSE) for details.


### PR DESCRIPTION
The README.md file is visible both on GitHub and PYPI.

The links were relative, which works on GitHub but not PYPI.

This PR changes links to absolute.

