### PR TITLE
Fix HTTP server using `compio`, `cyper` and restrict to shard 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core 0.5.2",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -780,6 +781,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2272,6 +2284,28 @@ dependencies = [
  "serde_urlencoded",
  "thiserror 2.0.12",
  "url",
+]
+
+[[package]]
+name = "cyper-axum"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "544ea99187b3adfa95f94f41dbc3e0f144a0e0398071ad0c60fb170692d5df6d"
+dependencies = [
+ "axum 0.8.4",
+ "axum-core 0.5.2",
+ "compio 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compio-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cyper-core",
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "hyper-util",
+ "send_wrapper",
+ "socket2 0.5.10",
+ "tokio",
+ "tower 0.5.2",
+ "tower-service",
 ]
 
 [[package]]
@@ -7652,10 +7686,12 @@ dependencies = [
  "chrono",
  "clap",
  "compio 0.15.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-net 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console-subscriber",
  "crossbeam",
  "ctrlc",
  "cyper",
+ "cyper-axum",
  "dashmap",
  "derive_more 2.0.1",
  "dotenvy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,15 +308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned-array"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c92d086290f52938013f6242ac62bf7d401fab8ad36798a609faa65c3fd2c"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,48 +1478,18 @@ dependencies = [
 [[package]]
 name = "compio"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713c6293af093c202ad318e8f7bdc1de1a36d7a793bb77f7fc6bd6f1788659a9"
-dependencies = [
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-dispatcher",
- "compio-driver 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-fs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-io 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-net 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-process",
- "compio-quic",
- "compio-runtime 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-signal",
- "compio-tls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "compio"
-version = "0.15.0"
 source = "git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be#fe4243f0b6811ebc325afd081c9b087b4d9817be"
 dependencies = [
- "compio-buf 0.6.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-driver 0.8.1 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-fs 0.8.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-io 0.7.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-buf",
+ "compio-driver",
+ "compio-fs",
+ "compio-io",
  "compio-log 0.1.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
  "compio-macros",
- "compio-net 0.8.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-runtime 0.8.1 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-tls 0.6.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
-]
-
-[[package]]
-name = "compio-buf"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce94a45a47ef8c0e3f44084fe67c8effc25e7ac1de6de2ee1a29a59e6c6ba8e"
-dependencies = [
- "arrayvec",
- "bytes",
- "libc",
+ "compio-net",
+ "compio-quic",
+ "compio-runtime",
+ "compio-tls",
 ]
 
 [[package]]
@@ -1542,50 +1503,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "compio-dispatcher"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cdf8c613be826be410d8744ab30acc49cc5134a78e2aa25efae9efa44bed6a7"
-dependencies = [
- "compio-driver 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-runtime 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "flume",
- "futures-channel",
-]
-
-[[package]]
-name = "compio-driver"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737212fe00b4af769f7e8f156c25ffafd5888d4d21834e100ea068dea1086ef8"
-dependencies = [
- "aligned-array",
- "cfg-if",
- "cfg_aliases",
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-channel",
- "crossbeam-queue",
- "futures-util",
- "io-uring",
- "io_uring_buf_ring",
- "libc",
- "once_cell",
- "paste",
- "polling",
- "slab",
- "socket2 0.5.10",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "compio-driver"
 version = "0.8.1"
 source = "git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be#fe4243f0b6811ebc325afd081c9b087b4d9817be"
 dependencies = [
  "cfg-if",
  "cfg_aliases",
- "compio-buf 0.6.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-buf",
  "compio-log 0.1.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
  "crossbeam-channel",
  "crossbeam-queue",
@@ -1604,32 +1528,14 @@ dependencies = [
 [[package]]
 name = "compio-fs"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bcf65e631d521c666bca25595f8e5c78173e96f0b3b61f0a7d93f31d9661d32"
-dependencies = [
- "cfg-if",
- "cfg_aliases",
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-driver 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-io 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-runtime 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
- "os_pipe",
- "widestring",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "compio-fs"
-version = "0.8.0"
 source = "git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be#fe4243f0b6811ebc325afd081c9b087b4d9817be"
 dependencies = [
  "cfg-if",
  "cfg_aliases",
- "compio-buf 0.6.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-driver 0.8.1 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-io 0.7.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-runtime 0.8.1 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-buf",
+ "compio-driver",
+ "compio-io",
+ "compio-runtime",
  "libc",
  "os_pipe",
  "widestring",
@@ -1639,21 +1545,9 @@ dependencies = [
 [[package]]
 name = "compio-io"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b05cc4142659f2c90b6e44c68568ff71c83c6fb9285aca686952250b914932"
-dependencies = [
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util",
- "paste",
- "pin-project-lite",
-]
-
-[[package]]
-name = "compio-io"
-version = "0.7.0"
 source = "git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be#fe4243f0b6811ebc325afd081c9b087b4d9817be"
 dependencies = [
- "compio-buf 0.6.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-buf",
  "futures-util",
  "paste",
  "pin-project-lite",
@@ -1690,32 +1584,13 @@ dependencies = [
 [[package]]
 name = "compio-net"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1fabe3393bc0c3a0dca8e99a35bf97e42caa12bb3cc6bba83df04e28c9c142"
-dependencies = [
- "cfg-if",
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-driver 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-io 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-runtime 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "either",
- "libc",
- "once_cell",
- "socket2 0.5.10",
- "widestring",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "compio-net"
-version = "0.8.0"
 source = "git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be#fe4243f0b6811ebc325afd081c9b087b4d9817be"
 dependencies = [
  "cfg-if",
- "compio-buf 0.6.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-driver 0.8.1 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-io 0.7.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-runtime 0.8.1 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-buf",
+ "compio-driver",
+ "compio-io",
+ "compio-runtime",
  "either",
  "libc",
  "once_cell",
@@ -1725,32 +1600,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "compio-process"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3867cfe7b23eaae89ff815aba4fdde61cb6fd55f81fd368128300c6b7e645016"
-dependencies = [
- "cfg-if",
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-driver 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-io 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-runtime 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "compio-quic"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f107e044329f1e171930801b09bfc6e764c5e171e45c7a3e382f98561da619a"
+source = "git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be#fe4243f0b6811ebc325afd081c9b087b4d9817be"
 dependencies = [
  "cfg_aliases",
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-io 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-net 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-runtime 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compio-buf",
+ "compio-io",
+ "compio-log 0.1.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-net",
+ "compio-runtime",
  "flume",
  "futures-util",
  "libc",
@@ -1758,28 +1617,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "thiserror 2.0.12",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "compio-runtime"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df559e87b7ab05ba61c32619f6076dd5cc2daf5a8cb30cb9931fb355d20aff"
-dependencies = [
- "async-task",
- "cfg-if",
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-driver 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue",
- "futures-util",
- "libc",
- "once_cell",
- "scoped-tls",
- "slab",
- "socket2 0.5.10",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1789,8 +1627,8 @@ source = "git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd
 dependencies = [
  "async-task",
  "cfg-if",
- "compio-buf 0.6.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-driver 0.8.1 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-buf",
+ "compio-driver",
  "compio-log 0.1.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
  "core_affinity",
  "crossbeam-queue",
@@ -1804,39 +1642,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "compio-signal"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d2931880b03b33d4df7d2b8a008e93731366d185358c7442fc8d24d5f9c1bd"
-dependencies = [
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-driver 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-runtime 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
- "once_cell",
- "os_pipe",
- "slab",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "compio-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542bb0e0f6f65cb84bc09b7e052fa54f006d1ba228a8dfad6d7b9676defe7232"
-dependencies = [
- "compio-buf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compio-io 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls",
-]
-
-[[package]]
 name = "compio-tls"
 version = "0.6.0"
 source = "git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be#fe4243f0b6811ebc325afd081c9b087b4d9817be"
 dependencies = [
- "compio-buf 0.6.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-io 0.7.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio-buf",
+ "compio-io",
  "rustls",
 ]
 
@@ -1995,16 +1806,6 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2265,12 +2066,11 @@ dependencies = [
 [[package]]
 name = "cyper"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b65af5073b4f53c9697b611b414042e71c6a14e11088438a67b1ef36f51ca2"
+source = "git+https://github.com/krishvishal/cyper.git?rev=cd75e266df6ab0a9b9474eb7dda1735650d17db6#cd75e266df6ab0a9b9474eb7dda1735650d17db6"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "compio 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compio",
  "cyper-core",
  "encoding_rs",
  "futures-util",
@@ -2289,12 +2089,11 @@ dependencies = [
 [[package]]
 name = "cyper-axum"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544ea99187b3adfa95f94f41dbc3e0f144a0e0398071ad0c60fb170692d5df6d"
+source = "git+https://github.com/krishvishal/cyper.git?rev=cd75e266df6ab0a9b9474eb7dda1735650d17db6#cd75e266df6ab0a9b9474eb7dda1735650d17db6"
 dependencies = [
  "axum 0.8.4",
  "axum-core 0.5.2",
- "compio 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compio",
  "compio-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cyper-core",
  "futures-channel",
@@ -2302,7 +2101,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "send_wrapper",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower 0.5.2",
  "tower-service",
@@ -2311,11 +2110,10 @@ dependencies = [
 [[package]]
 name = "cyper-core"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6343deaa569c748860d9afefab636648e7e6f9abdfc26b3b9dde327170ae6b2b"
+source = "git+https://github.com/krishvishal/cyper.git?rev=cd75e266df6ab0a9b9474eb7dda1735650d17db6#cd75e266df6ab0a9b9474eb7dda1735650d17db6"
 dependencies = [
  "cfg-if",
- "compio 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compio",
  "futures-util",
  "hyper",
  "hyper-util",
@@ -4659,7 +4457,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "compio 0.15.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
+ "compio",
  "ctor",
  "derive_more 2.0.1",
  "env_logger",
@@ -5399,23 +5197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -7206,7 +6987,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -7234,7 +7015,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -7243,7 +7024,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.2.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -7440,25 +7221,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -7685,8 +7453,8 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "compio 0.15.0 (git+https://github.com/compio-rs/compio.git?rev=fe4243f0b6811ebc325afd081c9b087b4d9817be)",
- "compio-net 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compio",
+ "compio-net",
  "console-subscriber",
  "crossbeam",
  "ctrlc",
@@ -7723,11 +7491,12 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rusty-s3",
+ "send_wrapper",
  "serde",
  "serde_with",
  "serial_test",
  "sharded_queue",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "static-toml",
  "strum",
  "sysinfo 0.36.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -5358,6 +5368,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "never-say-never"
 version = "6.6.666"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7145,7 +7172,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -7173,7 +7200,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -7182,7 +7209,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -7379,12 +7406,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ config = { version = "0.15.13" }
 comfy-table = "7.1.4"
 crc32fast = "1.5.0"
 crossbeam = "0.8.4"
+cyper = "0.4.0"
 dashmap = "6.1.0"
 derive_builder = "0.20.2"
 derive_more = { version = "2.0.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ comfy-table = "7.1.4"
 crc32fast = "1.5.0"
 crossbeam = "0.8.4"
 dashmap = "6.1.0"
+socket2 = "=0.5.10"
 derive_builder = "0.20.2"
 derive_more = { version = "2.0.1", features = ["full"] }
 derive-new = "0.7.0"
@@ -128,9 +129,11 @@ compio = { git = "https://github.com/compio-rs/compio.git", rev = "fe4243f0b6811
     "time",
     "rustls",
 ] }
-cyper = { version = "0.4.0", features = ["rustls"], default-features = false }
-cyper-axum = "0.4.0"
-tokio = { version = "1.46.1", features = ["full"] }
+cyper = { git = "https://github.com/krishvishal/cyper.git", rev = "cd75e266df6ab0a9b9474eb7dda1735650d17db6", features = [
+    "rustls",
+], default-features = false }
+cyper-axum = { git = "https://github.com/krishvishal/cyper", rev = "cd75e266df6ab0a9b9474eb7dda1735650d17db6" }
+compio-net = { git = "https://github.com/compio-rs/compio.git", rev = "fe4243f0b6811ebc325afd081c9b087b4d9817be" }
 tokio-rustls = "0.26.2"
 toml = "0.9.2"
 tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ async_zip = { version = "0.0.17", features = [
     "deflate",
     "zstd",
 ] }
-axum = "0.8.4"
+axum = { version = "0.8.4", features = ["macros"] }
 axum-server = { version = "0.7.2", features = ["tls-rustls"] }
 bcrypt = "0.17.0"
 bincode = { version = "2.0.1", features = ["serde"] }
@@ -83,7 +83,6 @@ config = { version = "0.15.13" }
 comfy-table = "7.1.4"
 crc32fast = "1.5.0"
 crossbeam = "0.8.4"
-cyper = "0.4.0"
 dashmap = "6.1.0"
 derive_builder = "0.20.2"
 derive_more = { version = "2.0.1", features = ["full"] }
@@ -122,8 +121,15 @@ simd-json = { version = "0.15.1", features = ["serde_impl"] }
 sysinfo = "0.36.1"
 tempfile = "3.20.0"
 thiserror = "2.0.12"
-compio =  { git = "https://github.com/compio-rs/compio.git", rev = "fe4243f0b6811ebc325afd081c9b087b4d9817be", features = ["runtime", "macros", "io-uring", "time", "rustls"] }
-cyper = { version = "0.4.0", features = ["rustls"], default-features = false}
+compio = { git = "https://github.com/compio-rs/compio.git", rev = "fe4243f0b6811ebc325afd081c9b087b4d9817be", features = [
+    "runtime",
+    "macros",
+    "io-uring",
+    "time",
+    "rustls",
+] }
+cyper = { version = "0.4.0", features = ["rustls"], default-features = false }
+cyper-axum = "0.4.0"
 tokio = { version = "1.46.1", features = ["full"] }
 tokio-rustls = "0.26.2"
 toml = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ simd-json = { version = "0.15.1", features = ["serde_impl"] }
 sysinfo = "0.36.1"
 tempfile = "3.20.0"
 thiserror = "2.0.12"
+tokio = { version = "1.46.1", features = ["full"] }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "fe4243f0b6811ebc325afd081c9b087b4d9817be", features = [
     "runtime",
     "macros",

--- a/core/server/Cargo.toml
+++ b/core/server/Cargo.toml
@@ -46,6 +46,7 @@ blake3 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
+cyper = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4", features = ["termination"] }
@@ -67,6 +68,13 @@ lending-iterator = "0.1.7"
 hash32 = "1.0.0"
 mimalloc = { workspace = true, optional = true }
 moka = { version = "0.12.10", features = ["future"] }
+compio = { git = "https://github.com/compio-rs/compio.git", rev = "fe4243f0b6811ebc325afd081c9b087b4d9817be", features = [
+    "runtime",
+    "macros",
+    "io-uring",
+    "time",
+    "rustls",
+] }
 nix = { version = "0.30", features = ["fs"] }
 once_cell = "1.21.3"
 opentelemetry = { version = "0.30.0", features = ["trace", "logs"] }

--- a/core/server/Cargo.toml
+++ b/core/server/Cargo.toml
@@ -47,6 +47,8 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 cyper = { workspace = true }
+cyper-axum = { workspace = true }
+compio-net = "0.8.0"
 console-subscriber = { workspace = true, optional = true }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4", features = ["termination"] }
@@ -68,13 +70,6 @@ lending-iterator = "0.1.7"
 hash32 = "1.0.0"
 mimalloc = { workspace = true, optional = true }
 moka = { version = "0.12.10", features = ["future"] }
-compio = { git = "https://github.com/compio-rs/compio.git", rev = "fe4243f0b6811ebc325afd081c9b087b4d9817be", features = [
-    "runtime",
-    "macros",
-    "io-uring",
-    "time",
-    "rustls",
-] }
 nix = { version = "0.30", features = ["fs"] }
 once_cell = "1.21.3"
 opentelemetry = { version = "0.30.0", features = ["trace", "logs"] }
@@ -126,6 +121,7 @@ tracing-subscriber = { workspace = true }
 twox-hash = { workspace = true }
 ulid = "1.2.1"
 uuid = { workspace = true }
+send_wrapper = "0.6.0"
 rusty-s3 = "0.7.0"
 
 [build-dependencies]

--- a/core/server/Cargo.toml
+++ b/core/server/Cargo.toml
@@ -48,7 +48,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 cyper = { workspace = true }
 cyper-axum = { workspace = true }
-compio-net = "0.8.0"
+compio-net = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4", features = ["termination"] }
@@ -65,7 +65,7 @@ futures = { workspace = true }
 human-repr = { workspace = true }
 iggy_common = { workspace = true }
 jsonwebtoken = "9.3.1"
-socket2 = "0.5.10"
+socket2 = "0.6.0"
 lending-iterator = "0.1.7"
 hash32 = "1.0.0"
 mimalloc = { workspace = true, optional = true }
@@ -109,7 +109,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 compio = { workspace = true }
-cyper = { workspace = true }
 tokio-rustls = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }

--- a/core/server/src/http/consumer_groups.rs
+++ b/core/server/src/http/consumer_groups.rs
@@ -58,10 +58,13 @@ async fn get_consumer_group(
     let identifier_stream_id = Identifier::from_str_value(&stream_id)?;
     let identifier_topic_id = Identifier::from_str_value(&topic_id)?;
     let identifier_group_id = Identifier::from_str_value(&group_id)?;
-    let system = state.system.read().await;
-    let Ok(consumer_group) = system.get_consumer_group(
+    let stream = state
+        .shard
+        .get_stream(&identifier_stream_id)
+        .map_err(|_| CustomError::ResourceNotFound)?;
+    let Ok(consumer_group) = state.shard.get_consumer_group(
         &Session::stateless(identity.user_id, identity.ip_address),
-        &identifier_stream_id,
+        &stream,
         &identifier_topic_id,
         &identifier_group_id,
     ) else {
@@ -71,7 +74,6 @@ async fn get_consumer_group(
         return Err(CustomError::ResourceNotFound);
     };
 
-    let consumer_group = consumer_group.read().await;
     let consumer_group = mapper::map_consumer_group(&consumer_group);
     Ok(Json(consumer_group))
 }
@@ -83,8 +85,8 @@ async fn get_consumer_groups(
 ) -> Result<Json<Vec<ConsumerGroup>>, CustomError> {
     let stream_id = Identifier::from_str_value(&stream_id)?;
     let topic_id = Identifier::from_str_value(&topic_id)?;
-    let system = state.system.read().await;
-    let consumer_groups = system.get_consumer_groups(
+
+    let consumer_groups = state.shard.get_consumer_groups(
         &Session::stateless(identity.user_id, identity.ip_address),
         &stream_id,
         &topic_id,
@@ -103,24 +105,40 @@ async fn create_consumer_group(
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.topic_id = Identifier::from_str_value(&topic_id)?;
     command.validate()?;
-    let mut system = state.system.write().await;
-    let consumer_group = system
-            .create_consumer_group(
-                &Session::stateless(identity.user_id, identity.ip_address),
-                &command.stream_id,
-                &command.topic_id,
-                command.group_id,
-                &command.name,
-            )
-            .await
-            .with_error_context(|error| format!("{COMPONENT} (error: {error}) - failed to create consumer group, stream ID: {}, topic ID: {}, group ID: {:?}", stream_id, topic_id, command.group_id))?;
-    let consumer_group = consumer_group.read().await;
-    let group_id = consumer_group.group_id;
-    let consumer_group_details = mapper::map_consumer_group(&consumer_group);
-    drop(consumer_group);
 
-    let system = system.downgrade();
-    system
+    let group_id_identifier = state.shard
+        .create_consumer_group(
+            &Session::stateless(identity.user_id, identity.ip_address),
+            &command.stream_id,
+            &command.topic_id,
+            command.group_id,
+            &command.name,
+        )
+        .with_error_context(|error| format!("{COMPONENT} (error: {error}) - failed to create consumer group, stream ID: {}, topic ID: {}, group ID: {:?}", stream_id, topic_id, command.group_id))?;
+
+    let group_id = group_id_identifier.get_u32_value().unwrap_or_default();
+
+    let stream = state
+        .shard
+        .get_stream(&command.stream_id)
+        .map_err(|_| CustomError::ResourceNotFound)?;
+    let Ok(consumer_group) = state.shard.get_consumer_group(
+        &Session::stateless(identity.user_id, identity.ip_address),
+        &stream,
+        &command.topic_id,
+        &group_id_identifier,
+    ) else {
+        return Err(CustomError::ResourceNotFound);
+    };
+    let Some(consumer_group) = consumer_group else {
+        return Err(CustomError::ResourceNotFound);
+    };
+
+    let consumer_group_details = mapper::map_consumer_group(&consumer_group);
+
+    // Use the group_id for state management
+    state
+        .shard
         .state
         .apply(
             identity.user_id,
@@ -141,19 +159,18 @@ async fn delete_consumer_group(
     let identifier_topic_id = Identifier::from_str_value(&topic_id)?;
     let identifier_group_id = Identifier::from_str_value(&group_id)?;
 
-    let mut system = state.system.write().await;
-    system
-            .delete_consumer_group(
-                &Session::stateless(identity.user_id, identity.ip_address),
-                &identifier_stream_id,
-                &identifier_topic_id,
-                &identifier_group_id,
-            )
-            .await
-            .with_error_context(|error| format!("{COMPONENT} (error: {error}) - failed to delete consumer group with ID: {group_id} for topic with ID: {topic_id} in stream with ID: {stream_id}"))?;
+    state.shard
+        .delete_consumer_group(
+            &Session::stateless(identity.user_id, identity.ip_address),
+            &identifier_stream_id,
+            &identifier_topic_id,
+            &identifier_group_id,
+        )
+        .await
+        .with_error_context(|error| format!("{COMPONENT} (error: {error}) - failed to delete consumer group with ID: {group_id} for topic with ID: {topic_id} in stream with ID: {stream_id}"))?;
 
-    let system = system.downgrade();
-    system
+    state
+        .shard
         .state
         .apply(
             identity.user_id,

--- a/core/server/src/http/consumer_offsets.rs
+++ b/core/server/src/http/consumer_offsets.rs
@@ -21,6 +21,7 @@ use crate::http::error::CustomError;
 use crate::http::jwt::json_web_token::Identity;
 use crate::http::shared::AppState;
 use crate::streaming::session::Session;
+use axum::debug_handler;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{delete, get};
@@ -33,6 +34,7 @@ use iggy_common::Validatable;
 use iggy_common::delete_consumer_offset::DeleteConsumerOffset;
 use iggy_common::get_consumer_offset::GetConsumerOffset;
 use iggy_common::store_consumer_offset::StoreConsumerOffset;
+use send_wrapper::SendWrapper;
 use std::sync::Arc;
 
 pub fn router(state: Arc<AppState>) -> Router {
@@ -48,20 +50,22 @@ pub fn router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+#[debug_handler]
 async fn get_consumer_offset(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
     Path((stream_id, topic_id)): Path<(String, String)>,
-    mut query: Query<GetConsumerOffset>,
+    query: Query<GetConsumerOffset>,
 ) -> Result<Json<ConsumerOffsetInfo>, CustomError> {
+    let mut query = query;
     query.stream_id = Identifier::from_str_value(&stream_id)?;
     query.topic_id = Identifier::from_str_value(&topic_id)?;
     query.validate()?;
     let consumer = Consumer::new(query.0.consumer.id);
-    let system = state.system.read().await;
-    let Ok(offset) = system
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
+    let Ok(offset) = state.shard
         .get_consumer_offset(
-            &Session::stateless(identity.user_id, identity.ip_address),
+            &session,
             &consumer,
             &query.0.stream_id,
             &query.0.topic_id,
@@ -79,6 +83,7 @@ async fn get_consumer_offset(
     Ok(Json(offset))
 }
 
+#[debug_handler]
 async fn store_consumer_offset(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
@@ -88,11 +93,11 @@ async fn store_consumer_offset(
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.topic_id = Identifier::from_str_value(&topic_id)?;
     command.validate()?;
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
     let consumer = Consumer::new(command.0.consumer.id);
-    let system = state.system.read().await;
-    system
+    state.shard
         .store_consumer_offset(
-            &Session::stateless(identity.user_id, identity.ip_address),
+            &session,
             consumer,
             &command.0.stream_id,
             &command.0.topic_id,
@@ -104,6 +109,7 @@ async fn store_consumer_offset(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 async fn delete_consumer_offset(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
@@ -111,10 +117,10 @@ async fn delete_consumer_offset(
     query: Query<DeleteConsumerOffset>,
 ) -> Result<StatusCode, CustomError> {
     let consumer = Consumer::new(consumer_id.try_into()?);
-    let system = state.system.read().await;
-    system
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
+    state.shard        
         .delete_consumer_offset(
-            &Session::stateless(identity.user_id, identity.ip_address),
+            &session,
             consumer,
             &query.stream_id,
             &query.topic_id,

--- a/core/server/src/http/diagnostics.rs
+++ b/core/server/src/http/diagnostics.rs
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+use crate::http::http_server::CompioSocketAddr;
 use crate::http::shared::RequestDetails;
 use crate::streaming::utils::random_id;
 use axum::body::Body;
@@ -25,12 +26,11 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-use std::net::SocketAddr;
 use tokio::time::Instant;
 use tracing::{debug, error};
 
 pub async fn request_diagnostics(
-    ConnectInfo(ip_address): ConnectInfo<SocketAddr>,
+    ConnectInfo(ip_address): ConnectInfo<CompioSocketAddr>,
     mut request: Request<Body>,
     next: Next,
 ) -> Result<Response, StatusCode> {
@@ -40,6 +40,7 @@ pub async fn request_diagnostics(
         .path_and_query()
         .map(|p| p.as_str())
         .unwrap_or("/");
+    let ip_address = ip_address.0;
     debug!(
         "Processing a request {} {} with ID: {request_id} from client with IP address: {ip_address}...",
         request.method(),

--- a/core/server/src/http/http_shard_wrapper.rs
+++ b/core/server/src/http/http_shard_wrapper.rs
@@ -1,0 +1,464 @@
+use std::cell::Ref;
+use std::rc::Rc;
+
+use iggy_common::{
+    CompressionAlgorithm, Consumer, ConsumerOffsetInfo, Identifier, IggyError, IggyExpiry,
+    MaxTopicSize, Partitioning, Permissions, Stats, UserId, UserStatus,
+};
+use send_wrapper::SendWrapper;
+
+use crate::binary::handlers::messages::poll_messages_handler::IggyPollMetadata;
+use crate::shard::system::messages::PollingArgs;
+use crate::state::command::EntryCommand;
+use crate::streaming::personal_access_tokens::personal_access_token::PersonalAccessToken;
+use crate::streaming::segments::{IggyMessagesBatchMut, IggyMessagesBatchSet};
+use crate::streaming::streams::stream::Stream;
+use crate::streaming::topics::consumer_group::ConsumerGroup;
+use crate::streaming::topics::topic::Topic;
+use crate::streaming::users::user::User;
+use crate::{shard::IggyShard, streaming::session::Session};
+
+/// A wrapper around IggyShard that is safe to use in HTTP handlers.
+///
+/// # Safety
+/// This wrapper is only safe to use when:
+/// 1. The HTTP server runs on a single thread (compio's thread-per-core model)
+/// 2. All operations are confined to shard 0's thread
+/// 3. The underlying IggyShard is never accessed from multiple threads
+///
+/// The safety guarantee is provided by the HTTP server architecture where
+/// all HTTP requests are handled on the same thread that owns the IggyShard.
+pub struct HttpSafeShard {
+    inner: Rc<IggyShard>,
+}
+
+// Safety: HttpSafeShard is only used in HTTP handlers on shard 0's thread.
+// All operations are confined to the thread that created the IggyShard instance.
+// The underlying IggyShard contains RefCell and Rc types that are not thread-safe,
+// but they are never accessed across threads in the HTTP server context with
+// compio's single-threaded model.
+unsafe impl Send for HttpSafeShard {}
+unsafe impl Sync for HttpSafeShard {}
+
+impl HttpSafeShard {
+    pub fn new(shard: Rc<IggyShard>) -> Self {
+        Self { inner: shard }
+    }
+
+    pub fn shard(&self) -> &IggyShard {
+        &self.inner
+    }
+
+    pub async fn get_consumer_offset(
+        &self,
+        session: &SendWrapper<Session>,
+        consumer: &Consumer,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+    ) -> Result<Option<ConsumerOffsetInfo>, IggyError> {
+        let future = SendWrapper::new(self.shard().get_consumer_offset(
+            session,
+            consumer,
+            stream_id,
+            topic_id,
+            partition_id,
+        ));
+        future.await
+    }
+
+    pub async fn store_consumer_offset(
+        &self,
+        session: &SendWrapper<Session>,
+        consumer: Consumer,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+        offset: u64,
+    ) -> Result<(), IggyError> {
+        let future = SendWrapper::new(self.shard().store_consumer_offset(
+            session,
+            consumer,
+            stream_id,
+            topic_id,
+            partition_id,
+            offset,
+        ));
+        future.await
+    }
+
+    pub async fn delete_consumer_offset(
+        &self,
+        session: &SendWrapper<Session>,
+        consumer: Consumer,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+    ) -> Result<(), IggyError> {
+        let future = SendWrapper::new(self.shard().delete_consumer_offset(
+            session,
+            consumer,
+            stream_id,
+            topic_id,
+            partition_id,
+        ));
+        future.await
+    }
+
+    pub fn get_streams(&self) -> Vec<Ref<'_, Stream>> {
+        self.shard().get_streams()
+    }
+
+    pub fn get_stream(&self, stream_id: &Identifier) -> Result<Ref<'_, Stream>, IggyError> {
+        self.shard().get_stream(stream_id)
+    }
+
+    pub async fn delete_stream(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+    ) -> Result<Stream, IggyError> {
+        self.shard().delete_stream(session, stream_id)
+    }
+
+    pub async fn update_stream(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        name: &str,
+    ) -> Result<(), IggyError> {
+        self.shard().update_stream(session, stream_id, name).await
+    }
+
+    pub async fn purge_stream(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+    ) -> Result<(), IggyError> {
+        self.shard().purge_stream(session, stream_id).await
+    }
+
+    // pub fn get_topics(
+    //     &self,
+    //     session: &Session,
+    //     stream_id: &Identifier,
+    // ) -> Result<Vec<&Topic>, IggyError> {
+    //     self.shard().get_topics(session, stream_id)
+    // }
+
+    pub fn find_topic<'topic, 'stream>(
+        &self,
+        session: &Session,
+        stream: &'stream Stream,
+        topic_id: &Identifier,
+    ) -> Result<&'topic Topic, IggyError>
+    where
+        'stream: 'topic,
+    {
+        self.shard().find_topic(session, stream, topic_id)
+    }
+
+    pub async fn create_topic(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: Option<u32>,
+        name: &str,
+        partitions_count: u32,
+        message_expiry: IggyExpiry,
+        compression_algorithm: CompressionAlgorithm,
+        max_topic_size: MaxTopicSize,
+        replication_factor: Option<u8>,
+    ) -> Result<(Identifier, Vec<u32>), IggyError> {
+        self.shard()
+            .create_topic(
+                session,
+                stream_id,
+                topic_id,
+                name,
+                partitions_count,
+                message_expiry,
+                compression_algorithm,
+                max_topic_size,
+                replication_factor,
+            )
+            .await
+    }
+
+    pub async fn delete_topic(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+    ) -> Result<Topic, IggyError> {
+        self.shard()
+            .delete_topic(session, stream_id, topic_id)
+            .await
+    }
+
+    pub async fn update_topic(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        name: &str,
+        message_expiry: IggyExpiry,
+        compression_algorithm: CompressionAlgorithm,
+        max_topic_size: MaxTopicSize,
+        replication_factor: Option<u8>,
+    ) -> Result<(), IggyError> {
+        self.shard()
+            .update_topic(
+                session,
+                stream_id,
+                topic_id,
+                name,
+                message_expiry,
+                compression_algorithm,
+                max_topic_size,
+                replication_factor,
+            )
+            .await
+    }
+
+    pub async fn purge_topic(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+    ) -> Result<(), IggyError> {
+        self.shard().purge_topic(session, stream_id, topic_id).await
+    }
+
+    pub async fn get_users(&self, session: &Session) -> Result<Vec<User>, IggyError> {
+        self.shard().get_users(session).await
+    }
+
+    pub fn create_user(
+        &self,
+        session: &Session,
+        username: &str,
+        password: &str,
+        status: UserStatus,
+        permissions: Option<Permissions>,
+    ) -> Result<User, IggyError> {
+        self.shard()
+            .create_user(session, username, password, status, permissions)
+    }
+
+    pub fn delete_user(&self, session: &Session, user_id: &Identifier) -> Result<User, IggyError> {
+        self.shard().delete_user(session, user_id)
+    }
+
+    pub fn update_user(
+        &self,
+        session: &Session,
+        user_id: &Identifier,
+        username: Option<String>,
+        status: Option<UserStatus>,
+    ) -> Result<User, IggyError> {
+        self.shard().update_user(session, user_id, username, status)
+    }
+
+    pub fn update_permissions(
+        &self,
+        session: &Session,
+        user_id: &Identifier,
+        permissions: Option<Permissions>,
+    ) -> Result<(), IggyError> {
+        self.shard()
+            .update_permissions(session, user_id, permissions)
+    }
+
+    pub async fn change_password(
+        &self,
+        session: &Session,
+        user_id: &Identifier,
+        current_password: &str,
+        new_password: &str,
+    ) -> Result<(), IggyError> {
+        self.shard()
+            .change_password(session, user_id, current_password, new_password)
+    }
+
+    pub fn login_user(
+        &self,
+        username: &str,
+        password: &str,
+        session: Option<&Session>,
+    ) -> Result<User, IggyError> {
+        self.shard().login_user(username, password, session)
+    }
+
+    pub fn logout_user(&self, session: &Session) -> Result<(), IggyError> {
+        self.shard().logout_user(session)
+    }
+
+    pub fn get_personal_access_tokens(
+        &self,
+        session: &Session,
+    ) -> Result<Vec<PersonalAccessToken>, IggyError> {
+        self.shard().get_personal_access_tokens(session)
+    }
+
+    pub fn create_personal_access_token(
+        &self,
+        session: &Session,
+        name: &str,
+        expiry: IggyExpiry,
+    ) -> Result<(PersonalAccessToken, String), IggyError> {
+        self.shard()
+            .create_personal_access_token(session, name, expiry)
+    }
+
+    pub fn delete_personal_access_token(
+        &self,
+        session: &Session,
+        name: &str,
+    ) -> Result<(), IggyError> {
+        self.shard().delete_personal_access_token(session, name)
+    }
+
+    pub fn login_with_personal_access_token(
+        &self,
+        token: &str,
+        session: Option<&Session>,
+    ) -> Result<User, IggyError> {
+        self.shard()
+            .login_with_personal_access_token(token, session)
+    }
+
+    pub async fn get_stats(&self) -> Result<Stats, IggyError> {
+        self.shard().get_stats().await
+    }
+
+    pub async fn poll_messages(
+        &self,
+        client_id: u32,
+        user_id: u32,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        consumer: Consumer,
+        maybe_partition_id: Option<u32>,
+        args: PollingArgs,
+    ) -> Result<(IggyPollMetadata, IggyMessagesBatchSet), IggyError> {
+        let future = SendWrapper::new(self.shard().poll_messages(
+            client_id,
+            user_id,
+            stream_id,
+            topic_id,
+            consumer.clone(),
+            maybe_partition_id,
+            args,
+        ));
+
+        future.await
+    }
+
+    pub fn get_consumer_group<'cg, 'stream>(
+        &self,
+        session: &Session,
+        stream: &'stream Stream,
+        topic_id: &Identifier,
+        group_id: &Identifier,
+    ) -> Result<Option<Ref<'cg, ConsumerGroup>>, IggyError>
+    where
+        'stream: 'cg,
+    {
+        self.shard()
+            .get_consumer_group(session, stream, topic_id, group_id)
+    }
+
+    pub fn get_consumer_groups(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+    ) -> Result<Vec<ConsumerGroup>, IggyError> {
+        self.shard()
+            .get_consumer_groups(session, stream_id, topic_id)
+    }
+
+    pub fn create_consumer_group(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        group_id: Option<u32>,
+        name: &str,
+    ) -> Result<Identifier, IggyError> {
+        self.shard()
+            .create_consumer_group(session, stream_id, topic_id, group_id, name)
+    }
+
+    pub async fn delete_consumer_group(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        consumer_group_id: &Identifier,
+    ) -> Result<(), IggyError> {
+        // Wrap the entire operation in SendWrapper since it's async
+        let future = SendWrapper::new(self.shard().delete_consumer_group(
+            session,
+            stream_id,
+            topic_id,
+            consumer_group_id,
+        ));
+        future.await
+    }
+
+    pub async fn append_messages(
+        &self,
+        user_id: u32,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partitioning: &Partitioning,
+        batch: IggyMessagesBatchMut,
+    ) -> Result<(), IggyError> {
+        let future = SendWrapper::new(self.shard().append_messages(
+            user_id,
+            stream_id,
+            topic_id,
+            partitioning,
+            batch,
+        ));
+        future.await
+    }
+
+    pub async fn create_partitions(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partitions_count: u32,
+    ) -> Result<Vec<u32>, IggyError> {
+        self.shard()
+            .create_partitions(session, stream_id, topic_id, partitions_count)
+            .await
+    }
+
+    pub async fn delete_partitions(
+        &self,
+        session: &Session,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partitions_count: u32,
+    ) -> Result<Vec<u32>, IggyError> {
+        let future = SendWrapper::new(self.shard().delete_partitions(
+            session,
+            stream_id,
+            topic_id,
+            partitions_count,
+        ));
+        future.await
+    }
+
+    pub fn try_find_stream(
+        &self,
+        session: &Session,
+        identifier: &Identifier,
+    ) -> Result<Option<Ref<'_, Stream>>, IggyError> {
+        self.shard().try_find_stream(session, identifier)
+    }
+}

--- a/core/server/src/http/jwt/cleaner.rs
+++ b/core/server/src/http/jwt/cleaner.rs
@@ -18,13 +18,12 @@
 
 use crate::http::shared::AppState;
 use iggy_common::IggyTimestamp;
-use std::sync::Arc;
-use monoio::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tracing::{error, trace};
 
 pub fn start_expired_tokens_cleaner(app_state: Arc<AppState>) {
-    monoio::spawn(async move {
-        let mut interval_timer = monoio::time::interval(Duration::from_secs(300));
+    compio::runtime::spawn(async move {
+        let mut interval_timer = compio::time::interval(Duration::from_secs(300));
         loop {
             interval_timer.tick().await;
             trace!("Deleting expired tokens...");
@@ -37,5 +36,6 @@ pub fn start_expired_tokens_cleaner(app_state: Arc<AppState>) {
                     error!("Failed to delete expired revoked access tokens. Error: {err}");
                 });
         }
-    });
+    })
+    .detach();
 }

--- a/core/server/src/http/jwt/storage.rs
+++ b/core/server/src/http/jwt/storage.rs
@@ -17,8 +17,6 @@
  */
 
 use crate::http::jwt::COMPONENT;
-use crate::streaming::utils::PooledBuffer;
-use crate::streaming::utils::file;
 use crate::{
     http::jwt::json_web_token::RevokedAccessToken, streaming::persistence::persister::PersisterKind,
 };
@@ -27,7 +25,6 @@ use anyhow::Context;
 use error_set::ErrContext;
 use iggy_common::IggyError;
 use std::sync::Arc;
-use tokio::io::AsyncReadExt;
 use tracing::{error, info};
 
 #[derive(Debug)]
@@ -47,31 +44,18 @@ impl TokenStorage {
     pub async fn load_all_revoked_access_tokens(
         &self,
     ) -> Result<Vec<RevokedAccessToken>, IggyError> {
-        let file = file::open(&self.path).await;
-        if file.is_err() {
-            info!("No revoked access tokens found to load.");
-            return Ok(vec![]);
-        }
+        // Check if file exists by trying to get metadata (equivalent to original file open check)
+        let file_size = match compio::fs::metadata(&self.path).await {
+            Err(_) => {
+                info!("No revoked access tokens found to load.");
+                return Ok(vec![]);
+            }
+            Ok(metadata) => metadata.len() as usize,
+        };
 
         info!("Loading revoked access tokens from: {}", self.path);
-        let mut file = file.map_err(|error| {
-            error!("Cannot open revoked access tokens file: {error}");
-            IggyError::CannotReadFile
-        })?;
-        let file_size = file
-            .metadata()
-            .await
-            .with_error_context(|error| {
-                format!(
-                    "{COMPONENT} (error: {error}) - failed to read file metadata, path: {}",
-                    self.path
-                )
-            })
-            .map_err(|_| IggyError::CannotReadFileMetadata)?
-            .len() as usize;
-        let mut buffer = PooledBuffer::with_capacity(file_size);
-        buffer.put_bytes(0, file_size);
-        file.read_exact(&mut buffer)
+
+        let buffer = compio::fs::read(&self.path)
             .await
             .with_error_context(|error| {
                 format!(
@@ -79,7 +63,18 @@ impl TokenStorage {
                     self.path
                 )
             })
-            .map_err(|_| IggyError::CannotReadFile)?;
+            .map_err(|error| {
+                error!("Cannot open revoked access tokens file: {error}");
+                IggyError::CannotReadFile
+            })?;
+
+        if buffer.len() != file_size {
+            error!(
+                "File size mismatch: expected {file_size}, got {}",
+                buffer.len()
+            );
+            return Err(IggyError::CannotReadFile);
+        }
 
         let tokens: AHashMap<String, u64> =
             bincode::serde::decode_from_slice(&buffer, bincode::config::standard())
@@ -110,7 +105,7 @@ impl TokenStorage {
             .with_context(|| "Failed to serialize revoked access tokens")
             .map_err(|_| IggyError::CannotSerializeResource)?;
         self.persister
-            .overwrite(&self.path, &bytes)
+            .overwrite(&self.path, bytes)
             .await
             .with_error_context(|error| {
                 format!(
@@ -144,7 +139,7 @@ impl TokenStorage {
             .with_context(|| "Failed to serialize revoked access tokens")
             .map_err(|_| IggyError::CannotSerializeResource)?;
         self.persister
-            .overwrite(&self.path, &bytes)
+            .overwrite(&self.path, bytes)
             .await
             .with_error_context(|error| {
                 format!(

--- a/core/server/src/http/metrics.rs
+++ b/core/server/src/http/metrics.rs
@@ -31,6 +31,6 @@ pub async fn metrics(
     request: Request<Body>,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    state.shard.metrics.increment_http_requests();
+    state.shard.shard().metrics.increment_http_requests();
     Ok(next.run(request).await)
 }

--- a/core/server/src/http/metrics.rs
+++ b/core/server/src/http/metrics.rs
@@ -31,6 +31,6 @@ pub async fn metrics(
     request: Request<Body>,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    state.system.read().await.metrics.increment_http_requests();
+    state.shard.metrics.increment_http_requests();
     Ok(next.run(request).await)
 }

--- a/core/server/src/http/mod.rs
+++ b/core/server/src/http/mod.rs
@@ -16,23 +16,22 @@
  * under the License.
  */
 
-/*
-pub mod consumer_groups;
-pub mod consumer_offsets;
 pub mod diagnostics;
 pub mod error;
 pub mod http_server;
 pub mod jwt;
 mod mapper;
-pub mod messages;
 pub mod metrics;
-pub mod partitions;
-pub mod personal_access_tokens;
 mod shared;
-pub mod streams;
-pub mod system;
-pub mod topics;
-pub mod users;
-*/
+
+pub mod consumer_groups;
+pub mod consumer_offsets;
+// pub mod messages;
+// pub mod partitions;
+// pub mod personal_access_tokens;
+// pub mod streams;
+// pub mod system;
+// pub mod topics;
+// pub mod users;
 
 pub const COMPONENT: &str = "HTTP";

--- a/core/server/src/http/mod.rs
+++ b/core/server/src/http/mod.rs
@@ -19,6 +19,7 @@
 pub mod diagnostics;
 pub mod error;
 pub mod http_server;
+mod http_shard_wrapper;
 pub mod jwt;
 mod mapper;
 pub mod metrics;
@@ -26,12 +27,12 @@ mod shared;
 
 pub mod consumer_groups;
 pub mod consumer_offsets;
-// pub mod messages;
-// pub mod partitions;
-// pub mod personal_access_tokens;
-// pub mod streams;
-// pub mod system;
-// pub mod topics;
-// pub mod users;
+pub mod messages;
+pub mod partitions;
+pub mod personal_access_tokens;
+pub mod streams;
+pub mod system;
+pub mod topics;
+pub mod users;
 
 pub const COMPONENT: &str = "HTTP";

--- a/core/server/src/http/partitions.rs
+++ b/core/server/src/http/partitions.rs
@@ -20,6 +20,7 @@ use crate::http::COMPONENT;
 use crate::http::error::CustomError;
 use crate::http::jwt::json_web_token::Identity;
 use crate::http::shared::AppState;
+use crate::shard::transmission::event::ShardEvent;
 use crate::state::command::EntryCommand;
 use crate::streaming::session::Session;
 use axum::extract::{Path, Query, State};
@@ -31,6 +32,7 @@ use iggy_common::Identifier;
 use iggy_common::Validatable;
 use iggy_common::create_partitions::CreatePartitions;
 use iggy_common::delete_partitions::DeletePartitions;
+use iggy_common::locking::IggyRwLockFn;
 use send_wrapper::SendWrapper;
 use std::sync::Arc;
 use tracing::instrument;
@@ -64,13 +66,59 @@ async fn create_partitions(
         command.partitions_count,
     ));
 
-    create_future.await
+    let partition_ids = create_future.await
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to create partitions, stream ID: {stream_id}, topic ID: {topic_id}"
             )
         })?;
 
+    let broadcast_future = SendWrapper::new(async {
+        let shard = state.shard.shard();
+
+        let event = ShardEvent::CreatedPartitions {
+            stream_id: command.stream_id.clone(),
+            topic_id: command.topic_id.clone(),
+            partitions_count: partition_ids.len() as u32,
+        };
+        let _responses = shard.broadcast_event_to_all_shards(event.into()).await;
+
+        let stream = shard.get_stream(&command.stream_id)?;
+        let topic = stream.get_topic(&command.topic_id)?;
+        let numeric_stream_id = stream.stream_id;
+        let numeric_topic_id = topic.topic_id;
+
+        let records = shard
+            .create_shard_table_records(&partition_ids, numeric_stream_id, numeric_topic_id)
+            .collect::<Vec<_>>();
+
+        for (ns, shard_info) in records.iter() {
+            let partition = topic.get_partition(ns.partition_id)?;
+            let mut partition = partition.write().await;
+            partition.persist().await?;
+            if shard_info.id() == shard.id {
+                partition.open().await?;
+            }
+        }
+
+        shard.insert_shard_table_records(records);
+
+        let event = ShardEvent::CreatedShardTableRecords {
+            stream_id: numeric_stream_id,
+            topic_id: numeric_topic_id,
+            partition_ids: partition_ids.clone(),
+        };
+        let _responses = shard.broadcast_event_to_all_shards(event.into()).await;
+
+        Ok::<(), CustomError>(())
+    });
+
+    broadcast_future.await
+            .with_error_context(|error| {
+                format!(
+                    "{COMPONENT} (error: {error}) - failed to broadcast partition events, stream ID: {stream_id}, topic ID: {topic_id}"
+                )
+            })?;
     let command = EntryCommand::CreatePartitions(command);
     let state_future =
         SendWrapper::new(state.shard.shard().state.apply(identity.user_id, &command));

--- a/core/server/src/http/personal_access_tokens.rs
+++ b/core/server/src/http/personal_access_tokens.rs
@@ -29,7 +29,7 @@ use crate::streaming::session::Session;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::{delete, get, post};
-use axum::{Extension, Json, Router};
+use axum::{Extension, Json, Router, debug_handler};
 use error_set::ErrContext;
 use iggy_common::IdentityInfo;
 use iggy_common::Validatable;
@@ -37,6 +37,7 @@ use iggy_common::create_personal_access_token::CreatePersonalAccessToken;
 use iggy_common::delete_personal_access_token::DeletePersonalAccessToken;
 use iggy_common::login_with_personal_access_token::LoginWithPersonalAccessToken;
 use iggy_common::{PersonalAccessTokenInfo, RawPersonalAccessToken};
+use send_wrapper::SendWrapper;
 use std::sync::Arc;
 use tracing::instrument;
 
@@ -57,14 +58,15 @@ pub fn router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+#[debug_handler]
 async fn get_personal_access_tokens(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Json<Vec<PersonalAccessTokenInfo>>, CustomError> {
-    let system = state.system.read().await;
-    let personal_access_tokens = system
+    let personal_access_tokens = state
+        .shard
+        .shard()
         .get_personal_access_tokens(&Session::stateless(identity.user_id, identity.ip_address))
-        .await
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to get personal access tokens, user ID: {}",
@@ -75,6 +77,7 @@ async fn get_personal_access_tokens(
     Ok(Json(personal_access_tokens))
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_create_personal_access_token", fields(iggy_user_id = identity.user_id))]
 async fn create_personal_access_token(
     State(state): State<Arc<AppState>>,
@@ -82,14 +85,12 @@ async fn create_personal_access_token(
     Json(command): Json<CreatePersonalAccessToken>,
 ) -> Result<Json<RawPersonalAccessToken>, CustomError> {
     command.validate()?;
-    let system = state.system.read().await;
-    let token = system
+    let (_personal_access_token, token) = state.shard
             .create_personal_access_token(
                 &Session::stateless(identity.user_id, identity.ip_address),
                 &command.name,
                 command.expiry,
             )
-            .await
             .with_error_context(|error| {
                 format!(
                     "{COMPONENT} (error: {error}) - failed to create personal access token, user ID: {}",
@@ -98,16 +99,14 @@ async fn create_personal_access_token(
             })?;
 
     let token_hash = PersonalAccessToken::hash_token(&token);
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::CreatePersonalAccessToken(CreatePersonalAccessTokenWithHash {
-                command,
-                hash: token_hash,
-            }),
-        )
-        .await
+    let command = EntryCommand::CreatePersonalAccessToken(CreatePersonalAccessTokenWithHash {
+        command,
+        hash: token_hash,
+    });
+    let state_future =
+        SendWrapper::new(state.shard.shard().state.apply(identity.user_id, &command));
+
+    state_future.await
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to apply create personal access token with hash, user ID: {}",
@@ -117,34 +116,30 @@ async fn create_personal_access_token(
     Ok(Json(RawPersonalAccessToken { token }))
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_delete_personal_access_token", fields(iggy_user_id = identity.user_id))]
 async fn delete_personal_access_token(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
     Path(name): Path<String>,
 ) -> Result<StatusCode, CustomError> {
-    let mut system = state.system.write().await;
-    system
-            .delete_personal_access_token(
-                &Session::stateless(identity.user_id, identity.ip_address),
-                &name,
-            )
-            .await
-            .with_error_context(|error| {
-                format!(
-                    "{COMPONENT} (error: {error}) - failed to delete personal access token, user ID: {}",
-                    identity.user_id
-                )
-            })?;
-
-    let system = system.downgrade();
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::DeletePersonalAccessToken(DeletePersonalAccessToken { name }),
+    state.shard
+        .delete_personal_access_token(
+            &Session::stateless(identity.user_id, identity.ip_address),
+            &name,
         )
-        .await
+        .with_error_context(|error| {
+            format!(
+                "{COMPONENT} (error: {error}) - failed to delete personal access token, user ID: {}",
+                identity.user_id
+            )
+        })?;
+
+    let command = EntryCommand::DeletePersonalAccessToken(DeletePersonalAccessToken { name });
+    let state_future =
+        SendWrapper::new(state.shard.shard().state.apply(identity.user_id, &command));
+
+    state_future.await
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to apply delete personal access token, user ID: {}",
@@ -160,10 +155,10 @@ async fn login_with_personal_access_token(
     Json(command): Json<LoginWithPersonalAccessToken>,
 ) -> Result<Json<IdentityInfo>, CustomError> {
     command.validate()?;
-    let system = state.system.read().await;
-    let user = system
+    let user = state
+        .shard
+        .shard()
         .login_with_personal_access_token(&command.token, None)
-        .await
         .with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to login with personal access token")
         })?;

--- a/core/server/src/http/shared.rs
+++ b/core/server/src/http/shared.rs
@@ -16,13 +16,14 @@
  * under the License.
  */
 
-use crate::{http::jwt::jwt_manager::JwtManager, shard::IggyShard};
+use super::http_shard_wrapper::HttpSafeShard;
+use crate::http::jwt::jwt_manager::JwtManager;
 use std::net::SocketAddr;
 use ulid::Ulid;
 
 pub struct AppState {
     pub jwt_manager: JwtManager,
-    pub shard: IggyShard,
+    pub shard: HttpSafeShard,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/core/server/src/http/streams.rs
+++ b/core/server/src/http/streams.rs
@@ -25,7 +25,7 @@ use crate::streaming::session::Session;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::{delete, get};
-use axum::{Extension, Json, Router};
+use axum::{Extension, Json, Router, debug_handler};
 use error_set::ErrContext;
 use iggy_common::Identifier;
 use iggy_common::Validatable;
@@ -34,6 +34,7 @@ use iggy_common::delete_stream::DeleteStream;
 use iggy_common::purge_stream::PurgeStream;
 use iggy_common::update_stream::UpdateStream;
 use iggy_common::{Stream, StreamDetails};
+use send_wrapper::SendWrapper;
 
 use crate::state::command::EntryCommand;
 use crate::state::models::CreateStreamWithId;
@@ -51,14 +52,14 @@ pub fn router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+#[debug_handler]
 async fn get_stream(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
     Path(stream_id): Path<String>,
 ) -> Result<Json<StreamDetails>, CustomError> {
-    let system = state.system.read().await;
     let stream_id = Identifier::from_str_value(&stream_id)?;
-    let Ok(stream) = system.try_find_stream(
+    let Ok(stream) = state.shard.shard().try_find_stream(
         &Session::stateless(identity.user_id, identity.ip_address),
         &stream_id,
     ) else {
@@ -68,16 +69,18 @@ async fn get_stream(
         return Err(CustomError::ResourceNotFound);
     };
 
-    let stream = mapper::map_stream(stream);
+    let stream = mapper::map_stream(&SendWrapper::new(stream));
     Ok(Json(stream))
 }
 
+#[debug_handler]
 async fn get_streams(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Json<Vec<Stream>>, CustomError> {
-    let system = state.system.read().await;
-    let streams = system
+    let streams: Vec<std::cell::Ref<'_, crate::streaming::streams::stream::Stream>> = state
+        .shard
+        .shard()
         .find_streams(&Session::stateless(identity.user_id, identity.ip_address))
         .with_error_context(|error| {
             format!(
@@ -85,10 +88,16 @@ async fn get_streams(
                 identity.user_id
             )
         })?;
-    let streams = mapper::map_streams(&streams);
+    let stream_refs = {
+        let refs: Vec<&crate::streaming::streams::stream::Stream> =
+            streams.iter().map(|ref_guard| &**ref_guard).collect();
+        refs
+    };
+    let streams = mapper::map_streams(&stream_refs);
     Ok(Json(streams))
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_create_stream", fields(iggy_user_id = identity.user_id))]
 async fn create_stream(
     State(state): State<Arc<AppState>>,
@@ -97,39 +106,55 @@ async fn create_stream(
 ) -> Result<Json<StreamDetails>, CustomError> {
     command.validate()?;
 
-    let mut system = state.system.write().await;
-    let stream = system
-        .create_stream(
-            &Session::stateless(identity.user_id, identity.ip_address),
-            command.stream_id,
-            &command.name,
+    let session = Session::stateless(identity.user_id, identity.ip_address);
+    let create_stream_future = SendWrapper::new(state.shard.shard().create_stream(
+        &session,
+        command.stream_id,
+        &command.name,
+    ));
+
+    let stream_identifier = create_stream_future.await.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to create stream, stream ID: {:?}",
+            command.stream_id
         )
-        .await
+    })?;
+
+    let stream = state
+        .shard
+        .shard()
+        .find_stream(&Session::stateless(identity.user_id, identity.ip_address), &stream_identifier)
         .with_error_context(|error| {
             format!(
-                "{COMPONENT} (error: {error}) - failed to create stream, stream ID: {:?}",
-                command.stream_id
+                "{COMPONENT} (error: {error}) - failed to find created stream, stream ID: {stream_identifier}"
             )
         })?;
-    let stream_id = stream.stream_id;
-    let response = Json(mapper::map_stream(stream));
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(identity.user_id, &EntryCommand::CreateStream(CreateStreamWithId {
-            stream_id,
-            command
-        }))
+    let response = Json(mapper::map_stream(&SendWrapper::new(stream)));
+
+    let entry_command = EntryCommand::CreateStream(CreateStreamWithId {
+        stream_id: command.stream_id.unwrap(), // TODO: handle unwrap
+        command,
+    });
+    let state_future = SendWrapper::new(
+        state
+            .shard
+            .shard()
+            .state
+            .apply(identity.user_id, &entry_command),
+    );
+
+    state_future
         .await
         .with_error_context(|error| {
             format!(
-                "{COMPONENT} (error: {error}) - failed to apply create stream, stream ID: {stream_id}",
+                "{COMPONENT} (error: {error}) - failed to apply create stream, stream ID: {stream_identifier}",
             )
         })?;
     Ok(response)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_update_stream", fields(iggy_user_id = identity.user_id, iggy_stream_id = stream_id))]
 async fn update_stream(
     State(state): State<Arc<AppState>>,
@@ -140,33 +165,35 @@ async fn update_stream(
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.validate()?;
 
-    let mut system = state.system.write().await;
-    system
-        .update_stream(
-            &Session::stateless(identity.user_id, identity.ip_address),
-            &command.stream_id,
-            &command.name,
-        )
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to update stream, stream ID: {stream_id}"
-            )
-        })?;
+    let session = Session::stateless(identity.user_id, identity.ip_address);
+    let update_stream_future = SendWrapper::new(state.shard.shard().update_stream(
+        &session,
+        &command.stream_id,
+        &command.name,
+    ));
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(identity.user_id, &EntryCommand::UpdateStream(command))
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to apply update stream, stream ID: {stream_id}"
-            )
-        })?;
+    update_stream_future.await.with_error_context(|error| {
+        format!("{COMPONENT} (error: {error}) - failed to update stream, stream ID: {stream_id}")
+    })?;
+
+    let entry_command = EntryCommand::UpdateStream(command);
+    let state_future = SendWrapper::new(
+        state
+            .shard
+            .shard()
+            .state
+            .apply(identity.user_id, &entry_command),
+    );
+
+    state_future.await.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to apply update stream, stream ID: {stream_id}"
+        )
+    })?;
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_delete_stream", fields(iggy_user_id = identity.user_id, iggy_stream_id = stream_id))]
 async fn delete_stream(
     State(state): State<Arc<AppState>>,
@@ -175,32 +202,33 @@ async fn delete_stream(
 ) -> Result<StatusCode, CustomError> {
     let identifier_stream_id = Identifier::from_str_value(&stream_id)?;
 
-    let mut system = state.system.write().await;
-    system
+    state
+        .shard
+        .shard()
         .delete_stream(
             &Session::stateless(identity.user_id, identity.ip_address),
             &identifier_stream_id,
         )
-        .await
         .with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to delete stream with ID: {stream_id}",)
         })?;
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::DeleteStream(DeleteStream {
-                stream_id: identifier_stream_id,
-            }),
+    let entry_command = EntryCommand::DeleteStream(DeleteStream {
+        stream_id: identifier_stream_id,
+    });
+    let state_future = SendWrapper::new(
+        state
+            .shard
+            .shard()
+            .state
+            .apply(identity.user_id, &entry_command),
+    );
+
+    state_future.await.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to apply delete stream with ID: {stream_id}",
         )
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to apply delete stream with ID: {stream_id}",
-            )
-        })?;
+    })?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -211,29 +239,33 @@ async fn purge_stream(
     Path(stream_id): Path<String>,
 ) -> Result<StatusCode, CustomError> {
     let identifier_stream_id = Identifier::from_str_value(&stream_id)?;
-    let system = state.system.read().await;
-    system
-        .purge_stream(
-            &Session::stateless(identity.user_id, identity.ip_address),
-            &identifier_stream_id,
+    let session = Session::stateless(identity.user_id, identity.ip_address);
+    let purge_stream_future = SendWrapper::new(
+        state
+            .shard
+            .shard()
+            .purge_stream(&session, &identifier_stream_id),
+    );
+
+    purge_stream_future.await.with_error_context(|error| {
+        format!("{COMPONENT} (error: {error}) - failed to purge stream, stream ID: {stream_id}")
+    })?;
+
+    let entry_command = EntryCommand::PurgeStream(PurgeStream {
+        stream_id: identifier_stream_id,
+    });
+    let state_future = SendWrapper::new(
+        state
+            .shard
+            .shard()
+            .state
+            .apply(identity.user_id, &entry_command),
+    );
+
+    state_future.await.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to apply purge stream, stream ID: {stream_id}"
         )
-        .await
-        .with_error_context(|error| {
-            format!("{COMPONENT} (error: {error}) - failed to purge stream, stream ID: {stream_id}")
-        })?;
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::PurgeStream(PurgeStream {
-                stream_id: identifier_stream_id,
-            }),
-        )
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to apply purge stream, stream ID: {stream_id}"
-            )
-        })?;
+    })?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/core/server/src/http/topics.rs
+++ b/core/server/src/http/topics.rs
@@ -27,15 +27,17 @@ use crate::streaming::session::Session;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::{delete, get};
-use axum::{Extension, Json, Router};
+use axum::{Extension, Json, Router, debug_handler};
 use error_set::ErrContext;
-use iggy_common::Identifier;
 use iggy_common::Validatable;
 use iggy_common::create_topic::CreateTopic;
 use iggy_common::delete_topic::DeleteTopic;
+use iggy_common::locking::IggyRwLockFn;
 use iggy_common::purge_topic::PurgeTopic;
 use iggy_common::update_topic::UpdateTopic;
+use iggy_common::{Identifier, Sizeable};
 use iggy_common::{Topic, TopicDetails};
+use send_wrapper::SendWrapper;
 use std::sync::Arc;
 use tracing::instrument;
 
@@ -56,40 +58,117 @@ pub fn router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+#[debug_handler]
 async fn get_topic(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
     Path((stream_id, topic_id)): Path<(String, String)>,
 ) -> Result<Json<TopicDetails>, CustomError> {
-    let system = state.system.read().await;
     let identity_stream_id = Identifier::from_str_value(&stream_id)?;
     let identity_topic_id = Identifier::from_str_value(&topic_id)?;
-    let Ok(topic) = system.try_find_topic(
-        &Session::stateless(identity.user_id, identity.ip_address),
-        &identity_stream_id,
-        &identity_topic_id,
-    ) else {
-        return Err(CustomError::ResourceNotFound);
-    };
-    let Some(topic) = topic else {
-        return Err(CustomError::ResourceNotFound);
+
+    // Extract all the data we need synchronously first
+    let (topic_data, partition_futures) = {
+        let stream = state
+            .shard
+            .shard()
+            .get_stream(&identity_stream_id)
+            .with_error_context(|error| {
+                format!("{COMPONENT} (error: {error}) - failed to get stream with ID: {stream_id}")
+            })?;
+
+        let Ok(topic) = state.shard.shard().try_find_topic(
+            &Session::stateless(identity.user_id, identity.ip_address),
+            &stream,
+            &identity_topic_id,
+        ) else {
+            return Err(CustomError::ResourceNotFound);
+        };
+
+        let Some(topic) = topic else {
+            return Err(CustomError::ResourceNotFound);
+        };
+
+        // Extract basic topic data synchronously
+        let topic_data = (
+            topic.topic_id,
+            topic.created_at,
+            topic.name.clone(),
+            topic.get_size_bytes(),
+            topic.get_messages_count(),
+            topic.get_partitions().len() as u32,
+            topic.message_expiry,
+            topic.compression_algorithm,
+            topic.max_topic_size,
+            topic.replication_factor,
+        );
+
+        // Get all partition references and create futures for them
+        let partition_futures: Vec<_> = topic
+            .get_partitions()
+            .iter()
+            .map(|partition| {
+                let partition_clone = partition.clone();
+                SendWrapper::new(async move {
+                    let partition_guard = partition_clone.read().await;
+                    iggy_common::Partition {
+                        id: partition_guard.partition_id,
+                        created_at: partition_guard.created_at,
+                        segments_count: partition_guard.get_segments().len() as u32,
+                        current_offset: partition_guard.current_offset,
+                        size: partition_guard.get_size_bytes(),
+                        messages_count: partition_guard.get_messages_count(),
+                    }
+                })
+            })
+            .collect();
+
+        (topic_data, partition_futures)
     };
 
-    let topic = mapper::map_topic(topic).await;
-    Ok(Json(topic))
+    let mut partitions = Vec::new();
+    for partition_future in partition_futures {
+        partitions.push(partition_future.await);
+    }
+    partitions.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let topic_details = TopicDetails {
+        id: topic_data.0,
+        created_at: topic_data.1,
+        name: topic_data.2,
+        size: topic_data.3,
+        messages_count: topic_data.4,
+        partitions_count: topic_data.5,
+        partitions,
+        message_expiry: topic_data.6,
+        compression_algorithm: topic_data.7,
+        max_topic_size: topic_data.8,
+        replication_factor: topic_data.9,
+    };
+
+    Ok(Json(topic_details))
 }
 
+#[debug_handler]
 async fn get_topics(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
     Path(stream_id): Path<String>,
 ) -> Result<Json<Vec<Topic>>, CustomError> {
     let stream_id = Identifier::from_str_value(&stream_id)?;
-    let system = state.system.read().await;
-    let topics = system
+
+    let stream = state
+        .shard
+        .shard()
+        .get_stream(&stream_id)
+        .with_error_context(|error| {
+            format!("{COMPONENT} (error: {error}) - failed to get stream with ID: {stream_id}")
+        })?;
+
+    let topics = state.shard.shard()
         .find_topics(
             &Session::stateless(identity.user_id, identity.ip_address),
-            &stream_id,
+            &stream,
         )
         .with_error_context(|error| {
             format!(
@@ -100,6 +179,7 @@ async fn get_topics(
     Ok(Json(topics))
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_create_topic", fields(iggy_user_id = identity.user_id, iggy_stream_id = stream_id))]
 async fn create_topic(
     State(state): State<Arc<AppState>>,
@@ -110,10 +190,11 @@ async fn create_topic(
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.validate()?;
 
-    let mut system = state.system.write().await;
-    let topic = system
-        .create_topic(
-            &Session::stateless(identity.user_id, identity.ip_address),
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
+
+    let (topic_id, _) = {
+        let future = SendWrapper::new(state.shard.shard().create_topic(
+            &session,
             &command.stream_id,
             command.topic_id,
             &command.name,
@@ -122,32 +203,109 @@ async fn create_topic(
             command.compression_algorithm,
             command.max_topic_size,
             command.replication_factor,
-        )
-        .await
-        .with_error_context(|error| {
-            format!("{COMPONENT} (error: {error}) - failed to create topic, stream ID: {stream_id}")
-        })?;
-    command.message_expiry = topic.message_expiry;
-    command.max_topic_size = topic.max_topic_size;
-    let topic_id = topic.topic_id;
-    let response = Json(mapper::map_topic(topic).await);
+        ));
+        future.await
+    }
+    .with_error_context(|error| {
+        format!("{COMPONENT} (error: {error}) - failed to create topic, stream ID: {stream_id}")
+    })?;
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(identity.user_id, &EntryCommand::CreateTopic(CreateTopicWithId {
-            topic_id,
-            command
-        }))
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to apply create topic, stream ID: {stream_id}",
-            )
+    let (topic_data, partition_futures) = {
+        let stream = state
+            .shard
+            .shard()
+            .get_stream(&command.stream_id)
+            .with_error_context(|error| {
+                format!("{COMPONENT} (error: {error}) - failed to get stream with ID: {stream_id}")
+            })?;
+        let topic = state.shard.shard().find_topic(&session, &stream, &topic_id).with_error_context(|error| {
+            format!("{COMPONENT} (error: {error}) - failed to get topic with ID: {topic_id} in stream with ID: {stream_id}")
         })?;
+
+        command.message_expiry = topic.message_expiry;
+        command.max_topic_size = topic.max_topic_size;
+
+        let topic_data = (
+            topic.topic_id,
+            topic.created_at,
+            topic.name.clone(),
+            topic.get_size_bytes(),
+            topic.get_messages_count(),
+            topic.get_partitions().len() as u32,
+            topic.message_expiry,
+            topic.compression_algorithm,
+            topic.max_topic_size,
+            topic.replication_factor,
+        );
+
+        let partition_futures: Vec<_> = topic
+            .get_partitions()
+            .iter()
+            .map(|partition| {
+                let partition_clone = partition.clone();
+                SendWrapper::new(async move {
+                    let partition_guard = partition_clone.read().await;
+                    iggy_common::Partition {
+                        id: partition_guard.partition_id,
+                        created_at: partition_guard.created_at,
+                        segments_count: partition_guard.get_segments().len() as u32,
+                        current_offset: partition_guard.current_offset,
+                        size: partition_guard.get_size_bytes(),
+                        messages_count: partition_guard.get_messages_count(),
+                    }
+                })
+            })
+            .collect();
+
+        (topic_data, partition_futures)
+    };
+
+    let mut partitions = Vec::new();
+    for partition_future in partition_futures {
+        partitions.push(partition_future.await);
+    }
+    partitions.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let topic_details = TopicDetails {
+        id: topic_data.0,
+        created_at: topic_data.1,
+        name: topic_data.2,
+        size: topic_data.3,
+        messages_count: topic_data.4,
+        partitions_count: topic_data.5,
+        partitions,
+        message_expiry: topic_data.6,
+        compression_algorithm: topic_data.7,
+        max_topic_size: topic_data.8,
+        replication_factor: topic_data.9,
+    };
+
+    let response = Json(topic_details);
+
+    {
+        let entry_command = EntryCommand::CreateTopic(CreateTopicWithId {
+            topic_id: topic_data.0,
+            command,
+        });
+        let future = SendWrapper::new(
+            state
+                .shard
+                .shard()
+                .state
+                .apply(identity.user_id, &entry_command),
+        );
+        future.await
+    }
+    .with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to apply create topic, stream ID: {stream_id}",
+        )
+    })?;
+
     Ok(response)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_update_topic", fields(iggy_user_id = identity.user_id, iggy_stream_id = stream_id, iggy_topic_id = topic_id))]
 async fn update_topic(
     State(state): State<Arc<AppState>>,
@@ -159,40 +317,59 @@ async fn update_topic(
     command.topic_id = Identifier::from_str_value(&topic_id)?;
     command.validate()?;
 
-    let mut system = state.system.write().await;
-    let topic = system
-            .update_topic(
-                &Session::stateless(identity.user_id, identity.ip_address),
-                &command.stream_id,
-                &command.topic_id,
-                &command.name,
-                command.message_expiry,
-                command.compression_algorithm,
-                command.max_topic_size,
-                command.replication_factor,
-            )
-            .await
-            .with_error_context(|error| {
-                format!(
-                    "{COMPONENT} (error: {error}) - failed to update topic, stream ID: {stream_id}, topic ID: {topic_id}"
-                )
-            })?;
-    command.message_expiry = topic.message_expiry;
-    command.max_topic_size = topic.max_topic_size;
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(identity.user_id, &EntryCommand::UpdateTopic(command))
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to apply update topic, stream ID: {stream_id}, topic ID: {topic_id}"
-            )
+    {
+        let future = SendWrapper::new(state.shard.shard().update_topic(
+            &session,
+            &command.stream_id,
+            &command.topic_id,
+            &command.name,
+            command.message_expiry,
+            command.compression_algorithm,
+            command.max_topic_size,
+            command.replication_factor,
+        ));
+        future.await
+    }.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to update topic, stream ID: {stream_id}, topic ID: {topic_id}"
+        )
+    })?;
+
+    let (message_expiry, max_topic_size) = {
+        let stream = state
+            .shard
+            .shard()
+            .get_stream(&command.stream_id)
+            .with_error_context(|error| {
+                format!("{COMPONENT} (error: {error}) - failed to get stream with ID: {stream_id}")
+            })?;
+        let topic = state.shard.shard().find_topic(&session, &stream, &command.topic_id).with_error_context(|error| {
+            format!("{COMPONENT} (error: {error}) - failed to get topic with ID: {topic_id} in stream with ID: {stream_id}")
         })?;
+
+        (topic.message_expiry, topic.max_topic_size)
+    };
+
+    command.message_expiry = message_expiry;
+    command.max_topic_size = max_topic_size;
+
+    {
+        let entry_command = EntryCommand::UpdateTopic(command);
+        let future = SendWrapper::new(state.shard.shard().state
+            .apply(identity.user_id, &entry_command));
+        future.await
+    }.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to apply update topic, stream ID: {stream_id}, topic ID: {topic_id}"
+        )
+    })?;
+
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_delete_topic", fields(iggy_user_id = identity.user_id, iggy_stream_id = stream_id, iggy_topic_id = topic_id))]
 async fn delete_topic(
     State(state): State<Arc<AppState>>,
@@ -202,39 +379,42 @@ async fn delete_topic(
     let identifier_stream_id = Identifier::from_str_value(&stream_id)?;
     let identifier_topic_id = Identifier::from_str_value(&topic_id)?;
 
-    let mut system = state.system.write().await;
-    system
-            .delete_topic(
-                &Session::stateless(identity.user_id, identity.ip_address),
-                &identifier_stream_id,
-                &identifier_topic_id,
-            )
-            .await
-            .with_error_context(|error| {
-                format!(
-                    "{COMPONENT} (error: {error}) - failed to delete topic with ID: {topic_id} in stream with ID: {stream_id}",
-                )
-            })?;
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::DeleteTopic(DeleteTopic {
-                stream_id: identifier_stream_id,
-                topic_id: identifier_topic_id,
-            }),
+    {
+        let future = SendWrapper::new(state.shard.shard().delete_topic(
+            &session,
+            &identifier_stream_id,
+            &identifier_topic_id,
+        ));
+        future.await
+    }.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to delete topic with ID: {topic_id} in stream with ID: {stream_id}",
         )
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to apply delete topic, stream ID: {stream_id}, topic ID: {topic_id}"
-            )
-        })?;
+    })?;
+
+    {
+        let entry_command = EntryCommand::DeleteTopic(DeleteTopic {
+            stream_id: identifier_stream_id,
+            topic_id: identifier_topic_id,
+        });
+        let future = SendWrapper::new(state.shard.shard().state
+            .apply(
+                identity.user_id,
+                &entry_command,
+            ));
+        future.await
+    }.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to apply delete topic, stream ID: {stream_id}, topic ID: {topic_id}"
+        )
+    })?;
+
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_purge_topic", fields(iggy_user_id = identity.user_id, iggy_stream_id = stream_id, iggy_topic_id = topic_id))]
 async fn purge_topic(
     State(state): State<Arc<AppState>>,
@@ -243,33 +423,38 @@ async fn purge_topic(
 ) -> Result<StatusCode, CustomError> {
     let identifier_stream_id = Identifier::from_str_value(&stream_id)?;
     let identifier_topic_id = Identifier::from_str_value(&topic_id)?;
-    let system = state.system.read().await;
-    system
-        .purge_topic(
-            &Session::stateless(identity.user_id, identity.ip_address),
+
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
+
+    {
+        let future = SendWrapper::new(state.shard.shard().purge_topic(
+            &session,
             &identifier_stream_id,
             &identifier_topic_id,
+        ));
+        future.await
+    }.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to purge topic, stream ID: {stream_id}, topic ID: {topic_id}"
         )
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to purge topic, stream ID: {stream_id}, topic ID: {topic_id}"
-            )
-        })?;
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::PurgeTopic(PurgeTopic {
-                stream_id: identifier_stream_id,
-                topic_id: identifier_topic_id,
-            }),
+    })?;
+
+    {
+        let entry_command = EntryCommand::PurgeTopic(PurgeTopic {
+            stream_id: identifier_stream_id,
+            topic_id: identifier_topic_id,
+        });
+        let future = SendWrapper::new(state.shard.shard().state
+            .apply(
+                identity.user_id,
+                &entry_command,
+            ));
+        future.await
+    }.with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to apply purge topic, stream ID: {stream_id}, topic ID: {topic_id}"
         )
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to apply purge topic, stream ID: {stream_id}, topic ID: {topic_id}"
-            )
-        })?;
+    })?;
+
     Ok(StatusCode::NO_CONTENT)
 }

--- a/core/server/src/http/users.rs
+++ b/core/server/src/http/users.rs
@@ -25,6 +25,7 @@ use crate::http::shared::AppState;
 use crate::state::command::EntryCommand;
 use crate::state::models::CreateUserWithId;
 use crate::streaming::session::Session;
+use crate::streaming::users::user::User;
 use crate::streaming::utils::crypto;
 use ::iggy_common::change_password::ChangePassword;
 use ::iggy_common::create_user::CreateUser;
@@ -35,12 +36,13 @@ use ::iggy_common::update_user::UpdateUser;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::{delete, get, post, put};
-use axum::{Extension, Json, Router};
+use axum::{Extension, Json, Router, debug_handler};
 use error_set::ErrContext;
 use iggy_common::Identifier;
 use iggy_common::IdentityInfo;
 use iggy_common::Validatable;
 use iggy_common::{UserInfo, UserInfoDetails};
+use send_wrapper::SendWrapper;
 use serde::Deserialize;
 use std::sync::Arc;
 use tracing::instrument;
@@ -60,14 +62,14 @@ pub fn router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+#[debug_handler]
 async fn get_user(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
     Path(user_id): Path<String>,
 ) -> Result<Json<UserInfoDetails>, CustomError> {
     let identifier_user_id = Identifier::from_str_value(&user_id)?;
-    let system = state.system.read().await;
-    let Ok(user) = system.find_user(
+    let Ok(user) = state.shard.shard().find_user(
         &Session::stateless(identity.user_id, identity.ip_address),
         &identifier_user_id,
     ) else {
@@ -77,28 +79,34 @@ async fn get_user(
         return Err(CustomError::ResourceNotFound);
     };
 
-    let user = mapper::map_user(user);
+    let user = mapper::map_user(&user);
     Ok(Json(user))
 }
 
+#[debug_handler]
 async fn get_users(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Json<Vec<UserInfo>>, CustomError> {
-    let system = state.system.read().await;
-    let users = system
-        .get_users(&Session::stateless(identity.user_id, identity.ip_address))
-        .await
-        .with_error_context(|error| {
-            format!(
-                "{COMPONENT} (error: {error}) - failed to get users, user ID: {}",
-                identity.user_id
-            )
-        })?;
-    let users = mapper::map_users(&users);
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
+
+    let users = {
+        let future = SendWrapper::new(state.shard.shard().get_users(&session));
+        future.await
+    }
+    .with_error_context(|error| {
+        format!(
+            "{COMPONENT} (error: {error}) - failed to get users, user ID: {}",
+            identity.user_id
+        )
+    })?;
+
+    let user_refs: Vec<&User> = users.iter().collect();
+    let users = mapper::map_users(&user_refs);
     Ok(Json(users))
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_create_user", fields(iggy_user_id = identity.user_id))]
 async fn create_user(
     State(state): State<Arc<AppState>>,
@@ -107,52 +115,58 @@ async fn create_user(
 ) -> Result<Json<UserInfoDetails>, CustomError> {
     command.validate()?;
 
-    let mut system = state.system.write().await;
-    let user = system
+    let session = SendWrapper::new(Session::stateless(identity.user_id, identity.ip_address));
+
+    let user = state
+        .shard
+        .shard()
         .create_user(
-            &Session::stateless(identity.user_id, identity.ip_address),
+            &session,
             &command.username,
             &command.password,
             command.status,
             command.permissions.clone(),
         )
-        .await
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to create user, username: {}",
                 command.username
             )
         })?;
-    let user_id = user.id;
-    let response = Json(mapper::map_user(user));
 
-    // For the security of the system, we hash the password before storing it in metadata.
-    let system = system.downgrade();
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::CreateUser(CreateUserWithId {
-                user_id,
-                command: CreateUser {
-                    username: command.username.to_owned(),
-                    password: crypto::hash_password(&command.password),
-                    status: command.status,
-                    permissions: command.permissions.clone(),
-                },
-            }),
-        )
-        .await
-        .with_error_context(|error| {
+    let user_id = user.id;
+    let response = Json(mapper::map_user(&user));
+
+    {
+        let username = command.username.clone();
+        let entry_command = EntryCommand::CreateUser(CreateUserWithId {
+            user_id: user_id,
+            command: CreateUser {
+                username: command.username.to_owned(),
+                password: crypto::hash_password(&command.password),
+                status: command.status,
+                permissions: command.permissions.clone(),
+            },
+        });
+        let future = SendWrapper::new(
+            state
+                .shard
+                .shard()
+                .state
+                .apply(identity.user_id, &entry_command),
+        );
+        future.await.with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to apply create user, username: {}",
-                command.username
+                username
             )
         })?;
+    }
 
     Ok(response)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_update_user", fields(iggy_user_id = identity.user_id, iggy_updated_user_id = user_id))]
 async fn update_user(
     State(state): State<Arc<AppState>>,
@@ -163,32 +177,43 @@ async fn update_user(
     command.user_id = Identifier::from_str_value(&user_id)?;
     command.validate()?;
 
-    let mut system = state.system.write().await;
-    system
+    let session = Session::stateless(identity.user_id, identity.ip_address);
+
+    state
+        .shard
+        .shard()
         .update_user(
-            &Session::stateless(identity.user_id, identity.ip_address),
+            &session,
             &command.user_id,
             command.username.clone(),
             command.status,
         )
-        .await
         .with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to update user, user ID: {user_id}")
         })?;
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(identity.user_id, &EntryCommand::UpdateUser(command))
-        .await
-        .with_error_context(|error| {
+    {
+        let username = command.username.clone();
+        let entry_command = EntryCommand::UpdateUser(command);
+        let future = SendWrapper::new(
+            state
+                .shard
+                .shard()
+                .state
+                .apply(identity.user_id, &entry_command),
+        );
+        future.await.with_error_context(|error| {
             format!(
-                "{COMPONENT} (error: {error}) - failed to apply update user, user ID: {user_id}"
+                "{COMPONENT} (error: {error}) - failed to apply update user, username: {}",
+                username.unwrap()
             )
         })?;
+    }
+
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_update_permissions", fields(iggy_user_id = identity.user_id, iggy_updated_user_id = user_id))]
 async fn update_permissions(
     State(state): State<Arc<AppState>>,
@@ -199,33 +224,37 @@ async fn update_permissions(
     command.user_id = Identifier::from_str_value(&user_id)?;
     command.validate()?;
 
-    let mut system = state.system.write().await;
-    system
-        .update_permissions(
-            &Session::stateless(identity.user_id, identity.ip_address),
-            &command.user_id,
-            command.permissions.clone(),
-        )
-        .await
+    let session = Session::stateless(identity.user_id, identity.ip_address);
+    state
+        .shard
+        .shard()
+        .update_permissions(&session, &command.user_id, command.permissions.clone())
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to update permissions, user ID: {user_id}"
             )
         })?;
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(identity.user_id, &EntryCommand::UpdatePermissions(command))
-        .await
-        .with_error_context(|error| {
+    {
+        let entry_command = EntryCommand::UpdatePermissions(command);
+        let future = SendWrapper::new(
+            state
+                .shard
+                .shard()
+                .state
+                .apply(identity.user_id, &entry_command),
+        );
+        future.await.with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to apply update permissions, user ID: {user_id}"
             )
         })?;
+    }
+
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_change_password", fields(iggy_user_id = identity.user_id, iggy_updated_user_id = user_id))]
 async fn change_password(
     State(state): State<Arc<AppState>>,
@@ -236,40 +265,40 @@ async fn change_password(
     command.user_id = Identifier::from_str_value(&user_id)?;
     command.validate()?;
 
-    let mut system = state.system.write().await;
-    system
+    let session = Session::stateless(identity.user_id, identity.ip_address);
+    state
+        .shard
+        .shard()
         .change_password(
-            &Session::stateless(identity.user_id, identity.ip_address),
+            &session,
             &command.user_id,
             &command.current_password,
             &command.new_password,
         )
-        .await
         .with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to change password, user ID: {user_id}")
         })?;
 
-    // For the security of the system, we hash the password before storing it in metadata.
-    let system = system.downgrade();
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::ChangePassword(ChangePassword {
-                user_id: command.user_id,
-                current_password: "".into(),
-                new_password: crypto::hash_password(&command.new_password),
-            }),
-        )
-        .await
-        .with_error_context(|error| {
+    {
+        let entry_command = EntryCommand::ChangePassword(command);
+        let future = SendWrapper::new(
+            state
+                .shard
+                .shard()
+                .state
+                .apply(identity.user_id, &entry_command),
+        );
+        future.await.with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to apply change password, user ID: {user_id}"
             )
         })?;
+    }
+
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_delete_user", fields(iggy_user_id = identity.user_id, iggy_deleted_user_id = user_id))]
 async fn delete_user(
     State(state): State<Arc<AppState>>,
@@ -278,43 +307,45 @@ async fn delete_user(
 ) -> Result<StatusCode, CustomError> {
     let identifier_user_id = Identifier::from_str_value(&user_id)?;
 
-    let mut system = state.system.write().await;
-    system
-        .delete_user(
-            &Session::stateless(identity.user_id, identity.ip_address),
-            &identifier_user_id,
-        )
-        .await
+    let session = Session::stateless(identity.user_id, identity.ip_address);
+    state
+        .shard
+        .shard()
+        .delete_user(&session, &identifier_user_id)
         .with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to delete user with ID: {user_id}")
         })?;
 
-    let system = system.downgrade();
-    system
-        .state
-        .apply(
-            identity.user_id,
-            &EntryCommand::DeleteUser(DeleteUser {
-                user_id: identifier_user_id,
-            }),
-        )
-        .await
-        .with_error_context(|error| {
+    {
+        let entry_command = EntryCommand::DeleteUser(DeleteUser {
+            user_id: identifier_user_id,
+        });
+        let future = SendWrapper::new(
+            state
+                .shard
+                .shard()
+                .state
+                .apply(identity.user_id, &entry_command),
+        );
+        future.await.with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to apply delete user with ID: {user_id}")
         })?;
+    }
+
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_login_user")]
 async fn login_user(
     State(state): State<Arc<AppState>>,
     Json(command): Json<LoginUser>,
 ) -> Result<Json<IdentityInfo>, CustomError> {
     command.validate()?;
-    let system = state.system.read().await;
-    let user = system
+    let user = state
+        .shard
+        .shard()
         .login_user(&command.username, &command.password, None)
-        .await
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to login, username: {}",
@@ -325,45 +356,56 @@ async fn login_user(
     Ok(Json(map_generated_access_token_to_identity_info(tokens)))
 }
 
+#[debug_handler]
 #[instrument(skip_all, name = "trace_logout_user", fields(iggy_user_id = identity.user_id))]
 async fn logout_user(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<StatusCode, CustomError> {
-    let system = state.system.read().await;
-    system
-        .logout_user(&Session::stateless(identity.user_id, identity.ip_address))
-        .await
+    let session = Session::stateless(identity.user_id, identity.ip_address);
+    state
+        .shard
+        .shard()
+        .logout_user(&session)
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to logout, user ID: {}",
                 identity.user_id
             )
         })?;
-    state
-        .jwt_manager
-        .revoke_token(&identity.token_id, identity.token_expiry)
-        .await
-        .with_error_context(|error| {
+
+    {
+        let revoke_token_future = SendWrapper::new(
+            state
+                .jwt_manager
+                .revoke_token(&identity.token_id, identity.token_expiry),
+        );
+
+        revoke_token_future.await.with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - failed to revoke token, user ID: {}",
                 identity.user_id
             )
         })?;
+    }
+
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[debug_handler]
 async fn refresh_token(
     State(state): State<Arc<AppState>>,
     Json(command): Json<RefreshToken>,
 ) -> Result<Json<IdentityInfo>, CustomError> {
-    let token = state
-        .jwt_manager
-        .refresh_token(&command.token)
-        .await
-        .with_error_context(|error| {
+    let token = {
+        let refresh_token_future =
+            SendWrapper::new(state.jwt_manager.refresh_token(&command.token));
+
+        refresh_token_future.await.with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to refresh token")
-        })?;
+        })?
+    };
+
     Ok(Json(map_generated_access_token_to_identity_info(token)))
 }
 

--- a/core/server/src/shard/mod.rs
+++ b/core/server/src/shard/mod.rs
@@ -166,6 +166,9 @@ pub struct IggyShard {
     pub(crate) tcp_bound_address: Cell<Option<SocketAddr>>,
 }
 
+// unsafe impl Send for IggyShard {}
+// unsafe impl Sync     for IggyShard {}
+
 impl IggyShard {
     pub fn builder() -> IggyShardBuilder {
         Default::default()

--- a/core/server/src/shard/system/partitions.rs
+++ b/core/server/src/shard/system/partitions.rs
@@ -18,7 +18,6 @@
 
 use super::COMPONENT;
 use crate::shard::IggyShard;
-use crate::shard::transmission::event::ShardEvent;
 use crate::streaming::session::Session;
 use error_set::ErrContext;
 use iggy_common::Identifier;
@@ -73,58 +72,6 @@ impl IggyShard {
             })?;
             partition_ids
         };
-
-        {
-            let event = ShardEvent::CreatedPartitions {
-                stream_id: stream_id.clone(),
-                topic_id: topic_id.clone(),
-                partitions_count: partition_ids.len() as u32,
-            };
-            let _responses = self.broadcast_event_to_all_shards(event.into()).await;
-
-            let stream = self.get_stream(stream_id).with_error_context(|error| {
-                format!("{COMPONENT} (error: {error}) - failed to get stream with ID: {stream_id}")
-            })?;
-            let topic = stream.get_topic(topic_id).with_error_context(|error| {
-            format!("{COMPONENT} (error: {error}) - failed to get topic with ID: {topic_id} in stream with ID: {stream_id}")
-        })?;
-            let numeric_stream_id = stream.stream_id;
-            let numeric_topic_id = topic.topic_id;
-
-            let records = self
-                .create_shard_table_records(&partition_ids, numeric_stream_id, numeric_topic_id)
-                .collect::<Vec<_>>();
-
-            for (ns, shard_info) in records.iter() {
-                let partition = topic.get_partition(ns.partition_id).with_error_context(|error| {
-                format!("{COMPONENT} (error: {error}) - failed to get partition with ID: {} in topic with ID: {topic_id}", ns.partition_id)
-            })?;
-                let mut partition = partition.write().await;
-                partition.persist().await.with_error_context(|error| {
-                    format!(
-                        "{COMPONENT} (error: {error}) - failed to persist partition with ID: {}",
-                        ns.partition_id
-                    )
-                })?;
-                if shard_info.id() == self.id {
-                    let partition_id = ns.partition_id;
-                    partition.open().await.with_error_context(|error| {
-                    format!(
-                        "{COMPONENT} (error: {error}) - failed to open partition with ID: {partition_id} in topic with ID: {topic_id} for stream with ID: {stream_id}"
-                    )
-                })?;
-                }
-            }
-
-            self.insert_shard_table_records(records);
-
-            let event = ShardEvent::CreatedShardTableRecords {
-                stream_id: numeric_stream_id,
-                topic_id: numeric_topic_id,
-                partition_ids: partition_ids.clone(),
-            };
-            let _responses = self.broadcast_event_to_all_shards(event.into()).await;
-        }
 
         let mut stream = self.get_stream_mut(stream_id).with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to get stream with ID: {stream_id}")

--- a/core/server/src/shard/system/partitions.rs
+++ b/core/server/src/shard/system/partitions.rs
@@ -18,6 +18,7 @@
 
 use super::COMPONENT;
 use crate::shard::IggyShard;
+use crate::shard::transmission::event::ShardEvent;
 use crate::streaming::session::Session;
 use error_set::ErrContext;
 use iggy_common::Identifier;
@@ -72,6 +73,58 @@ impl IggyShard {
             })?;
             partition_ids
         };
+
+        {
+            let event = ShardEvent::CreatedPartitions {
+                stream_id: stream_id.clone(),
+                topic_id: topic_id.clone(),
+                partitions_count: partition_ids.len() as u32,
+            };
+            let _responses = self.broadcast_event_to_all_shards(event.into()).await;
+
+            let stream = self.get_stream(stream_id).with_error_context(|error| {
+                format!("{COMPONENT} (error: {error}) - failed to get stream with ID: {stream_id}")
+            })?;
+            let topic = stream.get_topic(topic_id).with_error_context(|error| {
+            format!("{COMPONENT} (error: {error}) - failed to get topic with ID: {topic_id} in stream with ID: {stream_id}")
+        })?;
+            let numeric_stream_id = stream.stream_id;
+            let numeric_topic_id = topic.topic_id;
+
+            let records = self
+                .create_shard_table_records(&partition_ids, numeric_stream_id, numeric_topic_id)
+                .collect::<Vec<_>>();
+
+            for (ns, shard_info) in records.iter() {
+                let partition = topic.get_partition(ns.partition_id).with_error_context(|error| {
+                format!("{COMPONENT} (error: {error}) - failed to get partition with ID: {} in topic with ID: {topic_id}", ns.partition_id)
+            })?;
+                let mut partition = partition.write().await;
+                partition.persist().await.with_error_context(|error| {
+                    format!(
+                        "{COMPONENT} (error: {error}) - failed to persist partition with ID: {}",
+                        ns.partition_id
+                    )
+                })?;
+                if shard_info.id() == self.id {
+                    let partition_id = ns.partition_id;
+                    partition.open().await.with_error_context(|error| {
+                    format!(
+                        "{COMPONENT} (error: {error}) - failed to open partition with ID: {partition_id} in topic with ID: {topic_id} for stream with ID: {stream_id}"
+                    )
+                })?;
+                }
+            }
+
+            self.insert_shard_table_records(records);
+
+            let event = ShardEvent::CreatedShardTableRecords {
+                stream_id: numeric_stream_id,
+                topic_id: numeric_topic_id,
+                partition_ids: partition_ids.clone(),
+            };
+            let _responses = self.broadcast_event_to_all_shards(event.into()).await;
+        }
 
         let mut stream = self.get_stream_mut(stream_id).with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to get stream with ID: {stream_id}")

--- a/core/server/src/shard/system/streams.rs
+++ b/core/server/src/shard/system/streams.rs
@@ -19,6 +19,7 @@
 use super::COMPONENT;
 use crate::shard::IggyShard;
 use crate::shard::namespace::IggyNamespace;
+use crate::shard::transmission::event::ShardEvent;
 use crate::streaming::partitions::partition;
 use crate::streaming::session::Session;
 use crate::streaming::streams::stream::Stream;
@@ -223,6 +224,13 @@ impl IggyShard {
         let id = stream.stream_id;
 
         stream.persist().await?;
+
+        let event = ShardEvent::CreatedStream {
+            stream_id: stream_id,
+            name: name.to_string(),
+        };
+        let _responses = self.broadcast_event_to_all_shards(event.into()).await;
+
         self.streams_ids.borrow_mut().insert(name.to_owned(), id);
         self.streams.borrow_mut().insert(id, stream);
         self.metrics.increment_streams(1);

--- a/core/server/src/shard/system/streams.rs
+++ b/core/server/src/shard/system/streams.rs
@@ -19,7 +19,6 @@
 use super::COMPONENT;
 use crate::shard::IggyShard;
 use crate::shard::namespace::IggyNamespace;
-use crate::shard::transmission::event::ShardEvent;
 use crate::streaming::partitions::partition;
 use crate::streaming::session::Session;
 use crate::streaming::streams::stream::Stream;
@@ -224,12 +223,6 @@ impl IggyShard {
         let id = stream.stream_id;
 
         stream.persist().await?;
-
-        let event = ShardEvent::CreatedStream {
-            stream_id: stream_id,
-            name: name.to_string(),
-        };
-        let _responses = self.broadcast_event_to_all_shards(event.into()).await;
 
         self.streams_ids.borrow_mut().insert(name.to_owned(), id);
         self.streams.borrow_mut().insert(id, stream);

--- a/core/server/src/shard/system/topics.rs
+++ b/core/server/src/shard/system/topics.rs
@@ -178,58 +178,11 @@ impl IggyShard {
         let topic = stream
                 .get_topic(&topic_id)
                 .with_error_context(|error| {
-                    format!("{COMPONENT} (error: {error}) - failed to get topic with ID: {topic_id} in stream with ID: {stream_id}")
+                    format!("{COMPONENT} (error: {error}) - failed to get topic with ID: {topic_id} in stream with ID: {numeric_stream_id}")
                 })?;
         topic.persist().await.with_error_context(|error| {
             format!("{COMPONENT} (error: {error}) - failed to persist topic: {topic}")
         })?;
-
-        let event = ShardEvent::CreatedTopic {
-            stream_id: stream_id.clone(),
-            topic_id: topic_id.clone(),
-            name: name.to_string(),
-            partitions_count,
-            message_expiry,
-            compression_algorithm,
-            max_topic_size,
-            replication_factor: Some(replication_factor.unwrap_or(1)),
-        };
-        let _responses = self.broadcast_event_to_all_shards(event.into()).await;
-
-        let numeric_topic_id = topic.topic_id;
-        let records = self
-            .create_shard_table_records(&partition_ids, numeric_stream_id, numeric_topic_id)
-            .collect::<Vec<_>>();
-
-        for (ns, shard_info) in records.iter() {
-            let partition = topic.get_partition(ns.partition_id).with_error_context(|error| {
-                format!("{COMPONENT} (error: {error}) - failed to get partition with ID: {} in topic with ID: {topic_id}", ns.partition_id)
-            })?;
-
-            let mut partition = partition.write().await;
-            partition.persist().await.with_error_context(|error| {
-                format!("{COMPONENT} (error: {error}) - failed to persist partition: {partition}")
-            })?;
-
-            if shard_info.id() == self.id {
-                let partition_id = ns.partition_id;
-                partition.open().await.with_error_context(|error| {
-                    format!(
-                        "{COMPONENT} (error: {error}) - failed to open partition with ID: {partition_id} in topic with ID: {topic_id} for stream with ID: {stream_id}"
-                    )
-                })?;
-            }
-        }
-
-        self.insert_shard_table_records(records);
-
-        let event = ShardEvent::CreatedShardTableRecords {
-            stream_id: numeric_stream_id,
-            topic_id: numeric_topic_id,
-            partition_ids: partition_ids.clone(),
-        };
-
-        let _responses = self.broadcast_event_to_all_shards(event.into()).await;
 
         self.metrics.increment_topics(1);
         self.metrics.increment_partitions(partitions_count);

--- a/core/server/src/shard/system/users.rs
+++ b/core/server/src/shard/system/users.rs
@@ -203,7 +203,14 @@ impl IggyShard {
         }
 
         let user_id = USER_ID.fetch_add(1, Ordering::SeqCst);
-        let user = User::new(user_id, username, password, status, permissions.clone());
+        let current_user_id = USER_ID.load(Ordering::SeqCst);
+        let user = User::new(
+            current_user_id,
+            username,
+            password,
+            status,
+            permissions.clone(),
+        );
         self.permissioner
             .borrow_mut()
             .init_permissions_for_user(user_id, permissions);

--- a/core/server/src/streaming/clients/client_manager.rs
+++ b/core/server/src/streaming/clients/client_manager.rs
@@ -22,7 +22,6 @@ use ahash::AHashMap;
 use iggy_common::IggyError;
 use iggy_common::IggyTimestamp;
 use iggy_common::UserId;
-use iggy_common::locking::IggyRwLockFn;
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
 use std::rc::Rc;
@@ -130,11 +129,12 @@ impl ClientManager {
     }
 
     pub fn delete_client(&mut self, client_id: u32) -> Option<Client> {
-        let client = self.clients.remove(&client_id);
-        if let Some(client) = client.as_ref() {
+        if let Some(mut client) = self.clients.remove(&client_id) {
             client.session.clear_user_id();
+            Some(client)
+        } else {
+            None
         }
-        client
     }
 
     pub fn join_consumer_group(

--- a/core/server/src/tcp/tcp_socket.rs
+++ b/core/server/src/tcp/tcp_socket.rs
@@ -58,7 +58,7 @@ pub fn build(ipv6: bool, config: &TcpSocketConfig) -> Socket {
             .set_keepalive(config.keepalive)
             .expect("Unable to set SO_KEEPALIVE on socket");
         socket
-            .set_nodelay(config.nodelay)
+            .set_tcp_nodelay(config.nodelay)
             .expect("Unable to set TCP_NODELAY on socket");
         socket
             .set_linger(Some(config.linger.get_duration()))
@@ -92,7 +92,7 @@ mod tests {
         assert!(socket.recv_buffer_size().unwrap() >= buffer_size as usize);
         assert!(socket.send_buffer_size().unwrap() >= buffer_size as usize);
         assert!(socket.keepalive().unwrap());
-        assert!(socket.nodelay().unwrap());
+        assert!(socket.tcp_nodelay().unwrap());
         assert_eq!(socket.linger().unwrap(), Some(linger_dur));
     }
 }


### PR DESCRIPTION
Fixes the broken HTTP server by migrating from tokio to compio-based implementation and restricting execution to shard 0 only.

Key Changes:

- Migrate HTTP server to use `compio` and `cyper-axum`.
 - Restrict HTTP server to run only on shard 0 to prevent resource duplication across shards
- Introduce `HttpSafeShard` type which wraps over IggyShard to make it `Send + Sync` in http server context.
- Update all HTTP handlers to use `SendWrapper` due to axum interface requiring `Send`. 
- Simplify `Session` by removing atomic operations.
- Update dependencies to use fork versions of compio and cyper libraries to solve panic issue.
- Fix user_id to current one instead of returned previous value by `fetch_add`. This is probably not correct. But works for now.
- Fix partitions, streams, topics create methods such that changes are broadcasted to all shards



Fixes #1937