### PR TITLE
fix(python): fix proper typing for complex enums

### DIFF
--- a/foreign/python/Cargo.toml
+++ b/foreign/python/Cargo.toml
@@ -15,7 +15,7 @@ pyo3-async-runtimes = { version = "0.25.0", features = [
     "attributes",
     "tokio-runtime",
 ] }
-pyo3-stub-gen = "0.9.1"
+pyo3-stub-gen = "0.11.1"
 tokio = "1.40.0"
 
 [lib]

--- a/foreign/python/Cargo.toml
+++ b/foreign/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-py"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Dario Lencina Talarico <darioalessandrolencina@gmail.com>", "Albin Skott <albin@mattsson.io>"]
 license = "Apache-2.0"

--- a/foreign/python/Cargo.toml
+++ b/foreign/python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iggy-py"
 version = "0.4.0"
 edition = "2021"
-authors = ["Dario Lencina Talarico <darioalessandrolencina@gmail.com>"]
+authors = ["Dario Lencina Talarico <darioalessandrolencina@gmail.com>", "Albin Skott <albin@mattsson.io>"]
 license = "Apache-2.0"
 description = "Apache Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 documentation = "https://iggy.apache.org/docs/"

--- a/foreign/python/iggy_py.pyi
+++ b/foreign/python/iggy_py.pyi
@@ -23,7 +23,159 @@ import builtins
 import collections.abc
 import datetime
 import typing
-from enum import Enum
+
+class AutoCommit:
+    r"""
+    The auto-commit configuration for storing the offset on the server.
+    """
+    class Disabled(AutoCommit):
+        r"""
+        The auto-commit is disabled and the offset must be stored manually by the consumer.
+        """
+        __match_args__ = ((),)
+        def __new__(cls) -> AutoCommit.Disabled: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class Interval(AutoCommit):
+        r"""
+        The auto-commit is enabled and the offset is stored on the server after a certain interval.
+        """
+        __match_args__ = ("_0",)
+        @property
+        def _0(self) -> datetime.timedelta: ...
+        def __new__(cls, _0:datetime.timedelta) -> AutoCommit.Interval: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class IntervalOrWhen(AutoCommit):
+        r"""
+        The auto-commit is enabled and the offset is stored on the server after a certain interval or depending on the mode when consuming the messages.
+        """
+        __match_args__ = ("_0", "_1",)
+        @property
+        def _0(self) -> datetime.timedelta: ...
+        @property
+        def _1(self) -> AutoCommitWhen: ...
+        def __new__(cls, _0:datetime.timedelta, _1:AutoCommitWhen) -> AutoCommit.IntervalOrWhen: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class IntervalOrAfter(AutoCommit):
+        r"""
+        The auto-commit is enabled and the offset is stored on the server after a certain interval or depending on the mode after consuming the messages.
+        """
+        __match_args__ = ("_0", "_1",)
+        @property
+        def _0(self) -> datetime.timedelta: ...
+        @property
+        def _1(self) -> AutoCommitAfter: ...
+        def __new__(cls, _0:datetime.timedelta, _1:AutoCommitAfter) -> AutoCommit.IntervalOrAfter: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class When(AutoCommit):
+        r"""
+        The auto-commit is enabled and the offset is stored on the server depending on the mode when consuming the messages.
+        """
+        __match_args__ = ("_0",)
+        @property
+        def _0(self) -> AutoCommitWhen: ...
+        def __new__(cls, _0:AutoCommitWhen) -> AutoCommit.When: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class After(AutoCommit):
+        r"""
+        The auto-commit is enabled and the offset is stored on the server depending on the mode after consuming the messages.
+        """
+        __match_args__ = ("_0",)
+        @property
+        def _0(self) -> AutoCommitAfter: ...
+        def __new__(cls, _0:AutoCommitAfter) -> AutoCommit.After: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    ...
+
+class AutoCommitAfter:
+    r"""
+    The auto-commit mode for storing the offset on the server **after** receiving the messages.
+    """
+    class ConsumingAllMessages(AutoCommitAfter):
+        r"""
+        The offset is stored on the server after all the messages are consumed.
+        """
+        __match_args__ = ((),)
+        def __new__(cls) -> AutoCommitAfter.ConsumingAllMessages: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class ConsumingEachMessage(AutoCommitAfter):
+        r"""
+        The offset is stored on the server after consuming each message.
+        """
+        __match_args__ = ((),)
+        def __new__(cls) -> AutoCommitAfter.ConsumingEachMessage: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class ConsumingEveryNthMessage(AutoCommitAfter):
+        r"""
+        The offset is stored on the server after consuming every Nth message.
+        """
+        __match_args__ = ("_0",)
+        @property
+        def _0(self) -> builtins.int: ...
+        def __new__(cls, _0:builtins.int) -> AutoCommitAfter.ConsumingEveryNthMessage: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    ...
+
+class AutoCommitWhen:
+    r"""
+    The auto-commit mode for storing the offset on the server.
+    """
+    class PollingMessages(AutoCommitWhen):
+        r"""
+        The offset is stored on the server when the messages are received.
+        """
+        __match_args__ = ((),)
+        def __new__(cls) -> AutoCommitWhen.PollingMessages: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class ConsumingAllMessages(AutoCommitWhen):
+        r"""
+        The offset is stored on the server when all the messages are consumed.
+        """
+        __match_args__ = ((),)
+        def __new__(cls) -> AutoCommitWhen.ConsumingAllMessages: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class ConsumingEachMessage(AutoCommitWhen):
+        r"""
+        The offset is stored on the server when consuming each message.
+        """
+        __match_args__ = ((),)
+        def __new__(cls) -> AutoCommitWhen.ConsumingEachMessage: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    class ConsumingEveryNthMessage(AutoCommitWhen):
+        r"""
+        The offset is stored on the server when consuming every Nth message.
+        """
+        __match_args__ = ("_0",)
+        @property
+        def _0(self) -> builtins.int: ...
+        def __new__(cls, _0:builtins.int) -> AutoCommitWhen.ConsumingEveryNthMessage: ...
+        def __len__(self) -> builtins.int: ...
+        def __getitem__(self, key:builtins.int) -> typing.Any: ...
+    
+    ...
 
 class IggyClient:
     r"""
@@ -153,6 +305,33 @@ class IggyConsumer:
         Returns an awaitable that completes when shutdown is signaled or a PyRuntimeError on failure.
         """
 
