### PR TITLE
test(server): add QUIC transport coverage to consumer group scenarios

### DIFF
--- a/core/integration/tests/server/cg.rs
+++ b/core/integration/tests/server/cg.rs
@@ -24,10 +24,9 @@ use crate::server::scenarios::{
 use integration::iggy_harness;
 
 // Consumer group scenarios do not support HTTP (stateful operations).
-// TODO: Add QUIC support.
 
 #[iggy_harness(
-    test_client_transport = [Tcp, WebSocket],
+    test_client_transport = [Tcp, WebSocket, Quic],
     server(tcp.socket.override_defaults = true, tcp.socket.nodelay = true)
 )]
 async fn join(harness: &TestHarness) {
@@ -35,7 +34,7 @@ async fn join(harness: &TestHarness) {
 }
 
 #[iggy_harness(
-    test_client_transport = [Tcp, WebSocket],
+    test_client_transport = [Tcp, WebSocket, Quic],
     server(tcp.socket.override_defaults = true, tcp.socket.nodelay = true)
 )]
 async fn single_client(harness: &TestHarness) {
@@ -43,7 +42,7 @@ async fn single_client(harness: &TestHarness) {
 }
 
 #[iggy_harness(
-    test_client_transport = [Tcp, WebSocket],
+    test_client_transport = [Tcp, WebSocket, Quic],
     server(tcp.socket.override_defaults = true, tcp.socket.nodelay = true)
 )]
 async fn multiple_clients(harness: &TestHarness) {
@@ -51,7 +50,7 @@ async fn multiple_clients(harness: &TestHarness) {
 }
 
 #[iggy_harness(
-    test_client_transport = [Tcp, WebSocket],
+    test_client_transport = [Tcp, WebSocket, Quic],
     server(tcp.socket.override_defaults = true, tcp.socket.nodelay = true)
 )]
 async fn auto_commit_reconnection(harness: &TestHarness) {
@@ -59,7 +58,7 @@ async fn auto_commit_reconnection(harness: &TestHarness) {
 }
 
 #[iggy_harness(
-    test_client_transport = [Tcp, WebSocket],
+    test_client_transport = [Tcp, WebSocket, Quic],
     server(tcp.socket.override_defaults = true, tcp.socket.nodelay = true)
 )]
 async fn new_messages_after_restart(harness: &TestHarness) {
@@ -67,7 +66,7 @@ async fn new_messages_after_restart(harness: &TestHarness) {
 }
 
 #[iggy_harness(
-    test_client_transport = [Tcp, WebSocket],
+    test_client_transport = [Tcp, WebSocket, Quic],
     server(tcp.socket.override_defaults = true, tcp.socket.nodelay = true)
 )]
 async fn offset_cleanup(harness: &TestHarness) {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3206 

## Rationale

Closes the TODO at `core/integration/tests/server/cg.rs:27`. QUIC is already
supported by the harness and exercised by `verify_consumer_group_partition_assignment.rs`,
so adding it to these scenarios is a free coverage gain on a production transport.

## What changed?

Consumer group operations (join, multi-client polling, auto-commit
reconnection, message visibility after server restart, offset cleanup)
were only end-to-end verified against the TCP and WebSocket transports.
The QUIC transport had no coverage for these flows, even though QUIC is
a supported production transport and is already exercised elsewhere
(e.g. `verify_consumer_group_partition_assignment.rs`).

The harness now drives each of the six consumer-group scenarios through
a QUIC client in addition to TCP and WebSocket, closing the coverage
gap and catching any QUIC-specific framing, reconnect, or restart
regressions in consumer-group code paths.

## Local Execution

- Pre-commit hooks ran (`prek run` — all applicable hooks passed)
- Test count for `server::cg::*`: 12 → 18 (added 6 QUIC variants), all passing
  - `cargo test -p integration --test mod server::cg::`

## AI Usage

1. **Tool**: Claude (used as a research/explanation assistant via Claude Code)
2. **Scope**: Codebase exploration and guidance only.
3. **Verification**: Ran the full test scope locally and confirmed 18/18 pass.
4. **Yes**, I can explain every line.