### PR TITLE
chore(repo,ci): fix macOS pre-merge, bump versions

### DIFF
--- a/.github/actions/utils/setup-rust-with-cache/action.yml
+++ b/.github/actions/utils/setup-rust-with-cache/action.yml
@@ -59,6 +59,13 @@ runs:
 
     - name: Setup Rust toolchain
       run: |
+        # macOS runners provision Rust via the Homebrew `rustup` formula, which
+        # installs only `rustup-init` plus brew shims that resolve back to it in
+        # installer mode - so `cargo` errors out and ~/.cargo/bin has no proxies.
+        # Run rustup-init once to generate the real cargo/rustc proxies.
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          rustup-init -y --no-modify-path --default-toolchain none
+        fi
         rustup show
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bench-dashboard-frontend"
-version = "0.7.0"
+version = "0.7.1-edge.1"
 dependencies = [
  "bench-dashboard-shared",
  "bench-report",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "bench-report"
-version = "0.3.0"
+version = "0.3.1-edge.1"
 dependencies = [
  "charming",
  "colored",
@@ -6294,7 +6294,7 @@ checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "iggy"
-version = "0.10.0"
+version = "0.10.1-edge.1"
 dependencies = [
  "async-broadcast",
  "async-dropper",
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-bench"
-version = "0.5.0"
+version = "0.5.1-edge.1"
 dependencies = [
  "async-trait",
  "bench-report",
@@ -6354,7 +6354,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-bench-dashboard-server"
-version = "0.7.0"
+version = "0.7.1-edge.1"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cli"
-version = "0.13.0"
+version = "0.13.1-edge.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6412,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-connectors"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -6464,7 +6464,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-mcp"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "axum",
  "axum-server",
@@ -6498,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_binary_protocol"
-version = "0.10.0"
+version = "0.10.1-edge.1"
 dependencies = [
  "aligned-vec",
  "bytemuck",
@@ -6512,7 +6512,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_common"
-version = "0.10.0"
+version = "0.10.1-edge.1"
 dependencies = [
  "aes-gcm",
  "aligned-vec",
@@ -6560,7 +6560,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_delta_sink"
-version = "0.1.0"
+version = "0.1.1-edge.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_elasticsearch_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_elasticsearch_source"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_http_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_iceberg_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "arrow-json 57.3.0",
  "async-trait",
@@ -6658,7 +6658,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_influxdb_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -6680,7 +6680,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_influxdb_source"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -6703,7 +6703,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_mongodb_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "humantime",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_postgres_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6739,7 +6739,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_postgres_source"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -6761,7 +6761,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_quickwit_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_random_source"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_sdk"
-version = "0.3.0"
+version = "0.3.1-edge.1"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -6831,7 +6831,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_connector_stdout_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -11246,7 +11246,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.8.0"
+version = "0.8.1-edge.1"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,11 +173,11 @@ hwlocality = "1.0.0-alpha.12"
 iceberg = "0.9.1"
 iceberg-catalog-rest = "0.9.1"
 iceberg-storage-opendal = "0.9.1"
-iggy = { path = "core/sdk", version = "0.10.0" }
-iggy-cli = { path = "core/cli", version = "0.13.0" }
-iggy_binary_protocol = { path = "core/binary_protocol", version = "0.10.0" }
-iggy_common = { path = "core/common", version = "0.10.0" }
-iggy_connector_sdk = { path = "core/connectors/sdk", version = "0.3.0" }
+iggy = { path = "core/sdk", version = "0.10.1-edge.1" }
+iggy-cli = { path = "core/cli", version = "0.13.1-edge.1" }
+iggy_binary_protocol = { path = "core/binary_protocol", version = "0.10.1-edge.1" }
+iggy_common = { path = "core/common", version = "0.10.1-edge.1" }
+iggy_connector_sdk = { path = "core/connectors/sdk", version = "0.3.1-edge.1" }
 integration = { path = "core/integration" }
 journal = { path = "core/journal" }
 js-sys = "0.3"

--- a/bdd/python/uv.lock
+++ b/bdd/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apache-iggy"
-version = "0.8.0"
+version = "0.8.1.dev1"
 source = { directory = "../../foreign/python" }
 
 [package.metadata]

--- a/core/ai/mcp/Cargo.toml
+++ b/core/ai/mcp/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy-mcp"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "MCP Server for Iggy message streaming platform"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/bench/Cargo.toml
+++ b/core/bench/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy-bench"
-version = "0.5.0"
+version = "0.5.1-edge.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/apache/iggy"

--- a/core/bench/dashboard/frontend/Cargo.toml
+++ b/core/bench/dashboard/frontend/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "bench-dashboard-frontend"
 license = "Apache-2.0"
-version = "0.7.0"
+version = "0.7.1-edge.1"
 edition = "2024"
 publish = false
 

--- a/core/bench/dashboard/server/Cargo.toml
+++ b/core/bench/dashboard/server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "iggy-bench-dashboard-server"
 license = "Apache-2.0"
-version = "0.7.0"
+version = "0.7.1-edge.1"
 edition = "2024"
 publish = false
 

--- a/core/bench/report/Cargo.toml
+++ b/core/bench/report/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "bench-report"
-version = "0.3.0"
+version = "0.3.1-edge.1"
 edition = "2024"
 description = "Benchmark report and chart generation library for iggy-bench binary and iggy-benchmarks-dashboard web app"
 license = "Apache-2.0"

--- a/core/binary_protocol/Cargo.toml
+++ b/core/binary_protocol/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_binary_protocol"
-version = "0.10.0"
+version = "0.10.1-edge.1"
 description = "Wire protocol types and codec for the Iggy binary protocol. Shared between server and SDK."
 edition = "2024"
 license = "Apache-2.0"

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy-cli"
-version = "0.13.0"
+version = "0.13.1-edge.1"
 edition = "2024"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/apache/iggy"

--- a/core/common/Cargo.toml
+++ b/core/common/Cargo.toml
@@ -16,7 +16,7 @@
 # under the License.
 [package]
 name = "iggy_common"
-version = "0.10.0"
+version = "0.10.1-edge.1"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/runtime/Cargo.toml
+++ b/core/connectors/runtime/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy-connectors"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Connectors runtime for Iggy message streaming platform"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sdk/Cargo.toml
+++ b/core/connectors/sdk/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_sdk"
-version = "0.3.0"
+version = "0.3.1-edge.1"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sinks/delta_sink/Cargo.toml
+++ b/core/connectors/sinks/delta_sink/Cargo.toml
@@ -17,7 +17,8 @@
 
 [package]
 name = "iggy_connector_delta_sink"
-version = "0.1.0"
+version = "0.1.1-edge.1"
+description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 license = "Apache-2.0"
 keywords = ["iggy", "messaging", "streaming"]
@@ -26,6 +27,7 @@ homepage = "https://iggy.apache.org"
 documentation = "https://iggy.apache.org/docs"
 repository = "https://github.com/apache/iggy"
 readme = "../../README.md"
+publish = false
 
 [package.metadata.cargo-machete]
 ignored = ["dashmap", "once_cell"]

--- a/core/connectors/sinks/elasticsearch_sink/Cargo.toml
+++ b/core/connectors/sinks/elasticsearch_sink/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_elasticsearch_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy Elasticsearch sink connector"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sinks/http_sink/Cargo.toml
+++ b/core/connectors/sinks/http_sink/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_http_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy HTTP sink connector for delivering stream messages to any HTTP endpoint via webhooks, REST APIs, or serverless functions."
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sinks/iceberg_sink/Cargo.toml
+++ b/core/connectors/sinks/iceberg_sink/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_iceberg_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 edition = "2024"
 license = "Apache-2.0"
 keywords = ["iggy", "messaging", "streaming"]

--- a/core/connectors/sinks/influxdb_sink/Cargo.toml
+++ b/core/connectors/sinks/influxdb_sink/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_influxdb_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy InfluxDB sink connector for storing stream messages as line protocol"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sinks/mongodb_sink/Cargo.toml
+++ b/core/connectors/sinks/mongodb_sink/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_mongodb_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy MongoDB sink connector for storing stream messages into MongoDB database"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sinks/postgres_sink/Cargo.toml
+++ b/core/connectors/sinks/postgres_sink/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_postgres_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy PostgreSQL sink connector for storing stream messages into PostgreSQL database"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sinks/quickwit_sink/Cargo.toml
+++ b/core/connectors/sinks/quickwit_sink/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_quickwit_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sinks/stdout_sink/Cargo.toml
+++ b/core/connectors/sinks/stdout_sink/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_stdout_sink"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sources/elasticsearch_source/Cargo.toml
+++ b/core/connectors/sources/elasticsearch_source/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_elasticsearch_source"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy Elasticsearch source connector"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sources/influxdb_source/Cargo.toml
+++ b/core/connectors/sources/influxdb_source/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_influxdb_source"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy InfluxDB source connector for polling Flux query results"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sources/postgres_source/Cargo.toml
+++ b/core/connectors/sources/postgres_source/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_postgres_source"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy PostgreSQL source connector supporting CDC and table polling for message streaming platform"
 edition = "2024"
 license = "Apache-2.0"

--- a/core/connectors/sources/random_source/Cargo.toml
+++ b/core/connectors/sources/random_source/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_connector_random_source"
-version = "0.4.0"
+version = "0.4.1-edge.1"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 license = "Apache-2.0"

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy"
-version = "0.10.0"
+version = "0.10.1-edge.1"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 license = "Apache-2.0"

--- a/core/server/Cargo.toml
+++ b/core/server/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "server"
-version = "0.8.0"
+version = "0.8.1-edge.1"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apache-iggy"
-version = "0.8.0"
+version = "0.8.1.dev1"
 source = { directory = "../../foreign/python" }
 
 [package.metadata]

--- a/foreign/csharp/Iggy_SDK/Iggy_SDK.csproj
+++ b/foreign/csharp/Iggy_SDK/Iggy_SDK.csproj
@@ -7,7 +7,7 @@
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <AssemblyName>Apache.Iggy</AssemblyName>
         <RootNamespace>Apache.Iggy</RootNamespace>
-        <Version>0.8.0</Version>
+        <Version>0.8.1-edge.1</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 

--- a/foreign/go/contracts/version.go
+++ b/foreign/go/contracts/version.go
@@ -17,4 +17,4 @@
 
 package iggcon
 
-const Version = "0.8.0"
+const Version = "0.8.1-edge.1"

--- a/foreign/java/gradle.properties
+++ b/foreign/java/gradle.properties
@@ -17,5 +17,5 @@
 # under the License.
 #
 
-version=0.8.0
+version=0.8.1-SNAPSHOT
 group=org.apache.iggy

--- a/foreign/node/package.json
+++ b/foreign/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apache-iggy",
   "type": "module",
-  "version": "0.8.0",
+  "version": "0.8.1-edge.1",
   "description": "Official Apache Iggy NodeJS SDK",
   "keywords": [
     "iggy",

--- a/foreign/python/Cargo.toml
+++ b/foreign/python/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "apache-iggy"
-version = "0.8.0"
+version = "0.8.1-dev1"
 edition = "2024"
 authors = ["Iggy Committers <dev@iggy.apache.org>"]
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ repository = "https://github.com/apache/iggy"
 [dependencies]
 bytes = "1.11.1"
 futures = "0.3.32"
-iggy = { path = "../../core/sdk", version = "0.10.0" }
+iggy = { path = "../../core/sdk", version = "0.10.1-edge.1" }
 pyo3 = "0.28.2"
 pyo3-async-runtimes = { version = "0.28.0", features = [
     "attributes",

--- a/foreign/python/pyproject.toml
+++ b/foreign/python/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "maturin"
 [project]
 name = "apache-iggy"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1.dev1"
 description = "Apache Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/foreign/python/uv.lock
+++ b/foreign/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apache-iggy"
-version = "0.8.0"
+version = "0.8.1.dev1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -39,8 +39,19 @@ Components:
   rust-server          core/server
   rust-cli             core/cli + workspace dep
   rust-connector-sdk   core/connectors/sdk + workspace dep
+  rust-mcp             core/ai/mcp
+  rust-bench           core/bench
+  rust-bench-dashboard-frontend   core/bench/dashboard/frontend
+  rust-bench-dashboard-server     core/bench/dashboard/server
+  rust-bench-report    core/bench/report
   rust-all             All Rust crates at once
-  --all                All components (Rust + SDKs + web-ui)
+  rust-connector-runtime          core/connectors/runtime
+  rust-connector-<name>-sink      core/connectors/sinks/<name>_sink
+  rust-connector-<name>-source    core/connectors/sources/<name>_source
+  connectors-sinks     All connector sink crates at once
+  connectors-sources   All connector source crates at once
+  connectors-all       runtime + all sink + all source crates
+  --all                All components (Rust + connectors + SDKs + web-ui)
   sdk-python           foreign/python/Cargo.toml + foreign/python/pyproject.toml
   sdk-node             foreign/node/package.json
   sdk-go               foreign/go/contracts/version.go
@@ -68,14 +79,19 @@ Examples:
   bump-version.sh rust-all --minor --edge --dry-run
   bump-version.sh --all --strip-edge
   bump-version.sh rust-sdk --patch
+  bump-version.sh connectors-all --patch --edge
+  bump-version.sh rust-connector-stdout-sink --minor
   bump-version.sh sdk-python --set 0.8.0
-  bump-version.sh --status
+  bump-version.sh --status connectors-all
 EOF
 }
 
-RUST_COMPONENTS="rust-sdk rust-common rust-binary-protocol rust-server rust-cli rust-connector-sdk"
+RUST_COMPONENTS="rust-sdk rust-common rust-binary-protocol rust-server rust-cli rust-connector-sdk rust-mcp rust-bench rust-bench-dashboard-frontend rust-bench-dashboard-server rust-bench-report"
+CONNECTOR_SINK_COMPONENTS="rust-connector-delta-sink rust-connector-elasticsearch-sink rust-connector-http-sink rust-connector-iceberg-sink rust-connector-influxdb-sink rust-connector-mongodb-sink rust-connector-postgres-sink rust-connector-quickwit-sink rust-connector-stdout-sink"
+CONNECTOR_SOURCE_COMPONENTS="rust-connector-elasticsearch-source rust-connector-influxdb-source rust-connector-postgres-source rust-connector-random-source"
+CONNECTOR_COMPONENTS="rust-connector-runtime ${CONNECTOR_SINK_COMPONENTS} ${CONNECTOR_SOURCE_COMPONENTS}"
 SDK_COMPONENTS="sdk-python sdk-node sdk-go sdk-csharp sdk-java"
-ALL_COMPONENTS="${RUST_COMPONENTS} ${SDK_COMPONENTS} web-ui"
+ALL_COMPONENTS="${RUST_COMPONENTS} ${CONNECTOR_COMPONENTS} ${SDK_COMPONENTS} web-ui"
 
 # Returns "file:format" lines per component.
 # Format keys: cargo, cargo-ws-dep:PKG, cargo-dep:PKG, python-cargo, pyproject, json, csproj, gradle, go
@@ -106,6 +122,32 @@ get_version_files() {
             echo "core/connectors/sdk/Cargo.toml:cargo"
             echo "Cargo.toml:cargo-ws-dep:iggy_connector_sdk"
             ;;
+        rust-connector-runtime)
+            echo "core/connectors/runtime/Cargo.toml:cargo"
+            ;;
+        rust-connector-*-sink)
+            local dir="${component#rust-connector-}"
+            echo "core/connectors/sinks/${dir//-/_}/Cargo.toml:cargo"
+            ;;
+        rust-connector-*-source)
+            local dir="${component#rust-connector-}"
+            echo "core/connectors/sources/${dir//-/_}/Cargo.toml:cargo"
+            ;;
+        rust-mcp)
+            echo "core/ai/mcp/Cargo.toml:cargo"
+            ;;
+        rust-bench)
+            echo "core/bench/Cargo.toml:cargo"
+            ;;
+        rust-bench-dashboard-frontend)
+            echo "core/bench/dashboard/frontend/Cargo.toml:cargo"
+            ;;
+        rust-bench-dashboard-server)
+            echo "core/bench/dashboard/server/Cargo.toml:cargo"
+            ;;
+        rust-bench-report)
+            echo "core/bench/report/Cargo.toml:cargo"
+            ;;
         sdk-python)
             echo "foreign/python/Cargo.toml:python-cargo"
             echo "foreign/python/pyproject.toml:pyproject"
