### PR TITLE
docs: clarify compression placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The name is an abbreviation for the Italian Greyhound - small yet extremely fast
 - **[Model Context Protocol](https://github.com/apache/iggy/tree/master/core/ai/mcp)** - provide context to LLM with **MCP server**
 - Optional server-side as well as client-side **data encryption** using AES-256-GCM
 - Optional metadata support in the form of **message headers**
+- Message compression is not currently performed by the server. Topic compression
+  values are reserved for future disk/network compression support; for now, use
+  message headers for manual userspace compression (see
+  `examples/rust/src/message-headers/message-compression`).
 - Optional **data backups and archiving** to disk or **S3** compatible cloud storage (e.g. AWS S3)
 - Support for **OpenTelemetry** logs & traces + Prometheus metrics
 - Built-in **CLI** to manage the streaming server installable via `cargo install iggy-cli`
@@ -320,7 +324,7 @@ Get `dev` stream details:
 
 `cargo run --bin iggy -- -u <iggy_username> -p <iggy_password> stream get dev`
 
-Create a topic named `sample` (numerical ID will be assigned by server automatically) for stream `dev`, with 2 partitions (IDs 1 and 2), disabled compression (`none`) and disabled message expiry (skipped optional parameter):
+Create a topic named `sample` (numerical ID will be assigned by server automatically) for stream `dev`, with 2 partitions (IDs 1 and 2), no topic compression (`none`) and disabled message expiry (skipped optional parameter). Topic compression options are placeholders for future server-side support and do not currently compress stored or transmitted messages:
 
 `cargo run --bin iggy -- -u <iggy_username> -p <iggy_password> topic create dev sample 2 none`
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,9 @@ The name is an abbreviation for the Italian Greyhound - small yet extremely fast
 - **[Model Context Protocol](https://github.com/apache/iggy/tree/master/core/ai/mcp)** - provide context to LLM with **MCP server**
 - Optional server-side as well as client-side **data encryption** using AES-256-GCM
 - Optional metadata support in the form of **message headers**
-- Message compression is not currently performed by the server. Topic compression
-  values are reserved for future disk/network compression support; for now, use
-  message headers for manual userspace compression (see
-  `examples/rust/src/message-headers/message-compression`).
+- Server-side message compression is not supported yet. Topic compression values
+  are reserved for future disk/network compression support; use message headers
+  for manual compression today (see `examples/rust/src/message-headers/message-compression`).
 - Optional **data backups and archiving** to disk or **S3** compatible cloud storage (e.g. AWS S3)
 - Support for **OpenTelemetry** logs & traces + Prometheus metrics
 - Built-in **CLI** to manage the streaming server installable via `cargo install iggy-cli`
@@ -324,7 +323,7 @@ Get `dev` stream details:
 
 `cargo run --bin iggy -- -u <iggy_username> -p <iggy_password> stream get dev`
 
-Create a topic named `sample` (numerical ID will be assigned by server automatically) for stream `dev`, with 2 partitions (IDs 1 and 2), no topic compression (`none`) and disabled message expiry (skipped optional parameter). Topic compression options are placeholders for future server-side support and do not currently compress stored or transmitted messages:
+Create a topic named `sample` (numerical ID will be assigned by server automatically) for stream `dev`, with 2 partitions (IDs 1 and 2), no topic compression (`none`), and disabled message expiry (skipped optional parameter). Other compression values are reserved for future server-side support:
 
 `cargo run --bin iggy -- -u <iggy_username> -p <iggy_password> topic create dev sample 2 none`
 

--- a/core/sdk/README.md
+++ b/core/sdk/README.md
@@ -43,7 +43,7 @@ Official Rust client SDK for [Apache Iggy](https://iggy.apache.org), the persist
 - **Auto-commit** offset policies: `Interval`, `When`, `After`, `IntervalOrWhen`, `IntervalOrAfter`, or disabled.
 - **Stream builder** (`IggyStream`, `IggyStreamProducer`, `IggyStreamConsumer`) for declarative producer + consumer setup on shared or separate stream/topic.
 - **Reliability**: automatic reconnection with retries, heartbeat, send retries, and offset auto-commit handled by the high-level API.
-- **Message features**: optional headers (`HeaderKey` / `HeaderValue`), client-side AES-256-GCM encryption (via `Aes256GcmEncryptor`), per-topic compression (currently `None` and `Gzip`), server-honored message expiry, and server-side deduplication.
+- **Message features**: optional headers (`HeaderKey` / `HeaderValue`), client-side AES-256-GCM encryption (via `Aes256GcmEncryptor`), placeholder per-topic compression metadata (`None` and `Gzip`; runtime compression is not supported yet), server-honored message expiry, and server-side deduplication.
 - **Admin**: stream/topic/partition CRUD, consumer-group management, server-side consumer offsets, system stats.
 
 ## Installation

--- a/core/sdk/README.md
+++ b/core/sdk/README.md
@@ -43,7 +43,7 @@ Official Rust client SDK for [Apache Iggy](https://iggy.apache.org), the persist
 - **Auto-commit** offset policies: `Interval`, `When`, `After`, `IntervalOrWhen`, `IntervalOrAfter`, or disabled.
 - **Stream builder** (`IggyStream`, `IggyStreamProducer`, `IggyStreamConsumer`) for declarative producer + consumer setup on shared or separate stream/topic.
 - **Reliability**: automatic reconnection with retries, heartbeat, send retries, and offset auto-commit handled by the high-level API.
-- **Message features**: optional headers (`HeaderKey` / `HeaderValue`), client-side AES-256-GCM encryption (via `Aes256GcmEncryptor`), placeholder per-topic compression metadata (`None` and `Gzip`; runtime compression is not supported yet), server-honored message expiry, and server-side deduplication.
+- **Message features**: optional headers (`HeaderKey` / `HeaderValue`), client-side AES-256-GCM encryption (via `Aes256GcmEncryptor`), topic compression metadata (`None` and `Gzip`; no runtime compression yet), server-honored message expiry, and server-side deduplication.
 - **Admin**: stream/topic/partition CRUD, consumer-group management, server-side consumer offsets, system stats.
 
 ## Installation

--- a/core/server/config.toml
+++ b/core/server/config.toml
@@ -415,9 +415,8 @@ key = ""
 
 # Compression configuration
 [system.compression]
-# Placeholder for future server-side compression support. The server does not
-# currently compress messages on disk or over the network. Use `none` for now;
-# manual userspace compression can be implemented with message headers.
+# Reserved for future server-side compression support; use "none" today.
+# For manual compression, store the algorithm in message headers.
 # Allows overriding the default compression algorithm per data segment (boolean).
 # `true` will permit different compression algorithms for individual segments.
 # `false` will make all data segments use the default compression algorithm.

--- a/core/server/config.toml
+++ b/core/server/config.toml
@@ -415,13 +415,16 @@ key = ""
 
 # Compression configuration
 [system.compression]
+# Placeholder for future server-side compression support. The server does not
+# currently compress messages on disk or over the network. Use `none` for now;
+# manual userspace compression can be implemented with message headers.
 # Allows overriding the default compression algorithm per data segment (boolean).
-# `true` permits different compression algorithms for individual segments.
-# `false` means all data segments use the default compression algorithm.
+# `true` will permit different compression algorithms for individual segments.
+# `false` will make all data segments use the default compression algorithm.
 allow_override = false
 
 # The default compression algorithm used for data storage (string).
-# "none" indicates no compression, other values can specify different algorithms.
+# "none" indicates no compression. Other values are reserved for future support.
 default_algorithm = "none"
 
 # Stream configuration

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -103,7 +103,7 @@ cargo run --example message-headers-type-consumer
 
 Demonstrates using HeaderKey/HeaderValue for message metadata instead of payload-based typing, with header-based message routing.
 
-Shows how user headers can be used for message compression in transit:
+Shows how user headers can be used for manual userspace message compression in transit. This is the current workaround while built-in topic/server compression remains unsupported:
 
 ```bash
 cargo run --example message-headers-compression-producer

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -103,7 +103,7 @@ cargo run --example message-headers-type-consumer
 
 Demonstrates using HeaderKey/HeaderValue for message metadata instead of payload-based typing, with header-based message routing.
 
-Shows how user headers can be used for manual userspace message compression in transit. This is the current workaround while built-in topic/server compression remains unsupported:
+Shows manual message compression using headers. This is the current workaround while built-in compression is unsupported:
 
 ```bash
 cargo run --example message-headers-compression-producer


### PR DESCRIPTION
## Which issue does this PR close?


Refs #18, #30, #3028

## Rationale

Compression-related configuration and topic metadata are visible today, but built-in message compression is not currently supported by the server. This can make it look like topic compression compresses messages on disk or over the network, while the current supported workaround is manual userspace compression with message headers.

This documentation-only change follows the clarification from #3028 that disk compression, network compression, and combined compression are separate future work areas.
## What changed?

The README topic creation example now says `none` means no topic compression and notes that topic compression options are placeholders for future server-side support.

The server config comments, Rust SDK README, and Rust examples README now clarify that runtime compression is unsupported today and point users toward message-header-based userspace compression as the current workaround.


## Local Execution

- Passed: `git diff --check`
- Not run: code tests, because this PR only changes documentation and config comments
- Not run: `typos`, because it is not installed in my local environment
- Pre-commit hooks: not run
