### PR TITLE
fix(ci): build Python wheels from correct commit instead of master HEAD

### DIFF
--- a/.github/workflows/_build_python_wheels.yml
+++ b/.github/workflows/_build_python_wheels.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: true
         description: "Use latest CI configuration and scripts from master branch"
+      commit:
+        type: string
+        required: false
+        default: ""
+        description: "Specific commit to checkout for building wheels"
     outputs:
       artifact_name:
         description: "Name of the uploaded artifact containing wheels"
@@ -53,6 +58,8 @@ jobs:
           chmod +x /tmp/copy-latest-from-master.sh
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit }}
 
       - name: Save and apply latest CI from master
         if: inputs.use_latest_ci
@@ -109,6 +116,8 @@ jobs:
           chmod +x /tmp/copy-latest-from-master.sh
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit }}
 
       - name: Save and apply latest CI from master
         if: inputs.use_latest_ci
@@ -149,6 +158,8 @@ jobs:
           chmod +x /tmp/copy-latest-from-master.sh
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit }}
 
       - name: Save and apply latest CI from master
         if: inputs.use_latest_ci
@@ -190,6 +201,8 @@ jobs:
           chmod +x /tmp/copy-latest-from-master.sh
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit }}
 
       - name: Save and apply latest CI from master
         if: inputs.use_latest_ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -451,6 +451,7 @@ jobs:
     with:
       upload_artifacts: true
       use_latest_ci: ${{ inputs.use_latest_ci }}
+      commit: ${{ needs.validate.outputs.commit }}
 
   # Sequential Rust crate publishing to handle dependencies properly
   publish-rust-crates:


### PR DESCRIPTION
Python wheel builds were incorrectly using master HEAD instead of the specified release commit when use_latest_ci=true. Added commit parameter to _build_python_wheels.yml workflow to ensure wheels are built from the intended release commit, matching behavior of other SDK builds.