### PR TITLE
ci: scope runner disk cleanup per job and trim rust pre-merge setup

### DIFF
--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -33,28 +33,39 @@ runs:
     - name: Setup Rust with cache
       uses: ./.github/actions/utils/setup-rust-with-cache
       with:
-        read-cache: ${{ inputs.task == 'sort' && 'false' || 'true' }}
         # Miri builds against a nightly toolchain with a separate `target/miri`
         # subtree; isolate its cache from the stable `dev` namespace so the
         # two don't evict each other.
         shared-key: ${{ inputs.task == 'miri' && 'miri' || 'dev' }}
-        print-cache-status: ${{ startsWith(inputs.task, 'test-') }}
+        # fmt/sort/machete never build into target/, so the multi-GB cache
+        # restore is pure overhead. Compiling legs (check/clippy/doctest/test-*)
+        # keep it; a cold cache there recompiles the whole dep tree.
+        read-cache: ${{ (inputs.task == 'fmt' || inputs.task == 'sort' || inputs.task == 'machete') && 'false' || 'true' }}
+        # Light legs fit in the runner's ~89 GiB default headroom; skip the
+        # ~20-45s reclaim. Disk-heavy legs (coverage build + testcontainers
+        # images on test-*, cross-builds, miri, verify-publish) keep it.
+        free-disk-space: ${{ (inputs.task == 'fmt' || inputs.task == 'sort' || inputs.task == 'clippy' || inputs.task == 'check' || inputs.task == 'machete' || inputs.task == 'doctest') && 'false' || 'true' }}
 
+    - name: Install cargo-sort
+      if: inputs.task == 'sort'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-sort
+
+    - name: Install cargo-machete
+      if: inputs.task == 'machete'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-machete
+
+    # cargo-http-registry has no prebuilt artifact in taiki-e/install-action,
+    # so it stays a source build. verify-publish is a low-frequency task.
     - name: Install tools for specific tasks
+      if: inputs.task == 'verify-publish'
       run: |
-        case "${{ inputs.task }}" in
-          sort)
-            cargo install cargo-sort --locked
-            ;;
-          machete)
-            cargo install cargo-machete --locked
-            ;;
-          verify-publish)
-            if ! command -v cargo-http-registry >/dev/null 2>&1; then
-              cargo install cargo-http-registry --locked
-            fi
-            ;;
-        esac
+        if ! command -v cargo-http-registry >/dev/null 2>&1; then
+          cargo install cargo-http-registry --locked
+        fi
       shell: bash
 
     # DAG-based test scoping: use cargo-rail to compute affected crates from the
@@ -158,7 +169,7 @@ runs:
     - name: Install dependencies for Rust tests
       if: startsWith(inputs.task, 'test-') && runner.os == 'Linux'
       run: |
