### PR TITLE
ci: run stale-prs unmark jobs on arm runner

### DIFF
--- a/.github/workflows/stale-prs-unmark-on-activity.yml
+++ b/.github/workflows/stale-prs-unmark-on-activity.yml
@@ -55,7 +55,7 @@ concurrency:
 jobs:
   unmark:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 2
     steps:
       - name: Download triage event artifact

--- a/.github/workflows/stale-prs-unmark.yml
+++ b/.github/workflows/stale-prs-unmark.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   unmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 2
     if: contains(github.event.pull_request.labels.*.name, 'S-stale')
     steps:


### PR DESCRIPTION
Align stale-prs-unmark and stale-prs-unmark-on-activity with
pr-triage-apply/collect which already use ubuntu-24.04-arm.
Same runner pool, fewer cold starts, and matches the rest of
the PR-triage pipeline these jobs are part of.