+class PollingStrategy:
+    class Offset(PollingStrategy):
+        __match_args__ = ("value",)
+        @property
+        def value(self) -> builtins.int: ...
+        def __new__(cls, value:builtins.int) -> PollingStrategy.Offset: ...
+    
+    class Timestamp(PollingStrategy):
+        __match_args__ = ("value",)
+        @property
+        def value(self) -> builtins.int: ...
+        def __new__(cls, value:builtins.int) -> PollingStrategy.Timestamp: ...
+    
+    class First(PollingStrategy):
+        __match_args__ = ((),)
+        def __new__(cls) -> PollingStrategy.First: ...
+    
+    class Last(PollingStrategy):
+        __match_args__ = ((),)
+        def __new__(cls) -> PollingStrategy.Last: ...
+    
+    class Next(PollingStrategy):
+        __match_args__ = ((),)
+        def __new__(cls) -> PollingStrategy.Next: ...
+    
+    ...
+
 class ReceiveMessage:
     r"""
     A Python class representing a received message.
@@ -212,88 +391,22 @@ class SendMessage:
         """
 
 class StreamDetails:
-    id: builtins.int
-    name: builtins.str
-    messages_count: builtins.int
-    topics_count: builtins.int
+    @property
+    def id(self) -> builtins.int: ...
+    @property
+    def name(self) -> builtins.str: ...
+    @property
+    def messages_count(self) -> builtins.int: ...
+    @property
+    def topics_count(self) -> builtins.int: ...
 
 class TopicDetails:
-    id: builtins.int
-    name: builtins.str
-    messages_count: builtins.int
-    partitions_count: builtins.int
-
-class AutoCommit(Enum):
-    r"""
-    The auto-commit configuration for storing the offset on the server.
-    """
-    Disabled = ...
-    r"""
-    The auto-commit is disabled and the offset must be stored manually by the consumer.
-    """
-    Interval = ...
-    r"""
-    The auto-commit is enabled and the offset is stored on the server after a certain interval.
-    """
-    IntervalOrWhen = ...
-    r"""
-    The auto-commit is enabled and the offset is stored on the server after a certain interval or depending on the mode when consuming the messages.
-    """
-    IntervalOrAfter = ...
-    r"""
-    The auto-commit is enabled and the offset is stored on the server after a certain interval or depending on the mode after consuming the messages.
-    """
-    When = ...
-    r"""
-    The auto-commit is enabled and the offset is stored on the server depending on the mode when consuming the messages.
-    """
-    After = ...
-    r"""
-    The auto-commit is enabled and the offset is stored on the server depending on the mode after consuming the messages.
-    """
-
-class AutoCommitAfter(Enum):
-    r"""
-    The auto-commit mode for storing the offset on the server **after** receiving the messages.
-    """
-    ConsumingAllMessages = ...
-    r"""
-    The offset is stored on the server after all the messages are consumed.
-    """
-    ConsumingEachMessage = ...
-    r"""
-    The offset is stored on the server after consuming each message.
-    """
-    ConsumingEveryNthMessage = ...
-    r"""
-    The offset is stored on the server after consuming every Nth message.
-    """
-
-class AutoCommitWhen(Enum):
-    r"""
-    The auto-commit mode for storing the offset on the server.
-    """
-    PollingMessages = ...
-    r"""
-    The offset is stored on the server when the messages are received.
-    """
-    ConsumingAllMessages = ...
-    r"""
-    The offset is stored on the server when all the messages are consumed.
-    """
-    ConsumingEachMessage = ...
-    r"""
-    The offset is stored on the server when consuming each message.
-    """
-    ConsumingEveryNthMessage = ...
-    r"""
-    The offset is stored on the server when consuming every Nth message.
-    """
-
-class PollingStrategy(Enum):
-    Offset = ...
-    Timestamp = ...
-    First = ...
-    Last = ...
-    Next = ...
+    @property
+    def id(self) -> builtins.int: ...
+    @property
+    def name(self) -> builtins.str: ...
+    @property
+    def messages_count(self) -> builtins.int: ...
+    @property
+    def partitions_count(self) -> builtins.int: ...
 

