### PR TITLE
refactor(server-ng): move bootstrap directories to server_common

### DIFF
--- a/core/configs/src/server_config/system.rs
+++ b/core/configs/src/server_config/system.rs
@@ -28,6 +28,7 @@ use iggy_common::{CompressionAlgorithm, IggyDuration};
 use serde::{Deserialize, Serialize};
 use serde_with::DisplayFromStr;
 use serde_with::serde_as;
+use server_common::bootstrap::SystemPaths;
 
 pub const INDEX_EXTENSION: &str = "index";
 pub const LOG_EXTENSION: &str = "log";
@@ -330,5 +331,27 @@ impl SystemConfig {
             IggyExpiry::ServerDefault => self.topic.message_expiry,
             _ => message_expiry,
         }
+    }
+}
+
+impl SystemPaths for SystemConfig {
+    fn get_system_path(&self) -> String {
+        SystemConfig::get_system_path(self)
+    }
+
+    fn get_state_path(&self) -> String {
+        SystemConfig::get_state_path(self)
+    }
+
+    fn get_state_messages_file_path(&self) -> String {
+        SystemConfig::get_state_messages_file_path(self)
+    }
+
+    fn get_streams_path(&self) -> String {
+        SystemConfig::get_streams_path(self)
+    }
+
+    fn get_runtime_path(&self) -> String {
+        SystemConfig::get_runtime_path(self)
     }
 }

--- a/core/server-ng/src/bootstrap.rs
+++ b/core/server-ng/src/bootstrap.rs
@@ -99,10 +99,11 @@ use partitions::{
     IggyIndexWriter, IggyPartition, IggyPartitions, MessagesWriter, PartitionsConfig, Segment,
 };
 use server_common::Message;
+use server_common::bootstrap::create_directories;
+use server_common::executor::create_shard_executor;
 use server_common::sharding::{IggyNamespace, LocalIdx, PartitionLocation, ShardId};
 // TODO: decouple bootstrap/storage helpers and logging from the `server` crate.
 use secrecy::ExposeSecret;
-use server::bootstrap::{create_directories, create_shard_executor};
 use server::log::logger::Logging;
 use server::shard_allocator::{ShardAllocator, ShardInfo};
 use server::streaming::partitions::storage::{load_consumer_group_offsets, load_consumer_offsets};

--- a/core/server/src/bootstrap.rs
+++ b/core/server/src/bootstrap.rs
@@ -47,10 +47,9 @@ use crate::{
         stats::{PartitionStats, StreamStats, TopicStats},
         storage::SystemStorage,
         users::user::User,
-        utils::{crypto, file::overwrite},
+        utils::crypto,
     },
 };
-use compio::fs::create_dir_all;
 use err_trail::ErrContext;
 use iggy_common::SemanticVersion;
 use iggy_common::{
@@ -61,7 +60,7 @@ use iggy_common::{
     },
 };
 use slab::Slab;
