### PR TITLE
feat(php): add SDK examples component

### DIFF
--- a/.github/config/components.yml
+++ b/.github/config/components.yml
@@ -402,6 +402,18 @@ components:
       - "scripts/utils.sh"
     tasks: ["examples-python"]
 
+  examples-php:
+    depends_on:
+      - "rust-server"
+      - "rust-sdk" # All SDKs depend on core SDK changes
+      - "sdk-php"
+      - "ci-infrastructure"
+    paths:
+      - "examples/php/**"
+      - "scripts/run-examples-from-readme.sh"
+      - "scripts/utils.sh"
+    tasks: ["examples-php"]
+
   examples-node:
     depends_on:
       - "rust-server"

--- a/.github/workflows/_test_examples.yml
+++ b/.github/workflows/_test_examples.yml
@@ -65,6 +65,29 @@ jobs:
         if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-python'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
+      - name: Install PHP build dependencies
+        if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-php'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            libclang-dev \
+            libhwloc-dev \
+            libssl-dev \
+            php8.3-cli \
+            php8.3-dev \
+            pkg-config
+
+          php_bin="$(command -v php8.3)"
+          php_config="$(command -v php-config8.3)"
+          {
+            echo "PHP=${php_bin}"
+            echo "PHP_CONFIG=${php_config}"
+          } >> "$GITHUB_ENV"
+          "${php_bin}" --version
+          "${php_config}" --version
+
       - name: Cache uv
         if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-python'
         uses: actions/cache@v5
@@ -123,6 +146,20 @@ jobs:
             fi
           fi
 
+      - name: Build PHP extension for examples
+        if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-php'
+        shell: bash
+        run: |
+          export CARGO_TARGET_DIR="${GITHUB_WORKSPACE}/target"
+          cargo build --manifest-path foreign/php/Cargo.toml
+          extension="$(find target/debug -maxdepth 1 -name 'libiggy_php.so' -print -quit)"
+          if [ -z "$extension" ]; then
+            echo "PHP extension was not produced"
+            exit 1
+          fi
+          echo "PHP_IGGY_EXTENSION=$(realpath "$extension")" >> "$GITHUB_ENV"
+          ls -lh "$extension"
+
       - name: Build Node SDK for examples
         if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-node'
         run: |
@@ -149,6 +186,10 @@ jobs:
       - name: Run Python examples
         if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-python'
         run: ./scripts/run-examples-from-readme.sh --language python
+
+      - name: Run PHP examples
+        if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-php'
+        run: ./scripts/run-examples-from-readme.sh --language php
 
       - name: Run Node.js examples
         if: startsWith(inputs.component, 'examples-') && inputs.task == 'examples-node'

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -34,5 +34,6 @@ php -d extension="${PHP_IGGY_EXTENSION:-../../foreign/php/target/debug/libiggy_p
 php -d extension="${PHP_IGGY_EXTENSION:-../../foreign/php/target/debug/libiggy_php.so}" basic/consumer.php
 ```
 
-The examples use `IGGY_CONNECTION_STRING` when it is set. Otherwise they connect
-to `iggy+tcp://iggy:iggy@127.0.0.1:8090`.
+The examples use `IGGY_CONNECTION_STRING` when it is set. Otherwise they build
+`iggy+tcp://iggy:iggy@127.0.0.1:8090` from `IGGY_HOST`, `IGGY_PORT`,
+`IGGY_USERNAME`, and `IGGY_PASSWORD`, which can be set individually.

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -1,0 +1,38 @@
+# Iggy PHP Examples
+
+This directory contains sample applications that show how to use the Apache
+Iggy PHP SDK extension.
+
+## Running Examples
+
+Start the server from the repository root:
+
+```bash
+cargo run --bin iggy-server -- --fresh --with-default-root-credentials
+```
+
+From `examples/php`, build the PHP extension and point PHP at it:
+
+```bash
+(cd ../../foreign/php && cargo build)
+export PHP_IGGY_EXTENSION="$(pwd)/../../foreign/php/target/debug/libiggy_php.so"
+```
+
+On macOS, use `../../foreign/php/target/debug/libiggy_php.dylib` instead.
+
+### Getting Started
+
+```bash
+php -d extension="${PHP_IGGY_EXTENSION:-../../foreign/php/target/debug/libiggy_php.so}" getting-started/producer.php
+php -d extension="${PHP_IGGY_EXTENSION:-../../foreign/php/target/debug/libiggy_php.so}" getting-started/consumer.php
+```
+
+### Basic Usage
+
+```bash
+php -d extension="${PHP_IGGY_EXTENSION:-../../foreign/php/target/debug/libiggy_php.so}" basic/producer.php
+php -d extension="${PHP_IGGY_EXTENSION:-../../foreign/php/target/debug/libiggy_php.so}" basic/consumer.php
+```
+
+The examples use `IGGY_CONNECTION_STRING` when it is set. Otherwise they connect
+to `iggy+tcp://iggy:iggy@127.0.0.1:8090`.

