### PR TITLE
fix(php): pin ext-php-rs and cargo-php to stop flaky stubs load

### DIFF
--- a/.github/actions/php/pre-merge/action.yml
+++ b/.github/actions/php/pre-merge/action.yml
@@ -82,7 +82,7 @@ runs:
       run: |
         "${PHP}" -r 'json_decode(file_get_contents("foreign/php/composer.json"), true, 512, JSON_THROW_ON_ERROR);'
         cargo fmt --manifest-path foreign/php/Cargo.toml -- --check
-        cargo install cargo-php --locked
+        cargo install cargo-php --locked --version 0.1.21
         cargo build --manifest-path foreign/php/Cargo.toml
         extension="$(find "${CARGO_TARGET_DIR}/debug" -maxdepth 1 -name 'libiggy_php.so' -print -quit)"
         if [ -z "$extension" ]; then

--- a/foreign/php/Cargo.toml
+++ b/foreign/php/Cargo.toml
@@ -31,7 +31,7 @@ crate-type = ["cdylib"]
 [dependencies]
 bytes = "1.11.1"
 futures = "0.3.32"
-ext-php-rs = "0.15.13"
+ext-php-rs = "=0.15.14"
 iggy = { path = "../../core/sdk" }
 tokio = "1.52.3"
 

--- a/foreign/php/Dockerfile.test
+++ b/foreign/php/Dockerfile.test
@@ -54,7 +54,7 @@ COPY foreign/php/scripts/ ./foreign/php/scripts/
 
 WORKDIR /workspace/foreign/php
 
-RUN cargo install cargo-php --locked
+RUN cargo install cargo-php --locked --version 0.1.21
 RUN composer install --no-interaction --prefer-dist
 RUN cargo php install --yes
 RUN chmod +x ./scripts/test.sh


### PR DESCRIPTION
The PHP pre-merge job intermittently failed unrelated PRs with
`cargo php stubs` dying on `dlopen ... undefined symbol:
zend_hash_update`. The job triggers on any rust-sdk/server/ci
change, so the noise landed on connector and server PRs that
never touched PHP.

Root cause was two unpinned build inputs. `ext-php-rs = "0.15.13"`
is a caret range, so each branch's lockfile could float the patch;
0.15.15 regresses the stubs step (the freshly built extension is
loaded outside a PHP process, where Zend symbols are absent).
`cargo install cargo-php` also reinstalled the latest release every
run. Different PRs hit different version combos, hence the flakiness.

Pin ext-php-rs to =0.15.14 (already in master's lock, known good)
and cargo-php to 0.1.21, removing both floating inputs so the
result no longer depends on when the job runs.
