### PR TITLE
chore(repo): add ASF incubator status and update readme

### DIFF
--- a/.github/workflows/edge-release.yml
+++ b/.github/workflows/edge-release.yml
@@ -88,6 +88,12 @@ jobs:
 
             **This release is automatically updated on every push to master.**
 
+            > Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+            >
+            > Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+            >
+            > While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
+
             ## Binaries included
             - `iggy-server` - The server binary
             - `iggy` - The command-line interface
@@ -120,4 +126,4 @@ jobs:
             - Server version: ${{ steps.meta.outputs.server_version }}
             - Commit: ${{ github.sha }}
 
-            **Not an official ASF release** - for development/testing only.
+            **Not an official ASF release.** Edge builds are for development/testing only.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 ARG RUST_VERSION=1.95
 
 FROM rust:${RUST_VERSION}-slim-bookworm AS builder

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://benchmarks.iggy.apache.org/assets/iggy-light.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://benchmarks.iggy.apache.org/assets/iggy-dark.svg">
-    <img alt="Apache Iggy" src="https://benchmarks.iggy.apache.org/assets/iggy-dark.svg" width="400">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-darkbg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg">
+    <img alt="Apache Iggy" src="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg" width="400">
   </picture>
 </div>
 

--- a/bdd/Dockerfile
+++ b/bdd/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 FROM rust:1.89.0-alpine3.22 AS builder
 RUN apk add musl-dev
 

--- a/bdd/csharp/Dockerfile
+++ b/bdd/csharp/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 COPY ./foreign/csharp ./foreign/csharp

--- a/bdd/go/Dockerfile
+++ b/bdd/go/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 FROM golang:1.25.0-alpine
 
 RUN apk add --no-cache gcc musl-dev

--- a/bdd/java/Dockerfile
+++ b/bdd/java/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 ARG RUST_VERSION=1.95
 FROM rust:${RUST_VERSION}
 

--- a/bdd/node/Dockerfile
+++ b/bdd/node/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 FROM node:24-slim
 
 COPY ./foreign/node .

--- a/bdd/python/Dockerfile
+++ b/bdd/python/Dockerfile
@@ -15,6 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
 # syntax=docker/dockerfile:1
 ARG RUST_VERSION=1.95
 FROM rust:${RUST_VERSION}-slim-trixie

--- a/bdd/rust/Dockerfile
+++ b/bdd/rust/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 ARG RUST_VERSION=1.95
 FROM rust:${RUST_VERSION}
 

--- a/core/ai/mcp/Dockerfile
+++ b/core/ai/mcp/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 ARG RUST_VERSION=1.95
 ARG ALPINE_VERSION=3.22
 

--- a/core/bench/dashboard/server/Dockerfile
+++ b/core/bench/dashboard/server/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 ARG RUST_VERSION=1.95
 
 # Build stage

--- a/core/binary_protocol/Cargo.toml
+++ b/core/binary_protocol/Cargo.toml
@@ -26,7 +26,7 @@ categories = ["command-line-utilities", "database", "network-programming"]
 homepage = "https://iggy.apache.org"
 documentation = "https://iggy.apache.org/docs"
 repository = "https://github.com/apache/iggy"
-readme = "../../README.md"
+readme = "README.md"
 
 [dependencies]
 aligned-vec = { workspace = true }

--- a/core/binary_protocol/README.md
+++ b/core/binary_protocol/README.md
@@ -6,11 +6,11 @@
   </picture>
 </div>
 
-# Go SDK for Iggy
+# iggy_binary_protocol
 
