### PR TITLE
fix(message_bus): expose background_tasks_len in release builds

### DIFF
--- a/core/message_bus/src/lib.rs
+++ b/core/message_bus/src/lib.rs
@@ -623,7 +623,7 @@ impl IggyMessageBus {
     /// callers. A long-running bus is expected to keep this number
     /// bounded under sustained accept traffic; a leak shows up here as
     /// monotonic growth proportional to total accepts.
-    #[cfg(any(test, debug_assertions))]
+    #[doc(hidden)]
     #[must_use]
     pub fn background_tasks_len(&self) -> usize {
         self.background_tasks.borrow().len()


### PR DESCRIPTION
The accessor was gated by `#[cfg(any(test, debug_assertions))]`,
which hid it from the `installer_panic_cleanup` integration test
in release builds: integration tests live in a separate crate, so
the library's `cfg(test)` is unset, and `debug_assertions` is off
under `--release`. Both predicates failed only in the release ×
integration-test quadrant, which CI does not exercise.

Drop the cfg and mark `#[doc(hidden)]`. The accessor is a zero-cost
getter over a `RefCell<Vec<_>>` and carries no prod risk; doc-hidden
preserves the "test-only invariant probe" signal without breaking
external test crates.

Fixes #3234
