### PR TITLE
fix(connector): fix clippy

### DIFF
--- a/core/connectors/sources/postgres_source/src/lib.rs
+++ b/core/connectors/sources/postgres_source/src/lib.rs
@@ -179,15 +179,15 @@ impl PostgresSource {
             "pg_replicate" => {
                 #[cfg(feature = "cdc_pg_replicate")]
                 {
-                    return Err(Error::InitError(
+                    Err(Error::InitError(
                         "pg_replicate backend not yet implemented".to_string(),
-                    ));
+                    ))
                 }
                 #[cfg(not(feature = "cdc_pg_replicate"))]
                 {
-                    return Err(Error::InitError(
+                    Err(Error::InitError(
                         "cdc_backend 'pg_replicate' requested but feature 'cdc_pg_replicate' is not enabled at build time".to_string(),
-                    ));
+                    ))
                 }
             }
             other => Err(Error::InitError(format!(


### PR DESCRIPTION
### Description

Updated a few lines introduced in #2197 as those failed clippy ([ref](https://github.com/apache/iggy/actions/runs/18272305757/job/52016817185)). clippy was not triggered in that PR because of misconfiguration in `components.yml`. That needs to be patched later on.

### Test

clippy worked in this [CI run](https://github.com/apache/iggy/actions/runs/18293239509/job/52085446530?pr=2237) which includes changes in this PR.