### PR TITLE
chore(rust): bump toolchain to 1.96 and sync stray Dockerfiles

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -63,7 +63,7 @@ jobs:
 
       # cargo-rail computes the affected crate set for the Docker :edge gate.
       # Metadata-only `cargo rail plan` (no compile), so it runs on the runner's
-      # preinstalled cargo (rust-toolchain.toml pins 1.95.0) and skips the
+      # preinstalled cargo (rust-toolchain.toml pins 1.96.0) and skips the
       # heavyweight build-cache restore.
       - name: Install cargo-rail
         uses: taiki-e/install-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@
 # or stability of the code, it does indicate that the project has yet to be
 # fully endorsed by the ASF.
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 
 FROM rust:${RUST_VERSION}-slim-bookworm AS builder
 

--- a/bdd/Dockerfile
+++ b/bdd/Dockerfile
@@ -27,7 +27,7 @@
 # or stability of the code, it does indicate that the project has yet to be
 # fully endorsed by the ASF.
 
-FROM rust:1.95.0-alpine3.22 AS builder
+FROM rust:1.96.0-alpine3.22 AS builder
 RUN apk add musl-dev
 
 WORKDIR /app

--- a/bdd/java/Dockerfile
+++ b/bdd/java/Dockerfile
@@ -27,7 +27,7 @@
 # or stability of the code, it does indicate that the project has yet to be
 # fully endorsed by the ASF.
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 FROM rust:${RUST_VERSION}
 
 FROM gradle:9.5.1-jdk17

--- a/bdd/python/Dockerfile
+++ b/bdd/python/Dockerfile
@@ -27,7 +27,7 @@
 # or stability of the code, it does indicate that the project has yet to be
 # fully endorsed by the ASF.
 # syntax=docker/dockerfile:1
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 FROM rust:${RUST_VERSION}-slim-trixie
 
 RUN apt-get update && \

--- a/bdd/rust/Dockerfile
+++ b/bdd/rust/Dockerfile
@@ -27,7 +27,7 @@
 # or stability of the code, it does indicate that the project has yet to be
 # fully endorsed by the ASF.
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 FROM rust:${RUST_VERSION}
 
 WORKDIR /app

--- a/core/ai/mcp/Dockerfile
+++ b/core/ai/mcp/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 ARG ALPINE_VERSION=3.23
 
 FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION}-alpine${ALPINE_VERSION} AS chef

--- a/core/bench/dashboard/server/Dockerfile
+++ b/core/bench/dashboard/server/Dockerfile
@@ -27,7 +27,7 @@
 # or stability of the code, it does indicate that the project has yet to be
 # fully endorsed by the ASF.
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 
 # Build stage
 FROM rust:${RUST_VERSION}-slim-trixie AS builder

--- a/core/connectors/runtime/Dockerfile
+++ b/core/connectors/runtime/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 ARG ALPINE_VERSION=3.23
 
 FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION}-alpine${ALPINE_VERSION} AS chef

--- a/core/server-ng/Dockerfile
+++ b/core/server-ng/Dockerfile
@@ -27,7 +27,7 @@
 # or stability of the code, it does indicate that the project has yet to be
 # fully endorsed by the ASF.
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 ARG ALPINE_VERSION=3.23
 
 # ── from-source path ─────────────────────────────────────────────────────────

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -27,7 +27,7 @@
 # or stability of the code, it does indicate that the project has yet to be
 # fully endorsed by the ASF.
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.96
 ARG ALPINE_VERSION=3.23
 
 # ── from-source path ─────────────────────────────────────────────────────────

--- a/foreign/php/Dockerfile.test
+++ b/foreign/php/Dockerfile.test
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.95-slim-bookworm
+FROM rust:1.96-slim-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,6 +16,6 @@
 # under the License.
 
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]
 profile = "default"

--- a/scripts/ci/sync-rustc-version.sh
+++ b/scripts/ci/sync-rustc-version.sh
@@ -91,31 +91,47 @@ TOTAL_FILES=0
 FIXED_FILES=0
 
 for dockerfile in $DOCKERFILES; do
