### PR TITLE
fix(ci): auto-create directories in copy-latest-from-master.sh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,11 @@ on:
         type: boolean
         required: false
         default: true
+      skip_tag_creation:
+        description: "Skip creating git tags (useful for re-publishing or testing)"
+        type: boolean
+        required: false
+        default: false
       commit:
         description: "Commit SHA to publish from"
         type: string
@@ -48,11 +53,6 @@ on:
         type: string
         required: false
         default: ""
-      skip_tag_creation:
-        description: "Skip creating git tags (useful for re-publishing or testing)"
-        type: boolean
-        required: false
-        default: false
 
 env:
   IGGY_CI_BUILD: true

--- a/scripts/copy-latest-from-master.sh
+++ b/scripts/copy-latest-from-master.sh
@@ -110,10 +110,10 @@ case "$COMMAND" in
             rel_path="${saved_file#$TMP_SAVED/}"
             dest_dir=$(dirname "$rel_path")
 
-            # Check if destination directory exists
+            # Create destination directory if it doesn't exist
             if [ "$dest_dir" != "." ] && [ ! -d "$dest_dir" ]; then
-                echo "  ℹ️  Skipping $rel_path - destination directory '$dest_dir' does not exist"
-                continue
+                echo "  📁 Creating directory: $dest_dir"
+                mkdir -p "$dest_dir"
             fi
 
             # Copy the file


### PR DESCRIPTION
Replace directory existence check with automatic creation using
`mkdir -p` to ensure all files are copied even when destination
directories don't exist.
