### PR TITLE
chore(deps): bump workspace; migrate sqlx 0.9 + keyring 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,9 +1174,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "autotools"
@@ -1221,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.8.16"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1235,12 +1246,13 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "sha1 0.10.6",
  "time",
  "tokio",
@@ -1285,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1300,7 +1312,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -1310,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.111.0"
+version = "1.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc418346e3cb248c7d59e642acbcb06488b7c7cd2ba6ebc79e8003f618c60099"
+checksum = "08d2b44e71eda015705fe8a2d3f8061003432ad722d4e321ac38b3e2680fbe49"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1327,16 +1339,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.98.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1351,16 +1363,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.100.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1375,16 +1387,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.103.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1400,16 +1412,16 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -1420,7 +1432,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -1450,7 +1462,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -1469,7 +1481,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -1485,10 +1497,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -1513,20 +1527,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1538,16 +1553,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1566,17 +1581,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1602,13 +1628,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -1625,7 +1652,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -1656,7 +1683,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -1688,7 +1715,7 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "hyper",
  "hyper-util",
@@ -1990,6 +2017,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,7 +2060,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
@@ -2197,21 +2233,21 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "buoyant_kernel"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3ca37afa82755db7b4fd51a4eab9e53eeb0aa1898fae15d373bd6df4bdf0f8"
+checksum = "2235eb320cd7178862a32dd111bd0c0f71a368e393add4914c50129add478eab"
 dependencies = [
  "arrow",
  "buoyant_kernel_derive",
@@ -2225,7 +2261,7 @@ dependencies = [
  "parquet 58.3.0",
  "percent-encoding",
  "rand 0.9.4",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "roaring",
  "rustc_version",
  "serde",
@@ -2408,6 +2444,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -2700,7 +2745,7 @@ dependencies = [
  "compio-buf",
  "compio-log",
  "crossbeam-queue",
- "flume 0.12.0",
+ "flume",
  "futures-util",
  "io-uring",
  "io_uring_buf_ring",
@@ -2800,7 +2845,7 @@ dependencies = [
  "compio-log",
  "compio-net",
  "compio-runtime",
- "flume 0.12.0",
+ "flume",
  "futures-util",
  "libc",
  "quinn-proto",
@@ -3204,9 +3249,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossfire"
-version = "3.1.13"
+version = "3.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f956539b6d6369ec3e2b7a2cfa7652b9c2a1d51982338b111f5a814515ae1d"
+checksum = "4d8c4de3db833e7ef74050bae09d5f3fa8f9d1507d3c2689c6e8c50b71208b18"
 dependencies = [
  "crossbeam-utils",
  "embed-collections",
@@ -3246,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -3427,7 +3472,7 @@ dependencies = [
  "cyper-core",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -3620,9 +3665,27 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
+ "fastrand",
+ "hkdf 0.12.4",
+ "num",
+ "once_cell",
  "openssl",
+ "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -3710,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "deltalake-core"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bbd066e5d0d66bb8459e6cb26e40ada6c83f05481b432d50d5071240021145d"
+checksum = "c8e67c5de0c7cc492a22c6e5bd7f37cfb59c471dd135617058eac609ddcfb878"
 dependencies = [
  "arrow",
  "arrow-arith 58.3.0",
@@ -4047,7 +4110,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -4146,9 +4209,9 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
 dependencies = [
  "base64",
  "serde",
@@ -4249,9 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -4291,7 +4354,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -4302,9 +4365,9 @@ dependencies = [
 
 [[package]]
 name = "embed-collections"
-version = "0.11.6"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00ad60ee701d42d7b613057ee691272ffa40b90335e6a1e901a7fc4bf0769b8"
+checksum = "82e4033966f8f27b67150cff46840aa0cf68da9d83454e84c903d76f939ff698"
 
 [[package]]
 name = "embedded-io"
@@ -4429,17 +4492,6 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4636,9 +4688,9 @@ dependencies = [
 
 [[package]]
 name = "file-operation"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6741d67ff1b3ffb62e08ed890e1315f94db5f0558396c428dc2c99de03b3c0f"
+checksum = "8f96e80691f85459f0645173d75b909813cb28f99e1a5b08dcced2d5a0234b19"
 dependencies = [
  "tokio",
 ]
@@ -4693,17 +4745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin",
 ]
 
 [[package]]
@@ -4951,9 +4992,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -5337,7 +5378,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils 0.3.0",
- "http 1.4.0",
+ "http 1.4.1",
  "js-sys",
  "pin-project",
  "serde",
@@ -5581,7 +5622,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -5672,8 +5713,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -5696,11 +5735,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5815,6 +5854,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5865,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -5891,7 +5939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -5902,7 +5950,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -5991,7 +6039,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -6023,7 +6071,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-util",
  "log",
@@ -6058,7 +6106,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "hyper",
  "ipnet",
@@ -6174,7 +6222,7 @@ checksum = "a49dfef578060c3a2a3f619522dcb25382a7ce85336dcb500495d4b8d72ae714"
 dependencies = [
  "async-trait",
  "chrono",
- "http 1.4.0",
+ "http 1.4.1",
  "iceberg",
  "itertools 0.13.0",
  "reqwest 0.12.28",
@@ -6338,14 +6386,14 @@ dependencies = [
  "bytemuck",
  "bytes",
  "dashmap",
- "flume 0.12.0",
+ "flume",
  "futures",
  "futures-util",
  "iggy_binary_protocol",
  "iggy_common",
  "mockall",
  "quinn",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -6422,18 +6470,20 @@ name = "iggy-cli"
 version = "0.13.1-edge.1"
 dependencies = [
  "anyhow",
+ "apple-native-keyring-store",
  "async-trait",
  "bytes",
  "chrono",
  "clap",
  "clap_complete",
  "comfy-table",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "figlet-rs",
  "iggy",
  "iggy_binary_protocol",
  "iggy_common",
- "keyring",
+ "keyring-core",
  "passterm",
  "secrecy",
  "serde",
@@ -6445,6 +6495,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
@@ -6464,7 +6515,7 @@ dependencies = [
  "dotenvy",
  "figlet-rs",
  "figment",
- "flume 0.12.0",
+ "flume",
  "futures",
  "iggy",
  "iggy_common",
@@ -6478,7 +6529,7 @@ dependencies = [
  "opentelemetry_sdk",
  "postcard",
  "prometheus-client",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -6646,7 +6697,7 @@ dependencies = [
  "bytes",
  "humantime",
  "iggy_connector_sdk",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -6691,7 +6742,7 @@ dependencies = [
  "iggy_common",
  "iggy_connector_sdk",
  "once_cell",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "secrecy",
  "serde",
@@ -6714,7 +6765,7 @@ dependencies = [
  "iggy_connector_sdk",
  "once_cell",
  "regex",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "secrecy",
  "serde",
@@ -6790,7 +6841,7 @@ dependencies = [
  "dashmap",
  "iggy_connector_sdk",
  "once_cell",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_yaml_ng",
  "simd-json",
@@ -6825,7 +6876,7 @@ dependencies = [
  "base64",
  "dashmap",
  "flatbuffers",
- "http 1.4.0",
+ "http 1.4.1",
  "humantime",
  "iggy",
  "iggy_common",
@@ -6837,7 +6888,7 @@ dependencies = [
  "protox-parse",
  "rand 0.10.1",
  "regex",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "rmp-serde",
  "serde",
@@ -7035,6 +7086,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -7057,6 +7109,7 @@ dependencies = [
  "configs",
  "configs_derive",
  "ctor 1.0.6",
+ "dbus-secret-service-keyring-store",
  "deltalake",
  "dtor 1.0.3",
  "figment",
@@ -7069,7 +7122,7 @@ dependencies = [
  "iggy_common",
  "iggy_connector_sdk",
  "jsonwebtoken",
- "keyring",
+ "keyring-core",
  "lazy_static",
  "libc",
  "mongodb",
@@ -7077,7 +7130,7 @@ dependencies = [
  "predicates",
  "rand 0.10.1",
  "rcgen",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "reqwest-retry",
  "rmcp",
@@ -7199,9 +7252,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -7209,14 +7262,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7335,9 +7388,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -7390,15 +7443,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "dbus-secret-service",
  "log",
- "openssl",
- "zeroize",
 ]
 
 [[package]]
@@ -7634,9 +7684,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2892ae4ea6fa2cb7acb0e236a6880d39523239cd9089de71d220910ccc806790"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
@@ -7647,17 +7697,14 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -7745,9 +7792,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "logos"
@@ -7755,7 +7802,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
 ]
 
 [[package]]
@@ -7775,12 +7831,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "logos-derive"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
- "logos-codegen",
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
 ]
 
 [[package]]
@@ -7930,6 +8009,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8018,9 +8107,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebca48a43116bc25f18a61360f1be98412f50cc218f5e52c823086b999a4a21a"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -8153,7 +8242,7 @@ dependencies = [
  "hickory-resolver",
  "hmac 0.12.1",
  "macro_magic",
- "md-5",
+ "md-5 0.10.6",
  "mongocrypt",
  "mongodb-internal-macros",
  "pbkdf2",
@@ -8589,13 +8678,13 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "httparse",
  "humantime",
  "hyper",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.39.4",
@@ -8631,7 +8720,7 @@ dependencies = [
  "futures",
  "futures-util",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -8700,11 +8789,11 @@ dependencies = [
  "crc32c",
  "futures",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign",
@@ -8804,9 +8893,9 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
  "opentelemetry",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -8815,13 +8904,13 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -8849,9 +8938,9 @@ checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -8973,7 +9062,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -9129,9 +9218,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pbkdf2"
@@ -9359,12 +9448,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -9713,11 +9796,11 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
 dependencies = [
- "logos",
+ "logos 0.16.1",
  "miette",
  "prost",
  "prost-types",
@@ -9753,7 +9836,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
 dependencies = [
- "logos",
+ "logos 0.15.1",
  "miette",
  "prost-types",
  "thiserror 2.0.18",
@@ -10154,15 +10237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10252,7 +10326,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "home",
- "http 1.4.0",
+ "http 1.4.1",
  "log",
  "percent-encoding",
  "quick-xml 0.37.5",
@@ -10277,7 +10351,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -10311,9 +10385,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -10322,7 +10396,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -10362,8 +10436,8 @@ checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.0",
- "reqwest 0.13.3",
+ "http 1.4.1",
+ "reqwest 0.13.4",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -10379,9 +10453,9 @@ dependencies = [
  "async-trait",
  "futures",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 2.0.18",
@@ -10399,9 +10473,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.1",
  "matchit",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "tracing",
 ]
@@ -10517,13 +10591,13 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "pastey 0.2.2",
+ "pastey 0.2.3",
  "pin-project-lite",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
@@ -11143,9 +11217,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -11316,7 +11390,7 @@ dependencies = [
  "err_trail",
  "error_set",
  "figlet-rs",
- "flume 0.12.0",
+ "flume",
  "fs2",
  "futures",
  "hash32 1.0.0",
@@ -11826,9 +11900,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -11839,12 +11913,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -11854,12 +11929,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
@@ -11872,14 +11946,14 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11890,15 +11964,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -11909,59 +11983,44 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -11970,23 +12029,21 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera 0.8.0",
+ "etcetera",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac 0.12.1",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -11998,13 +12055,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
- "flume 0.11.1",
+ "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -12014,7 +12072,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -12451,16 +12508,16 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera 0.11.0",
+ "etcetera",
  "ferroid",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
  "pin-project-lite",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_with",
@@ -12863,7 +12920,7 @@ dependencies = [
  "base64",
  "bytes",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -12946,7 +13003,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -13109,7 +13166,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -13128,7 +13185,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -13227,9 +13284,9 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typetag"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -13240,9 +13297,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13413,7 +13470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
 ]
@@ -13709,16 +13766,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -13729,9 +13780,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13739,9 +13790,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13749,9 +13800,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -13762,9 +13813,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -13855,9 +13906,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13921,13 +13972,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "widestring"
@@ -14092,6 +14139,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14169,15 +14229,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -14225,21 +14276,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -14301,12 +14337,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -14325,12 +14355,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -14346,12 +14370,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -14385,12 +14403,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -14406,12 +14418,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -14433,12 +14439,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -14454,12 +14454,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -14513,7 +14507,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,9 @@ ahash = { version = "0.8.12", features = ["serde"] }
 aligned-vec = "0.6.4"
 anyhow = "1.0.102"
 apache-avro = "0.21.0"
+apple-native-keyring-store = { version = "1.0.0", features = ["keychain"] }
 argon2 = "0.5.3"
+# Pinned to 57 because iceberg 0.9.1 still requires arrow/parquet 57.
 arrow = "57.3.1"
 arrow-array = "57.3.1"
 arrow-json = "57.3.1"
@@ -128,7 +130,7 @@ configs_derive = { path = "core/configs_derive", version = "0.1.0" }
 consensus = { path = "core/consensus" }
 console-subscriber = "0.5.0"
 crossbeam = "0.8.4"
-crossfire = "3.1.13"
+crossfire = "3.1.16"
 csv = "1.4.0"
 ctor = "1.0.6"
 ctrlc = { version = "3.5", features = ["termination"] }
@@ -137,6 +139,7 @@ cyper = { version = "0.8.3", features = ["rustls"], default-features = false }
 cyper-axum = { version = "0.8.0" }
 darling = "0.23"
 dashmap = "6.2.1"
+dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust", "vendored"] }
 deltalake = { version = "0.32.3", features = ["azure", "gcs", "s3"] }
 derive-new = "0.7.0"
 derive_builder = "0.20.2"
@@ -153,7 +156,7 @@ err_trail = { version = "0.11.0", features = ["tracing"] }
 error_set = "0.9.1"
 figlet-rs = "1.0.0"
 figment = { version = "0.10.19", features = ["toml", "env"] }
-file-operation = "0.8.20"
+file-operation = "0.8.21"
 flatbuffers = "25.12.19"
 flume = "0.12.0"
 fs2 = "0.4.3"
@@ -184,12 +187,12 @@ integration = { path = "core/integration" }
 journal = { path = "core/journal" }
 js-sys = "0.3"
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
-keyring = { version = "3.6.3", features = ["sync-secret-service", "vendored"] }
+keyring-core = "1.0.0"
 lazy_static = "1.5.0"
 left-right = "0.11"
 lending-iterator = "0.1.7"
 libc = "0.2.186"
-log = "0.4.29"
+log = "0.4.30"
 lz4_flex = "0.13.1"
 message_bus = { path = "core/message_bus" }
 metadata = { path = "core/metadata" }
@@ -214,7 +217,7 @@ opentelemetry-otlp = { version = "0.32.0", features = [
     "reqwest-client",
 ] }
 opentelemetry-semantic-conventions = "0.32.0"
-opentelemetry_sdk = { version = "0.32.0", features = [
+opentelemetry_sdk = { version = "0.32.1", features = [
     "logs",
     "trace",
     "experimental_async_runtime",
@@ -241,7 +244,7 @@ rand_xoshiro = "0.8.1"
 rayon = "1.12.0"
 rcgen = "0.14.8"
 regex = "1.12.3"
-reqwest = { version = "0.13.3", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }
 reqwest-middleware = { version = "0.5.2", features = ["json", "query"] }
 reqwest-retry = "0.9.1"
 reqwest-tracing = "0.7.1"
@@ -259,7 +262,7 @@ sd-notify = "0.5"
 secrecy = { version = "0.10", features = ["serde"] }
 send_wrapper = "0.6.0"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 serde_with = { version = "3.20.0", features = ["base64", "macros"] }
 serde_yaml_ng = "0.10.0"
 serial_test = "3.4.0"
@@ -271,8 +274,9 @@ simd-json = { version = "0.17.0", features = ["serde_impl"] }
 slab = "0.4.12"
 smallvec = "1.15"
 socket2 = "0.6.3"
-sqlx = { version = "0.8.6", features = [
-    "runtime-tokio-rustls",
+sqlx = { version = "0.9.0", features = [
+    "runtime-tokio",
+    "tls-rustls",
     "postgres",
     "chrono",
     "uuid",
@@ -322,6 +326,7 @@ web-sys = { version = "0.3", features = [
     "ResizeObserverEntry",
 ] }
 webpki-roots = "1.0.7"
+windows-native-keyring-store = "1.1.0"
 yew = { version = "0.23", features = ["csr"] }
 yew-router = "0.20"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -41,7 +41,12 @@ path = "src/main.rs"
 
 [features]
 default = ["login-session"]
-login-session = ["dep:keyring"]
+login-session = [
+    "dep:keyring-core",
+    "dep:dbus-secret-service-keyring-store",
+    "dep:apple-native-keyring-store",
+    "dep:windows-native-keyring-store",
+]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -56,7 +61,7 @@ figlet-rs = { workspace = true }
 iggy = { workspace = true }
 iggy_binary_protocol = { workspace = true }
 iggy_common = { workspace = true }
-keyring = { workspace = true, optional = true }
+keyring-core = { workspace = true, optional = true }
 passterm = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
@@ -67,6 +72,15 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, default-features = false }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dbus-secret-service-keyring-store = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-native-keyring-store = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/core/cli/src/commands/binary_personal_access_tokens/create_personal_access_token.rs
+++ b/core/cli/src/commands/binary_personal_access_tokens/create_personal_access_token.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use iggy_common::Client;
 use iggy_common::PersonalAccessTokenExpiry;
 use iggy_common::create_personal_access_token::CreatePersonalAccessToken;
-use keyring::Entry;
+use keyring_core::Entry;
 use tracing::{Level, event};
 
 pub struct CreatePersonalAccessTokenCmd {

--- a/core/cli/src/commands/binary_personal_access_tokens/delete_personal_access_tokens.rs
+++ b/core/cli/src/commands/binary_personal_access_tokens/delete_personal_access_tokens.rs
@@ -21,7 +21,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use iggy_common::Client;
 use iggy_common::delete_personal_access_token::DeletePersonalAccessToken;
-use keyring::Entry;
+use keyring_core::Entry;
 use tracing::{Level, event};
 
 pub struct DeletePersonalAccessTokenCmd {

--- a/core/cli/src/commands/binary_system/session.rs
+++ b/core/cli/src/commands/binary_system/session.rs
@@ -16,10 +16,46 @@
  * under the License.
  */
 
-use keyring::{Entry, Result};
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+use std::sync::Mutex;
+
+#[cfg(target_os = "macos")]
+use apple_native_keyring_store::keychain::Store;
+#[cfg(target_os = "linux")]
+use dbus_secret_service_keyring_store::store::Store;
+use keyring_core::{Entry, error::Result};
+use tracing::warn;
+#[cfg(target_os = "windows")]
+use windows_native_keyring_store::store::Store;
+
+use crate::commands::cli_command::PRINT_TARGET;
 
 const SESSION_TOKEN_NAME: &str = "iggy-cli-session";
 const SESSION_KEYRING_SERVICE_NAME: &str = "iggy-cli-session";
+
+/// `keyring-core` 1.x has no implicit default backend. Register one on the
+/// first `Entry::new` so unrelated CLI subcommands never touch the OS keyring.
+///
+/// The mutex serializes concurrent callers so two threads cannot both observe
+/// an empty default store and race to install one. `get_default_store()` acts
+/// as the idempotency check, so a transient `Store::new()` failure stays
+/// retryable on the next call.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub fn ensure_default_store() -> Result<()> {
+    static INIT_LOCK: Mutex<()> = Mutex::new(());
+    let _guard = INIT_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    if keyring_core::get_default_store().is_some() {
+        return Ok(());
+    }
+    let store = Store::new()?;
+    keyring_core::set_default_store(store);
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+pub fn ensure_default_store() -> Result<()> {
+    Ok(())
+}
 
 pub struct ServerSession {
     server_address: String,
@@ -43,6 +79,10 @@ impl ServerSession {
     }
 
     pub fn is_active(&self) -> bool {
+        if let Err(e) = ensure_default_store() {
+            warn!(target: PRINT_TARGET, "keyring backend unavailable, treating session as inactive: {e}");
+            return false;
+        }
         if let Ok(entry) = Entry::new(&self.get_service_name(), &self.get_token_name()) {
             return entry.get_password().is_ok();
         }
@@ -51,12 +91,17 @@ impl ServerSession {
     }
 
     pub fn store(&self, token: &str) -> Result<()> {
+        ensure_default_store()?;
         let entry = Entry::new(&self.get_service_name(), &self.get_token_name())?;
         entry.set_password(token)?;
         Ok(())
     }
 
     pub fn get_token(&self) -> Option<String> {
+        if let Err(e) = ensure_default_store() {
+            warn!(target: PRINT_TARGET, "keyring backend unavailable, cannot read session token: {e}");
+            return None;
+        }
         if let Ok(entry) = Entry::new(&self.get_service_name(), &self.get_token_name())
             && let Ok(token) = entry.get_password()
         {
@@ -67,6 +112,7 @@ impl ServerSession {
     }
 
     pub fn delete(&self) -> Result<()> {
+        ensure_default_store()?;
         let entry = Entry::new(&self.get_service_name(), &self.get_token_name())?;
         entry.delete_credential()
     }

--- a/core/cli/src/credentials.rs
+++ b/core/cli/src/credentials.rs
@@ -21,7 +21,7 @@ use crate::error::{CmdToolError, IggyCmdError};
 use anyhow::{Context, bail};
 use iggy::clients::client::IggyClient;
 use iggy::prelude::{Args, IggyError, PersonalAccessTokenClient, UserClient};
-use iggy_cli::commands::binary_system::session::ServerSession;
+use iggy_cli::commands::binary_system::session::{ServerSession, ensure_default_store};
 use passterm::{Stream, isatty, prompt_password_tty};
 use secrecy::{ExposeSecret, SecretString};
 use std::env::var;
@@ -29,7 +29,7 @@ use std::env::var;
 #[cfg(feature = "login-session")]
 mod credentials_login_session {
     pub(crate) use iggy_cli::commands::cli_command::PRINT_TARGET;
-    pub(crate) use keyring::Entry;
+    pub(crate) use keyring_core::Entry;
     pub(crate) use tracing::{Level, event};
 }
 
@@ -91,6 +91,7 @@ impl<'a> IggyCredentials<'a> {
                     let server_address = format!("iggy:{server_address}");
                     event!(target: PRINT_TARGET, Level::DEBUG,"Checking token presence under service: {} and name: {}",
                     server_address, token_name);
+                    ensure_default_store()?;
                     let entry = Entry::new(&server_address, token_name)?;
                     let token = entry.get_password()?;
 

--- a/core/cli/src/main.rs
+++ b/core/cli/src/main.rs
@@ -97,6 +97,7 @@ use tracing::{Level, event};
 #[cfg(feature = "login-session")]
 mod main_login_session {
     pub(crate) use crate::args::session::SessionAction;
+    pub(crate) use iggy_cli::commands::binary_system::session::ensure_default_store;
     pub(crate) use iggy_cli::commands::binary_system::session_status::SessionStatusCmd;
     pub(crate) use iggy_cli::commands::binary_system::{login::LoginCmd, logout::LogoutCmd};
     pub(crate) use iggy_cli::commands::utils::login_session_expiry::LoginSessionExpiry;
@@ -376,6 +377,14 @@ async fn main() -> Result<(), IggyCmdError> {
 
     let mut logging = Logging::new();
     logging.init(args.cli.quiet, &args.cli.debug);
+
+    // keyring-core 1.x has no implicit default backend. Register one up front
+    // so any subcommand that touches `Entry::new` (login, PAT store/delete,
+    // token-name lookup) sees the backend regardless of code-path ordering.
+    #[cfg(feature = "login-session")]
+    if let Err(e) = ensure_default_store() {
+        tracing::warn!(target: PRINT_TARGET, "keyring backend unavailable: {e}");
+    }
 
     let command = args.command.clone().unwrap();
 

--- a/core/connectors/sinks/postgres_sink/src/lib.rs
+++ b/core/connectors/sinks/postgres_sink/src/lib.rs
@@ -216,7 +216,7 @@ impl PostgresSink {
         sql.push_str(&format!(", payload {payload_type}"));
         sql.push_str(", created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW())");
 
-        sqlx::query(&sql)
+        sqlx::query(sqlx::AssertSqlSafe(sql))
             .execute(pool)
             .await
             .map_err(|e| Error::InitError(format!("Failed to create table '{table_name}': {e}")))?;
@@ -368,7 +368,7 @@ impl PostgresSink {
         include_origin_timestamp: bool,
         payload_format: PayloadFormat,
     ) -> Result<(), (sqlx::Error, bool)> {
-        let mut query_builder = sqlx::query(query);
+        let mut query_builder = sqlx::query(sqlx::AssertSqlSafe(query));
 
         for message in messages {
             let payload_bytes = message.payload.clone().try_into_vec().map_err(|e| {

--- a/core/connectors/sources/postgres_source/src/lib.rs
+++ b/core/connectors/sources/postgres_source/src/lib.rs
@@ -325,16 +325,23 @@ impl PostgresSource {
             .publication_name
             .as_deref()
             .unwrap_or("iggy_publication");
+        let quoted_publication = quote_identifier(publication_name)?;
         let tables_clause = if self.config.tables.is_empty() {
             "FOR ALL TABLES".to_string()
         } else {
-            format!("FOR TABLE {}", self.config.tables.join(", "))
+            let quoted_tables = self
+                .config
+                .tables
+                .iter()
+                .map(|t| quote_qualified_identifier(t))
+                .collect::<Result<Vec<_>, _>>()?;
+            format!("FOR TABLE {}", quoted_tables.join(", "))
         };
 
         let create_publication_sql =
-            format!("CREATE PUBLICATION IF NOT EXISTS {publication_name} {tables_clause}");
+            format!("CREATE PUBLICATION IF NOT EXISTS {quoted_publication} {tables_clause}");
 
-        sqlx::query(&create_publication_sql)
+        sqlx::query(sqlx::AssertSqlSafe(create_publication_sql))
             .execute(pool)
             .await
             .map_err(|e| Error::InitError(format!("Failed to create publication: {e}")))?;
@@ -344,14 +351,15 @@ impl PostgresSource {
             .replication_slot
             .as_deref()
             .unwrap_or("iggy_slot");
-        let create_slot_sql = format!(
-            "SELECT pg_create_logical_replication_slot('{slot_name}', 'pgoutput') WHERE NOT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{slot_name}')"
-        );
 
-        sqlx::query(&create_slot_sql)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| Error::InitError(format!("Failed to create replication slot: {e}")))?;
+        sqlx::query(
+            "SELECT pg_create_logical_replication_slot($1, 'pgoutput') \
+             WHERE NOT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+        )
+        .bind(slot_name)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| Error::InitError(format!("Failed to create replication slot: {e}")))?;
 
         info!("PostgreSQL CDC setup completed. Publication: {publication_name}, Slot: {slot_name}");
         Ok(())
@@ -406,7 +414,7 @@ impl PostgresSource {
         );
 
         // Database I/O without holding the lock
-        let rows = sqlx::query(&logical_repl_sql)
+        let rows = sqlx::query(sqlx::AssertSqlSafe(logical_repl_sql))
             .fetch_all(pool)
             .await
             .map_err(|e| {
@@ -498,7 +506,7 @@ impl PostgresSource {
 
             // Database I/O without holding the lock
             let rows = with_retry(
-                || sqlx::query(&query).fetch_all(pool),
+                || sqlx::query(sqlx::AssertSqlSafe(query.as_str())).fetch_all(pool),
                 self.get_max_retries(),
                 self.retry_delay.as_millis() as u64,
             )
@@ -563,7 +571,7 @@ impl PostgresSource {
             return Ok(());
         }
 
-        let quoted_table = quote_identifier(table)?;
+        let quoted_table = quote_qualified_identifier(table)?;
         let quoted_pk = quote_identifier(pk_column)?;
 
         let ids_list = ids
@@ -588,7 +596,7 @@ impl PostgresSource {
                 debug!("Deleting {} processed rows from '{table}'", ids.len());
             }
 
-            sqlx::query(&delete_query)
+            sqlx::query(sqlx::AssertSqlSafe(delete_query))
                 .execute(pool)
                 .await
                 .map_err(|e| {
@@ -607,7 +615,7 @@ impl PostgresSource {
                 debug!("Marking {} rows as processed in '{table}'", ids.len());
             }
 
-            sqlx::query(&update_query)
+            sqlx::query(sqlx::AssertSqlSafe(update_query))
                 .execute(pool)
                 .await
                 .map_err(|e| {
@@ -645,7 +653,7 @@ impl PostgresSource {
         last_offset: &Option<String>,
         batch_size: u32,
     ) -> Result<String, Error> {
-        let quoted_table = quote_identifier(table)?;
+        let quoted_table = quote_qualified_identifier(table)?;
         let quoted_tracking = quote_identifier(tracking_column)?;
 
         let base_query = format!("SELECT * FROM {quoted_table}");
@@ -1056,13 +1064,28 @@ fn extract_column_value(
 
 fn quote_identifier(name: &str) -> Result<String, Error> {
     if name.is_empty() {
-        return Err(Error::InvalidConfig);
+        return Err(Error::InvalidConfigValue(
+            "identifier must not be empty".to_string(),
+        ));
     }
     if name.contains('\0') {
-        return Err(Error::InvalidConfig);
+        return Err(Error::InvalidConfigValue(format!(
+            "identifier '{name}' contains NUL byte"
+        )));
     }
     let escaped = name.replace('"', "\"\"");
     Ok(format!("\"{escaped}\""))
+}
+
+/// Quote a possibly schema-qualified identifier like `public.users` as
+/// `"public"."users"`. Each dot-separated segment is validated and quoted
+/// independently so that schema-qualified table names survive intact.
+fn quote_qualified_identifier(name: &str) -> Result<String, Error> {
+    if !name.contains('.') {
+        return quote_identifier(name);
+    }
+    let parts: Result<Vec<_>, _> = name.split('.').map(quote_identifier).collect();
+    Ok(parts?.join("."))
 }
 
 fn format_offset_value(value: &str) -> String {
@@ -1277,6 +1300,30 @@ mod tests {
     fn given_empty_identifier_should_fail() {
         let result = quote_identifier("");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn given_unqualified_name_should_quote_as_single_identifier() {
+        let result = quote_qualified_identifier("users").expect("Failed to quote");
+        assert_eq!(result, "\"users\"");
+    }
+
+    #[test]
+    fn given_schema_qualified_name_should_quote_each_segment() {
+        let result = quote_qualified_identifier("public.users").expect("Failed to quote");
+        assert_eq!(result, "\"public\".\"users\"");
+    }
+
+    #[test]
+    fn given_qualified_name_with_quote_chars_should_escape_each_segment() {
+        let result = quote_qualified_identifier("my\"schema.my\"table").expect("Failed to quote");
+        assert_eq!(result, "\"my\"\"schema\".\"my\"\"table\"");
+    }
+
+    #[test]
+    fn given_qualified_name_with_empty_segment_should_fail() {
+        assert!(quote_qualified_identifier("public.").is_err());
+        assert!(quote_qualified_identifier(".users").is_err());
     }
 
     #[test]

--- a/core/integration/Cargo.toml
+++ b/core/integration/Cargo.toml
@@ -50,7 +50,7 @@ iggy_binary_protocol = { workspace = true }
 iggy_common = { workspace = true }
 iggy_connector_sdk = { workspace = true, features = ["api"] }
 jsonwebtoken = { workspace = true }
-keyring = { workspace = true }
+keyring-core = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
 mongodb = { workspace = true }
@@ -87,3 +87,6 @@ url = { workspace = true }
 uuid = { workspace = true }
 wiremock = "0.6"
 zip = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dbus-secret-service-keyring-store = { workspace = true }

--- a/core/integration/tests/cli/common/keyring.rs
+++ b/core/integration/tests/cli/common/keyring.rs
@@ -1,0 +1,36 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#[cfg(target_os = "linux")]
+use dbus_secret_service_keyring_store::store::Store;
+#[cfg(target_os = "linux")]
+use std::sync::Once;
+
+/// `keyring-core` 1.x has no implicit default backend; tests must register one
+/// before any `Entry::new` (directly or via `ServerSession`).
+#[cfg(target_os = "linux")]
+pub(crate) fn ensure_keyring_store() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let store = Store::new().expect("Failed to create dbus secret-service store");
+        keyring_core::set_default_store(store);
+    });
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn ensure_keyring_store() {}

--- a/core/integration/tests/cli/common/mod.rs
+++ b/core/integration/tests/cli/common/mod.rs
@@ -18,8 +18,10 @@
 
 pub(crate) mod command;
 pub(crate) mod help;
+pub(crate) mod keyring;
 pub(crate) use crate::cli::common::command::IggyCmdCommand;
 pub(crate) use crate::cli::common::help::{CLAP_INDENT, TestHelpCmd, USAGE_PREFIX};
+pub(crate) use crate::cli::common::keyring::ensure_keyring_store;
 use assert_cmd::assert::{Assert, OutputAssertExt};
 use assert_cmd::prelude::CommandCargoExt;
 use async_trait::async_trait;

--- a/core/integration/tests/cli/personal_access_token/test_pat_login_options.rs
+++ b/core/integration/tests/cli/personal_access_token/test_pat_login_options.rs
@@ -16,12 +16,12 @@
  * under the License.
  */
 
-use crate::cli::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use crate::cli::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, ensure_keyring_store};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::prelude::Client;
 use iggy::prelude::PersonalAccessTokenExpiry;
-use keyring::Entry;
+use keyring_core::Entry;
 use predicates::str::{contains, starts_with};
 use serial_test::parallel;
 use std::fmt::{Display, Formatter, Result};
@@ -53,6 +53,7 @@ struct TestLoginOptions {
 
 impl TestLoginOptions {
     fn new(token_name: String, using_token: UsingToken, server_address: String) -> Self {
+        ensure_keyring_store();
         Self {
             token_name: token_name.clone(),
             token_value: None,

--- a/core/integration/tests/cli/system/test_login_cmd.rs
+++ b/core/integration/tests/cli/system/test_login_cmd.rs
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-use crate::cli::common::{IggyCmdCommand, IggyCmdTestCase};
+use crate::cli::common::{IggyCmdCommand, IggyCmdTestCase, ensure_keyring_store};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::prelude::Client;
@@ -40,6 +40,7 @@ pub(super) struct TestLoginCmd {
 
 impl TestLoginCmd {
     pub(super) fn new(server_address: String, login_type: TestLoginCmdType) -> Self {
+        ensure_keyring_store();
         Self {
             server_address,
             login_type,

--- a/core/integration/tests/cli/system/test_logout_cmd.rs
+++ b/core/integration/tests/cli/system/test_logout_cmd.rs
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-use crate::cli::common::{IggyCmdCommand, IggyCmdTestCase};
+use crate::cli::common::{IggyCmdCommand, IggyCmdTestCase, ensure_keyring_store};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::prelude::Client;
@@ -30,6 +30,7 @@ pub(super) struct TestLogoutCmd {
 
 impl TestLogoutCmd {
     pub(super) fn new(server_address: String) -> Self {
+        ensure_keyring_store();
         Self { server_address }
     }
 }

--- a/core/integration/tests/connectors/fixtures/postgres/container.rs
+++ b/core/integration/tests/connectors/fixtures/postgres/container.rs
@@ -110,7 +110,7 @@ pub trait PostgresSourceOps: PostgresOps {
     ) -> impl std::future::Future<Output = i64> + Send + 'a {
         async move {
             let query = format!("SELECT COUNT(*) FROM {}", self.table_name());
-            let count: (i64,) = sqlx::query_as(&query)
+            let count: (i64,) = sqlx::query_as(sqlx::AssertSqlSafe(query))
                 .fetch_one(pool)
                 .await
                 .unwrap_or_else(|e| panic!("Failed to count rows: {e}"));

--- a/core/integration/tests/connectors/fixtures/postgres/sink.rs
+++ b/core/integration/tests/connectors/fixtures/postgres/sink.rs
@@ -52,7 +52,11 @@ impl PostgresSinkFixture {
     pub async fn wait_for_table(&self, pool: &Pool<Postgres>, table: &str) {
         let query = format!("SELECT 1 FROM {table} LIMIT 1");
         for _ in 0..DEFAULT_POLL_ATTEMPTS {
-            if sqlx::query(&query).fetch_optional(pool).await.is_ok() {
+            if sqlx::query(sqlx::AssertSqlSafe(query.as_str()))
+                .fetch_optional(pool)
+                .await
+                .is_ok()
+            {
                 return;
             }
             sleep(Duration::from_millis(DEFAULT_POLL_INTERVAL_MS)).await;
@@ -74,7 +78,10 @@ impl PostgresSinkFixture {
     {
         let mut rows = Vec::new();
         for _ in 0..DEFAULT_POLL_ATTEMPTS {
-            if let Ok(fetched) = sqlx::query_as::<_, T>(query).fetch_all(pool).await {
+            if let Ok(fetched) = sqlx::query_as::<_, T>(sqlx::AssertSqlSafe(query))
+                .fetch_all(pool)
+                .await
+            {
                 rows = fetched;
                 if rows.len() >= expected_count {
                     return Ok(rows);

--- a/core/integration/tests/connectors/fixtures/postgres/source.rs
+++ b/core/integration/tests/connectors/fixtures/postgres/source.rs
@@ -65,7 +65,7 @@ impl PostgresSourceJsonFixture {
             )",
             Self::TABLE
         );
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .execute(pool)
             .await
             .unwrap_or_else(|e| panic!("Failed to create table: {e}"));
@@ -87,7 +87,7 @@ impl PostgresSourceJsonFixture {
             "INSERT INTO {} (id, name, count, amount, active, timestamp, tag) VALUES ($1, $2, $3, $4, $5, $6, $7)",
             Self::TABLE
         );
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .bind(id)
             .bind(name)
             .bind(count)
@@ -163,7 +163,7 @@ impl PostgresSourceByteaFixture {
             )",
             Self::TABLE
         );
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .execute(pool)
             .await
             .unwrap_or_else(|e| panic!("Failed to create table: {e}"));
@@ -171,7 +171,7 @@ impl PostgresSourceByteaFixture {
 
     pub async fn insert_payload(&self, pool: &Pool<Postgres>, id: i32, payload: &[u8]) {
         let query = format!("INSERT INTO {} (id, payload) VALUES ($1, $2)", Self::TABLE);
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .bind(id)
             .bind(payload)
             .execute(pool)
@@ -243,7 +243,7 @@ impl PostgresSourceJsonbFixture {
             )",
             Self::TABLE
         );
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .execute(pool)
             .await
             .unwrap_or_else(|e| panic!("Failed to create table: {e}"));
@@ -251,7 +251,7 @@ impl PostgresSourceJsonbFixture {
 
     pub async fn insert_json(&self, pool: &Pool<Postgres>, id: i32, data: &serde_json::Value) {
         let query = format!("INSERT INTO {} (id, data) VALUES ($1, $2)", Self::TABLE);
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .bind(id)
             .bind(data)
             .execute(pool)
@@ -327,7 +327,7 @@ impl PostgresSourceDeleteFixture {
             )",
             Self::TABLE
         );
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .execute(pool)
             .await
             .unwrap_or_else(|e| panic!("Failed to create table: {e}"));
@@ -335,7 +335,7 @@ impl PostgresSourceDeleteFixture {
 
     pub async fn insert_row(&self, pool: &Pool<Postgres>, name: &str, value: i32) {
         let query = format!("INSERT INTO {} (name, value) VALUES ($1, $2)", Self::TABLE);
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .bind(name)
             .bind(value)
             .execute(pool)
@@ -414,7 +414,7 @@ impl PostgresSourceMarkFixture {
             )",
             Self::TABLE
         );
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .execute(pool)
             .await
             .unwrap_or_else(|e| panic!("Failed to create table: {e}"));
@@ -425,7 +425,7 @@ impl PostgresSourceMarkFixture {
             "INSERT INTO {} (name, value, is_processed) VALUES ($1, $2, $3)",
             Self::TABLE
         );
-        sqlx::query(&query)
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .bind(name)
             .bind(value)
             .bind(false)
@@ -443,7 +443,7 @@ impl PostgresSourceMarkFixture {
             "SELECT COUNT(*) FROM {} WHERE is_processed = FALSE",
             Self::TABLE
         );
-        let count: (i64,) = sqlx::query_as(&query)
+        let count: (i64,) = sqlx::query_as(sqlx::AssertSqlSafe(query))
             .fetch_one(pool)
             .await
             .unwrap_or_else(|e| panic!("Failed to count rows: {e}"));
@@ -455,7 +455,7 @@ impl PostgresSourceMarkFixture {
             "SELECT COUNT(*) FROM {} WHERE is_processed = TRUE",
             Self::TABLE
         );
-        let count: (i64,) = sqlx::query_as(&query)
+        let count: (i64,) = sqlx::query_as(sqlx::AssertSqlSafe(query))
             .fetch_one(pool)
             .await
             .unwrap_or_else(|e| panic!("Failed to count rows: {e}"));


### PR DESCRIPTION
sqlx 0.9 added the `SqlSafeStr` audit trait: dynamic `String`
queries are wrapped in `sqlx::AssertSqlSafe` across the
postgres connectors and fixtures. Runtime/TLS feature split:
`runtime-tokio-rustls` -> `runtime-tokio` + `tls-rustls`.

keyring 4 moved the library API to `keyring-core` plus
backend crates. Use `dbus-secret-service-keyring-store`
(`crypto-rust`, OpenSSL-free) and register it as the default
store at iggy-cli startup under `login-session`.
