### PR TITLE
ci: stop Dependabot bumping iggy in java examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -194,6 +194,12 @@ updates:
       - "java"
     cooldown:
       default-days: 7
+    ignore:
+      # examples/java wires iggy's own artifact to the local build via
+      # dependency substitution (settings.gradle.kts) behind a
+      # `local-dev` placeholder version. A Dependabot bump to a real
+      # release breaks example CI, which builds against the local tree.
+      - dependency-name: "org.apache.iggy:*"
     groups:
       java:
         patterns:


### PR DESCRIPTION
examples/java declares the published coordinate org.apache.iggy:iggy
behind a local-dev placeholder and swaps it to the local build via
dependency substitution in settings.gradle.kts. Dependabot does not see
the substitution, so it "upgrades" local-dev to a real release (0.8.0 in
PR #3473), which breaks example CI since that builds against the local
tree. Ignore org.apache.iggy:* in the gradle ecosystem so our own
artifact is never bumped.
