### PR TITLE
ci: free ~30GB on Linux runners via jlumbroso composite

### DIFF
--- a/.github/actions/cpp-bazel/pre-merge/action.yml
+++ b/.github/actions/cpp-bazel/pre-merge/action.yml
@@ -26,6 +26,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free disk space
+      if: inputs.task != 'lint'
+      uses: ./.github/actions/utils/free-disk-space
+
     - name: Setup Bazel with cache
       if: inputs.task != 'lint'
       uses: ./.github/actions/utils/setup-cpp-with-cache

--- a/.github/actions/csharp-dotnet/pre-merge/action.yml
+++ b/.github/actions/csharp-dotnet/pre-merge/action.yml
@@ -27,10 +27,21 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free disk space
+      if: inputs.task != 'lint'
+      uses: ./.github/actions/utils/free-disk-space
+
+    # Install both runtimes the SDK targets (see foreign/csharp/*.csproj
+    # <TargetFrameworks>net8.0;net10.0</TargetFrameworks>). free-disk-space
+    # wipes the runner's preinstalled /usr/share/dotnet, so setup-dotnet
+    # must provide every TFM the test binaries are built against - otherwise
+    # the net8.0 test binary aborts with exit 150 "framework not found".
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: "10.0.x"
+        dotnet-version: |
+          8.0.x
+          10.0.x
 
     - name: Setup Rust with cache
       if: inputs.task == 'test' || inputs.task == 'e2e'

--- a/.github/actions/go/pre-merge/action.yml
+++ b/.github/actions/go/pre-merge/action.yml
@@ -26,6 +26,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free disk space
+      if: inputs.task != 'lint'
+      uses: ./.github/actions/utils/free-disk-space
+
     - name: Setup Go
       uses: ./.github/actions/utils/setup-go-with-cache
 

--- a/.github/actions/java-gradle/pre-merge/action.yml
+++ b/.github/actions/java-gradle/pre-merge/action.yml
@@ -26,6 +26,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free disk space
+      if: inputs.task != 'lint'
+      uses: ./.github/actions/utils/free-disk-space
+
     - name: Setup Java with cache
       uses: ./.github/actions/utils/setup-java-with-cache
       with:

--- a/.github/actions/node-npm/pre-merge/action.yml
+++ b/.github/actions/node-npm/pre-merge/action.yml
@@ -26,6 +26,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free disk space
+      if: inputs.task != 'lint'
+      uses: ./.github/actions/utils/free-disk-space
+
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/actions/php/pre-merge/action.yml
+++ b/.github/actions/php/pre-merge/action.yml
@@ -26,6 +26,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free disk space
+      if: inputs.task != 'lint'
+      uses: ./.github/actions/utils/free-disk-space
+
     - name: Install PHP build dependencies
       shell: bash
       run: |

--- a/.github/actions/python-maturin/pre-merge/action.yml
+++ b/.github/actions/python-maturin/pre-merge/action.yml
@@ -26,6 +26,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free disk space
+      if: inputs.task != 'lint'
+      uses: ./.github/actions/utils/free-disk-space
+
     - name: Setup Python
       uses: actions/setup-python@v6
       with:

--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -30,17 +30,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Cleanup disk space
-      if: runner.os == 'Linux'
-      run: |
-        echo "Disk space before cleanup:"
-        df -h
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        # sudo docker image prune --all --force
-        # sudo docker builder prune -a
-        echo "Disk space after cleanup:"
-        df -h
-      shell: bash
+    - name: Free disk space
+      uses: ./.github/actions/utils/free-disk-space
 
     - name: Setup Rust with cache
       uses: ./.github/actions/utils/setup-rust-with-cache

--- a/.github/actions/utils/free-disk-space/action.yml
+++ b/.github/actions/utils/free-disk-space/action.yml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: free-disk-space
+description: >
+  Free ~30 GB on Linux GitHub-hosted runners by removing preinstalled tooling
+  Apache Iggy CI does not use (Android SDK, .NET, Haskell, large APT packages,
+  Docker images, swap). No-op on macOS / Windows runners. Used by every
+  pre-merge SDK action to prevent ENOSPC during heavy build/test jobs.
+
+inputs:
+  tool-cache:
+    description: >
+      Also wipe /opt/hostedtoolcache (~5 GB). Off by default: setup-node,
+      setup-python, setup-java, taiki-e/install-action all cache binaries
+      there, and re-fetching them costs more than the space saved.
+    required: false
+    default: "false"
+  swap-storage:
+    description: >
+      Remove the runner's swap file (~4 GB). Safe for short jobs but heavy
+      Rust link / Bazel jobs may benefit from keeping it; set to "false"
+      if the job OOMs after enabling cleanup.
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Free disk space
+      if: runner.os == 'Linux'
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: ${{ inputs.tool-cache }}
+        android: "true"
+        dotnet: "true"
+        haskell: "true"
+        large-packages: "true"
+        docker-images: "true"
+        swap-storage: ${{ inputs.swap-storage }}

--- a/.github/workflows/_test_bdd.yml
+++ b/.github/workflows/_test_bdd.yml
@@ -37,16 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Cleanup disk space
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          echo "Disk space after cleanup:"
-          df -h
-
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        uses: ./.github/actions/utils/free-disk-space
 
       - name: Skip noop
         if: inputs.component == 'noop'

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -43,8 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cleanup disk space
-        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+      - name: Free disk space
+        uses: ./.github/actions/utils/free-disk-space
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
PR #3326 C++ e2e failed with ENOSPC writing runner
log, cascading to C++ build/test cancellation and
finalize_pr failure. Only Rust pre-merge and two
workflows had inline cleanup (~14GB freed); cpp,
csharp, java, node, go, python, php had none.

Wrap jlumbroso/free-disk-space@v1.3.1 (SHA-pinned,
already used by apache/infrastructure-actions and
rust-lang/rust) in a shared composite. Frees ~30GB
by also wiping Haskell, large APT packages, Docker
images, and swap. Replace inline cleanups; invoke
from every SDK pre-merge, gated to skip fast lint
tasks where the ~90s apt removals dominate runtime.
