### PR TITLE
fix(ci): use `1.89` as default Rust version instead of `unknown`

### DIFF
--- a/.github/actions/utils/docker-buildx/action.yml
+++ b/.github/actions/utils/docker-buildx/action.yml
@@ -220,8 +220,8 @@ runs:
           echo "RUST_VERSION=$ver" >> "$GITHUB_ENV"
           echo "Using toolchain: $ver"
         else
-          echo "RUST_VERSION=unknown" >> "$GITHUB_ENV"
-          echo "No rust-toolchain.toml found; labeling as unknown"
+          echo "RUST_VERSION=1.89" >> "$GITHUB_ENV"
+          echo "No rust-toolchain.toml found; labeling as 1.89"
         fi
 
     - name: Compose build args


### PR DESCRIPTION
Only if `rust-toolchain.toml` is not present.