@@ -127,7 +169,7 @@ get_version_files() {
             ;;
         *)
             echo -e "${RED}Unknown component: ${component}${NC}" >&2
-            echo "Valid: rust-all ${ALL_COMPONENTS}" >&2
+            echo "Valid: rust-all connectors-all connectors-sinks connectors-sources ${ALL_COMPONENTS}" >&2
             return 1
             ;;
     esac
@@ -339,13 +381,14 @@ write_version() {
 cmd_status() {
     local filter="${1:-}"
     local components
-    if [[ "$filter" == "rust-all" ]]; then
-        components="$RUST_COMPONENTS"
-    elif [[ -n "$filter" ]]; then
-        components="$filter"
-    else
-        components="$ALL_COMPONENTS"
-    fi
+    case "$filter" in
+        rust-all)           components="$RUST_COMPONENTS" ;;
+        connectors-all)     components="$CONNECTOR_COMPONENTS" ;;
+        connectors-sinks)   components="$CONNECTOR_SINK_COMPONENTS" ;;
+        connectors-sources) components="$CONNECTOR_SOURCE_COMPONENTS" ;;
+        "")                 components="$ALL_COMPONENTS" ;;
+        *)                  components="$filter" ;;
+    esac
 
     for comp in $components; do
         echo -e "${CYAN}${comp}${NC}"
