### PR TITLE
feat(php): map Iggy errors to typed exceptions

### DIFF
--- a/foreign/php/iggy-php.stubs.php
+++ b/foreign/php/iggy-php.stubs.php
@@ -475,3 +475,25 @@ namespace Iggy {
         public function __construct() {}
     }
 }
+
+namespace Iggy\Exception {
+    class AuthenticationException extends Iggy\Exception\IggyException {
+        public function __construct() {}
+    }
+
+    class ConnectionException extends Iggy\Exception\IggyException {
+        public function __construct() {}
+    }
+
+    class IggyException extends \Exception {
+        public function __construct() {}
+    }
+
+    class NotFoundException extends Iggy\Exception\IggyException {
+        public function __construct() {}
+    }
+
+    class TransientException extends Iggy\Exception\IggyException {
+        public function __construct() {}
+    }
+}

--- a/foreign/php/src/client.rs
+++ b/foreign/php/src/client.rs
@@ -348,14 +348,14 @@ impl IggyClient {
                 );
             }
             (Some(_), None) => {
-                return Err(
-                    "'init_retry_interval_micros' is required if 'init_retries' is set".into(),
-                );
+                return Err(to_php_exception(
+                    "'init_retry_interval_micros' is required if 'init_retries' is set",
+                ));
             }
             (None, Some(_)) => {
-                return Err(
-                    "'init_retries' is required if 'init_retry_interval_micros' is set".into(),
-                );
+                return Err(to_php_exception(
+                    "'init_retries' is required if 'init_retry_interval_micros' is set",
+                ));
             }
             (None, None) => {}
         }
