### PR TITLE
fix(server): Output generated root password in info level

### DIFF
--- a/core/server/src/streaming/systems/users.rs
+++ b/core/server/src/streaming/systems/users.rs
@@ -123,7 +123,7 @@ impl System {
             info!("Using the default root user credentials...");
             username = Ok(DEFAULT_ROOT_USERNAME.to_string());
             let generated_password = crypto::generate_secret(20..40);
-            println!("Generated root user password: {generated_password}");
+            info!("Generated root user password: {generated_password}");
             password = Ok(generated_password);
         }
 


### PR DESCRIPTION
## Summary

Fixes [commit 4323c4f450dcbf14ae025bbac06d0a20fcdbe8ed](https://github.com/apache/iggy/commit/4323c4f450dcbf14ae025bbac06d0a20fcdbe8ed), output the generate password for root user in info level, instead of stdout.

## Test
Before the change
```
$ cargo r --bin iggy-server
...
2025-09-28T03:00:09.902914Z  INFO ThreadId(01) trace_system_init: server::streaming::systems::info: System version 0.5.0 is up to date.
2025-09-28T03:00:09.902994Z  INFO ThreadId(01) trace_system_init: server::streaming::systems::users: Loading users...
2025-09-28T03:00:09.903016Z  INFO ThreadId(01) trace_system_init: server::streaming::systems::users: No users found, creating the root user...
2025-09-28T03:00:09.903052Z  INFO ThreadId(01) trace_system_init: server::streaming::systems::users: Using the default root user credentials...
Generated root user password: <generated_password>
```

After the change
```
$ cargo r --bin iggy-server
...
2025-09-28T03:01:26.443629Z  INFO ThreadId(01) trace_system_init: server::streaming::systems::users: No users found, creating the root user...
2025-09-28T03:01:26.443667Z  INFO ThreadId(01) trace_system_init: server::streaming::systems::users: Using the default root user credentials...
2025-09-28T03:01:26.443873Z  INFO ThreadId(01) trace_system_init: server::streaming::systems::users: Generated root user password: egoO2DVtX4VwxiRb2Y5UcCkh
```


