### PR TITLE
feat(python_sdk): create client from connection string

### DIFF
--- a/foreign/python/apache_iggy.pyi
+++ b/foreign/python/apache_iggy.pyi
@@ -190,6 +190,13 @@ class IggyClient:
         This initializes a new runtime for asynchronous operations.
         Future versions might utilize asyncio for more Pythonic async.
         """
+    @classmethod
+    def from_connection_string(cls, connection_string:builtins.str) -> IggyClient:
+        r"""
+        Constructs a new IggyClient from a connection string.
+        
+        Returns an error if the connection string provided is invalid.
+        """
     def ping(self) -> collections.abc.Awaitable[None]:
         r"""
         Sends a ping request to the server to check connectivity.

--- a/foreign/python/tests/conftest.py
+++ b/foreign/python/tests/conftest.py
@@ -24,92 +24,10 @@ and connecting to Iggy servers in various configurations.
 
 import asyncio
 import os
-import socket
-import time
-
+from .utils import get_server_config, wait_for_ping, wait_for_server
 import pytest
 
 from apache_iggy import IggyClient
-
-
-def get_server_config() -> tuple[str, int]:
-    """
-    Get server configuration from environment variables or defaults.
-
-    Returns:
-        tuple: (host, port) for the Iggy server
-    """
-    host = os.environ.get("IGGY_SERVER_HOST", "127.0.0.1")
-    port = int(os.environ.get("IGGY_SERVER_TCP_PORT", "8090"))
-
-    # Convert hostname to IP address for the Rust client
-    if host not in ("127.0.0.1", "localhost"):
-        try:
-            # Resolve hostname to IP address
-            host_ip = socket.gethostbyname(host)
-            host = host_ip
-        except socket.gaierror:
-            # If resolution fails, keep the original host
-            pass
-    elif host == "localhost":
-        host = "127.0.0.1"
-
-    return host, port
-
-
-def wait_for_server(host: str, port: int, timeout: int = 60, interval: int = 2) -> None:
-    """
-    Wait for the server to become available.
-
-    Args:
-        host: Server hostname or IP
-        port: Server port
-        timeout: Maximum time to wait in seconds
-        interval: Time between connection attempts in seconds
-
-    Raises:
-        TimeoutError: If server doesn't become available within timeout
-    """
-    start_time = time.time()
-
-    while True:
-        try:
-            with socket.create_connection((host, port), timeout=interval):
-                return
-        except (socket.timeout, ConnectionRefusedError, OSError):
-            elapsed_time = time.time() - start_time
-            if elapsed_time >= timeout:
-                raise TimeoutError(
-                    f"Server not available at {host}:{port} after {timeout}s"
-                )
-            time.sleep(interval)
-
-
-async def wait_for_ping(client: IggyClient, timeout: int = 30, interval: int = 2) -> None:
-    """
-    Wait for the server to respond to ping requests.
-
-    Args:
-        client: Iggy client instance
-        timeout: Maximum time to wait in seconds
-        interval: Time between ping attempts in seconds
-
-    Raises:
-        TimeoutError: If server doesn't respond to ping within timeout
-    """
-    start_time = time.time()
-
-    while True:
-        try:
-            await client.ping()
-            return
-        except Exception:
-            elapsed_time = time.time() - start_time
-            if elapsed_time >= timeout:
-                raise TimeoutError(
-                    f"Server not responding to ping after {timeout}s"
-                )
-            await asyncio.sleep(interval)
 
 
 @pytest.fixture(scope="session")

--- a/foreign/python/tests/test_iggy_sdk.py
+++ b/foreign/python/tests/test_iggy_sdk.py
@@ -28,6 +28,8 @@ import uuid
 
 import pytest
 
+from .utils import get_server_config, wait_for_ping, wait_for_server
+
 from apache_iggy import IggyClient, PollingStrategy, AutoCommit
 from apache_iggy import SendMessage as Message
 
@@ -44,6 +46,18 @@ class TestConnectivity:
     async def test_client_not_none(self, iggy_client: IggyClient):
         """Test that client fixture is properly initialized."""
         assert iggy_client is not None
+
+    @pytest.mark.asyncio
+    async def test_client_from_connection_string(self):
+        """Test that client can be created and set up with a connection string."""
+        host, port = get_server_config()
+        wait_for_server(host, port)
+
+        client = IggyClient.from_connection_string(
+            f"iggy+tcp://iggy:iggy@{host}:{port}"
+        )
+        await client.connect()
+        await wait_for_ping(client)
 
 
 class TestStreamOperations:

--- a/foreign/python/tests/utils.py
+++ b/foreign/python/tests/utils.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Utility functions for tests.
+"""
+
+import asyncio
+import os
+import socket
+import time
+
+from apache_iggy import IggyClient
+
+
+def get_server_config() -> tuple[str, int]:
+    """
+    Get server configuration from environment variables or defaults.
+
+    Returns:
+        tuple: (host, port) for the Iggy server
+    """
+    host = os.environ.get("IGGY_SERVER_HOST", "127.0.0.1")
+    port = int(os.environ.get("IGGY_SERVER_TCP_PORT", "8090"))
+
+    # Convert hostname to IP address for the Rust client
+    if host not in ("127.0.0.1", "localhost"):
+        try:
+            # Resolve hostname to IP address
+            host_ip = socket.gethostbyname(host)
+            host = host_ip
+        except socket.gaierror:
+            # If resolution fails, keep the original host
+            pass
+    elif host == "localhost":
+        host = "127.0.0.1"
+
+    return host, port
+
+
+def wait_for_server(host: str, port: int, timeout: int = 60, interval: int = 2) -> None:
+    """
+    Wait for the server to become available.
+
+    Args:
+        host: Server hostname or IP
+        port: Server port
+        timeout: Maximum time to wait in seconds
+        interval: Time between connection attempts in seconds
+
+    Raises:
+        TimeoutError: If server doesn't become available within timeout
+    """
+    start_time = time.time()
+
+    while True:
+        try:
+            with socket.create_connection((host, port), timeout=interval):
+                return
+        except (socket.timeout, ConnectionRefusedError, OSError):
+            elapsed_time = time.time() - start_time
+            if elapsed_time >= timeout:
+                raise TimeoutError(
+                    f"Server not available at {host}:{port} after {timeout}s"
+                )
+            time.sleep(interval)
+
+
+async def wait_for_ping(
+    client: IggyClient, timeout: int = 30, interval: int = 2
+) -> None:
+    """
+    Wait for the server to respond to ping requests.
+
+    Args:
+        client: Iggy client instance
+        timeout: Maximum time to wait in seconds
+        interval: Time between ping attempts in seconds
+
+    Raises:
+        TimeoutError: If server doesn't respond to ping within timeout
+    """
+    start_time = time.time()
+
+    while True:
+        try:
+            await client.ping()
+            return
+        except Exception:
+            elapsed_time = time.time() - start_time
+            if elapsed_time >= timeout:
+                raise TimeoutError(f"Server not responding to ping after {timeout}s")
+            await asyncio.sleep(interval)


### PR DESCRIPTION
### Description

Added one method `IggyClient.from_connection_string` to the python SDK. This method allows users to basically connect to iggy running with different configurations. The existing constructor only allows connections to TCP servers.

This is the simplest way of allowing users to build clients with flexibility. I thought about generating bindings for rust config types in `iggy_common`, which is what should be done eventually, but that is very tedious and messy and really needs a better plan. Allowing users to create clients from connection strings basically achieves the same goal with minimal code changes.

Also moved some test helper functions around to use them in the new test.

### Testing

Added one unit test.