### PR TITLE
ci: share runner disk cleanup across PHP, Rust, BDD, coverage

### DIFF
--- a/.github/actions/php/pre-merge/action.yml
+++ b/.github/actions/php/pre-merge/action.yml
@@ -26,6 +26,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free runner disk space
+      uses: ./.github/actions/utils/free-disk-space
+
     - name: Install PHP build dependencies
       shell: bash
       run: |

--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -30,17 +30,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Cleanup disk space
-      if: runner.os == 'Linux'
-      run: |
-        echo "Disk space before cleanup:"
-        df -h
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        # sudo docker image prune --all --force
-        # sudo docker builder prune -a
-        echo "Disk space after cleanup:"
-        df -h
-      shell: bash
+    - name: Free runner disk space
+      uses: ./.github/actions/utils/free-disk-space
 
     - name: Setup Rust with cache
       uses: ./.github/actions/utils/setup-rust-with-cache

--- a/.github/actions/utils/free-disk-space/action.yml
+++ b/.github/actions/utils/free-disk-space/action.yml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: free-disk-space
+description: >-
+  Reclaim disk space on GitHub-hosted Linux runners by removing
+  pre-installed toolchains the Iggy build does not use.
+  Logs reclaimed GiB and elapsed seconds.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cleanup disk space
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "Disk space before cleanup:"
+        df -h
+        before=$(df --output=avail -B1 / | tail -n1)
+        start=$(date +%s)
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        # Uncomment these if more space is needed
+        # sudo docker image prune --all --force
+        # sudo docker builder prune -a
+        end=$(date +%s)
+        after=$(df --output=avail -B1 / | tail -n1)
+        reclaimed_gib=$(awk -v b="$((after - before))" 'BEGIN { printf "%.2f", b/1024/1024/1024 }')
+        echo "::notice::Reclaimed ${reclaimed_gib} GiB in $((end - start))s"
+        echo "Disk space after cleanup:"
+        df -h

--- a/.github/workflows/_test_bdd.yml
+++ b/.github/workflows/_test_bdd.yml
@@ -37,16 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Cleanup disk space
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          echo "Disk space after cleanup:"
-          df -h
-
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Free runner disk space
+        uses: ./.github/actions/utils/free-disk-space
 
       - name: Skip noop
         if: inputs.component == 'noop'

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -43,8 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cleanup disk space
-        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+      - name: Free runner disk space
+        uses: ./.github/actions/utils/free-disk-space
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
PHP pre-merge runs the same Cargo build + composer install +
server boot stack as the Rust jobs and started hitting ENOSPC
on ubuntu-latest. Rust pre-merge, the BDD workflow, and the
coverage-baseline workflow all already removed the same set
of unused pre-installed toolchains (.NET, Android, GHC,
CodeQL) inline, so the fix is to share that cleanup rather
than copy it again.

Extract the rm + before/after df block into a new composite
action .github/actions/utils/free-disk-space, with reclaimed
GiB and elapsed seconds emitted as a ::notice:: so regressions
in GitHub-hosted image content are visible. Call it from PHP
and Rust pre-merge, _test_bdd, and coverage-baseline. The BDD
workflow now checks out the repo before invoking the action
since local composite actions need the workspace on disk.

Related change #3328 - the approach with jlumbroso action was
not worth it due to much longer execution time.