### PR TITLE
fix(web): use explicit css import to support latest vite build

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -20,7 +20,7 @@
 @import url('./tooltip.css') layer(base);
 @import url('./variables.css') layer(base);
 
-@import 'tailwindcss';
+@import 'tailwindcss/index.css';
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Which issue does this PR address?

fix web frontend build with new vite version 

Relates to #

fix https://github.com/apache/iggy/pull/3492 build failure with supported css import syntax

## What changed?

use explicit import supported by newer vite