### PR TITLE
fix(server): convert message header view to concrete type before serialization

### DIFF
--- a/core/server/src/streaming/systems/messages.rs
+++ b/core/server/src/streaming/systems/messages.rs
@@ -205,9 +205,9 @@ impl System {
         let mut position = 0;
 
         for message in batch.iter() {
-            let header = message.header();
-            let payload_length = header.payload_length();
-            let user_headers_length = header.user_headers_length();
+            let header = message.header().to_header();
+            let payload_length = header.payload_length;
+            let user_headers_length = header.user_headers_length;
             let payload_bytes = message.payload();
             let user_headers_bytes = message.user_headers();
 
@@ -221,7 +221,9 @@ impl System {
                         encrypted_messages.extend_from_slice(user_headers_bytes);
                     }
                     indexes.insert(0, position as u32, 0);
-                    position += IGGY_MESSAGE_HEADER_SIZE + payload_length + user_headers_length;
+                    position += IGGY_MESSAGE_HEADER_SIZE
+                        + payload_length as usize
+                        + user_headers_length as usize;
                 }
                 Err(error) => {
                     error!("Cannot encrypt the message. Error: {}", error);


### PR DESCRIPTION
`IggyMessageHeaderView` is a zero-copy read-only view that intentionally
panics on to_bytes(). Use `to_header()`` to convert to `IggyMessageHeader`
for serialization in encrypt_messages.
