### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/csharp-dotnet/post-merge/action.yml
+++ b/.github/actions/csharp-dotnet/post-merge/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: "10.0.x"
 

--- a/.github/actions/csharp-dotnet/pre-merge/action.yml
+++ b/.github/actions/csharp-dotnet/pre-merge/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: "10.0.x"
 
@@ -109,7 +109,7 @@ runs:
         find foreign/csharp/Iggy_SDK.Tests.Integration/bin -name "*.log" -path "*/container-logs/*" -exec cp {} foreign/csharp/reports/container-logs/ \; || true
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: inputs.task == 'e2e' && always()
       with:
         name: dotnet-test-results

--- a/.github/actions/go/pre-merge/action.yml
+++ b/.github/actions/go/pre-merge/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Lint
       if: inputs.task == 'lint'
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v9
       with:
         version: v2.11.3
         working-directory: foreign/go
@@ -92,7 +92,7 @@ runs:
 
     - name: Lint BDD
       if: inputs.task == 'lint' && hashFiles('bdd/go/go.mod') != ''
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v9
       with:
         version: v2.11.3
         working-directory: bdd/go
@@ -101,7 +101,7 @@ runs:
 
     - name: Lint Examples
       if: inputs.task == 'lint' && hashFiles('examples/go/go.mod') != ''
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v9
       with:
         version: v2.11.3
         working-directory: examples/go

--- a/.github/actions/node-npm/post-merge/action.yml
+++ b/.github/actions/node-npm/post-merge/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "23"
         registry-url: "https://registry.npmjs.org"

--- a/.github/actions/node-npm/pre-merge/action.yml
+++ b/.github/actions/node-npm/pre-merge/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "23"
         registry-url: "https://registry.npmjs.org"

--- a/.github/actions/python-maturin/post-merge/action.yml
+++ b/.github/actions/python-maturin/post-merge/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
 
     - name: Download pre-built wheels
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.wheels_artifact }}
         path: ${{ inputs.wheels_path }}
@@ -153,7 +153,7 @@ runs:
 
     - name: Install uv
       if: inputs.dry_run == 'false'
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
     - name: Publish to PyPI
       if: inputs.dry_run == 'false'

--- a/.github/actions/python-maturin/pre-merge/action.yml
+++ b/.github/actions/python-maturin/pre-merge/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
 
@@ -41,10 +41,10 @@ runs:
         tool: cargo-llvm-cov
 
     - name: Install uv
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
     - name: Cache uv
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('examples/python/uv.lock', 'foreign/python/uv.lock', 'bdd/python/uv.lock') }}
@@ -187,7 +187,7 @@ runs:
 
     - name: Upload test artifacts
       if: always() && inputs.task == 'test'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-test-results-${{ github.run_id }}-${{ github.run_attempt }}
         path: |

--- a/.github/actions/utils/docker-buildx/action.yml
+++ b/.github/actions/utils/docker-buildx/action.yml
@@ -130,12 +130,12 @@ runs:
     - name: Set up QEMU
       # Skip QEMU when building single platform on native runner (no emulation needed)
       if: inputs.platform == ''
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       with:
         platforms: all
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       with:
         driver-opts: |
           network=host
@@ -143,7 +143,7 @@ runs:
 
     - name: Login to Docker Hub
       if: steps.config.outputs.should_push == 'true'
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       with:
         username: ${{ env.DOCKERHUB_USER }}
         password: ${{ env.DOCKERHUB_TOKEN }}
@@ -167,7 +167,7 @@ runs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       with:
         images: ${{ steps.config.outputs.image }}
         # Tags are only used for local builds (dry-run). Push mode always uses digest.
@@ -343,7 +343,7 @@ runs:
     - name: Build and push (by digest)
       id: build-push
       if: steps.config.outputs.should_push == 'true'
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: ${{ steps.ctx.outputs.context }}
         file: ${{ steps.config.outputs.dockerfile }}
@@ -358,7 +358,7 @@ runs:
     - name: Build only (dry-run)
       id: build-only
       if: steps.config.outputs.should_push != 'true'
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: ${{ steps.ctx.outputs.context }}
         file: ${{ steps.config.outputs.dockerfile }}

--- a/.github/actions/utils/setup-cpp-with-cache/action.yml
+++ b/.github/actions/utils/setup-cpp-with-cache/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Bazel with cache
-      uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # v0.18.0
+      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # v0.19.0
       with:
         bazelisk-cache: true
         disk-cache: true

