### PR TITLE
chore: update Dockerfiles to build iggy-server on alpine

### DIFF
--- a/.github/changed-files-config.json
+++ b/.github/changed-files-config.json
@@ -1,5 +1,7 @@
 {
   "rust": [
+    "Dockerfile",
+    "Dockerfile.debug",
     "core/(bench|cli|examples|integration|sdk|server|tools|connectors|ai).*\\.rs",
     "bdd/rust/.*\\.rs",
     "core/Cargo.toml",
@@ -9,12 +11,16 @@
     ".github/workflows/ci-check-pr.yml"
   ],
   "shell": [
+    "Dockerfile",
+    "Dockerfile.debug",
     ".github/scripts/.*\\.sh",
     "scripts/.*\\.sh",
     ".github/workflows/ci-.*-shell.yml",
     ".github/workflows/ci-check-pr.yml"
   ],
   "rust-prod": [
+    "Dockerfile",
+    "Dockerfile.debug",
     "core/(bench|cli|examples|integration|sdk|server|tools|connectors|ai).*\\.rs",
     "bdd/rust/.*\\.rs",
     "core/Cargo.toml",
@@ -24,6 +30,8 @@
     ".github/workflows/ci-prod-rust.yml"
   ],
   "go-sdk": [
+    "Dockerfile",
+    "Dockerfile.debug",
     "foreign/go/.*\\.go",
     "foreign/go/go.mod",
     "foreign/go/go.sum",
@@ -36,12 +44,16 @@
     ".github/workflows/ci-check-go-sdk.yml"
   ],
   "java-sdk": [
+    "Dockerfile",
+    "Dockerfile.debug",
     "foreign/java/.*\\.java",
     "foreign/java/.*\\.kts",
     "foreign/java/.*\\.sh",
     ".github/workflows/ci-check-java-sdk.yml"
   ],
   "python-sdk": [
+    "Dockerfile",
+    "Dockerfile.debug",
     "foreign/python/.*\\.py",
     "foreign/python/.*\\.rs",
     "bdd/python/.*\\.py",
@@ -55,17 +67,23 @@
     ".github/workflows/ci-check-python-sdk.yml"
   ],
   "node-sdk": [
+    "Dockerfile",
+    "Dockerfile.debug",
     "foreign/node/.*\\.ts",
     "foreign/node/.*\\.js",
     "foreign/node/.*\\.json",
     ".github/workflows/ci-check-node-sdk.yml"
   ],
   "csharp-sdk": [
+    "Dockerfile",
+    "Dockerfile.debug",
     "foreign/csharp/.*\\.cs",
     "foreign/csharp/.*\\.csproj",
     ".github/workflows/ci-check-csharp-sdk.yml"
   ],
   "bdd": [
+    "Dockerfile",
+    "Dockerfile.debug",
     "bdd/.*\\.feature",
     "bdd/.*\\.py",
     "bdd/.*\\.rs",

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.89 AS builder
+FROM rust:1.89.0-alpine3.22 AS builder
+RUN apk add musl-dev
 WORKDIR /build
 COPY . /build
 RUN cargo build --bin iggy --release

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -16,7 +16,8 @@
 # under the License.
 
 # Debug/test build for faster compilation during development and testing
-FROM rust:1.89 AS builder
+FROM rust:1.89.0-alpine3.22 AS builder
+RUN apk add musl-dev
 WORKDIR /build
 COPY . /build
 # Build in debug mode for faster compilation times during testing

--- a/bdd/Dockerfile
+++ b/bdd/Dockerfile
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.89 AS builder
+FROM rust:1.89.0-alpine3.22 AS builder
+RUN apk add musl-dev
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
After the most recent push to `rust:1.89` tests fail when trying to run iggy-server in docker compose with a missing glibc issue. This changes to use a alpine image instead so we get a musl build.