--- a/examples/php/basic/consumer.php
+++ b/examples/php/basic/consumer.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/common.php';
+
+$stream = 'php-basic-stream';
+$topic = 'php-basic-topic';
+$client = iggy_client();
+
+ensure_stream_and_topic($client, $stream, $topic);
+print_polled_messages($client, $stream, $topic, 3);

--- a/examples/php/basic/producer.php
+++ b/examples/php/basic/producer.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/common.php';
+
+$stream = 'php-basic-stream';
+$topic = 'php-basic-topic';
+$client = iggy_client();
+
+ensure_stream_and_topic($client, $stream, $topic);
+send_payloads($client, $stream, $topic, [
+    'basic-message-alpha',
+    'basic-message-beta',
+    'basic-message-gamma',
+]);
+
+echo "Sent 3 PHP basic messages", PHP_EOL;

--- a/examples/php/basic/producer.php
+++ b/examples/php/basic/producer.php
@@ -28,10 +28,6 @@ $topic = 'php-basic-topic';
 $client = iggy_client();
 
 ensure_stream_and_topic($client, $stream, $topic);
-send_payloads($client, $stream, $topic, [
-    'basic-message-alpha',
-    'basic-message-beta',
-    'basic-message-gamma',
-]);
+send_payloads($client, $stream, $topic, example_payloads('basic', 3));
 
 echo "Sent 3 PHP basic messages", PHP_EOL;

--- a/examples/php/getting-started/consumer.php
+++ b/examples/php/getting-started/consumer.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/common.php';
+
+$stream = 'php-getting-started-stream';
+$topic = 'php-getting-started-topic';
+$client = iggy_client();
+
+ensure_stream_and_topic($client, $stream, $topic);
+print_polled_messages($client, $stream, $topic, 5);

--- a/examples/php/getting-started/producer.php
+++ b/examples/php/getting-started/producer.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/common.php';
+
+$stream = 'php-getting-started-stream';
+$topic = 'php-getting-started-topic';
+$client = iggy_client();
+
+ensure_stream_and_topic($client, $stream, $topic);
+send_payloads($client, $stream, $topic, example_payloads('getting-started', 5));
+
+echo "Sent 5 PHP getting-started messages", PHP_EOL;

--- a/examples/php/src/common.php
+++ b/examples/php/src/common.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 use Iggy\Client;
 use Iggy\PollingStrategy;
-use Iggy\ReceiveMessage;
 use Iggy\SendMessage;
 
 function iggy_connection_string(): string
@@ -56,7 +55,7 @@ function ensure_stream_and_topic(Client $client, string $stream, string $topic):
     }
 
     if ($client->getTopic($stream, $topic) === null) {
-        $client->createTopic($stream, $topic, 1, null, null, null, null);
+        $client->createTopic($stream, $topic, 1);
     }
 }
 
@@ -79,10 +78,6 @@ function print_polled_messages(Client $client, string $stream, string $topic, in
     }
 
     foreach ($messages as $message) {
-        if (!$message instanceof ReceiveMessage) {
-            continue;
-        }
-
         echo "Received message at offset {$message->offset()}: {$message->payload()}", PHP_EOL;
     }
 }

--- a/examples/php/src/common.php
+++ b/examples/php/src/common.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+use Iggy\Client;
+use Iggy\PollingStrategy;
+use Iggy\ReceiveMessage;
+use Iggy\SendMessage;
+
+function iggy_connection_string(): string
+{
+    $configured = getenv('IGGY_CONNECTION_STRING');
+    if ($configured !== false && $configured !== '') {
+        return $configured;
+    }
+
+    $host = getenv('IGGY_HOST') ?: '127.0.0.1';
+    $port = getenv('IGGY_PORT') ?: '8090';
+    $username = rawurlencode(getenv('IGGY_USERNAME') ?: 'iggy');
+    $password = rawurlencode(getenv('IGGY_PASSWORD') ?: 'iggy');
+
+    return "iggy+tcp://{$username}:{$password}@{$host}:{$port}";
+}
+
+function iggy_client(): Client
+{
+    $client = Client::fromConnectionString(iggy_connection_string());
+    $client->connect();
+
+    return $client;
+}
+
+function ensure_stream_and_topic(Client $client, string $stream, string $topic): void
+{
+    if ($client->getStream($stream) === null) {
+        $client->createStream($stream);
+    }
+
+    if ($client->getTopic($stream, $topic) === null) {
+        $client->createTopic($stream, $topic, 1, null, null, null, null);
+    }
+}
+
+function send_payloads(Client $client, string $stream, string $topic, array $payloads): void
+{
+    $messages = array_map(
+        static fn (string $payload): SendMessage => new SendMessage($payload),
+        $payloads,
+    );
+
+    $client->sendMessages($stream, $topic, 0, $messages);
+}
+
+function print_polled_messages(Client $client, string $stream, string $topic, int $count): void
+{
+    $messages = $client->pollMessages($stream, $topic, 0, PollingStrategy::first(), $count, true);
+
+    if (count($messages) < $count) {
+        throw new RuntimeException("Expected {$count} messages, received " . count($messages));
+    }
+
+    foreach ($messages as $message) {
+        if (!$message instanceof ReceiveMessage) {
+            continue;
+        }
+
+        echo "Received message at offset {$message->offset()}: {$message->payload()}", PHP_EOL;
+    }
+}
+
+function example_payloads(string $prefix, int $count): array
+{
+    return array_map(
+        static fn (int $index): string => "{$prefix}-message-{$index}",
+        range(1, $count),
+    );
+}

