### PR TITLE
ci: collapse status into finalize_pr, fix cancel hang

### DIFF
--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -280,7 +280,7 @@ jobs:
         binary-artifacts,
         typos,
       ]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Summary

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -191,11 +191,10 @@ jobs:
       task: ${{ matrix.task }}
 
   # Final status check
-  status:
-    name: CI Status
+  finalize_pr:
     runs-on: ubuntu-latest
     needs: [common, detect, test-rust, test-python, test-node, test-go, test-java, test-csharp, test-cpp, test-bdd, test-examples, test-other]
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Get job execution times
         id: times
@@ -439,17 +438,3 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "✅ **CI Passed** - All checks completed successfully!" >> $GITHUB_STEP_SUMMARY
           fi
-
-  finalize_pr:
-    runs-on: ubuntu-latest
-    needs:
-      - status
-    if: always()
-    steps:
-      - name: Everything is fine
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: exit 0
-
-      - name: Some tests failed
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -733,7 +733,7 @@ jobs:
     name: Docker ${{ matrix.name }} (${{ matrix.arch }})
     needs: [validate, plan, check-tags, build-python-wheels, publish-rust-crates]
     if: |
-      always() &&
+      !cancelled() &&
       needs.validate.outputs.has_targets == 'true' &&
       needs.plan.outputs.has_docker == 'true' &&
       fromJson(needs.plan.outputs.docker_matrix).include[0].key != 'noop' &&
@@ -837,7 +837,7 @@ jobs:
     name: Docker manifests
     needs: [validate, plan, publish-docker]
     if: |
-      always() &&
+      !cancelled() &&
       needs.validate.outputs.has_targets == 'true' &&
       needs.plan.outputs.has_docker == 'true' &&
       fromJson(needs.plan.outputs.docker_components).include[0].key != 'noop' &&
@@ -1040,7 +1040,7 @@ jobs:
     name: ${{ matrix.name }}
     needs: [validate, plan, check-tags, build-python-wheels, publish-rust-crates]
     if: |
-      always() &&
+      !cancelled() &&
       needs.validate.outputs.has_targets == 'true' &&
       fromJson(needs.plan.outputs.non_docker_targets).include[0].key != 'noop' &&
       (needs.build-python-wheels.result == 'success' || needs.build-python-wheels.result == 'skipped') &&
@@ -1350,7 +1350,7 @@ jobs:
         docker-manifests,
         publish,
       ]
-    if: always() && needs.validate.outputs.has_targets == 'true'
+    if: ${{ !cancelled() && needs.validate.outputs.has_targets == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download latest copy script from master


### PR DESCRIPTION
`status` aggregated test results and built CI Summary;
`finalize_pr` only re-checked status.result and exited 0/1,
adding a second runner per PR with no extra signal. ASF
branch protection (.asf.yaml) requires context `finalize_pr`
as the sole required check on master. Rename `status` ->
`finalize_pr` and drop `name: CI Status` so GitHub resolves
the context from the job key. Delete the old pass-through.

Job-level `if: always()` re-evaluates after cancel-in-progress
fires, schedules itself, and waits indefinitely for a runner
that never arrives, holding the concurrency lock and blocking
the next PR push for tens of minutes. Replace with
`!cancelled()` on all aggregator/release jobs (pre-merge
finalize_pr, _common.yml summary, publish-docker,
docker-manifests, publish, release final aggregator).
Step-level `always()` untouched (no phantom-queue risk).