--- a/.github/actions/utils/setup-go-with-cache/action.yml
+++ b/.github/actions/utils/setup-go-with-cache/action.yml
@@ -43,14 +43,14 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go toolchain
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
         cache: ${{ inputs.read-cache == 'true' }}
 
     - name: Setup additional Go module cache
       if: inputs.read-cache == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/go/pkg/mod
@@ -61,7 +61,7 @@ runs:
 
     - name: Setup golangci-lint cache
       if: inputs.read-cache == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/golangci-lint
         key: golangci-lint-${{ runner.os }}-${{ hashFiles('**/go.sum') }}

--- a/.github/actions/utils/setup-java-with-cache/action.yml
+++ b/.github/actions/utils/setup-java-with-cache/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Setup Java (with Gradle cache)
       if: inputs.gradle-cache-disabled != 'true'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
@@ -47,7 +47,7 @@ runs:
 
     - name: Setup Java (no cache)
       if: inputs.gradle-cache-disabled == 'true'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}

--- a/.github/actions/utils/setup-node-with-cache/action.yml
+++ b/.github/actions/utils/setup-node-with-cache/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: "npm"
@@ -49,7 +49,7 @@ runs:
 
     - name: Setup npm cache
       if: inputs.enabled == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.npm
         key: npm-${{ runner.os }}-${{ hashFiles(inputs.cache-dependency-path) }}

--- a/.github/workflows/_build_python_wheels.yml
+++ b/.github/workflows/_build_python_wheels.yml
@@ -69,7 +69,7 @@ jobs:
             -o /tmp/copy-latest-from-master.sh
           chmod +x /tmp/copy-latest-from-master.sh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit }}
 
@@ -80,7 +80,7 @@ jobs:
           /tmp/copy-latest-from-master.sh apply
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload wheels
         if: inputs.upload_artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-${{ matrix.target }}-${{ matrix.manylinux }}
           path: foreign/python/dist
@@ -124,7 +124,7 @@ jobs:
             -o /tmp/copy-latest-from-master.sh
           chmod +x /tmp/copy-latest-from-master.sh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit }}
 
@@ -135,7 +135,7 @@ jobs:
           /tmp/copy-latest-from-master.sh apply
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload wheels
         if: inputs.upload_artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.target }}
           path: foreign/python/dist
@@ -167,7 +167,7 @@ jobs:
             -o /tmp/copy-latest-from-master.sh
           chmod +x /tmp/copy-latest-from-master.sh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit }}
 
@@ -179,7 +179,7 @@ jobs:
           /tmp/copy-latest-from-master.sh apply
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           architecture: x64
@@ -194,7 +194,7 @@ jobs:
 
       - name: Upload wheels
         if: inputs.upload_artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-x64
           path: foreign/python/dist
@@ -210,7 +210,7 @@ jobs:
             -o /tmp/copy-latest-from-master.sh
           chmod +x /tmp/copy-latest-from-master.sh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit }}
 
@@ -229,7 +229,7 @@ jobs:
 
       - name: Upload sdist
         if: inputs.upload_artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: foreign/python/dist
@@ -244,7 +244,7 @@ jobs:
       artifact_name: ${{ steps.output.outputs.artifact_name }}
     steps:
       - name: Download all wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           merge-multiple: true
@@ -276,7 +276,7 @@ jobs:
           echo "**Total wheels built:** $(ls -1 dist/*.whl | wc -l)" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload combined artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-wheels-all
           path: dist

--- a/.github/workflows/_build_rust_artifacts.yml
+++ b/.github/workflows/_build_rust_artifacts.yml
@@ -85,7 +85,7 @@ jobs:
             -o /tmp/copy-latest-from-master.sh
           chmod +x /tmp/copy-latest-from-master.sh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit || github.sha }}
 
@@ -106,7 +106,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -176,7 +176,7 @@ jobs:
 
       - name: Upload artifact
         if: inputs.upload_artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ matrix.target }}
           path: ${{ steps.pkg.outputs.tarball }}
@@ -203,7 +203,7 @@ jobs:
             -o /tmp/copy-latest-from-master.sh
           chmod +x /tmp/copy-latest-from-master.sh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit || github.sha }}
 
@@ -256,7 +256,7 @@ jobs:
 
       - name: Upload artifact
         if: inputs.upload_artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: connector-plugins-${{ matrix.target }}
           path: ${{ steps.pkg.outputs.tarball }}
@@ -271,7 +271,7 @@ jobs:
     outputs:
       artifact_name: ${{ steps.output.outputs.artifact_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit || github.sha }}
 
