### PR TITLE
fix(connector): extract dynamic route field as raw JSON string

### DIFF
--- a/core/connectors/sinks/iceberg_sink/src/router/dynamic_router.rs
+++ b/core/connectors/sinks/iceberg_sink/src/router/dynamic_router.rs
@@ -23,6 +23,7 @@ use iceberg::Catalog;
 use iceberg::table::Table;
 use iggy_connector_sdk::{ConsumedMessage, Error, MessagesMetadata, Payload};
 use simd_json::base::ValueAsObject;
+use simd_json::prelude::ValueAsScalar;
 use std::collections::HashMap;
 use tracing::{info, warn};
 
@@ -86,16 +87,25 @@ impl DynamicRouter {
 
     fn extract_route_field(&self, message: &ConsumedMessage) -> Option<String> {
         match &message.payload {
-            Payload::Json(payload) => payload
-                .as_object()
-                .and_then(|obj| obj.get(&self.route_field))
-                .map(|val| val.to_string()),
+            Payload::Json(payload) => extract_route_field_value(payload, &self.route_field),
             _ => {
                 warn!("Unsupported format for iceberg connector");
                 None
             }
         }
     }
+}
+
+fn extract_route_field_value(payload: &simd_json::OwnedValue, route_field: &str) -> Option<String> {
+    // Route fields are table identifiers, so only JSON string values are valid here.
+    // Calling `to_string()` on a JSON value serializes it, turning "tpch.lineitem"
+    // into a string containing literal quote characters. `as_str()` returns the
+    // underlying string instead, which can be validated and used as the lookup key.
+    payload
+        .as_object()
+        .and_then(|obj| obj.get(route_field))
+        .and_then(|val| val.as_str())
+        .map(ToString::to_string)
 }
 
 #[async_trait]
@@ -165,5 +175,45 @@ impl Router for DynamicRouter {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract_route_field_value(
+        payload: &simd_json::OwnedValue,
+        route_field: &str,
+    ) -> Option<String> {
+        // Route values must be JSON strings. Using `as_str()` returns the
+        // underlying value (for example, `tpch.lineitem`) while `to_string()`
+        // would serialize the JSON value and include quote characters.
+        payload
+            .as_object()
+            .and_then(|obj| obj.get(route_field))
+            .and_then(|val| val.as_str())
+            .map(ToString::to_string)
+    }
+
+    #[test]
+    fn extracts_string_route_field_without_json_quotes() {
+        let payload = simd_json::json!({
+            "table": "tpch.lineitem"
+        });
+
+        assert_eq!(
+            extract_route_field_value(&payload, "table"),
+            Some("tpch.lineitem".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_non_string_route_field() {
+        let payload = simd_json::json!({
+            "table": 42
+        });
+
+        assert_eq!(extract_route_field_value(&payload, "table"), None);
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3177.

## Rationale

<!--
Why is this change needed? If the issue explains it well, a one-liner is fine.
-->

## What changed?

<!--
2-4 sentences. Problem first (before), then solution (after).

GOOD:

"Messages were unavailable when background message_saver committed the
journal and started async disk I/O before completion. Polling during
this window found neither journal nor disk data.

The fix freezes journal batches in the in-flight buffer before async persist."

GOOD:

"When many small messages accumulate in the journal, the flush passes
thousands of IO vectors to writev(), exceeding IOV_MAX (1024 on Linux)."

BAD:
- Walls of text
- "This PR adds..." (we can see the diff)
-->

## Local Execution

- Passed / not passed
- Pre-commit hooks ran / not ran

<!--
You must run your code locally before submitting.
"Relying on CI" is not acceptable - PRs from authors who haven't run the code will be closed.

Did you have `prek` installed? It runs automatically on commit and covers all project languages. See [CONTRIBUTING.md](https://github.com/apache/iggy/blob/master/CONTRIBUTING.md).
-->

## AI Usage

<!--
If AI tools were used, please answer:
1. Which tools? (e.g., GitHub Copilot, Claude, ChatGPT)
2. Scope of usage? (e.g., autocomplete, generated functions, entire implementation)
3. How did you verify the generated code works correctly?
4. Can you explain every line of the code if asked?

If no AI tools were used, write "None" or delete this section.
-->
