### PR TITLE
ci: declare explicit read-only permissions on reusable workflows

### DIFF
--- a/.github/workflows/_build_python_wheels.yml
+++ b/.github/workflows/_build_python_wheels.yml
@@ -43,6 +43,9 @@ on:
         description: "Name of the uploaded artifact containing wheels"
         value: ${{ jobs.collect.outputs.artifact_name }}
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/_build_rust_artifacts.yml
+++ b/.github/workflows/_build_rust_artifacts.yml
@@ -53,6 +53,9 @@ on:
         description: "Name of the uploaded artifact containing all artifacts"
         value: ${{ jobs.collect.outputs.artifact_name }}
 
+permissions:
+  contents: read
+
 env:
   IGGY_CI_BUILD: true
 

--- a/.github/workflows/_detect.yml
+++ b/.github/workflows/_detect.yml
@@ -51,6 +51,9 @@ on:
         description: "Matrix for other components"
         value: ${{ jobs.detect.outputs.other_matrix }}
 
+permissions:
+  contents: read
+
 jobs:
   detect:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks with `contents: read` to reusable workflows:
  - `.github/workflows/_detect.yml`
  - `.github/workflows/_build_rust_artifacts.yml`
  - `.github/workflows/_build_python_wheels.yml`

## Why
These reusable workflows perform checkout/build/packaging operations and do not require broad token privileges. Explicit read-only permissions tighten default GitHub token scope and make required access clear.