--- a/scripts/run-examples-from-readme.sh
+++ b/scripts/run-examples-from-readme.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 # Unified script to run SDK examples from README.md files.
 # Usage: ./scripts/run-examples-from-readme.sh [OPTIONS]
 #
-#   --language LANG   Language to test: rust|go|node|python|java|csharp (default: all)
+#   --language LANG   Language to test: rust|go|node|python|php|java|csharp (default: all)
 #   --target TARGET   Cargo target architecture for the server binary
 #   --skip-tls        Skip TLS example tests
 #
@@ -285,6 +285,49 @@ run_python_examples() {
 }
 
 # shellcheck disable=SC2329
+run_php_examples() {
+    resolve_server_binary "${TARGET}"
+
+    local php_bin="${PHP:-php}"
+    if [ -z "${PHP_IGGY_EXTENSION:-}" ]; then
+        local extension_candidate
+        for extension_candidate in \
+            target/debug/libiggy_php.so \
+            target/debug/libiggy_php.dylib \
+            target/debug/iggy_php.dll \
+            foreign/php/target/debug/libiggy_php.so \
+            foreign/php/target/debug/libiggy_php.dylib \
+            foreign/php/target/debug/iggy_php.dll; do
+            if [ -f "${extension_candidate}" ]; then
+                PHP_IGGY_EXTENSION="${extension_candidate}"
+                break
+            fi
+        done
+        export PHP_IGGY_EXTENSION
+    fi
+
+    if [ -z "${PHP_IGGY_EXTENSION:-}" ] || [ ! -f "${PHP_IGGY_EXTENSION}" ]; then
+        echo "Error: PHP extension not found. Build foreign/php first or set PHP_IGGY_EXTENSION."
+        exit 1
+    fi
+
+    TRANSFORM_COMMAND() {
+        local command="$1"
+        printf '%s\n' "${command/#php /\"${php_bin}\" }"
+    }
+
+    run_language_examples \
+        "PHP" \
+        "examples/php" \
+        "README.md" \
+        "^php " \
+        "" \
+        "" \
+        0 \
+        "--fresh"
+}
+
+# shellcheck disable=SC2329
 run_java_examples() {
     resolve_server_binary "${TARGET}"
     unset -f TRANSFORM_COMMAND 2>/dev/null || true
@@ -355,16 +398,17 @@ case "${LANGUAGE}" in
     node)   run_one run_node_examples   "Node"   ;;
     go)     run_one run_go_examples     "Go"     ;;
     python) run_one run_python_examples "Python" ;;
+    php)    run_one run_php_examples    "PHP"    ;;
     java)   run_one run_java_examples   "Java"   ;;
     csharp) run_one run_csharp_examples "C#"     ;;
     all)
-        for lang in rust node go python java csharp; do
+        for lang in rust node go python php java csharp; do
             run_one "run_${lang}_examples" "${lang}"
         done
         ;;
     *)
         echo "Unknown language: ${LANGUAGE}"
-        echo "Supported: rust, node, go, python, java, csharp, all"
+        echo "Supported: rust, node, go, python, php, java, csharp, all"
         exit 1
         ;;
 esac

--- a/scripts/run-examples-from-readme.sh
+++ b/scripts/run-examples-from-readme.sh
@@ -294,12 +294,10 @@ run_php_examples() {
         for extension_candidate in \
             target/debug/libiggy_php.so \
             target/debug/libiggy_php.dylib \
-            target/debug/iggy_php.dll \
             foreign/php/target/debug/libiggy_php.so \
-            foreign/php/target/debug/libiggy_php.dylib \
-            foreign/php/target/debug/iggy_php.dll; do
+            foreign/php/target/debug/libiggy_php.dylib; do
             if [ -f "${extension_candidate}" ]; then
-                PHP_IGGY_EXTENSION="${extension_candidate}"
+                PHP_IGGY_EXTENSION="$(pwd)/${extension_candidate}"
                 break
             fi
         done


### PR DESCRIPTION
## Summary

- add PHP SDK examples under `examples/php` for getting-started and basic producer/consumer flows
- add an `examples-php` component entry with PHP SDK, Rust SDK, Rust server, and CI infrastructure dependencies
- wire PHP examples into `_test_examples.yml` and `scripts/run-examples-from-readme.sh`

Closes #3311.

## Validation

- `php -l` for all PHP example files
- `bash -n scripts/run-examples-from-readme.sh`
- `git diff --check`
- `./scripts/ci/markdownlint.sh examples/php/README.md`
- `./scripts/ci/license-headers.sh --check`
- `cargo build --locked --bin iggy-server`
- `cargo build` in `foreign/php`
- pre-push hook: cargo clippy passed; Go lint suites passed; Java/C# skipped as no relevant files changed