@@ -641,6 +684,15 @@ case "$1" in
     rust-all)
         shift
         cmd_bump_multi "$RUST_COMPONENTS" "$@" ;;
+    connectors-all)
+        shift
+        cmd_bump_multi "$CONNECTOR_COMPONENTS" "$@" ;;
+    connectors-sinks)
+        shift
+        cmd_bump_multi "$CONNECTOR_SINK_COMPONENTS" "$@" ;;
+    connectors-sources)
+        shift
+        cmd_bump_multi "$CONNECTOR_SOURCE_COMPONENTS" "$@" ;;
     --*)
         echo -e "${RED}Expected component name, got flag: ${1}${NC}" >&2
         echo "Use: bump-version.sh <component> <flags>" >&2

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iggy-web-ui",
-  "version": "0.3.0",
+  "version": "0.3.1-edge.1",
   "private": true,
   "scripts": {
     "dev": "vite dev --port 3050",


### PR DESCRIPTION
Bump every workspace crate, language SDK, and the web UI
to *.1-edge.1 after the 0.8.0 release. The initial bump
missed the connector runtime, sinks, sources, and the
bench and mcp crates, leaving the workspace on mixed
versions.

Extend bump-version.sh with components for those crates
so --all and rust-all cover the whole workspace.

Fix cargo invoking rustup-init on macOS runners: the
Homebrew rustup formula installs only rustup-init plus
brew shims that resolve back to it, so ~/.cargo/bin has
no proxies. Run rustup-init once on macOS to generate
the real cargo/rustc proxies.