-Official Go client SDK for [Apache Iggy](https://iggy.apache.org) message streaming.
+[![Crate](https://img.shields.io/crates/v/iggy_binary_protocol?logo=rust&style=flat-square)](https://crates.io/crates/iggy_binary_protocol)
 
-The client currently supports TCP protocols with blocking implementation.
+Wire protocol types and codec for the [Apache Iggy](https://iggy.apache.org) binary protocol, shared between server and SDK. This crate is an internal building block. Most users should depend on the [`iggy`](https://crates.io/crates/iggy) SDK crate instead.
 
 > Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
 >
@@ -18,16 +18,12 @@ The client currently supports TCP protocols with blocking implementation.
 >
 > While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 
-## Installation
+## Links
 
-```bash
-go get github.com/apache/iggy/foreign/go
-```
+- [Project website](https://iggy.apache.org)
+- [GitHub repository](https://github.com/apache/iggy)
+- [Iggy SDK on crates.io](https://crates.io/crates/iggy)
 
-## Contributing
+## License
 
-Before creating a pull request, please run [golangci-lint](https://golangci-lint.run/welcome/quick-start/) and fix any reported lint issues:
-
-```shell
-golangci-lint run
-```
+Licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/apache/iggy/blob/master/LICENSE).

--- a/core/cli/README.md
+++ b/core/cli/README.md
@@ -1,11 +1,39 @@
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-darkbg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg">
+    <img alt="Apache Iggy" src="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg" width="320">
+  </picture>
+</div>
+
 # Apache Iggy CLI
 
-The interactive CLI allows you to interact with the Apache Iggy server from the command line.
+[![Crate](https://img.shields.io/crates/v/iggy-cli?logo=rust&style=flat-square)](https://crates.io/crates/iggy-cli)
 
-This is a great addition to the Web UI, especially for all the developers who prefer using the console tools.
+Interactive CLI for [Apache Iggy](https://iggy.apache.org). Manage streams, topics, partitions, users, consumer groups, and produce/consume messages from your terminal.
 
-Iggy CLI can be installed with `cargo install iggy-cli` and then simply accessed by typing `iggy` in your terminal.
+> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+>
+> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 
-![CLI](../../assets/cli.png)
+## Installation
 
-For more details please visit [Apache Iggy](https://iggy.apache.org) and its [GitHub repository](https://github.com/apache/iggy).
+```bash
+cargo install iggy-cli
+```
+
+Run `iggy --help` for the full command tree.
+
+![CLI](https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/cli.png)
+
+## Links
+
+- [Project website](https://iggy.apache.org)
+- [GitHub repository](https://github.com/apache/iggy)
+- [Iggy SDK on crates.io](https://crates.io/crates/iggy)
+
+## License
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/apache/iggy/blob/master/LICENSE).

--- a/core/common/Cargo.toml
+++ b/core/common/Cargo.toml
@@ -25,7 +25,7 @@ categories = ["command-line-utilities", "database", "network-programming"]
 homepage = "https://iggy.apache.org"
 documentation = "https://iggy.apache.org/docs"
 repository = "https://github.com/apache/iggy"
-readme = "../../README.md"
+readme = "README.md"
 
 [dependencies]
 aes-gcm = { workspace = true }

--- a/core/common/README.md
+++ b/core/common/README.md
@@ -6,11 +6,11 @@
   </picture>
 </div>
 
-# Go SDK for Iggy
+# iggy_common
 
-Official Go client SDK for [Apache Iggy](https://iggy.apache.org) message streaming.
+[![Crate](https://img.shields.io/crates/v/iggy_common?logo=rust&style=flat-square)](https://crates.io/crates/iggy_common)
 
-The client currently supports TCP protocols with blocking implementation.
+Common types and traits shared across the [Apache Iggy](https://iggy.apache.org) ecosystem (server, SDK, CLI, tooling). This crate is an internal building block. Most users should depend on the [`iggy`](https://crates.io/crates/iggy) SDK crate instead.
 
 > Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
 >
@@ -18,16 +18,12 @@ The client currently supports TCP protocols with blocking implementation.
 >
 > While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 
-## Installation
+## Links
 
-```bash
-go get github.com/apache/iggy/foreign/go
-```
+- [Project website](https://iggy.apache.org)
+- [GitHub repository](https://github.com/apache/iggy)
+- [Iggy SDK on crates.io](https://crates.io/crates/iggy)
 
-## Contributing
+## License
 
-Before creating a pull request, please run [golangci-lint](https://golangci-lint.run/welcome/quick-start/) and fix any reported lint issues:
-
-```shell
-golangci-lint run
-```
+Licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/apache/iggy/blob/master/LICENSE).

--- a/core/connectors/runtime/Dockerfile
+++ b/core/connectors/runtime/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 ARG RUST_VERSION=1.95
 ARG ALPINE_VERSION=3.22
 

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -26,7 +26,7 @@ categories = ["command-line-utilities", "database", "network-programming"]
 homepage = "https://iggy.apache.org"
 documentation = "https://iggy.apache.org/docs"
 repository = "https://github.com/apache/iggy"
-readme = "../../README.md"
+readme = "README.md"
 
 [dependencies]
 async-broadcast = { workspace = true }

--- a/core/sdk/README.md
+++ b/core/sdk/README.md
@@ -1,0 +1,154 @@
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-darkbg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg">
+    <img alt="Apache Iggy" src="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg" width="360">
+  </picture>
+</div>
+
+# Apache Iggy Rust SDK
+
+<div align="center">
+
+[Website](https://iggy.apache.org) | [Getting started](https://iggy.apache.org/docs/introduction/getting-started/) | [Documentation](https://iggy.apache.org/docs/) | [Examples](https://github.com/apache/iggy/tree/master/examples/rust) | [Discord](https://discord.gg/apache-iggy)
+
+</div>
+
+<p align="center">
+  <a href="https://crates.io/crates/iggy"><img alt="Crate" src="https://img.shields.io/crates/v/iggy?logo=rust&style=flat-square"></a>
+  <a href="https://iggy.apache.org/docs/sdk/rust/intro/"><img alt="Docs" src="https://img.shields.io/badge/docs-iggy.apache.org-blue?style=flat-square"></a>
+  <a href="https://crates.io/crates/iggy"><img alt="Downloads" src="https://img.shields.io/crates/d/iggy?style=flat-square"></a>
+  <a href="https://github.com/apache/iggy/blob/master/LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square"></a>
+</p>
+
+Official Rust client SDK for [Apache Iggy](https://iggy.apache.org), the persistent message streaming platform written in Rust. The SDK ships a low-level transport client (QUIC, TCP, HTTP, WebSocket) for direct command access and a high-level producer/consumer API with batching, consumer groups, and auto-commit.
+
+> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+>
+> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
+
+## Features
+
+- **Transports**: TCP (custom binary), QUIC, HTTP, WebSocket. One unified `IggyClient` API across all four.
+- **TLS** on every transport, configured via connection string (`?tls=true&tls_ca_file=/path/to/ca.crt`) or builder.
+- **Connection strings** with auto-login on `connect()`: `iggy://` (TCP default), `iggy+tcp://`, `iggy+quic://`, `iggy+http://`, `iggy+ws://`. Reconnection retries and heartbeat interval are configurable as URL options.
+- **Authentication**: username/password and Personal Access Tokens (PAT).
+- **Async, non-blocking** client built on Tokio with custom zero-copy (de)serialization.
+- **High-level builders** on `IggyClient`: `producer(stream, topic)`, `consumer(name, stream, topic, partition)`, and `consumer_group(name, stream, topic)`.
+- **Producer modes**: `direct` (synchronous send) and `background` (buffered with parallel shard workers using `OrderedSharding` or `BalancedSharding`). Configurable batch length / size and linger time.
+- **Partitioning**: `balanced`, `partition_key`, or explicit `partition_id`. Custom `Partitioner` is pluggable.
+- **Consumer**: standalone or consumer-group; consumed as an async `Stream`. Polling strategies: `next`, `offset`, `timestamp`, `first`, `last`.
+- **Auto-commit** offset policies: `Interval`, `When`, `After`, `IntervalOrWhen`, `IntervalOrAfter`, or disabled.
+- **Stream builder** (`IggyStream`, `IggyStreamProducer`, `IggyStreamConsumer`) for declarative producer + consumer setup on shared or separate stream/topic.
+- **Reliability**: automatic reconnection with retries, heartbeat, send retries, and offset auto-commit handled by the high-level API.
+- **Message features**: optional headers (`HeaderKey` / `HeaderValue`), client-side AES-256-GCM encryption (via `Aes256GcmEncryptor`), per-topic compression (currently `None` and `Gzip`), server-honored message expiry, and server-side deduplication.
+- **Admin**: stream/topic/partition CRUD, consumer-group management, server-side consumer offsets, system stats.
+
+## Installation
+
+```bash
+cargo add iggy
+```
+
+Optional features map to common scenarios. See the [Rust SDK docs](https://iggy.apache.org/docs/sdk/rust/intro/) for the full list.
+
+## Quick start
+
+```rust
+use std::error::Error;
+use std::str::FromStr;
+use futures_util::StreamExt;
+use iggy::prelude::*;
+
+const STREAM: &str = "telemetry";
+const TOPIC: &str = "device-events";
+const CONSUMER_GROUP: &str = "telemetry-ingester";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = IggyClient::from_connection_string(
+        "iggy://iggy:iggy@localhost:8090",
+    )?;
+    client.connect().await?;
+
+    let producer = client
+        .producer(STREAM, TOPIC)?
+        .direct(
+            DirectConfig::builder()
+                .batch_length(1000)
+                .linger_time(IggyDuration::from_str("1ms")?)
+                .build(),
+        )
+        .partitioning(Partitioning::balanced())
+        .build();
+    producer.init().await?;
+    producer
+        .send(vec![IggyMessage::from_str("Hello Apache Iggy")?])
+        .await?;
+
+    let mut consumer = client
+        .consumer_group(CONSUMER_GROUP, STREAM, TOPIC)?
+        .auto_commit(AutoCommit::IntervalOrWhen(
+            IggyDuration::from_str("1s")?,
+            AutoCommitWhen::ConsumingAllMessages,
+        ))
+        .create_consumer_group_if_not_exists()
+        .auto_join_consumer_group()
+        .polling_strategy(PollingStrategy::next())
+        .poll_interval(IggyDuration::from_str("1ms")?)
+        .batch_length(1000)
+        .build();
+    consumer.init().await?;
+
+    while let Some(message) = consumer.next().await {
+        match message {
+            Ok(message) => {
+                let payload = std::str::from_utf8(&message.message.payload)
+                    .unwrap_or("<non-utf8>");
+                println!(
+                    "offset={} partition={} current_offset={} payload={payload}",
+                    message.message.header.offset,
+                    message.partition_id,
+                    message.current_offset,
+                );
+                if let Some(headers) = message.message.user_headers_map()? {
+                    for (key, value) in headers {
+                        println!("  header {key} = {value:?}");
+                    }
+                }
+            }
+            Err(error) => eprintln!("poll error: {error}"),
+        }
+    }
+    Ok(())
+}
+```
+
+For lower-level control over individual commands (login, stream/topic management, raw send, polling by offset or timestamp), use the transport-specific clients directly. See the [examples](https://github.com/apache/iggy/tree/master/examples/rust) and the [Rust SDK docs](https://iggy.apache.org/docs/sdk/rust/intro/).
+
+## Versioning
+
+Stable releases follow semver (`x.y.z`). Edge releases (`x.y.z-edge.N`) are cut from `master` between stable versions and may include unreleased fixes; pin to a stable version for production.
+
+## Resources
+
+- [Rust SDK docs](https://iggy.apache.org/docs/sdk/rust/intro/)
+- [High-level SDK guide](https://iggy.apache.org/docs/sdk/rust/high-level-sdk/)
+- [Stream builder guide](https://iggy.apache.org/docs/sdk/rust/stream-builder/)
+- [Project documentation](https://iggy.apache.org/docs/)
+- [Runnable examples](https://github.com/apache/iggy/tree/master/examples/rust): getting-started, basic, new-sdk, stream-builder, multi-tenant, message-envelope, message-headers, tcp-tls, sink-data-producer.
+- [Benchmarking platform](https://benchmarks.iggy.apache.org)
+- [GitHub repository](https://github.com/apache/iggy)
+- [Discord community](https://discord.gg/apache-iggy)
+
+## Related crates
+
+- [`iggy_common`](https://crates.io/crates/iggy_common): shared types and traits.
+- [`iggy_binary_protocol`](https://crates.io/crates/iggy_binary_protocol): wire protocol codec.
+- [`iggy-cli`](https://crates.io/crates/iggy-cli): command-line tool, `cargo install iggy-cli`.
+
+## License
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/apache/iggy/blob/master/LICENSE).

--- a/core/server-ng/Dockerfile
+++ b/core/server-ng/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 ARG RUST_VERSION=1.95
 ARG ALPINE_VERSION=3.22
 

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 ARG RUST_VERSION=1.95
 ARG ALPINE_VERSION=3.22
 

--- a/foreign/cpp/README.md
+++ b/foreign/cpp/README.md
@@ -1,4 +1,20 @@
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-darkbg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg">
+    <img alt="Apache Iggy" src="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg" width="320">
+  </picture>
+</div>
+
 # Iggy C++ Client
+
+C++ client for [Apache Iggy](https://iggy.apache.org) message streaming.
+
+> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+>
+> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 
 Currently, the bazel build system relies on the system-provided cargo toolchain, so concurrent runs can race and lead to data corruption if executed remotely
 

--- a/foreign/csharp/README.md
+++ b/foreign/csharp/README.md
@@ -1,3 +1,11 @@
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-darkbg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg">
+    <img alt="Apache Iggy" src="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg" width="320">
+  </picture>
+</div>
+
 # C# SDK for [Iggy](https://github.com/apache/iggy) [![Nuget (with prereleases)](https://img.shields.io/nuget/v/Apache.Iggy)](https://www.nuget.org/packages/Apache.Iggy)
 
 ## Overview
@@ -5,6 +13,12 @@
 The Apache Iggy C# SDK provides a comprehensive client library for interacting with Iggy message streaming servers. It
 offers a modern, async-first API with support for multiple transport protocols and comprehensive message streaming
 capabilities.
+
+> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+>
+> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 
 ## Getting Started
 

--- a/foreign/java/README.md
+++ b/foreign/java/README.md
@@ -1,8 +1,22 @@
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-darkbg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg">
+    <img alt="Apache Iggy" src="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg" width="320">
+  </picture>
+</div>
+
 # Java SDK for Apache Iggy
 
 Official Java client SDK for [Apache Iggy](https://iggy.apache.org) message streaming.
 
-> This is part of the Apache Iggy monorepo. For the main project, see the [root repository](https://github.com/apache/iggy).
+_This is part of the Apache Iggy monorepo. For the main project, see the [root repository](https://github.com/apache/iggy)._
+
+> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+>
+> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 
 ## Installation
 
@@ -197,10 +211,10 @@ All exceptions thrown by the SDK inherit from `IggyException`. This allows you t
 
 See the **[Java Examples](../../examples/java/)** directory for runnable applications demonstrating the SDK:
 
-- **BlockingProducer** — synchronous message production with batch sending
-- **BlockingConsumer** — synchronous consumption with polling loops
-- **AsyncProducer** — high-throughput async production with pipelining
-- **AsyncConsumer** — async consumption with backpressure and error recovery
+- **BlockingProducer**: synchronous message production with batch sending
+- **BlockingConsumer**: synchronous consumption with polling loops
+- **AsyncProducer**: high-throughput async production with pipelining
+- **AsyncConsumer**: async consumption with backpressure and error recovery
 
 Each example includes comprehensive documentation on when to use blocking vs. async clients, CompletableFuture patterns, thread pool management, and performance characteristics.
 

--- a/foreign/java/external-processors/iggy-connector-flink/docker/Dockerfile.flink2_10-java21
+++ b/foreign/java/external-processors/iggy-connector-flink/docker/Dockerfile.flink2_10-java21
@@ -1,3 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 FROM flink:2.1.0-scala_2.12-java21
 
 # Set up directories for checkpoints and savepoints

--- a/foreign/node/README.md
+++ b/foreign/node/README.md
@@ -1,6 +1,20 @@
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-darkbg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg">
+    <img alt="Apache Iggy" src="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg" width="320">
+  </picture>
+</div>
+
 # Apache Iggy Node.js Client
 
 Apache Iggy Node.js client written in typescript, it currently only supports tcp & tls transports.
+
+> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+>
+> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 
 diclaimer: although all iggy commands & basic client/stream are implemented this is still a WIP, provided as is, and has still a long way to go to be considered "battle tested".
 

--- a/foreign/python/.devcontainer/Dockerfile
+++ b/foreign/python/.devcontainer/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 FROM mcr.microsoft.com/devcontainers/python:1-3.12-bullseye
 
 ENV VIRTUAL_ENV=/opt/venv

--- a/foreign/python/Dockerfile.test
+++ b/foreign/python/Dockerfile.test
@@ -15,6 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
 # Multi-stage build for Python SDK testing
 FROM python:3.10-slim AS base
 

--- a/foreign/python/README.md
+++ b/foreign/python/README.md
@@ -1,8 +1,22 @@
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-darkbg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg">
+    <img alt="Apache Iggy" src="https://raw.githubusercontent.com/apache/iggy/refs/heads/master/assets/logo/SVG/iggy-apache-color-lightbg.svg" width="320">
+  </picture>
+</div>
+
 # apache-iggy
 
 [![discord-badge](https://img.shields.io/discord/1144142576266530928)](https://discord.gg/C5Sux5NcRa)
 
 Apache Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second.
+
+> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+>
+> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 
 ## Installation
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
+# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a further review
+# indicates that the infrastructure, communications, and decision making
+# process have stabilized in a manner consistent with other successful ASF
+# projects.
+#
+# While incubation status is not necessarily a reflection of the completeness
+# or stability of the code, it does indicate that the project has yet to be
+# fully endorsed by the ASF.
+
 FROM node:lts-alpine AS deps
 WORKDIR /app
 COPY package*.json ./


### PR DESCRIPTION
Per ASF Incubator distribution policy, every artifact published under
apache/iggy must carry the standard incubation disclaimer. Added it
to 10 publishable READMEs (4 Rust crates + 6 foreign SDKs) and 17
Dockerfiles, plus dedicated READMEs for `iggy`, `iggy_common`,
`iggy_binary_protocol`, and `iggy-cli`.