-    # Skip files without ARG RUST_VERSION
-    if ! grep -q "^ARG RUST_VERSION=" "$dockerfile" 2>/dev/null; then
+    # Two ways a Dockerfile pins the toolchain:
+    #   1. `ARG RUST_VERSION=1.96`  (+ `FROM rust:${RUST_VERSION}...`)
+    #   2. hardcoded `FROM rust:1.96-slim` / `FROM rust:1.96.0-alpine`
+    # Both must stay in sync; a Dockerfile that pins neither is skipped.
+    if grep -q "^ARG RUST_VERSION=" "$dockerfile" 2>/dev/null; then
+        SOURCE="arg"
+        CURRENT_VERSION=$(grep "^ARG RUST_VERSION=" "$dockerfile" | head -1 | sed 's/^ARG RUST_VERSION=//')
+        EXPECTED_VERSION="$RUST_VERSION_SHORT"
+    elif grep -qE "FROM[[:space:]].*\brust:[0-9]" "$dockerfile" 2>/dev/null; then
+        SOURCE="from"
+        CURRENT_VERSION=$(grep -E "FROM[[:space:]].*\brust:[0-9]" "$dockerfile" | head -1 | sed -nE 's/.*\brust:([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/p')
+        # Preserve the file's precision: full patch (1.96.0) or short (1.96).
+        if [[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            EXPECTED_VERSION="$RUST_VERSION"
+        else
+            EXPECTED_VERSION="$RUST_VERSION_SHORT"
+        fi
+    else
         continue
     fi
 
     TOTAL_FILES=$((TOTAL_FILES + 1))
 
-    # Get current version in the Dockerfile
-    CURRENT_VERSION=$(grep "^ARG RUST_VERSION=" "$dockerfile" | head -1 | sed 's/^ARG RUST_VERSION=//')
-
     if [ "$MODE" = "check" ]; then
-        if [ "$CURRENT_VERSION" != "$RUST_VERSION_SHORT" ]; then
+        if [ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ]; then
             MISALIGNED_FILES+=("$dockerfile")
-            echo -e "${RED}✗${NC} $dockerfile: ${RED}$CURRENT_VERSION${NC} (expected: ${GREEN}$RUST_VERSION_SHORT${NC})"
+            echo -e "${RED}✗${NC} $dockerfile: ${RED}$CURRENT_VERSION${NC} (expected: ${GREEN}$EXPECTED_VERSION${NC})"
         else
             echo -e "${GREEN}✓${NC} $dockerfile: $CURRENT_VERSION"
         fi
     elif [ "$MODE" = "fix" ]; then
-        if [ "$CURRENT_VERSION" != "$RUST_VERSION_SHORT" ]; then
-            # Update the ARG RUST_VERSION line
-            sed -i "s/^ARG RUST_VERSION=.*/ARG RUST_VERSION=$RUST_VERSION_SHORT/" "$dockerfile"
+        if [ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ]; then
+            if [ "$SOURCE" = "arg" ]; then
+                sed -i "s/^ARG RUST_VERSION=.*/ARG RUST_VERSION=$EXPECTED_VERSION/" "$dockerfile"
+            else
+                sed -i -E "s/(\brust:)[0-9]+\.[0-9]+(\.[0-9]+)?/\1$EXPECTED_VERSION/g" "$dockerfile"
+            fi
             FIXED_FILES=$((FIXED_FILES + 1))
-            echo -e "${GREEN}Fixed${NC} $dockerfile: ${RED}$CURRENT_VERSION${NC} -> ${GREEN}$RUST_VERSION_SHORT${NC}"
+            echo -e "${GREEN}Fixed${NC} $dockerfile: ${RED}$CURRENT_VERSION${NC} -> ${GREEN}$EXPECTED_VERSION${NC}"
         else
-            echo -e "${GREEN}✓${NC} $dockerfile: already correct ($RUST_VERSION_SHORT)"
+            echo -e "${GREEN}✓${NC} $dockerfile: already correct ($CURRENT_VERSION)"
         fi
     fi
 done


### PR DESCRIPTION
rust-toolchain.toml now pins 1.96.0, propagated to every Docker
build image. Two Dockerfiles (bdd/Dockerfile, foreign/php test)
hardcode `FROM rust:<ver>` instead of the ARG RUST_VERSION
convention, so sync-rust-version.sh silently skipped them and
they stayed on 1.95.

Extend the sync script to also detect and rewrite hardcoded
`FROM rust:` versions, preserving each file's precision (full
patch vs short) and image suffix. Coverage goes 9 -> 11
Dockerfiles, closing the gap that let the two drift.
