### PR TITLE
fix(ci): use `manylinux: auto` for python publish step

### DIFF
--- a/.github/workflows/_build_python_wheels.yml
+++ b/.github/workflows/_build_python_wheels.yml
@@ -83,7 +83,7 @@ jobs:
               yum install -y perl-IPC-Cmd
             fi
             python3 -m pip --version || python3 -m ensurepip
-          manylinux: "2_28"
+          manylinux: "auto"
           args: --release --out dist --interpreter python3.8 python3.9 python3.10 python3.11 python3.12 python3.13
           sccache: "true"
 


### PR DESCRIPTION
This will let maturin automatically select the most appropriate
manylinux version, which should have a more modern toolchain that
better supports the ARM64 architecture extensions.