@@ -282,7 +282,7 @@ jobs:
           echo "server_version=$(scripts/extract-version.sh rust-server)" >> "$GITHUB_OUTPUT"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: "*-unknown-linux-*"
           path: dist
@@ -326,7 +326,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload combined artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-artifacts-all
           path: dist

--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -34,7 +34,7 @@ jobs:
     name: Check Rust versions sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check Rust versions are synchronized
         run: ./scripts/ci/sync-rust-version.sh --check
@@ -43,7 +43,7 @@ jobs:
     name: Check Python SDK versions sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check Python SDK versions are synchronized
         run: ./scripts/ci/python-sdk-version-sync.sh --check
@@ -52,7 +52,7 @@ jobs:
     name: Check version consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup yq
         run: |
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR Title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -138,7 +138,7 @@ jobs:
     name: Check license headers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Go
         uses: ./.github/actions/utils/setup-go-with-cache
@@ -156,7 +156,7 @@ jobs:
     name: Check licenses list
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/utils/setup-rust-with-cache
@@ -172,10 +172,10 @@ jobs:
     name: Markdown lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "23"
 
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install shellcheck
         run: |
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Need full history to get diff
 
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Need full history to get diff
 
@@ -230,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Need full history to get diff
 
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -263,11 +263,11 @@ jobs:
       FORCE_COLOR: 1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check typos
-        uses: crate-ci/typos@v1.41.0
+        uses: crate-ci/typos@v1.45.0
 
   summary:
     name: Common checks summary

--- a/.github/workflows/_detect.yml
+++ b/.github/workflows/_detect.yml
@@ -66,7 +66,7 @@ jobs:
       examples_matrix: ${{ steps.mk.outputs.examples_matrix }}
       other_matrix: ${{ steps.mk.outputs.other_matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build matrices
         id: mk
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const componentsJson = `${{ steps.config.outputs.components }}`;

--- a/.github/workflows/_publish_rust_crates.yml
+++ b/.github/workflows/_publish_rust_crates.yml
@@ -91,7 +91,7 @@ jobs:
           echo "✅ Downloaded latest copy script from master"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # No `|| github.sha` fallback: the `Resolve commit` step below
           # requires an explicit, non-empty `inputs.commit` so the tag step

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Skip noop
         if: inputs.component == 'noop'
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: startsWith(inputs.component, 'rust') && startsWith(inputs.task, 'test-')
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json
@@ -77,7 +77,7 @@ jobs:
       # Python SDK
       - name: Set up Docker Buildx for Python
         if: inputs.component == 'sdk-python' && inputs.task == 'test'
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Run Python SDK task
         if: inputs.component == 'sdk-python'
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload Python coverage to Codecov
         if: inputs.component == 'sdk-python' && inputs.task == 'test'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: reports/python-coverage.lcov
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload Node coverage to Codecov
         if: inputs.component == 'sdk-node' && (inputs.task == 'test' || inputs.task == 'e2e')
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: reports/node-coverage/${{ inputs.task == 'test' && 'unit' || 'e2e' }}/lcov.info
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload Go coverage to Codecov
         if: inputs.component == 'sdk-go' && (inputs.task == 'test' || inputs.task == 'e2e')
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: reports/${{ inputs.task == 'test' && 'go-coverage.out' || 'go-coverage-e2e.out' }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload Java coverage to Codecov
         if: inputs.component == 'sdk-java' && inputs.task == 'test'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: reports/java-coverage/jacocoAggregated.xml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload C# coverage to Codecov
         if: inputs.component == 'sdk-csharp' && (inputs.task == 'test' || inputs.task == 'e2e')
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: foreign/csharp/reports/coverage.cobertura.xml
@@ -233,7 +233,7 @@ jobs:
       # Upload reports
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.component }}-${{ inputs.task }}-reports-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/_test_bdd.yml
+++ b/.github/workflows/_test_bdd.yml
@@ -46,7 +46,7 @@ jobs:
           df -h
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Skip noop
         if: inputs.component == 'noop'
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.component }}-${{ inputs.task }}-reports-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/_test_examples.yml
+++ b/.github/workflows/_test_examples.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Skip noop
         if: inputs.component == 'noop'
@@ -57,17 +57,17 @@ jobs:
 
       - name: Setup Python
         if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Setup uv
         if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-python'
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Cache uv
         if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-python'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('examples/python/uv.lock', 'foreign/python/uv.lock', 'bdd/python/uv.lock') }}
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.component }}-${{ inputs.task }}-reports-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cleanup disk space
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
@@ -88,7 +88,7 @@ jobs:
         shell: bash
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Java with cache
         uses: ./.github/actions/utils/setup-java-with-cache
