### PR TITLE
ci: run PR title check from dedicated workflow

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,6 +39,7 @@ github:
         strict: true
         contexts:
           - "finalize_pr"
+          - "PR Title"
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 2

--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -18,12 +18,6 @@
 name: _common
 on:
   workflow_call:
-    inputs:
-      skip_pr_title:
-        type: boolean
-        required: false
-        default: false
-        description: "Skip PR title check (for push events)"
 
 permissions:
   contents: read
@@ -66,75 +60,6 @@ jobs:
 
       - name: Check version consistency
         run: ./scripts/extract-version.sh --check
-
-  pr-title:
-    name: Check PR Title
-    if: github.event_name == 'pull_request' && !inputs.skip_pr_title
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate PR Title
-        uses: amannn/action-semantic-pull-request@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            docs
-            style
-            refactor
-            perf
-            test
-            build
-            ci
-            chore
-            revert
-            repo
-            deps
-          scopes: |
-            bdd
-            bench
-            ci
-            cli
-            clock
-            common
-            connector
-            connectors
-            cpp
-            csharp
-            deps
-            deps-dev
-            docs
-            example
-            go
-            helm
-            integration
-            io_uring
-            java
-            journal
-            js
-            mcp
-            node
-            partitions
-            proc
-            pr_template
-            python
-            repo
-            rust
-            sdk
-            security
-            server
-            server-ng
-            shard
-            test
-            web
-            consensus
-            cluster
-            metadata
-            message_bus
-            storage
-            simulator
-            configs
 
   license-headers:
     name: Check license headers
@@ -269,7 +194,6 @@ jobs:
         rust-versions,
         python-versions,
         version-consistency,
-        pr-title,
         license-headers,
         third-party-licenses,
         markdown,
@@ -289,22 +213,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Check | Status | Description |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|-------------|" >> $GITHUB_STEP_SUMMARY
-
-          # PR-specific checks
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_TITLE="${{ needs.pr-title.result }}"
-
-            # Add emoji based on status
-            if [ "$PR_TITLE" = "success" ]; then
-              echo "| ✅ PR Title | success | Follows conventional format |" >> $GITHUB_STEP_SUMMARY
-            elif [ "$PR_TITLE" = "failure" ]; then
-              echo "| ❌ PR Title | failure | Must follow conventional format |" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "| ⏭️ PR Title | $PR_TITLE | Check skipped |" >> $GITHUB_STEP_SUMMARY
-            fi
-          else
-            echo "| ⏭️ PR Title | skipped | Not a pull request |" >> $GITHUB_STEP_SUMMARY
-          fi
 
           # Always-run checks
           RUST_VERSIONS="${{ needs.rust-versions.result }}"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,100 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: PR Title
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: Check PR Title
+    if: github.event.action != 'edited' || github.event.changes.title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR Title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            repo
+            deps
+          scopes: |
+            bdd
+            bench
+            ci
+            cli
+            clock
+            common
+            connector
+            connectors
+            cpp
+            csharp
+            deps
+            deps-dev
+            docs
+            example
+            go
+            helm
+            integration
+            io_uring
+            java
+            journal
+            js
+            mcp
+            node
+            partitions
+            proc
+            pr_template
+            python
+            repo
+            rust
+            sdk
+            security
+            server
+            server-ng
+            shard
+            test
+            web
+            consensus
+            cluster
+            metadata
+            message_bus
+            storage
+            simulator
+            configs

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -25,13 +25,9 @@ permissions:
   contents: read
   pull-requests: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   pr-title:
-    name: Check PR Title
+    name: PR Title
     if: github.event.action != 'edited' || github.event.changes.title
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes part of #3258.

## Rationale

<!--
Why is this change needed? If the issue explains it well, a one-liner is fine.
-->

## What changed?

<!--
2-4 sentences. Problem first (before), then solution (after).

GOOD:

"Messages were unavailable when background message_saver committed the
journal and started async disk I/O before completion. Polling during
this window found neither journal nor disk data.

The fix freezes journal batches in the in-flight buffer before async persist."

GOOD:

"When many small messages accumulate in the journal, the flush passes
thousands of IO vectors to writev(), exceeding IOV_MAX (1024 on Linux)."

BAD:
- Walls of text
- "This PR adds..." (we can see the diff)
-->

Move the semantic PR title validation out of common pre-merge checks so editing a PR title can retrigger only the lightweight title CI.

## Local Execution

- Passed / not passed
Passed
- Pre-commit hooks ran / not ran
Ran
<!--
You must run your code locally before submitting.
"Relying on CI" is not acceptable - PRs from authors who haven't run the code will be closed.

Did you have `prek` installed? It runs automatically on commit and covers all project languages. See [CONTRIBUTING.md](https://github.com/apache/iggy/blob/master/CONTRIBUTING.md).
-->

## AI Usage

<!--
If AI tools were used, please answer:
1. Which tools? (e.g., GitHub Copilot, Claude, ChatGPT)
2. Scope of usage? (e.g., autocomplete, generated functions, entire implementation)
3. How did you verify the generated code works correctly?
4. Can you explain every line of the code if asked?

If no AI tools were used, write "None" or delete this section.
-->