-use std::{env, path::Path, sync::Arc};
+use std::{env, sync::Arc};
 use tracing::{info, warn};
 
 pub fn create_shard_connections(
@@ -88,42 +87,6 @@ pub fn create_shard_connections(
 pub async fn load_config() -> Result<ServerConfig, ServerError> {
     let config = ServerConfig::load().await?;
     Ok(config)
-}
-
-pub async fn create_directories(config: &SystemConfig) -> Result<(), IggyError> {
-    let system_path = config.get_system_path();
-    if !Path::new(&system_path).exists() && create_dir_all(&system_path).await.is_err() {
-        return Err(IggyError::CannotCreateBaseDirectory(system_path));
-    }
-
-    let state_path = config.get_state_path();
-    if !Path::new(&state_path).exists() && create_dir_all(&state_path).await.is_err() {
-        return Err(IggyError::CannotCreateStateDirectory(state_path));
-    }
-    let state_log = config.get_state_messages_file_path();
-    if !Path::new(&state_log).exists() && (overwrite(&state_log).await).is_err() {
-        return Err(IggyError::CannotCreateStateDirectory(state_log));
-    }
-
-    let streams_path = config.get_streams_path();
-    if !Path::new(&streams_path).exists() && create_dir_all(&streams_path).await.is_err() {
-        return Err(IggyError::CannotCreateStreamsDirectory(streams_path));
-    }
-
-    let runtime_path = config.get_runtime_path();
-    if Path::new(&runtime_path).exists() && fs_utils::remove_dir_all(&runtime_path).await.is_err() {
-        return Err(IggyError::CannotRemoveRuntimeDirectory(runtime_path));
-    }
-
-    if create_dir_all(&runtime_path).await.is_err() {
-        return Err(IggyError::CannotCreateRuntimeDirectory(runtime_path));
-    }
-
-    info!(
-        "Initializing system, data will be stored at: {}",
-        config.get_system_path()
-    );
-    Ok(())
 }
 
 pub fn create_root_user() -> User {
@@ -170,7 +133,7 @@ pub fn create_root_user() -> User {
     User::root(&username, &password)
 }
 
-pub use server_common::create_shard_executor;
+pub use server_common::{create_directories, create_shard_executor};
 
 pub fn resolve_persister(enforce_fsync: bool) -> Arc<PersisterKind> {
     match enforce_fsync {

--- a/core/server_common/src/bootstrap.rs
+++ b/core/server_common/src/bootstrap.rs
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use compio::fs::{File, OpenOptions, create_dir_all};
+use iggy_common::IggyError;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tracing::info;
+
+#[derive(Debug, Clone)]
+struct DirEntry {
+    path: PathBuf,
+    is_dir: bool,
+}
+
+impl DirEntry {
+    fn file(path: PathBuf) -> Self {
+        Self {
+            path,
+            is_dir: false,
+        }
+    }
+
+    fn dir(path: PathBuf) -> Self {
+        Self { path, is_dir: true }
+    }
+}
+
+pub trait SystemPaths {
+    fn get_system_path(&self) -> String;
+
+    fn get_state_path(&self) -> String;
+
+    fn get_state_messages_file_path(&self) -> String;
+
+    fn get_streams_path(&self) -> String;
+
+    fn get_runtime_path(&self) -> String;
+}
+
+impl<T: SystemPaths> SystemPaths for Arc<T> {
+    fn get_system_path(&self) -> String {
+        self.as_ref().get_system_path()
+    }
+
+    fn get_state_path(&self) -> String {
+        self.as_ref().get_state_path()
+    }
+
+    fn get_state_messages_file_path(&self) -> String {
+        self.as_ref().get_state_messages_file_path()
+    }
+
+    fn get_streams_path(&self) -> String {
+        self.as_ref().get_streams_path()
+    }
+
+    fn get_runtime_path(&self) -> String {
+        self.as_ref().get_runtime_path()
+    }
+}
+
+pub async fn create_directories(config: &impl SystemPaths) -> Result<(), IggyError> {
+    let system_path = config.get_system_path();
+    if !Path::new(&system_path).exists() && create_dir_all(&system_path).await.is_err() {
+        return Err(IggyError::CannotCreateBaseDirectory(system_path));
+    }
+
+    let state_path = config.get_state_path();
+    if !Path::new(&state_path).exists() && create_dir_all(&state_path).await.is_err() {
+        return Err(IggyError::CannotCreateStateDirectory(state_path));
+    }
+    let state_log = config.get_state_messages_file_path();
+    if !Path::new(&state_log).exists() && overwrite(&state_log).await.is_err() {
+        return Err(IggyError::CannotCreateStateDirectory(state_log));
+    }
+
+    let streams_path = config.get_streams_path();
+    if !Path::new(&streams_path).exists() && create_dir_all(&streams_path).await.is_err() {
+        return Err(IggyError::CannotCreateStreamsDirectory(streams_path));
+    }
+
+    let runtime_path = config.get_runtime_path();
+    if Path::new(&runtime_path).exists() && remove_dir_all(&runtime_path).await.is_err() {
+        return Err(IggyError::CannotRemoveRuntimeDirectory(runtime_path));
+    }
+
+    if create_dir_all(&runtime_path).await.is_err() {
+        return Err(IggyError::CannotCreateRuntimeDirectory(runtime_path));
+    }
+
+    info!(
+        "Initializing system, data will be stored at: {}",
+        config.get_system_path()
+    );
+    Ok(())
+}
+
+async fn overwrite(path: &str) -> Result<File, io::Error> {
+    OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .await
+}
+
+async fn walk_dir(root: impl AsRef<Path>) -> io::Result<Vec<DirEntry>> {
+    let root = root.as_ref();
+
+    let metadata = compio::fs::metadata(root).await?;
+    if !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path is not a directory",
+        ));
+    }
+
+    let mut files = Vec::new();
+    let mut directories = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(current_dir) = stack.pop() {
+        directories.push(DirEntry::dir(current_dir.clone()));
+
+        for entry in std::fs::read_dir(&current_dir)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+            let metadata = compio::fs::symlink_metadata(&entry_path).await?;
+
+            if metadata.is_dir() {
+                stack.push(entry_path);
+            } else {
+                files.push(DirEntry::file(entry_path));
+            }
+        }
+    }
+
+    directories.reverse();
+    files.extend(directories);
+    Ok(files)
+}
+
+async fn remove_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
+    for entry in walk_dir(path).await? {
+        match entry.is_dir {
+            true => compio::fs::remove_dir(&entry.path).await?,
+            false => compio::fs::remove_file(&entry.path).await?,
+        }
+    }
+    Ok(())
+}