@@ -381,7 +381,9 @@ impl IggyClient {
 
 fn non_zero_duration_micros(field: &str, micros: u64) -> PhpResult<IggyDuration> {
     if micros == 0 {
-        return Err(format!("'{field}' must be greater than 0 microseconds").into());
+        return Err(to_php_exception(format!(
+            "'{field}' must be greater than 0 microseconds"
+        )));
     }
 
     Ok(IggyDuration::from(micros))

--- a/foreign/php/src/consumer.rs
+++ b/foreign/php/src/consumer.rs
@@ -171,9 +171,9 @@ impl IggyConsumer {
             .get_last_consumed_offset(current_partition_id)
             .is_none()
         {
-            return Err(
-                "'partition_id' is required until at least one message has been polled".into(),
-            );
+            return Err(to_php_exception(
+                "'partition_id' is required until at least one message has been polled",
+            ));
         }
 
         Ok(Some(current_partition_id))

--- a/foreign/php/src/error.rs
+++ b/foreign/php/src/error.rs
@@ -16,8 +16,156 @@
  * under the License.
  */
 
-use ext_php_rs::exception::PhpException;
+use ext_php_rs::{error::Error, exception::PhpException, php_class, zend::ce};
+use iggy::prelude::IggyError;
 
-pub(crate) fn to_php_exception(error: impl std::fmt::Display) -> PhpException {
-    PhpException::default(error.to_string())
+#[php_class]
+#[php(name = "Iggy\\Exception\\IggyException")]
+#[php(extends(ce = ce::exception, stub = "\\Exception"))]
+#[derive(Default)]
+pub struct IggyException;
+
+#[php_class]
+#[php(name = "Iggy\\Exception\\ConnectionException")]
+#[php(extends(IggyException))]
+#[derive(Default)]
+pub struct ConnectionException;
+
+#[php_class]
+#[php(name = "Iggy\\Exception\\AuthenticationException")]
+#[php(extends(IggyException))]
+#[derive(Default)]
+pub struct AuthenticationException;
+
+#[php_class]
+#[php(name = "Iggy\\Exception\\NotFoundException")]
+#[php(extends(IggyException))]
+#[derive(Default)]
+pub struct NotFoundException;
+
+#[php_class]
+#[php(name = "Iggy\\Exception\\TransientException")]
+#[php(extends(IggyException))]
+#[derive(Default)]
+pub struct TransientException;
+
+pub(crate) trait IntoPhpException {
+    fn into_php_exception(self) -> PhpException;
+}
+
+pub(crate) fn to_php_exception(error: impl IntoPhpException) -> PhpException {
+    error.into_php_exception()
+}
+
+impl IntoPhpException for IggyError {
+    fn into_php_exception(self) -> PhpException {
+        let message = self.to_string();
+
+        match PhpExceptionKind::from(&self) {
+            PhpExceptionKind::Connection => {
+                PhpException::from_class::<ConnectionException>(message)
+            }
+            PhpExceptionKind::Authentication => {
+                PhpException::from_class::<AuthenticationException>(message)
+            }
+            PhpExceptionKind::NotFound => PhpException::from_class::<NotFoundException>(message),
+            PhpExceptionKind::Transient => PhpException::from_class::<TransientException>(message),
+            PhpExceptionKind::Base => PhpException::from_class::<IggyException>(message),
+        }
+    }
+}
+
+impl IntoPhpException for Error {
+    fn into_php_exception(self) -> PhpException {
+        PhpException::from_class::<IggyException>(self.to_string())
+    }
+}
+
+impl IntoPhpException for String {
+    fn into_php_exception(self) -> PhpException {
+        PhpException::from_class::<IggyException>(self)
+    }
+}
+
+enum PhpExceptionKind {
+    Base,
+    Connection,
+    Authentication,
+    NotFound,
+    Transient,
+}
+
+impl From<&IggyError> for PhpExceptionKind {
+    fn from(error: &IggyError) -> Self {
+        match error {
+            IggyError::Disconnected
+            | IggyError::CannotEstablishConnection
+            | IggyError::StaleClient
+            | IggyError::TcpError
+            | IggyError::QuicError
+            | IggyError::InvalidServerAddress
+            | IggyError::InvalidClientAddress
+            | IggyError::InvalidIpAddress(_, _)
+            | IggyError::HttpError(_)
+            | IggyError::InvalidApiUrl(_)
+            | IggyError::NotConnected
+            | IggyError::ClientShutdown
+            | IggyError::InvalidTlsDomain
+            | IggyError::InvalidTlsCertificatePath
+            | IggyError::InvalidTlsCertificate
+            | IggyError::FailedToAddCertificate
+            | IggyError::ConnectionClosed
+            | IggyError::CannotCloseWebSocketConnection(_)
+            | IggyError::CannotCreateEndpoint
+            | IggyError::CannotParseUrl
+            | IggyError::WebSocketError
+            | IggyError::WebSocketConnectionError
+            | IggyError::WebSocketCloseError
+            | IggyError::WebSocketReceiveError
+            | IggyError::WebSocketSendError
+            | IggyError::InvalidConnectionString
+            | IggyError::CannotBindToSocket(_) => Self::Connection,
+            IggyError::Unauthenticated
+            | IggyError::Unauthorized
+            | IggyError::InvalidCredentials
+            | IggyError::InvalidUsername
+            | IggyError::InvalidPassword
+            | IggyError::InvalidUserStatus
+            | IggyError::UserInactive
+            | IggyError::InvalidPersonalAccessToken
+            | IggyError::PersonalAccessTokenExpired(_, _)
+            | IggyError::JwtMissing
+            | IggyError::AccessTokenMissing
+            | IggyError::InvalidAccessToken => Self::Authentication,
+            IggyError::StateFileNotFound
+            | IggyError::ResourceNotFound(_)
+            | IggyError::ClientNotFound(_)
+            | IggyError::StreamIdNotFound(_)
+            | IggyError::StreamNameNotFound(_)
+            | IggyError::StreamDirectoryNotFound(_)
+            | IggyError::TopicIdNotFound(_, _)
+            | IggyError::TopicNameNotFound(_, _)
+            | IggyError::TopicDirectoryNotFound(_)
+            | IggyError::PartitionNotFound(_, _, _)
+            | IggyError::ConsumerOffsetNotFound(_)
+            | IggyError::NotResolvedConsumer(_)
+            | IggyError::SegmentNotFound
+            | IggyError::ConsumerGroupIdNotFound(_, _)
+            | IggyError::ConsumerGroupNameNotFound(_, _)
+            | IggyError::ConsumerGroupMemberNotFound(_, _, _)
+            | IggyError::ShardNotFound(_, _, _) => Self::NotFound,
+            IggyError::HttpResponseError(408 | 429 | 500..=599, _)
+            | IggyError::EmptyResponse
+            | IggyError::CannotSendMessagesDueToClientDisconnection
+            | IggyError::BackgroundSendError
+            | IggyError::BackgroundSendTimeout
+            | IggyError::BackgroundSendBufferFull
+            | IggyError::BackgroundWorkerDisconnected
+            | IggyError::BackgroundSendBufferOverflow
+            | IggyError::ProducerSendFailed { .. }
+            | IggyError::TaskTimeout
+            | IggyError::ShardCommunicationError => Self::Transient,
+            _ => Self::Base,
+        }
+    }
 }

--- a/foreign/php/src/error.rs
+++ b/foreign/php/src/error.rs
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-use ext_php_rs::{error::Error, exception::PhpException, php_class, zend::ce};
+use ext_php_rs::{convert::IntoZval, error::Error, exception::PhpException, php_class, zend::ce};
 use iggy::prelude::IggyError;
 
 #[php_class]
@@ -77,13 +77,25 @@ impl IntoPhpException for IggyError {
 
 impl IntoPhpException for Error {
     fn into_php_exception(self) -> PhpException {
-        PhpException::from_class::<IggyException>(self.to_string())
+        match self {
+            Error::Exception(exception) => match exception.into_zval(false) {
+                Ok(object) => PhpException::default(String::new()).with_object(object),
+                Err(error) => PhpException::from_class::<IggyException>(error.to_string()),
+            },
+            error => PhpException::from_class::<IggyException>(error.to_string()),
+        }
     }
 }
 
 impl IntoPhpException for String {
     fn into_php_exception(self) -> PhpException {
         PhpException::from_class::<IggyException>(self)
+    }
+}
+
+impl IntoPhpException for &str {
+    fn into_php_exception(self) -> PhpException {
+        PhpException::from_class::<IggyException>(self.to_string())
     }
 }
 

--- a/foreign/php/src/lib.rs
+++ b/foreign/php/src/lib.rs
@@ -30,6 +30,10 @@ use ext_php_rs::prelude::*;
 
 use crate::client::IggyClient;
 use crate::consumer::{AutoCommit, AutoCommitWhen, IggyConsumer};
+use crate::error::{
+    AuthenticationException, ConnectionException, IggyException, NotFoundException,
+    TransientException,
+};
 use crate::receive_message::{PollingStrategy, ReceiveMessage};
 use crate::send_message::SendMessage;
 use crate::stream::StreamDetails;
@@ -38,6 +42,11 @@ use crate::topic::TopicDetails;
 #[php_module]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
+        .class::<IggyException>()
+        .class::<ConnectionException>()
+        .class::<AuthenticationException>()
+        .class::<NotFoundException>()
+        .class::<TransientException>()
         .class::<IggyClient>()
         .class::<IggyConsumer>()
         .class::<AutoCommit>()

--- a/foreign/php/src/lib.rs
+++ b/foreign/php/src/lib.rs
@@ -42,6 +42,8 @@ use crate::topic::TopicDetails;
 #[php_module]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
+        // Parent classes must be registered before subclasses because ext-php-rs resolves
+        // the parent ClassEntry during child registration.
         .class::<IggyException>()
         .class::<ConnectionException>()
         .class::<AuthenticationException>()

--- a/foreign/php/src/receive_message.rs
+++ b/foreign/php/src/receive_message.rs
@@ -21,6 +21,8 @@ use iggy::prelude::{
     IggyMessage as RustReceiveMessage, IggyMessageHeader, PollingStrategy as RustPollingStrategy,
 };
 
+use crate::error::to_php_exception;
+
 /// A PHP class representing a received message.
 ///
 /// This class wraps a Rust message, allowing PHP code to access its payload and metadata.
@@ -136,7 +138,7 @@ impl PollingStrategy {
     /// Poll messages at or after a UNIX timestamp expressed in seconds.
     pub fn timestamp_seconds(value: u64) -> PhpResult<Self> {
         let Some(micros) = value.checked_mul(1_000_000) else {
-            return Err("timestamp seconds value is too large".into());
+            return Err(to_php_exception("timestamp seconds value is too large"));
         };
 
         Ok(Self::timestamp_micros(micros))

--- a/foreign/php/tests/ErrorTest.php
+++ b/foreign/php/tests/ErrorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+use Iggy\Client as IggyClient;
+use Iggy\Exception\AuthenticationException;
+use Iggy\Exception\ConnectionException;
+use Iggy\Exception\IggyException;
+use Iggy\Exception\NotFoundException;
+use Iggy\Exception\TransientException;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorTest extends TestCase
+{
+    #[TestDox('Connection configuration errors use the typed connection exception')]
+    public function testConnectionConfigurationErrorsUseTypedException(): void
+    {
+        $throwable = assert_throws(static fn () => new IggyClient('127.0.0.1'));
+
+        assert_instance_of(ConnectionException::class, $throwable);
+        assert_instance_of(IggyException::class, $throwable);
+    }
+
+    #[TestDox('Authentication failures use the typed authentication exception')]
+    public function testAuthenticationErrorsUseTypedException(): void
+    {
+        $client = new IggyClient(server_host() . ':' . server_port());
+        $client->connect();
+
+        $throwable = assert_throws(static fn () => $client->loginUser('iggy', 'wrong-password'));
+
+        assert_instance_of(AuthenticationException::class, $throwable);
+        assert_instance_of(IggyException::class, $throwable);
+    }
+
+    #[TestDox('Missing resources use the typed not-found exception')]
+    public function testNotFoundErrorsUseTypedException(): void
+    {
+        $client = new_client();
+
+        $throwable = assert_throws(static fn () => $client->deleteStream(unique_name('missing-stream')));
+
+        assert_instance_of(NotFoundException::class, $throwable);
+        assert_instance_of(IggyException::class, $throwable);
+    }
+
+    #[TestDox('Transient exceptions share the Iggy exception base class')]
+    public function testTransientExceptionUsesIggyBase(): void
+    {
+        assert_true(is_subclass_of(TransientException::class, IggyException::class));
+    }
+}

--- a/foreign/php/tests/ErrorTest.php
+++ b/foreign/php/tests/ErrorTest.php
@@ -21,12 +21,16 @@
 
 declare(strict_types=1);
 
+use Iggy\AutoCommit;
 use Iggy\Client as IggyClient;
 use Iggy\Exception\AuthenticationException;
 use Iggy\Exception\ConnectionException;
 use Iggy\Exception\IggyException;
 use Iggy\Exception\NotFoundException;
 use Iggy\Exception\TransientException;
+use Iggy\PollingStrategy;
+use Iggy\ReceiveMessage;
+use Iggy\SendMessage;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
@@ -68,5 +72,55 @@ final class ErrorTest extends TestCase
     public function testTransientExceptionUsesIggyBase(): void
     {
         assert_true(is_subclass_of(TransientException::class, IggyException::class));
+    }
+
+    #[TestDox('Callback exceptions are rethrown without changing their PHP type')]
+    public function testCallbackExceptionIsRethrownAsOriginalException(): void
+    {
+        $client = new_client();
+        $consumerName = unique_name('callback-exception-consumer');
+        $streamName = unique_name('callback-exception-stream');
+        $topicName = unique_name('callback-exception-topic');
+
+        try {
+            create_stream_and_topic($client, $streamName, $topicName);
+            $client->sendMessages(
+                $streamName,
+                $topicName,
+                0,
+                [new SendMessage('callback exception payload')],
+            );
+
+            $consumer = $client->consumerGroup(
+                $consumerName,
+                $streamName,
+                $topicName,
+                0,
+                PollingStrategy::next(),
+                10,
+                AutoCommit::disabled(),
+                true,
+                true,
+                micros(1),
+                null,
+                null,
+                null,
+                false,
+            );
+
+            $throwable = assert_throws(
+                static fn () => $consumer->consumeMessages(
+                    static function (ReceiveMessage $message): void {
+                        throw new RuntimeException('callback abort');
+                    },
+                    1,
+                ),
+            );
+
+            assert_instance_of(RuntimeException::class, $throwable);
+            assert_same('callback abort', $throwable->getMessage());
+        } finally {
+            cleanup_stream_with_topics($client, $streamName, [$topicName]);
+        }
     }
 }

--- a/foreign/php/tests/bootstrap.php
+++ b/foreign/php/tests/bootstrap.php
@@ -40,6 +40,11 @@ function assert_not_null(mixed $value, string $message = 'expected value not to 
     Assert::assertNotNull($value, $message);
 }
 
+function assert_instance_of(string $expected, mixed $actual, string $message = ''): void
+{
+    Assert::assertInstanceOf($expected, $actual, $message);
+}
+
 function assert_null(mixed $value, string $message = 'expected value to be null'): void
 {
     Assert::assertNull($value, $message);


### PR DESCRIPTION
## Which issue does this PR address?

<!--
We generally require a GitHub issue for all bug fixes and enhancements. Link it with GitHub syntax, keep the line that applies and delete the other:
- `Closes #123` auto-closes the issue when this PR merges (full fix).
- `Relates to #123` links without closing (partial or related work).
-->

Closes #3294 

## Rationale

<!--
Why is this change needed? If the issue explains it well, a one-liner is fine.
-->
The PHP SDK exposed Iggy failures as generic PHP exceptions, so callers could not reliably handle common error categories without parsing exception messages.

## What changed?

<!--
2-4 sentences. Problem first (before), then solution (after).

GOOD:

"Messages were unavailable when background message_saver committed the
journal and started async disk I/O before completion. Polling during
this window found neither journal nor disk data.

The fix freezes journal batches in the in-flight buffer before async persist."

GOOD:

"When many small messages accumulate in the journal, the flush passes
thousands of IO vectors to writev(), exceeding IOV_MAX (1024 on Linux)."

BAD:
- Walls of text
- "This PR adds..." (we can see the diff)
-->
Maps `IggyError` to typed PHP exceptions under `Iggy\Exception`.

## Local Execution

- Passed
- Pre-commit hooks ran

<!--
You must run your code locally before submitting.
"Relying on CI" is not acceptable - PRs from authors who haven't run the code will be closed.

Did you have `prek` installed? It runs automatically on commit and covers all project languages. See [CONTRIBUTING.md](https://github.com/apache/iggy/blob/master/CONTRIBUTING.md).
-->

## AI Usage

<!--
If AI tools were used, please answer:
1. Which tools? (e.g., GitHub Copilot, Claude, ChatGPT)
2. Scope of usage? (e.g., autocomplete, generated functions, entire implementation)
3. How did you verify the generated code works correctly?
4. Can you explain every line of the code if asked?

If no AI tools were used, write "None" or delete this section.
-->
1. AI tools used: Codex
2. Scope of usage: explanation, validation commands
3. Verification: validated with commands
4. Yes