### PR TITLE
fix(server): resolve TODOs and optimize reference usage

### DIFF
--- a/core/server/src/shard/system/consumer_offsets.rs
+++ b/core/server/src/shard/system/consumer_offsets.rs
@@ -193,14 +193,23 @@ impl IggyShard {
         partition_id: usize,
         offset: u64,
     ) {
-        // TODO: This can use `with_partition_by_id` directly.
+        let stream_id_num = self
+            .streams2
+            .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
+        let topic_id_num =
+            self.streams2
+                .with_topic_by_id(stream_id, topic_id, topics::helpers::get_topic_id());
+
         match polling_consumer {
             PollingConsumer::Consumer(id, _) => {
-                self.streams2.with_stream_by_id(
+                self.streams2.with_partition_by_id(
                     stream_id,
-                    streams::helpers::store_consumer_offset(
+                    topic_id,
+                    partition_id,
+                    partitions::helpers::store_consumer_offset(
                         *id,
-                        topic_id,
+                        stream_id_num,
+                        topic_id_num,
                         partition_id,
                         offset,
                         &self.config.system,
@@ -208,11 +217,14 @@ impl IggyShard {
                 );
             }
             PollingConsumer::ConsumerGroup(_, id) => {
-                self.streams2.with_stream_by_id(
+                self.streams2.with_partition_by_id(
                     stream_id,
-                    streams::helpers::store_consumer_group_member_offset(
+                    topic_id,
+                    partition_id,
+                    partitions::helpers::store_consumer_group_member_offset(
                         *id,
-                        topic_id,
+                        stream_id_num,
+                        topic_id_num,
                         partition_id,
                         offset,
                         &self.config.system,

--- a/core/server/src/shard/system/streams.rs
+++ b/core/server/src/shard/system/streams.rs
@@ -178,18 +178,7 @@ impl IggyShard {
             })?;
         }
 
-        //TODO: Tech debt.
-        let topic_ids = self
-            .streams2
-            .with_stream_by_id(stream_id, streams::helpers::get_topic_ids());
-
-        // Purge each topic in the stream using bypass auth
-        for topic_id in topic_ids {
-            let topic_identifier = Identifier::numeric(topic_id as u32).unwrap();
-            self.purge_topic2(session, stream_id, &topic_identifier)
-                .await?;
-        }
-        Ok(())
+        self.purge_stream2_base(stream_id).await
     }
 
     pub async fn purge_stream2_bypass_auth(&self, stream_id: &Identifier) -> Result<(), IggyError> {

--- a/core/server/src/shard/system/users.rs
+++ b/core/server/src/shard/system/users.rs
@@ -515,21 +515,11 @@ impl IggyShard {
     pub fn logout_user(&self, session: &Session) -> Result<(), IggyError> {
         self.ensure_authenticated(session)?;
         let client_id = session.client_id;
-        let user_id = session.get_user_id();
-        self.logout_user_base(user_id, client_id)?;
+        self.logout_user_base(client_id)?;
         Ok(())
     }
 
-    fn logout_user_base(&self, user_id: u32, client_id: u32) -> Result<(), IggyError> {
-        // TODO(hubcio): not sure if user is needed here
-        let _user = self
-            .get_user(&Identifier::numeric(user_id)?)
-            .with_error_context(|error| {
-                format!(
-                    "{COMPONENT} (error: {error}) - failed to get user with id: {}",
-                    user_id,
-                )
-            })?;
+    fn logout_user_base(&self, client_id: u32) -> Result<(), IggyError> {
         if client_id > 0 {
             let mut client_manager = self.client_manager.borrow_mut();
             client_manager.clear_user_id(client_id)?;

--- a/core/server/src/streaming/topics/helpers.rs
+++ b/core/server/src/streaming/topics/helpers.rs
@@ -16,6 +16,7 @@ use crate::{
             },
             topic2::{Topic, TopicRef, TopicRefMut, TopicRoot},
         },
+        utils::hash,
     },
 };
 use iggy_common::{CompressionAlgorithm, Identifier, IggyExpiry, MaxTopicSize};
@@ -49,6 +50,23 @@ pub fn get_message_expiry() -> impl FnOnce(ComponentsById<TopicRef>) -> IggyExpi
 
 pub fn get_max_topic_size() -> impl FnOnce(ComponentsById<TopicRef>) -> MaxTopicSize {
     |(root, _, _)| root.max_topic_size()
+}
+
+pub fn calculate_partition_id_by_messages_key_hash(
+    shard_id: u16,
+    upperbound: usize,
+    messages_key: &[u8],
+) -> usize {
+    let messages_key_hash = hash::calculate_32(messages_key) as usize;
+    let partition_id = messages_key_hash % upperbound;
+    shard_trace!(
+        shard_id,
+        "Calculated partition ID: {} for messages key: {:?}, hash: {}",
+        partition_id,
+        messages_key,
+        messages_key_hash
+    );
+    partition_id
 }
 
 pub fn delete_topic(topic_id: &Identifier) -> impl FnOnce(&Topics) -> Topic {


### PR DESCRIPTION
- Fix consumer_offsets to use with_partition_by_id directly
- Move calculate_partition_id_by_messages_key_hash to topics helpers
- Refactor purge_stream2 to use purge_stream2_base helper
- Remove unnecessary user lookup in logout_user_base
- Replace Arc with references in snapshot functions
- Document snapshot thread pool limitation