--- a/foreign/python/pyproject.toml
+++ b/foreign/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "iggy_py"
 requires-python = ">=3.7"
-version = "0.4.0"
+version = "0.5.0"
 description = "Apache Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/foreign/python/pyproject.toml
+++ b/foreign/python/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [
     { name = "Dario Lencina Talarico", email = "darioalessandrolencina@gmail.com" },
+    { name = "Albin Skott", email = "albin@mattsson.io" },
 ]
 keywords = ["streaming", "messaging", "pubsub", "iggy", "rust", "performance"]
 classifiers = [

--- a/foreign/python/src/consumer.rs
+++ b/foreign/python/src/consumer.rs
@@ -31,7 +31,7 @@ use pyo3::types::{PyDelta, PyDeltaAccess, PyFunction};
 use pyo3::{prelude::*, type_object};
 use pyo3_async_runtimes::tokio::{future_into_py, get_runtime, into_future, scope};
 use pyo3_async_runtimes::TaskLocals;
-use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum, gen_stub_pymethods};
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_complex_enum, gen_stub_pymethods};
 use pyo3_stub_gen::PyStubType;
 use tokio::sync::oneshot::Sender;
 use tokio::sync::Mutex;
@@ -313,7 +313,7 @@ impl PyStubType for PyAsyncioEvent {
 
 /// The auto-commit configuration for storing the offset on the server.
 // #[derive(Debug, PartialEq, Copy, Clone)]
-#[gen_stub_pyclass_enum]
+#[gen_stub_pyclass_complex_enum]
 #[pyclass]
 pub enum AutoCommit {
     /// The auto-commit is disabled and the offset must be stored manually by the consumer.
@@ -354,7 +354,7 @@ impl Into<RustAutoCommit> for &AutoCommit {
 
 /// The auto-commit mode for storing the offset on the server.
 #[derive(Debug, PartialEq, Copy, Clone)]
-#[gen_stub_pyclass_enum]
+#[gen_stub_pyclass_complex_enum]
 #[pyclass]
 pub enum AutoCommitWhen {
     /// The offset is stored on the server when the messages are received.
@@ -382,7 +382,7 @@ impl Into<RustAutoCommitWhen> for &AutoCommitWhen {
 
 /// The auto-commit mode for storing the offset on the server **after** receiving the messages.
 #[derive(Debug, PartialEq, Copy, Clone)]
-#[gen_stub_pyclass_enum]
+#[gen_stub_pyclass_complex_enum]
 #[pyclass]
 pub enum AutoCommitAfter {
     /// The offset is stored on the server after all the messages are consumed.

--- a/foreign/python/src/receive_message.rs
+++ b/foreign/python/src/receive_message.rs
@@ -19,7 +19,7 @@
 use iggy::prelude::{IggyMessage as RustReceiveMessage, PollingStrategy as RustPollingStrategy};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum, gen_stub_pymethods};
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_complex_enum, gen_stub_pymethods};
 
 /// A Python class representing a received message.
 ///
@@ -86,7 +86,7 @@ impl ReceiveMessage {
 }
 
 #[derive(Clone, Copy)]
-#[gen_stub_pyclass_enum]
+#[gen_stub_pyclass_complex_enum]
 #[pyclass]
 pub enum PollingStrategy {
     Offset { value: u64 },

--- a/foreign/python/tests/test_iggy_sdk.py
+++ b/foreign/python/tests/test_iggy_sdk.py
@@ -25,7 +25,6 @@ Tests are marked as either 'unit' or 'integration' based on their requirements.
 import asyncio
 from datetime import timedelta
 import uuid
-from typing import List
 
 import pytest
 


### PR DESCRIPTION
This updates `pyo3-stub-gen` and uses the new `gen_stub_pyclass_complex_enum` to generate proper typing stubs for complex enums, now the entire test file type checks! (Still some `Any` where we want proper types but that has to wait for my upstream PR).

I've also taken the liberty to add myself to the authors lists of the Python SDK and the version has been bumped to prepare for the upcoming release.