### PR TITLE
fix(server): distribute partitions evenly in cooperative rebalancing

### DIFF
--- a/core/integration/tests/data_integrity/verify_consumer_group_partition_assignment.rs
+++ b/core/integration/tests/data_integrity/verify_consumer_group_partition_assignment.rs
@@ -2263,6 +2263,51 @@ async fn join_cg(client: &IggyClient) {
         .unwrap();
 }
 
+fn assert_balanced_partition_distribution(cg: &ConsumerGroupDetails, expected_total: u32) {
+    let member_count = cg.members.len() as u32;
+    assert!(member_count > 0, "No members in consumer group");
+
+    let total: u32 = cg.members.iter().map(|m| m.partitions_count).sum();
+    assert_eq!(
+        total, expected_total,
+        "Total partitions mismatch. Expected {expected_total}, got {total}. Members: {:?}",
+        cg.members
+    );
+
+    let fair_share = expected_total / member_count;
+    let remainder = expected_total % member_count;
+
+    let min_expected = fair_share;
+    let max_expected = if remainder > 0 {
+        fair_share + 1
+    } else {
+        fair_share
+    };
+
+    for member in &cg.members {
+        assert!(
+            member.partitions_count >= min_expected && member.partitions_count <= max_expected,
+            "Member {} has {} partitions, expected between {} and {}. \
+             Distribution is unbalanced! Members: {:?}",
+            member.id,
+            member.partitions_count,
+            min_expected,
+            max_expected,
+            cg.members
+        );
+    }
+
+    let counts: Vec<u32> = cg.members.iter().map(|m| m.partitions_count).collect();
+    let min_count = *counts.iter().min().unwrap();
+    let max_count = *counts.iter().max().unwrap();
+    assert!(
+        max_count - min_count <= 1,
+        "Partition distribution variance too high: min={min_count}, max={max_count}. \
+         Difference should be at most 1. Members: {:?}",
+        cg.members
+    );
+}
+
 #[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic], server(
     heartbeat.enabled = true,
     heartbeat.interval = "2s",
@@ -3262,6 +3307,539 @@ async fn should_not_complete_other_members_revocations_on_leave(harness: &TestHa
     );
 
     // Cleanup
