### PR TITLE
ci: run PR Title workflow on ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -29,7 +29,7 @@ jobs:
   pr-title:
     name: PR Title
     if: github.event.action != 'edited' || github.event.changes.title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Validate PR Title
         uses: amannn/action-semantic-pull-request@v6


### PR DESCRIPTION
Align PR Title runner with pr-triage-apply and
pr-triage-collect, which already use ubuntu-24.04-arm.
These runners appear to be less overloaded so these
light workflows run faster.
