### PR TITLE
ci: broaden dependabot coverage, add cooldown and PR caps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,14 +18,26 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/"
+      - "/foreign/cpp"
+      - "/foreign/python"
+      # TODO(hubcio): uncomment once #3235 is merged
+      # - "/foreign/php"
     schedule:
       interval: "weekly"
+      day: "monday"
     rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(deps): "
     reviewers:
       - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "rust"
+    cooldown:
+      default-days: 7
     groups:
       minor-and-patch:
         patterns:
@@ -38,11 +50,219 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "tuesday"
     rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(deps): "
     reviewers:
       - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "github_actions"
+      - "CI/CD"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "uv"
+    directories:
+      - "/foreign/python"
+      - "/bdd/python"
+      - "/examples/python"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "python"
+      - "python:uv"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/foreign/node"
+      - "/web"
+      - "/examples/node"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "javascript"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "gomod"
+    directories:
+      - "/foreign/go"
+      - "/bdd/go"
+      - "/examples/go"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "go"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "nuget"
+    directories:
+      - "/foreign/csharp"
+      - "/examples/csharp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "csharp"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "gradle"
+    directories:
+      - "/foreign/java"
+      - "/bdd/java"
+      - "/examples/java"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "java"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/core/server"
+      - "/core/server-ng"
+      - "/core/connectors/runtime"
+      - "/core/ai/mcp"
+      - "/core/bench/dashboard/server"
+      - "/web"
+      - "/bdd"
+      - "/bdd/csharp"
+      - "/bdd/go"
+      - "/bdd/java"
+      - "/bdd/node"
+      - "/bdd/python"
+      - "/bdd/rust"
+      - "/foreign/python"
+      - "/foreign/python/.devcontainer"
+      - "/foreign/java/external-processors/iggy-connector-flink/docker"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "docker"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "bazel"
+    directory: "/foreign/cpp"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "C++"
+    cooldown:
+      default-days: 7
     groups:
       minor-and-patch:
         patterns:

--- a/bdd/README.md
+++ b/bdd/README.md
@@ -15,7 +15,8 @@ bdd/
 ├── python/                     # Python SDK BDD implementation
 │   ├── Dockerfile              # Python BDD test container
 │   ├── tests/
-│   └── requirements.txt
+│   ├── pyproject.toml
+│   └── uv.lock
 ├── node/                       # Node SDK BDD implementation
 │   └── Dockerfile              # Node BDD test container
 ├── csharp/                     # csharp SDK BDD implementation

--- a/bdd/python/requirements.txt
+++ b/bdd/python/requirements.txt
@@ -1,4 +1,0 @@
-pytest>=7.0.0
-pytest-bdd>=6.0.0
-pytest-asyncio>=0.21.0
-maturin>=1.0.0


### PR DESCRIPTION
Was Rust workspace + GitHub Actions only, leaving 5 foreign SDKs,
17 Dockerfiles, and the C++ Bazel module on manual updates - stale
transitive deps and base image CVEs went unsurfaced.

Adds uv, npm, gomod, nuget, gradle, bazel, and docker. Cargo entry
also picks up /foreign/cpp and /foreign/python (workspace-excluded
crates with their own Cargo.lock). uv over pip - repo uses uv.lock
natively. nuget covers foreign + examples csharp; docker covers
production, bdd, foreign.

bdd/python/requirements.txt removed; pyproject+uv.lock is canonical
and pins had drifted (pytest>=7 vs >=9.0.3, orphan maturin).

Tunes existing entries: cooldown.default-days 7 (skip yanked
first-day releases), open-pull-requests-limit 3 (headroom so
ungrouped majors don't starve grouped minor-patch on one slot),
schedule.day stagger Mon-Fri (avoid Monday CI + reviewer herd),
per-ecosystem labels.
