### PR TITLE
chore(deps): update and pin .net nuget versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -171,6 +171,10 @@ updates:
       - "csharp"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "System.IO.Hashing"
+      - dependency-name: "Microsoft.SourceLink.GitHub"
+      - dependency-name: "Microsoft.Extensions.Logging.Abstractions"
     groups:
       minor-and-patch:
         patterns:

--- a/foreign/csharp/Directory.Packages.props
+++ b/foreign/csharp/Directory.Packages.props
@@ -5,17 +5,17 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.108" />
         <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
         <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="2.2.3" />
         <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
         <PackageVersion Include="Moq" Version="4.20.72" />
         <PackageVersion Include="Reqnroll.xunit.v3" Version="3.3.4" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />
-        <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
+        <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
         <PackageVersion Include="Testcontainers" Version="4.12.0" />
         <PackageVersion Include="TUnit" Version="1.45.29" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/foreign/csharp/Iggy_SDK/Iggy_SDK.csproj
+++ b/foreign/csharp/Iggy_SDK/Iggy_SDK.csproj
@@ -48,7 +48,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="System.IO.Hashing" />
     </ItemGroup>
 


### PR DESCRIPTION
- set .net nuget to minimum working version for publish .net8 version
- add to ignore version update in dependabot


The C# SDK is published as a NuGet package targeting net8.0 and net10.0. 
We intentionally depend on the lowest versions our library actually requires, 
so we don't force a higher floor on consumers — they remain free to bump 
these to newer versions in their own projects.