--- a/core/server_common/src/lib.rs
+++ b/core/server_common/src/lib.rs
@@ -16,12 +16,13 @@
  * under the License.
  */
 
+pub mod bootstrap;
 mod buffer;
 mod certificates;
 mod consensus_message;
 mod deduplication;
 pub mod diagnostics;
-mod executor;
+pub mod executor;
 mod in_flight;
 mod indexes_mut;
 // TODO(hubcio): iobuf was relocated verbatim from `core/binary_protocol/src/consensus/iobuf.rs`
@@ -45,6 +46,7 @@ mod segment_storage;
 pub mod send_messages2;
 pub mod sharding;
 
+pub use bootstrap::create_directories;
 pub use buffer::PooledBuffer;
 pub use certificates::generate_self_signed_certificate;
 pub use consensus_message::{


### PR DESCRIPTION
## Which issue does this PR address?

Relates to #3315

## Rationale

`server-ng` still imported bootstrap helpers from the legacy `server` crate. Moving directory bootstrap into `server_common` continues the shared-server extraction work and removes one `server::bootstrap` dependency from `server-ng`.

## What changed?

`create_shard_executor` already lived in `server_common`, but `server-ng` still imported it through `server::bootstrap`. `create_directories` also lived only in `server::bootstrap`, which kept `server-ng` coupled to the legacy server bootstrap module.

`create_directories` now lives in `server_common::bootstrap`, with a small `SystemPaths` trait so shared code can use system path accessors without creating a crate dependency cycle. The legacy `server::bootstrap::create_directories` path remains available through a re-export, and `server-ng` imports both helpers directly from `server_common`.

## Local Execution

- Passed:
  - `cargo fmt --all`
  - `cargo sort --no-format --workspace`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo build`
  - `cargo machete`
  - `cargo test -p server_common -p configs -p server -p server-ng`
  - `rg '^use server::bootstrap::' core/server-ng/`
- Full `cargo test` was started but not completed because unrelated external connector integration tests failed or hung locally.
- Pre-commit hooks not ran.

## AI Usage

AI tools were used.

1. Tool: ChatGPT/Codex.
2. Scope: implementation help, refactor guidance, and local verification commands.
3. Verification: ran formatting, cargo sort, clippy, build, machete, focused tests for touched crates, and the issue-specific `rg` check.
4. Yes, I can explain every line of the change if asked.