### PR TITLE
ci: split npm dependabot group into web and node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -102,8 +102,29 @@ updates:
 
   - package-ecosystem: "npm"
     directories:
-      - "/foreign/node"
       - "/web"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "apache/iggy-committers"
+    labels:
+      - "dependencies"
+      - "javascript"
+    cooldown:
+      default-days: 7
+    groups:
+      web:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/foreign/node"
       - "/examples/node"
     schedule:
       interval: "weekly"
@@ -120,7 +141,7 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      javascript:
+      node:
         patterns:
           - "*"
 


### PR DESCRIPTION
The single npm block bundled /web (SvelteKit frontend) with the
Node SDK dirs (/foreign/node, /examples/node) under one
"javascript" group. Frontend and SDK deps move on independent
cadences, so a shared group name conflated unrelated review
surfaces. Split into two npm blocks: /web (group "web") and the
SDK dirs (group "node"), keeping schedule, limits, and labels
intact.
