### PR TITLE
ci: ignore go and dotnet base-image bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -245,6 +245,11 @@ updates:
       # of the base image alone would fail that check.
       - dependency-name: "python"
       - dependency-name: "mcr.microsoft.com/devcontainers/python"
+      # Go and .NET toolchain base images are pinned deliberately to
+      # match the versions used across CI and the SDK builds. Bumping
+      # them is a manual decision, not Dependabot churn.
+      - dependency-name: "golang"
+      - dependency-name: "mcr.microsoft.com/dotnet/sdk"
     groups:
       docker:
         patterns:


### PR DESCRIPTION
The docker group keeps opening PRs that bump the golang and
mcr.microsoft.com/dotnet/sdk base images in bdd/go and bdd/csharp
(e.g. PR #3474). These toolchain versions are pinned deliberately to
stay aligned with the versions used across CI and the SDK builds, so a
lone base-image bump is churn at best and drift at worst. Ignore both
in the docker ecosystem, alongside the existing python pins.