-        sudo apt-get update --yes && sudo apt-get install --yes musl-tools gnome-keyring keyutils dbus-x11 libsecret-tools
+        sudo apt-get install --yes musl-tools gnome-keyring keyutils dbus-x11 libsecret-tools
         rm -f $HOME/.local/share/keyrings/*
       shell: bash
 

--- a/.github/actions/utils/free-disk-space/action.yml
+++ b/.github/actions/utils/free-disk-space/action.yml
@@ -21,11 +21,20 @@ description: >-
   pre-installed toolchains the Iggy build does not use.
   Logs reclaimed GiB and elapsed seconds.
 
+inputs:
+  aggressive:
+    description: >-
+      When "true", run jlumbroso/free-disk-space for a deep cleanup
+      (~30+ GiB) instead of the light built-in removal (~12 GiB).
+      Enable only for disk-heavy jobs (e.g. llvm-cov instrumented builds).
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
-    - name: Cleanup disk space
-      if: runner.os == 'Linux'
+    - name: Cleanup disk space (light)
+      if: runner.os == 'Linux' && inputs.aggressive != 'true'
       shell: bash
       run: |
         echo "Disk space before cleanup:"
@@ -51,3 +60,11 @@ runs:
         echo "::notice::Reclaimed ${reclaimed_gib} GiB in $((end - start))s"
         echo "Disk space after cleanup:"
         df -h
+
+    - name: Cleanup disk space (aggressive)
+      if: runner.os == 'Linux' && inputs.aggressive == 'true'
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        # Preserve the .NET SDK when actions/setup-dotnet provisioned it
+        # (DOTNET_ROOT set); removing it breaks subsequent dotnet invocations.
+        dotnet: ${{ env.DOTNET_ROOT == '' }}

--- a/.github/actions/utils/setup-rust-with-cache/action.yml
+++ b/.github/actions/utils/setup-rust-with-cache/action.yml
@@ -31,8 +31,17 @@ inputs:
     description: "Whether to save cache (true/false)"
     required: false
     default: "false"
-  print-cache-status:
-    description: "Whether to print cache status to job summary"
+  free-disk-space:
+    description: >-
+      Whether to reclaim runner disk before the build. Default "true".
+      Set "false" for light legs (fmt/sort/clippy/check/machete/doctest) that
+      fit in the ~89 GiB default headroom and should not pay the ~20-45s cost.
+    required: false
+    default: "true"
+  free-disk-space-aggressive:
+    description: >-
+      Forwarded to free-disk-space. When "true", run jlumbroso for a deep
+      cleanup. Enable for disk-heavy jobs (e.g. llvm-cov instrumented builds).
     required: false
     default: "false"
 
@@ -40,7 +49,10 @@ runs:
   using: "composite"
   steps:
     - name: Free runner disk space
+      if: inputs.free-disk-space == 'true'
       uses: ./.github/actions/utils/free-disk-space
+      with:
+        aggressive: ${{ inputs.free-disk-space-aggressive }}
 
     - name: Install system dependencies (Linux)
       if: runner.os == 'Linux'
@@ -82,16 +94,26 @@ runs:
         save-if: ${{ inputs.save-cache == 'true' }}
 
     - name: Cache status
-      if: inputs.read-cache == 'true' && inputs.print-cache-status == 'true'
+      if: inputs.read-cache == 'true'
       run: |
-        echo "### Rust Cache" >> $GITHUB_STEP_SUMMARY
+        CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
         if [ "${{ steps.rust-cache.outputs.cache-hit }}" == "true" ]; then
-          echo "✅ Cache hit" >> $GITHUB_STEP_SUMMARY
+          status="full hit"
         elif [ -d "target" ]; then
-          echo "🔶 Partial cache hit" >> $GITHUB_STEP_SUMMARY
+          status="partial hit"
         else
-          echo "❌ Cache miss" >> $GITHUB_STEP_SUMMARY
+          status="miss"
         fi
+        # Unpacked on-disk footprint of the restore. The cache action only logs
+        # the compressed size; this prints to the job log (stdout), so size is
+        # visible without opening the summary and without annotations.
+        echo "Rust cache: ${status}"
+        printf '%-10s %s\n' "SIZE" "PATH"
+        for dir in "${GITHUB_WORKSPACE}/target" "${CARGO_HOME_DIR}/registry" "${CARGO_HOME_DIR}/git"; do
+          if [ -d "${dir}" ]; then
+            printf '%-10s %s\n' "$(du -sh "${dir}" 2>/dev/null | cut -f1)" "${dir/#${GITHUB_WORKSPACE}\//}"
+          fi
+        done
       shell: bash
 
     - name: Install cargo-nextest

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -54,6 +54,10 @@ jobs:
         with:
           # Also warms the GitHub Actions build cache for subsequent PR builds
           save-cache: "true"
+          # llvm-cov instrumentation roughly doubles object sizes; the light
+          # cleanup leaves too little headroom (build hit "No space left on
+          # device" at ~34 MB free).
+          free-disk-space-aggressive: "true"
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2.79.3


### PR DESCRIPTION
The rust coverage baseline ran instrumented cargo-llvm-cov builds that
exhausted the runner disk ("No space left on device" at ~34 MB free);
object sizes roughly double under instrumentation and the light cleanup
(~12 GiB) left too little headroom. Add an opt-in `aggressive` input to
the free-disk-space action that runs jlumbroso/free-disk-space (~30+ GiB,
already on the ASF actions allowlist) instead of the light removal,
threaded through setup-rust-with-cache and enabled only on the coverage
job. The .NET SDK is preserved when provisioned so dotnet jobs stay safe.

The inverse also holds. The light cleanup costs ~20-45s, but the runner
has ~89 GiB free before it runs, far more than any non-coverage rust leg
needs. Make disk cleanup opt-out per task and skip it on the light legs
(fmt, sort, clippy, check, machete, doctest); the disk-heavy legs
(test-*, compat, miri, verify-publish, cross-builds) keep it. Every other
caller keeps the light path through the default.

While in the rust pre-merge action, two further setup trims: install
cargo-sort and cargo-machete from taiki-e/install-action prebuilt
binaries instead of compiling them from source on every run (cargo-http-registry
stays a source build, no prebuilt exists), and drop a redundant second
`apt-get update` in the test legs, since setup-rust-with-cache already
refreshed the apt lists earlier in the same job.