@@ -131,7 +131,7 @@ jobs:
           log-file: ${{ steps.iggy.outputs.log_file }}
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: foreign/java/build/reports/jacoco/aggregate/jacocoAggregated.xml
@@ -144,10 +144,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -203,7 +203,7 @@ jobs:
           dotnet-coverage merge ./reports/**/*.cobertura.xml -f cobertura -o ./reports/coverage.cobertura.xml
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: foreign/csharp/reports/coverage.cobertura.xml
@@ -216,10 +216,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -234,7 +234,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Install uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Install dependencies
         run: |
@@ -295,7 +295,7 @@ jobs:
         shell: bash
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: reports/python-coverage.lcov
@@ -308,10 +308,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "23"
           cache: "npm"
@@ -359,7 +359,7 @@ jobs:
           log-file: ${{ steps.iggy.outputs.log_file }}
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: reports/node-coverage/unit/lcov.info,reports/node-coverage/e2e/lcov.info
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Go
         uses: ./.github/actions/utils/setup-go-with-cache
@@ -433,7 +433,7 @@ jobs:
           log-file: ${{ steps.iggy.outputs.log_file }}
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: reports/go-coverage.out
@@ -446,7 +446,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust with cache
         uses: ./.github/actions/utils/setup-rust-with-cache

--- a/.github/workflows/edge-release.yml
+++ b/.github/workflows/edge-release.yml
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get server version
         id: meta
@@ -60,7 +60,7 @@ jobs:
           echo "server_version=${server_version}" >> "$GITHUB_OUTPUT"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rust-artifacts-all
           path: ./artifacts
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Create edge pre-release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: edge
           name: edge

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -47,7 +47,7 @@ jobs:
       crates_to_publish: ${{ steps.check.outputs.crates_to_publish }}
       sdks_to_publish: ${{ steps.check.outputs.sdks_to_publish }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -199,7 +199,7 @@ jobs:
     steps:
       - name: Get job execution times
         id: times
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const jobs = await github.rest.actions.listJobsForWorkflowRun({

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,7 +136,7 @@ jobs:
       has_targets: ${{ steps.check.outputs.has_targets }}
       is_workflow_call: ${{ steps.detect.outputs.is_workflow_call }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -260,7 +260,7 @@ jobs:
           chmod +x /tmp/copy-latest-from-master.sh
           echo "✅ Downloaded latest copy script from master"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate.outputs.commit }}
 
@@ -289,7 +289,7 @@ jobs:
 
       - name: Build matrix from inputs
         id: mk
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const componentsB64 = '${{ steps.cfg.outputs.components_b64 }}';
@@ -427,7 +427,7 @@ jobs:
           echo "✅ Downloaded latest copy script from master"
 
       - name: Checkout at commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate.outputs.commit }}
           # check-tags only runs `git ls-remote --tags` against origin,
@@ -727,7 +727,7 @@ jobs:
           echo "✅ Downloaded latest copy script from master"
 
       - name: Checkout at commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate.outputs.commit }}
           fetch-depth: 0
@@ -795,7 +795,7 @@ jobs:
 
       - name: Upload digest
         if: ${{ !inputs.dry_run }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-digest-${{ matrix.key }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -821,7 +821,7 @@ jobs:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate.outputs.commit }}
           # create-git-tag's shallow-safe fallback at action.yml:86-96
@@ -886,22 +886,22 @@ jobs:
           echo "📦 Image: $image"
 
       - name: Download amd64 digest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker-digest-${{ matrix.key }}-amd64
           path: ${{ runner.temp }}/digests
 
       - name: Download arm64 digest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker-digest-${{ matrix.key }}-arm64
           path: ${{ runner.temp }}/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ env.DOCKERHUB_TOKEN }}
@@ -1026,7 +1026,7 @@ jobs:
           echo "✅ Downloaded latest copy script from master"
 
       - name: Checkout at commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate.outputs.commit }}
           # create-git-tag falls back to a shallow fetch when the commit
@@ -1313,7 +1313,7 @@ jobs:
           chmod +x /tmp/copy-latest-from-master.sh
           echo "✅ Downloaded latest copy script from master"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate.outputs.commit }}
 


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to
Node.js 24 on June 2, 2026. Bump all actions to their
latest major versions to eliminate deprecation warnings
and ensure forward compatibility.

SHA-pinned actions use SHAs from the Apache
infrastructure-actions approved_patterns.yml.
