### PR TITLE
fix(go,csharp): remove duplicate consumer groups in DeserializeClient/MapClient

### DIFF
--- a/foreign/csharp/Iggy_SDK/Mappers/BinaryMapper.cs
+++ b/foreign/csharp/Iggy_SDK/Mappers/BinaryMapper.cs
@@ -239,26 +239,22 @@ internal static class BinaryMapper
     internal static ClientResponse MapClient(ReadOnlySpan<byte> payload)
     {
         var (response, position) = MapClientInfo(payload, 0);
-        var consumerGroups = new List<ConsumerGroupInfo>();
-        var length = payload.Length;
+        var consumerGroups = new List<ConsumerGroupInfo>(response.ConsumerGroupsCount);
 
-        while (position < length)
+        for (var i = 0; i < response.ConsumerGroupsCount; i++)
         {
-            for (var i = 0; i < response.ConsumerGroupsCount; i++)
-            {
-                var streamId = BinaryPrimitives.ReadInt32LittleEndian(payload[position..(position + 4)]);
-                var topicId = BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 4)..(position + 8)]);
-                var consumerGroupId = BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 8)..(position + 12)]);
-                var consumerGroup
-                    = new ConsumerGroupInfo
-                    {
-                        StreamId = streamId,
-                        TopicId = topicId,
-                        GroupId = consumerGroupId
-                    };
-                consumerGroups.Add(consumerGroup);
-                position += 12;
-            }
+            var streamId = BinaryPrimitives.ReadInt32LittleEndian(payload[position..(position + 4)]);
+            var topicId = BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 4)..(position + 8)]);
+            var consumerGroupId = BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 8)..(position + 12)]);
+            var consumerGroup
+                = new ConsumerGroupInfo
+                {
+                    StreamId = streamId,
+                    TopicId = topicId,
+                    GroupId = consumerGroupId
+                };
+            consumerGroups.Add(consumerGroup);
+            position += 12;
         }
 
         return new ClientResponse

--- a/foreign/go/binary_serialization/binary_response_deserializer.go
+++ b/foreign/go/binary_serialization/binary_response_deserializer.go
@@ -538,24 +538,22 @@ func MapClientInfo(payload []byte, position int) (iggcon.ClientInfo, int) {
 
 func DeserializeClient(payload []byte) *iggcon.ClientInfoDetails {
 	clientInfo, position := MapClientInfo(payload, 0)
-	consumerGroups := make([]iggcon.ConsumerGroupInfo, clientInfo.ConsumerGroupsCount)
-	length := len(payload)
+	consumerGroups := make([]iggcon.ConsumerGroupInfo, 0, clientInfo.ConsumerGroupsCount)
 
-	for position < length {
-		for i := uint32(0); i < clientInfo.ConsumerGroupsCount; i++ {
-			streamId := binary.LittleEndian.Uint32(payload[position : position+4])
-			topicId := binary.LittleEndian.Uint32(payload[position+4 : position+8])
-			groupId := binary.LittleEndian.Uint32(payload[position+8 : position+12])
+	for i := uint32(0); i < clientInfo.ConsumerGroupsCount; i++ {
+		streamId := binary.LittleEndian.Uint32(payload[position : position+4])
+		topicId := binary.LittleEndian.Uint32(payload[position+4 : position+8])
+		groupId := binary.LittleEndian.Uint32(payload[position+8 : position+12])
 
-			consumerGroup := iggcon.ConsumerGroupInfo{
-				StreamId: streamId,
-				TopicId:  topicId,
-				GroupId:  groupId,
-			}
-			consumerGroups = append(consumerGroups, consumerGroup)
-			position += 12
+		consumerGroup := iggcon.ConsumerGroupInfo{
+			StreamId: streamId,
+			TopicId:  topicId,
+			GroupId:  groupId,
 		}
+		consumerGroups = append(consumerGroups, consumerGroup)
+		position += 12
 	}
+
 	return &iggcon.ClientInfoDetails{
 		ClientInfo:     clientInfo,
 		ConsumerGroups: consumerGroups,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3131

## Rationale

`DeserializeClient` (Go) and `MapClient` (C#) return duplicate/zero-valued consumer groups due to incorrect slice pre-allocation and a redundant outer loop.

## What changed?

In Go, `make([]ConsumerGroupInfo, Count)` pre-allocated `Count` zero-valued entries, then `append` added real data after them—doubling the slice. The outer `for position < length` loop could also re-read groups if trailing bytes existed.

Fixed both SDKs by using `make([], 0, Count)` (Go) / `new List<>(Count)` (C#) for correct capacity-only allocation, and replaced the outer `while`/`for` loop with a single bounded `for i < Count` pass.

## Local Execution

- Passed
- Pre-commit hooks ran

## AI Usage

1. Opus 4.6
2. Minimal AI used
3. Verified via `go build`, `go vet`, `go test`, `dotnet build`, `dotnet test` (100/100 passed), and CI lint scripts
4. Yes, all code can be explained