### PR TITLE
fix(ci): fix the incorrect regex in ci-publish-go.yml

### DIFF
--- a/.github/workflows/ci-publish-go.yml
+++ b/.github/workflows/ci-publish-go.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Validate tag format
         run: |
-          if [[ ! "$TAG" =~ ^foreign/go/v([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})(-[0-9A-Za-z\-\.]+)?$ ]]; then
+          if [[ ! "$TAG" =~ ^foreign/go/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "Tag $TAG does not match required format: foreign/go/vX.Y.Z"
             exit 1
           fi


### PR DESCRIPTION
fix the incorrect regex in ci-publish-go.yml.

This is a script to test the pattern.
```shell
# bash

declare -a tests=(
  "foreign/go/v0.1.3-tt.1"
  "foreign/go/v1.23.456-alpha.1"
  "foreign/go/v2.0.0"
  "foreign/go/v12.34.56-rc-2.3"
  "foreign/go/v123.456.789-beta"
  "foreign/go/v1.2.3-alpha.beta-rc"
  "foreign/go/v1.2"
  "foreign/go/v1.2.3_"
  "foreign/go/v1.2.3-alpha_beta"
  "foreign/go/v1.2.3-rc+build"
)

for TAG in "${tests[@]}"; do
  if [[ "$TAG" =~ ^foreign/go/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(-[0-9A-Za-z.-]+)?$ ]]; then
    echo "✅ Valid:   $TAG"
  else
    echo "❌ Invalid: $TAG"
  fi
done
```