+    root_client
+        .delete_stream(&Identifier::named(STREAM_NAME).unwrap())
+        .await
+        .unwrap();
+}
+
+#[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic], server(
+    heartbeat.enabled = true,
+    heartbeat.interval = "2s",
+    tcp.socket.override_defaults = true,
+    tcp.socket.nodelay = true
+))]
+async fn should_distribute_16_partitions_evenly_across_16_consumers(harness: &TestHarness) {
+    let root_client = harness.root_client().await.unwrap();
+
+    root_client.create_stream(STREAM_NAME).await.unwrap();
+    root_client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            16,
+            CompressionAlgorithm::default(),
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+    root_client
+        .create_consumer_group(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            &Identifier::named(TOPIC_NAME).unwrap(),
+            CONSUMER_GROUP_NAME,
+        )
+        .await
+        .unwrap();
+
+    for partition_id in 0..16u32 {
+        let message = IggyMessage::from_str(&format!("msg-p{partition_id}")).unwrap();
+        let mut messages = vec![message];
+        root_client
+            .send_messages(
+                &Identifier::named(STREAM_NAME).unwrap(),
+                &Identifier::named(TOPIC_NAME).unwrap(),
+                &Partitioning::partition_id(partition_id),
+                &mut messages,
+            )
+            .await
+            .unwrap();
+    }
+
+    let client1 = harness.new_client().await.unwrap();
+    client1
+        .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+        .await
+        .unwrap();
+    join_cg(&client1).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members[0].partitions_count, 16);
+
+    let mut clients = vec![client1];
+    for _ in 2..=16 {
+        let client = harness.new_client().await.unwrap();
+        client
+            .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+            .await
+            .unwrap();
+        join_cg(&client).await;
+        clients.push(client);
+    }
+
+    sleep(Duration::from_millis(500)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 16);
+    assert_unique_partition_assignments(&cg);
+    assert_balanced_partition_distribution(&cg, 16);
+
+    for member in &cg.members {
+        assert_eq!(
+            member.partitions_count, 1,
+            "With 16 partitions and 16 consumers, each must have exactly 1. \
+             Member {} has {}. Members: {:?}",
+            member.id, member.partitions_count, cg.members
+        );
+    }
+
+    let consumer = Consumer::group(Identifier::named(CONSUMER_GROUP_NAME).unwrap());
+    let mut polled_partitions = HashSet::new();
+    for (i, client) in clients.iter().enumerate() {
+        let polled = client
+            .poll_messages(
+                &Identifier::named(STREAM_NAME).unwrap(),
+                &Identifier::named(TOPIC_NAME).unwrap(),
+                None,
+                &consumer,
+                &PollingStrategy::offset(0),
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+        if !polled.messages.is_empty() {
+            assert!(
+                polled_partitions.insert(polled.partition_id),
+                "Consumer {i} got partition {} already taken! Duplicate!",
+                polled.partition_id
+            );
+        }
+    }
+    assert_eq!(polled_partitions.len(), 16);
+
+    root_client
+        .delete_stream(&Identifier::named(STREAM_NAME).unwrap())
+        .await
+        .unwrap();
+}
+
+#[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic], server(
+    heartbeat.enabled = true,
+    heartbeat.interval = "2s",
+    tcp.socket.override_defaults = true,
+    tcp.socket.nodelay = true
+))]
+async fn should_distribute_excess_evenly_when_multiple_idle_members_join(harness: &TestHarness) {
+    let root_client = harness.root_client().await.unwrap();
+
+    root_client.create_stream(STREAM_NAME).await.unwrap();
+    root_client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            12,
+            CompressionAlgorithm::default(),
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+    root_client
+        .create_consumer_group(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            &Identifier::named(TOPIC_NAME).unwrap(),
+            CONSUMER_GROUP_NAME,
+        )
+        .await
+        .unwrap();
+
+    let client1 = harness.new_client().await.unwrap();
+    client1
+        .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+        .await
+        .unwrap();
+    join_cg(&client1).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members[0].partitions_count, 12);
+
+    let client2 = harness.new_client().await.unwrap();
+    let client3 = harness.new_client().await.unwrap();
+    let client4 = harness.new_client().await.unwrap();
+
+    for client in [&client2, &client3, &client4] {
+        client
+            .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+            .await
+            .unwrap();
+    }
+
+    let stream_id = Identifier::named(STREAM_NAME).unwrap();
+    let topic_id = Identifier::named(TOPIC_NAME).unwrap();
+    let group_id = Identifier::named(CONSUMER_GROUP_NAME).unwrap();
+
+    let (r2, r3, r4) = tokio::join!(
+        client2.join_consumer_group(&stream_id, &topic_id, &group_id),
+        client3.join_consumer_group(&stream_id, &topic_id, &group_id),
+        client4.join_consumer_group(&stream_id, &topic_id, &group_id),
+    );
+    r2.unwrap();
+    r3.unwrap();
+    r4.unwrap();
+
+    sleep(Duration::from_millis(500)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 4);
+    assert_unique_partition_assignments(&cg);
+    assert_balanced_partition_distribution(&cg, 12);
+
+    for member in &cg.members {
+        assert_eq!(
+            member.partitions_count, 3,
+            "With 12 partitions and 4 consumers, each should have exactly 3. \
+             Member {} has {}. Members: {:?}",
+            member.id, member.partitions_count, cg.members
+        );
+    }
+
+    root_client
+        .delete_stream(&Identifier::named(STREAM_NAME).unwrap())
+        .await
+        .unwrap();
+}
+
+#[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic], server(
+    heartbeat.enabled = true,
+    heartbeat.interval = "2s",
+    tcp.socket.override_defaults = true,
+    tcp.socket.nodelay = true
+))]
+async fn should_distribute_remainder_fairly_with_uneven_ratio(harness: &TestHarness) {
+    let root_client = harness.root_client().await.unwrap();
+
+    root_client.create_stream(STREAM_NAME).await.unwrap();
+    root_client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            10,
+            CompressionAlgorithm::default(),
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+    root_client
+        .create_consumer_group(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            &Identifier::named(TOPIC_NAME).unwrap(),
+            CONSUMER_GROUP_NAME,
+        )
+        .await
+        .unwrap();
+
+    let client1 = harness.new_client().await.unwrap();
+    client1
+        .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+        .await
+        .unwrap();
+    join_cg(&client1).await;
+
+    let mut clients = vec![client1];
+    for _ in 2..=4 {
+        let client = harness.new_client().await.unwrap();
+        client
+            .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+            .await
+            .unwrap();
+        join_cg(&client).await;
+        clients.push(client);
+    }
+
+    sleep(Duration::from_millis(500)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 4);
+    assert_unique_partition_assignments(&cg);
+    assert_balanced_partition_distribution(&cg, 10);
+
+    let mut count_with_3 = 0;
+    let mut count_with_2 = 0;
+    for member in &cg.members {
+        match member.partitions_count {
+            3 => count_with_3 += 1,
+            2 => count_with_2 += 1,
+            n => panic!(
+                "Member {} has {n} partitions, expected 2 or 3. Members: {:?}",
+                member.id, cg.members
+            ),
+        }
+    }
+    assert_eq!(
+        count_with_3, 2,
+        "Expected 2 members with 3 partitions (10/4=2 remainder 2). Members: {:?}",
+        cg.members
+    );
+    assert_eq!(
+        count_with_2, 2,
+        "Expected 2 members with 2 partitions. Members: {:?}",
+        cg.members
+    );
+
+    root_client
+        .delete_stream(&Identifier::named(STREAM_NAME).unwrap())
+        .await
+        .unwrap();
+}
+
+#[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic], server(
+    heartbeat.enabled = true,
+    heartbeat.interval = "2s",
+    tcp.socket.override_defaults = true,
+    tcp.socket.nodelay = true
+))]
+async fn should_collect_excess_from_multiple_overassigned_members(harness: &TestHarness) {
+    let root_client = harness.root_client().await.unwrap();
+
+    root_client.create_stream(STREAM_NAME).await.unwrap();
+    root_client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            16,
+            CompressionAlgorithm::default(),
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+    root_client
+        .create_consumer_group(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            &Identifier::named(TOPIC_NAME).unwrap(),
+            CONSUMER_GROUP_NAME,
+        )
+        .await
+        .unwrap();
+
+    let client1 = harness.new_client().await.unwrap();
+    let client2 = harness.new_client().await.unwrap();
+    for client in [&client1, &client2] {
+        client
+            .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+            .await
+            .unwrap();
+        join_cg(client).await;
+    }
+
+    sleep(Duration::from_millis(200)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 2);
+    let total: u32 = cg.members.iter().map(|m| m.partitions_count).sum();
+    assert_eq!(total, 16);
+
+    let mut new_clients = Vec::new();
+    for _ in 3..=8 {
+        let client = harness.new_client().await.unwrap();
+        client
+            .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+            .await
+            .unwrap();
+        join_cg(&client).await;
+        new_clients.push(client);
+    }
+
+    sleep(Duration::from_millis(500)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 8);
+    assert_unique_partition_assignments(&cg);
+    assert_balanced_partition_distribution(&cg, 16);
+
+    for member in &cg.members {
+        assert_eq!(
+            member.partitions_count, 2,
+            "With 16 partitions and 8 consumers, each should have exactly 2. \
+             Member {} has {}. Members: {:?}",
+            member.id, member.partitions_count, cg.members
+        );
+    }
+
+    root_client
+        .delete_stream(&Identifier::named(STREAM_NAME).unwrap())
+        .await
+        .unwrap();
+}
+
+#[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic], server(
+    heartbeat.enabled = true,
+    heartbeat.interval = "2s",
+    tcp.socket.override_defaults = true,
+    tcp.socket.nodelay = true
+))]
+async fn should_not_starve_any_member_in_large_scale_rebalance(harness: &TestHarness) {
+    let root_client = harness.root_client().await.unwrap();
+
+    root_client.create_stream(STREAM_NAME).await.unwrap();
+    root_client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            24,
+            CompressionAlgorithm::default(),
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+    root_client
+        .create_consumer_group(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            &Identifier::named(TOPIC_NAME).unwrap(),
+            CONSUMER_GROUP_NAME,
+        )
+        .await
+        .unwrap();
+
+    let first_client = harness.new_client().await.unwrap();
+    first_client
+        .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+        .await
+        .unwrap();
+    join_cg(&first_client).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members[0].partitions_count, 24);
+
+    let mut all_clients = vec![first_client];
+    for _ in 2..=8 {
+        let client = harness.new_client().await.unwrap();
+        client
+            .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+            .await
+            .unwrap();
+        join_cg(&client).await;
+        all_clients.push(client);
+    }
+
+    sleep(Duration::from_millis(500)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 8);
+    assert_unique_partition_assignments(&cg);
+    assert_balanced_partition_distribution(&cg, 24);
+
+    for member in &cg.members {
+        assert_eq!(
+            member.partitions_count, 3,
+            "With 24 partitions and 8 consumers, each should have exactly 3. \
+             Member {} has {}. This indicates the round-robin distribution is broken. \
+             Members: {:?}",
+            member.id, member.partitions_count, cg.members
+        );
+    }
+
+    root_client
+        .delete_stream(&Identifier::named(STREAM_NAME).unwrap())
+        .await
+        .unwrap();
+}
+
+#[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic], server(
+    heartbeat.enabled = true,
+    heartbeat.interval = "2s",
+    tcp.socket.override_defaults = true,
+    tcp.socket.nodelay = true
+))]
+async fn should_maintain_balance_after_member_churn(harness: &TestHarness) {
+    let root_client = harness.root_client().await.unwrap();
+
+    root_client.create_stream(STREAM_NAME).await.unwrap();
+    root_client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            16,
+            CompressionAlgorithm::default(),
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+    root_client
+        .create_consumer_group(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            &Identifier::named(TOPIC_NAME).unwrap(),
+            CONSUMER_GROUP_NAME,
+        )
+        .await
+        .unwrap();
+
+    let client1 = harness.new_client().await.unwrap();
+    let client2 = harness.new_client().await.unwrap();
+    let client3 = harness.new_client().await.unwrap();
+    let client4 = harness.new_client().await.unwrap();
+
+    for client in [&client1, &client2, &client3, &client4] {
+        client
+            .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+            .await
+            .unwrap();
+        join_cg(client).await;
+    }
+
+    sleep(Duration::from_millis(300)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 4);
+    assert_unique_partition_assignments(&cg);
+    assert_balanced_partition_distribution(&cg, 16);
+
+    drop(client3);
+    drop(client4);
+    sleep(Duration::from_millis(500)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 2);
+    let total: u32 = cg.members.iter().map(|m| m.partitions_count).sum();
+    assert_eq!(total, 16);
+
+    let client5 = harness.new_client().await.unwrap();
+    let client6 = harness.new_client().await.unwrap();
+    for client in [&client5, &client6] {
+        client
+            .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
+            .await
+            .unwrap();
+        join_cg(client).await;
+    }
+
+    sleep(Duration::from_millis(500)).await;
+
+    let cg = get_consumer_group(&root_client).await;
+    assert_eq!(cg.members_count, 4);
+    assert_unique_partition_assignments(&cg);
+    assert_balanced_partition_distribution(&cg, 16);
+
+    for member in &cg.members {
+        assert_eq!(
+            member.partitions_count, 4,
+            "After churn, each of 4 members should have 4 of 16 partitions. \
+             Member {} has {}. Members: {:?}",
+            member.id, member.partitions_count, cg.members
+        );
+    }
+
     root_client
         .delete_stream(&Identifier::named(STREAM_NAME).unwrap())
         .await

--- a/core/integration/tests/data_integrity/verify_consumer_group_partition_assignment.rs
+++ b/core/integration/tests/data_integrity/verify_consumer_group_partition_assignment.rs
@@ -2213,12 +2213,16 @@ fn assert_unique_partition_assignments(cg: &ConsumerGroupDetails) {
 }
 
 async fn setup_stream_topic_cg(client: &IggyClient) {
+    setup_stream_topic_cg_with_partitions(client, PARTITIONS_COUNT).await;
+}
+
+async fn setup_stream_topic_cg_with_partitions(client: &IggyClient, partitions: u32) {
     client.create_stream(STREAM_NAME).await.unwrap();
     client
         .create_topic(
             &Identifier::named(STREAM_NAME).unwrap(),
             TOPIC_NAME,
-            PARTITIONS_COUNT,
+            partitions,
             CompressionAlgorithm::default(),
             None,
             IggyExpiry::NeverExpire,
@@ -2296,16 +2300,6 @@ fn assert_balanced_partition_distribution(cg: &ConsumerGroupDetails, expected_to
             cg.members
         );
     }
-
-    let counts: Vec<u32> = cg.members.iter().map(|m| m.partitions_count).collect();
-    let min_count = *counts.iter().min().unwrap();
-    let max_count = *counts.iter().max().unwrap();
-    assert!(
-        max_count - min_count <= 1,
-        "Partition distribution variance too high: min={min_count}, max={max_count}. \
-         Difference should be at most 1. Members: {:?}",
-        cg.members
-    );
 }
 
 #[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic], server(
@@ -3322,27 +3316,7 @@ async fn should_not_complete_other_members_revocations_on_leave(harness: &TestHa
 async fn should_distribute_16_partitions_evenly_across_16_consumers(harness: &TestHarness) {
     let root_client = harness.root_client().await.unwrap();
 
-    root_client.create_stream(STREAM_NAME).await.unwrap();
-    root_client
-        .create_topic(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            TOPIC_NAME,
-            16,
-            CompressionAlgorithm::default(),
-            None,
-            IggyExpiry::NeverExpire,
-            MaxTopicSize::ServerDefault,
-        )
-        .await
-        .unwrap();
-    root_client
-        .create_consumer_group(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            &Identifier::named(TOPIC_NAME).unwrap(),
-            CONSUMER_GROUP_NAME,
-        )
-        .await
-        .unwrap();
+    setup_stream_topic_cg_with_partitions(&root_client, 16).await;
 
     for partition_id in 0..16u32 {
         let message = IggyMessage::from_str(&format!("msg-p{partition_id}")).unwrap();
@@ -3435,27 +3409,7 @@ async fn should_distribute_16_partitions_evenly_across_16_consumers(harness: &Te
 async fn should_distribute_excess_evenly_when_multiple_idle_members_join(harness: &TestHarness) {
     let root_client = harness.root_client().await.unwrap();
 
-    root_client.create_stream(STREAM_NAME).await.unwrap();
-    root_client
-        .create_topic(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            TOPIC_NAME,
-            12,
-            CompressionAlgorithm::default(),
-            None,
-            IggyExpiry::NeverExpire,
-            MaxTopicSize::ServerDefault,
-        )
-        .await
-        .unwrap();
-    root_client
-        .create_consumer_group(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            &Identifier::named(TOPIC_NAME).unwrap(),
-            CONSUMER_GROUP_NAME,
-        )
-        .await
-        .unwrap();
+    setup_stream_topic_cg_with_partitions(&root_client, 12).await;
 
     let client1 = harness.new_client().await.unwrap();
     client1
@@ -3522,27 +3476,7 @@ async fn should_distribute_excess_evenly_when_multiple_idle_members_join(harness
 async fn should_distribute_remainder_fairly_with_uneven_ratio(harness: &TestHarness) {
     let root_client = harness.root_client().await.unwrap();
 
-    root_client.create_stream(STREAM_NAME).await.unwrap();
-    root_client
-        .create_topic(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            TOPIC_NAME,
-            10,
-            CompressionAlgorithm::default(),
-            None,
-            IggyExpiry::NeverExpire,
-            MaxTopicSize::ServerDefault,
-        )
-        .await
-        .unwrap();
-    root_client
-        .create_consumer_group(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            &Identifier::named(TOPIC_NAME).unwrap(),
-            CONSUMER_GROUP_NAME,
-        )
-        .await
-        .unwrap();
+    setup_stream_topic_cg_with_partitions(&root_client, 10).await;
 
     let client1 = harness.new_client().await.unwrap();
     client1
@@ -3607,27 +3541,7 @@ async fn should_distribute_remainder_fairly_with_uneven_ratio(harness: &TestHarn
 async fn should_collect_excess_from_multiple_overassigned_members(harness: &TestHarness) {
     let root_client = harness.root_client().await.unwrap();
 
-    root_client.create_stream(STREAM_NAME).await.unwrap();
-    root_client
-        .create_topic(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            TOPIC_NAME,
-            16,
-            CompressionAlgorithm::default(),
-            None,
-            IggyExpiry::NeverExpire,
-            MaxTopicSize::ServerDefault,
-        )
-        .await
-        .unwrap();
-    root_client
-        .create_consumer_group(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            &Identifier::named(TOPIC_NAME).unwrap(),
-            CONSUMER_GROUP_NAME,
-        )
-        .await
-        .unwrap();
+    setup_stream_topic_cg_with_partitions(&root_client, 16).await;
 
     let client1 = harness.new_client().await.unwrap();
     let client2 = harness.new_client().await.unwrap();
@@ -3688,27 +3602,7 @@ async fn should_collect_excess_from_multiple_overassigned_members(harness: &Test
 async fn should_not_starve_any_member_in_large_scale_rebalance(harness: &TestHarness) {
     let root_client = harness.root_client().await.unwrap();
 
-    root_client.create_stream(STREAM_NAME).await.unwrap();
-    root_client
-        .create_topic(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            TOPIC_NAME,
-            24,
-            CompressionAlgorithm::default(),
-            None,
-            IggyExpiry::NeverExpire,
-            MaxTopicSize::ServerDefault,
-        )
-        .await
-        .unwrap();
-    root_client
-        .create_consumer_group(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            &Identifier::named(TOPIC_NAME).unwrap(),
-            CONSUMER_GROUP_NAME,
-        )
-        .await
-        .unwrap();
+    setup_stream_topic_cg_with_partitions(&root_client, 24).await;
 
     let first_client = harness.new_client().await.unwrap();
     first_client
@@ -3763,27 +3657,7 @@ async fn should_not_starve_any_member_in_large_scale_rebalance(harness: &TestHar
 async fn should_maintain_balance_after_member_churn(harness: &TestHarness) {
     let root_client = harness.root_client().await.unwrap();
 
-    root_client.create_stream(STREAM_NAME).await.unwrap();
-    root_client
-        .create_topic(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            TOPIC_NAME,
-            16,
-            CompressionAlgorithm::default(),
-            None,
-            IggyExpiry::NeverExpire,
-            MaxTopicSize::ServerDefault,
-        )
-        .await
-        .unwrap();
-    root_client
-        .create_consumer_group(
-            &Identifier::named(STREAM_NAME).unwrap(),
-            &Identifier::named(TOPIC_NAME).unwrap(),
-            CONSUMER_GROUP_NAME,
-        )
-        .await
-        .unwrap();
+    setup_stream_topic_cg_with_partitions(&root_client, 16).await;
 
     let client1 = harness.new_client().await.unwrap();
     let client2 = harness.new_client().await.unwrap();

--- a/core/server/src/metadata/consumer_group.rs
+++ b/core/server/src/metadata/consumer_group.rs
@@ -126,7 +126,7 @@ impl ConsumerGroupMeta {
             .collect();
 
         // Collect idle members (no partitions and not already a revocation target)
-        let mut idle_slab_ids: Vec<usize> = self
+        let idle_slab_ids: Vec<usize> = self
             .members
             .iter()
             .filter(|(id, m)| m.partitions.is_empty() && !revocation_targets.contains(id))
@@ -137,14 +137,21 @@ impl ConsumerGroupMeta {
             return;
         }
 
-        // Find over-assigned members and mark excess as pending revocation
+        // Two-pass distribution: we first collect ALL excess partitions, then distribute
+        // them round-robin. This ensures even distribution when one member holds many
+        // partitions and multiple idle members join. Without this, the first idle member
+        // would receive all excess partitions while others starve.
+        //
+        // Example: 16 partitions held by 1 member, 15 idle members join
+        //   Single-pass: member1 gets 15, members 2-15 get 0-1 each (unbalanced)
+        //   Two-pass: each of 16 members gets exactly 1 partition
+
+        // Pass 1: Collect excess partitions from over-assigned members
         let member_ids: Vec<usize> = self.members.iter().map(|(id, _)| id).collect();
         let mut members_with_remainder = remainder;
+        let mut all_excess: Vec<(PartitionId, usize)> = Vec::new();
 
         for &mid in &member_ids {
-            if idle_slab_ids.is_empty() {
-                break;
-            }
             let effective_count = self
                 .members
                 .get(mid)
@@ -158,7 +165,6 @@ impl ConsumerGroupMeta {
                 })
                 .unwrap_or(0);
 
-            // This member's max allowed partitions
             let max_allowed = if members_with_remainder > 0 {
                 fair_share + 1
             } else {
@@ -172,13 +178,11 @@ impl ConsumerGroupMeta {
                 continue;
             }
 
-            // Mark excess partitions as pending revocation (from the END of the list)
             let excess_count = effective_count - max_allowed;
             if members_with_remainder > 0 && effective_count > fair_share {
                 members_with_remainder = members_with_remainder.saturating_sub(1);
             }
 
-            // Collect partitions eligible for revocation (not already pending)
             let revocable: Vec<PartitionId> = self
                 .members
                 .get(mid)
@@ -198,23 +202,27 @@ impl ConsumerGroupMeta {
                 .unwrap_or_default();
 
             for partition_id in revocable.into_iter().take(excess_count) {
-                if idle_slab_ids.is_empty() {
-                    break;
-                }
-                let idle_id = idle_slab_ids.remove(0);
-                let target_member_id = self
-                    .members
-                    .get(idle_id)
-                    .map(|m| m.id)
-                    .unwrap_or(usize::MAX);
-                if let Some(member) = self.members.get_mut(mid) {
-                    member.pending_revocations.push(PendingRevocation {
-                        partition_id,
-                        target_slab_id: idle_id,
-                        target_member_id,
-                        created_at_micros: IggyTimestamp::now().as_micros(),
-                    });
-                }
+                all_excess.push((partition_id, mid));
+            }
+        }
+
+        // Pass 2: Distribute collected partitions round-robin across idle members
+        let now = IggyTimestamp::now().as_micros();
+        for (i, (partition_id, source_mid)) in all_excess.into_iter().enumerate() {
+            // Modulo ensures partitions cycle through idle members evenly
+            let idle_id = idle_slab_ids[i % idle_slab_ids.len()];
+            let target_member_id = self
+                .members
+                .get(idle_id)
+                .map(|m| m.id)
+                .unwrap_or(usize::MAX);
+            if let Some(member) = self.members.get_mut(source_mid) {
+                member.pending_revocations.push(PendingRevocation {
+                    partition_id,
+                    target_slab_id: idle_id,
+                    target_member_id,
+                    created_at_micros: now,
+                });
             }
         }
     }

--- a/core/server/src/metadata/consumer_group.rs
+++ b/core/server/src/metadata/consumer_group.rs
@@ -152,18 +152,20 @@ impl ConsumerGroupMeta {
         let mut all_excess: Vec<(PartitionId, usize)> = Vec::new();
 
         for &mid in &member_ids {
-            let effective_count = self
-                .members
-                .get(mid)
-                .map(|m| {
-                    let pending: HashSet<PartitionId> = m
-                        .pending_revocations
-                        .iter()
-                        .map(|revocation| revocation.partition_id)
-                        .collect();
-                    m.partitions.iter().filter(|p| !pending.contains(p)).count()
-                })
-                .unwrap_or(0);
+            let Some(member) = self.members.get(mid) else {
+                continue;
+            };
+
+            let pending: HashSet<PartitionId> = member
+                .pending_revocations
+                .iter()
+                .map(|revocation| revocation.partition_id)
+                .collect();
+            let effective_count = member
+                .partitions
+                .iter()
+                .filter(|p| !pending.contains(p))
+                .count();
 
             let max_allowed = if members_with_remainder > 0 {
                 fair_share + 1
@@ -183,23 +185,13 @@ impl ConsumerGroupMeta {
                 members_with_remainder = members_with_remainder.saturating_sub(1);
             }
 
-            let revocable: Vec<PartitionId> = self
-                .members
-                .get(mid)
-                .map(|m| {
-                    let pending: HashSet<PartitionId> = m
-                        .pending_revocations
-                        .iter()
-                        .map(|revocation| revocation.partition_id)
-                        .collect();
-                    m.partitions
-                        .iter()
-                        .rev()
-                        .filter(|p| !pending.contains(p))
-                        .copied()
-                        .collect()
-                })
-                .unwrap_or_default();
+            let revocable: Vec<PartitionId> = member
+                .partitions
+                .iter()
+                .rev()
+                .filter(|p| !pending.contains(p))
+                .copied()
+                .collect();
 
             for partition_id in revocable.into_iter().take(excess_count) {
                 all_excess.push((partition_id, mid));


### PR DESCRIPTION
## Summary
- Fix cooperative rebalancing to distribute partitions evenly across idle members
- Add 6 new integration tests verifying balanced distribution in various scenarios

## Problem
When multiple consumers joined a consumer group, the first idle member received most excess partitions while others starved. Example: 16 partitions held by 1 member + 15 new members → uneven distribution.

## Solution
Two-pass distribution approach:
1. **Pass 1:** Collect ALL excess partitions from over-assigned members
2. **Pass 2:** Distribute round-robin using `idle_slab_ids[i % idle_slab_ids.len()]`

Example: 16 partitions held by 1 member, 15 idle members join
- Before: first idle member gets many, others get 0-1
- After: each of 16 members gets exactly 1 partition

## Test plan
- [x] All 95 existing consumer group partition assignment tests pass
- [x] 6 new tests added covering balanced distribution scenarios:
  - 16 partitions → 16 consumers (exact benchmark scenario)
  - 12 partitions → 4 concurrent joins
  - 10 partitions → 4 members (uneven ratio with remainder)
  - 16 partitions with 2 over-assigned → 8 total members
  - 24 partitions → 8 members (large scale)
  - Member churn (leave + rejoin)

Closes #3334