### PR TITLE
ci: remove team from dependabot assignees field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,6 @@ updates:
     rebase-strategy: "disabled"
     commit-message:
       prefix: "chore(deps): "
-    assignees:
-      - "apache/iggy-committers"
     reviewers:
       - "apache/iggy-committers"
     groups:
@@ -43,8 +41,6 @@ updates:
     rebase-strategy: "disabled"
     commit-message:
       prefix: "chore(deps): "
-    assignees:
-      - "apache/iggy-committers"
     reviewers:
       - "apache/iggy-committers"
     groups:


### PR DESCRIPTION
GitHub assignees field accepts only individual users; teams
are valid only in reviewers. Dependabot failed on every PR
with: "could not be added as assignees: apache/iggy-committers".
Drop the assignees entries; team review is preserved via the
reviewers field which does support teams.
