### PR TITLE
feat(connectors): add OTLP gRPC source connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7092,6 +7092,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "iggy_connector_otlp_source"
+version = "0.4.1-edge.1"
+dependencies = [
+ "async-trait",
+ "dashmap",
+ "iggy_connector_sdk",
+ "once_cell",
+ "opentelemetry-proto",
+ "prost",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "iggy_connector_postgres_sink"
 version = "0.4.1-edge.1"
 dependencies = [
@@ -13453,6 +13470,7 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
+ "flate2",
  "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "core/connectors/sinks/surrealdb_sink",
     "core/connectors/sources/elasticsearch_source",
     "core/connectors/sources/influxdb_source",
+    "core/connectors/sources/otlp_source",
     "core/connectors/sources/postgres_source",
     "core/connectors/sources/random_source",
     "core/consensus",
@@ -233,6 +234,7 @@ nix = { version = "0.31.3", features = ["feature", "fs", "resource", "sched"] }
 nonzero_lit = "0.1.2"
 notify = "8.2.0"
 octocrab = "0.54.0"
+once_cell = "1.21.4"
 opentelemetry = { version = "0.32.0", features = ["trace", "logs"] }
 opentelemetry-appender-tracing = { version = "0.32.0", features = ["log"] }
 opentelemetry-otlp = { version = "0.32.0", features = [
@@ -243,6 +245,7 @@ opentelemetry-otlp = { version = "0.32.0", features = [
     "http-proto",
     "reqwest-client",
 ] }
+opentelemetry-proto = { version = "0.32.0", default-features = false }
 opentelemetry-semantic-conventions = "0.32.1"
 opentelemetry_sdk = { version = "0.32.1", features = [
     "logs",
@@ -332,6 +335,7 @@ tokio-rustls = "0.26.4"
 tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
 tokio-util = { version = "0.7.18", features = ["compat"] }
 toml = "1.1.3"
+tonic = { version = "0.14.6", default-features = false }
 tower-http = { version = "0.7.0", features = ["add-extension", "cors", "trace"] }
 tracing = "0.1.44"
 tracing-appender = "0.2.5"

--- a/core/connectors/sources/otlp_source/Cargo.toml
+++ b/core/connectors/sources/otlp_source/Cargo.toml
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "iggy_connector_otlp_source"
+version = "0.4.1-edge.1"
+description = "Iggy OTLP/gRPC source connector - receives logs, metrics, and traces from any OpenTelemetry SDK or Collector and writes them to Iggy streams as JSON"
+edition = "2024"
+license = "Apache-2.0"
+keywords = ["iggy", "messaging", "streaming", "opentelemetry", "otlp"]
+categories = ["command-line-utilities", "network-programming"]
+homepage = "https://iggy.apache.org"
+documentation = "https://iggy.apache.org/docs"
+repository = "https://github.com/apache/iggy"
+readme = "../../README.md"
+publish = false
+
+# dashmap and once_cell are not imported directly in this crate's source, but
+# the source_connector! macro (in iggy_connector_sdk::source) expands bare
+# `use dashmap::DashMap` and `use once_cell::sync::Lazy` into this crate's
+# namespace, so they must be listed here. Remove them only after the SDK macro
+# is updated to use `$crate::connector_macro_support::{DashMap, Lazy}`.
+[package.metadata.cargo-machete]
+ignored = ["dashmap", "once_cell"]
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+async-trait = { workspace = true }
+dashmap = { workspace = true }
+iggy_connector_sdk = { workspace = true }
+once_cell = { workspace = true }
+opentelemetry-proto = { workspace = true, features = [
+    "gen-tonic",
+    "logs",
+    "metrics",
+    "trace",
+] }
+prost = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true, features = ["transport", "router", "gzip"] }
+tracing = { workspace = true }

--- a/core/connectors/sources/otlp_source/README.md
+++ b/core/connectors/sources/otlp_source/README.md
@@ -1,0 +1,70 @@
+# OTLP Source
+
+Receives logs, metrics, and traces from any OpenTelemetry SDK or Collector
+over gRPC (OTLP/gRPC protocol) and writes them to an Iggy stream.
+
+## How it works
+
+The connector binds a gRPC server (default port 4317, the OTLP standard) and
+implements all three collector services: `LogsService`, `MetricsService`, and
+`TraceService`. Each incoming export request is deserialized from the
+`opentelemetry-proto` wire format and turned into messages according to
+`format` (see below). The messages are buffered in an in-process channel and
+drained by the runtime via the `poll()` call.
+
+Gzip is accepted on every service, since OTel SDKs and the Collector's OTLP
+exporter compress payloads by default. Responses are not gzipped: an export
+response carries at most a `partial_success` and is a couple of bytes, so the
+compression header would outweigh the body.
+
+When the channel is full the connector does not fail the export. It enqueues
+what fits and reports the remainder in the response's `partial_success`, so the
+client can retry only the rejected records instead of the whole batch.
+
+## Storage format
+
+`format = "json"` (default) decodes each record into a JSON document, one
+message per record. Use it when a downstream sink needs to query individual
+fields.
+
+`format = "proto"` forwards the raw `opentelemetry-proto` request bytes as a
+single message, without decoding. It is roughly 4-5x smaller on the wire and
+pairs zero-copy with `otlp_sink`'s `format = "proto"`. Individual fields are
+not queryable in this mode.
+
+## JSON schema
+
+Every document has a `signal` field (`"log"`, `"metric"`, or `"trace"`). Fields
+that would be empty or null are omitted, except on metrics, which always emit
+the full set.
+
+**Logs**: `timestamp_ns`, `observed_timestamp_ns`, `severity`,
+`severity_text`, `body`, `trace_id`, `span_id`, `service_name`, `resource`,
+`attributes`
+
+**Metrics**: `name`, `type` (`gauge`, `sum`, `histogram`,
+`exponential_histogram`, `summary`), `unit`, `timestamp_ns`, `value`,
+`service_name`, `resource`, `attributes`, plus `is_monotonic` on sums.
+`value` is a scalar for gauges and sums, and an object (`count`, `sum`, and
+`scale` on exponential histograms) for the aggregating types. One message is
+produced per data point, not per metric.
+
+**Traces**: `trace_id`, `span_id`, `parent_span_id`, `name`, `kind`,
+`start_time_ns`, `end_time_ns`, `status`, `status_message`, `service_name`,
+`resource`, `attributes`
+
+`resource` carries the resource-level attributes shared by every record in the
+same export request, and is repeated on each message so downstream sinks do not
+have to join.
+
+## Configuration
+
+```toml
+[plugin_config]
+listen_addr = "0.0.0.0:4317"   # gRPC bind address
+channel_capacity = 50000       # in-process buffer (messages), must be > 0
+batch_size = 1000              # max messages returned per poll()
+format = "json"                # "json" or "proto"
+```
+
+Point any OTel SDK or Collector at `grpc://host:4317` (no TLS by default).

--- a/core/connectors/sources/otlp_source/config.toml
+++ b/core/connectors/sources/otlp_source/config.toml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+type = "source"
+key = "otlp"
+enabled = true
+version = 0
+name = "OTLP source"
+path = "../../target/release/libiggy_connector_otlp_source"
+verbose = false
+
+[[streams]]
+stream = "otel"
+topic = "signals"
+schema = "json"
+batch_length = 1000
+linger_time = "5ms"
+
+[plugin_config]
+# gRPC bind address; 4317 is the OTLP standard port.
+listen_addr = "0.0.0.0:4317"
+# In-process buffer between the gRPC server and poll(). Must be greater than 0.
+# Exports that overflow it are reported back to the client via partial_success.
+channel_capacity = 50000
+# Maximum messages returned by a single poll().
+batch_size = 1000
+# "json" decodes each record into a queryable JSON document, one message per
+# record. "proto" forwards the raw opentelemetry-proto request as a single
+# message: 4-5x smaller and zero-copy with otlp_sink's proto format, but
+# individual fields are not queryable.
+format = "json"

--- a/core/connectors/sources/otlp_source/src/convert.rs
+++ b/core/connectors/sources/otlp_source/src/convert.rs
@@ -1,0 +1,799 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use iggy_connector_sdk::ProducedMessage;
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
+use opentelemetry_proto::tonic::metrics::v1::{Metric, metric, number_data_point};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+use std::fmt::Write as _;
+use tracing::warn;
+
+/// Resource attributes are shared by every record under one `ResourceLogs` /
+/// `ResourceSpans` / `ResourceMetrics` envelope. The documents below borrow the
+/// map instead of owning it so a batch of N records serializes the same
+/// attributes N times without cloning them N times.
+#[derive(Serialize)]
+struct LogDoc<'a> {
+    signal: &'static str,
+    timestamp_ns: u64,
+    observed_timestamp_ns: u64,
+    severity: &'static str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    severity_text: &'a str,
+    #[serde(skip_serializing_if = "is_absent")]
+    body: Option<Value>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    trace_id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    span_id: String,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    service_name: &'a str,
+    resource: &'a Map<String, Value>,
+    attributes: Map<String, Value>,
+}
+
+#[derive(Serialize)]
+struct SpanDoc<'a> {
+    signal: &'static str,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    trace_id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    span_id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    parent_span_id: String,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    name: &'a str,
+    kind: &'static str,
+    start_time_ns: u64,
+    end_time_ns: u64,
+    status: &'static str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    status_message: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    service_name: &'a str,
+    resource: &'a Map<String, Value>,
+    attributes: Map<String, Value>,
+}
+
+#[derive(Serialize)]
+struct MetricDoc<'a> {
+    signal: &'static str,
+    name: &'a str,
+    #[serde(rename = "type")]
+    metric_type: &'static str,
+    unit: &'a str,
+    timestamp_ns: u64,
+    value: Value,
+    service_name: &'a str,
+    resource: &'a Map<String, Value>,
+    attributes: Map<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_monotonic: Option<bool>,
+}
+
+/// Mirrors the pruning the JSON documents used to do after the fact: a field is
+/// omitted when it is absent, JSON null, or an empty string.
+fn is_absent(value: &Option<Value>) -> bool {
+    match value {
+        None | Some(Value::Null) => true,
+        Some(Value::String(text)) => text.is_empty(),
+        Some(_) => false,
+    }
+}
+
+pub fn export_logs_to_messages(req: ExportLogsServiceRequest) -> Vec<ProducedMessage> {
+    let mut messages = Vec::new();
+    for resource_logs in req.resource_logs {
+        let resource_attrs = extract_resource_attrs(resource_logs.resource.as_ref());
+        let service_name = resource_attrs
+            .get("service.name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+
+        for scope_logs in resource_logs.scope_logs {
+            for record in scope_logs.log_records {
+                let doc = LogDoc {
+                    signal: "log",
+                    timestamp_ns: record.time_unix_nano,
+                    observed_timestamp_ns: record.observed_time_unix_nano,
+                    severity: severity_number_to_text(record.severity_number),
+                    severity_text: &record.severity_text,
+                    body: record.body.as_ref().map(any_value_to_json),
+                    trace_id: bytes_to_hex(&record.trace_id),
+                    span_id: bytes_to_hex(&record.span_id),
+                    service_name: &service_name,
+                    resource: &resource_attrs,
+                    attributes: extract_attrs(&record.attributes),
+                };
+                match serde_json::to_vec(&doc) {
+                    Ok(payload) => messages.push(ProducedMessage {
+                        id: None,
+                        checksum: None,
+                        timestamp: (record.time_unix_nano != 0).then_some(record.time_unix_nano),
+                        origin_timestamp: None,
+                        headers: None,
+                        payload,
+                    }),
+                    Err(err) => warn!("Failed to serialize log record: {err}"),
+                }
+            }
+        }
+    }
+    messages
+}
+
+pub fn export_metrics_to_messages(req: ExportMetricsServiceRequest) -> Vec<ProducedMessage> {
+    let mut messages = Vec::new();
+    for resource_metrics in req.resource_metrics {
+        let resource_attrs = extract_resource_attrs(resource_metrics.resource.as_ref());
+        let service_name = resource_attrs
+            .get("service.name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+
+        for scope_metrics in resource_metrics.scope_metrics {
+            for metric in scope_metrics.metrics {
+                let data_points = metric_to_data_points(&metric, &resource_attrs, &service_name);
+                messages.extend(data_points);
+            }
+        }
+    }
+    messages
+}
+
+pub fn export_traces_to_messages(req: ExportTraceServiceRequest) -> Vec<ProducedMessage> {
+    let mut messages = Vec::new();
+    for resource_spans in req.resource_spans {
+        let resource_attrs = extract_resource_attrs(resource_spans.resource.as_ref());
+        let service_name = resource_attrs
+            .get("service.name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+
+        for scope_spans in resource_spans.scope_spans {
+            for span in scope_spans.spans {
+                let status_code = span
+                    .status
+                    .as_ref()
+                    .map(|s| status_code_to_text(s.code))
+                    .unwrap_or("unset");
+                let status_message = span
+                    .status
+                    .as_ref()
+                    .map(|s| s.message.as_str())
+                    .unwrap_or_default();
+
+                let doc = SpanDoc {
+                    signal: "trace",
+                    trace_id: bytes_to_hex(&span.trace_id),
+                    span_id: bytes_to_hex(&span.span_id),
+                    parent_span_id: bytes_to_hex(&span.parent_span_id),
+                    name: &span.name,
+                    kind: span_kind_to_text(span.kind),
+                    start_time_ns: span.start_time_unix_nano,
+                    end_time_ns: span.end_time_unix_nano,
+                    status: status_code,
+                    status_message,
+                    service_name: &service_name,
+                    resource: &resource_attrs,
+                    attributes: extract_attrs(&span.attributes),
+                };
+                match serde_json::to_vec(&doc) {
+                    Ok(payload) => messages.push(ProducedMessage {
+                        id: None,
+                        checksum: None,
+                        timestamp: (span.start_time_unix_nano != 0)
+                            .then_some(span.start_time_unix_nano),
+                        origin_timestamp: None,
+                        headers: None,
+                        payload,
+                    }),
+                    Err(err) => warn!("Failed to serialize span: {err}"),
+                }
+            }
+        }
+    }
+    messages
+}
+
+fn metric_to_data_points(
+    metric: &Metric,
+    resource_attrs: &Map<String, Value>,
+    service_name: &str,
+) -> Vec<ProducedMessage> {
+    let mut messages = Vec::new();
+
+    let base = |time_ns: u64,
+                value: Value,
+                attrs: &[KeyValue],
+                metric_type: &'static str|
+     -> MetricDoc<'_> {
+        MetricDoc {
+            signal: "metric",
+            name: &metric.name,
+            metric_type,
+            unit: &metric.unit,
+            timestamp_ns: time_ns,
+            value,
+            service_name,
+            resource: resource_attrs,
+            attributes: extract_attrs(attrs),
+            is_monotonic: None,
+        }
+    };
+
+    match &metric.data {
+        Some(metric::Data::Gauge(gauge)) => {
+            for dp in &gauge.data_points {
+                let value = number_dp_value(&dp.value);
+                let doc = base(dp.time_unix_nano, value, &dp.attributes, "gauge");
+                push_metric_doc(&doc, dp.time_unix_nano, &mut messages);
+            }
+        }
+        Some(metric::Data::Sum(sum)) => {
+            for dp in &sum.data_points {
+                let value = number_dp_value(&dp.value);
+                let mut doc = base(dp.time_unix_nano, value, &dp.attributes, "sum");
+                doc.is_monotonic = Some(sum.is_monotonic);
+                push_metric_doc(&doc, dp.time_unix_nano, &mut messages);
+            }
+        }
+        Some(metric::Data::Histogram(hist)) => {
+            for dp in &hist.data_points {
+                let doc = base(
+                    dp.time_unix_nano,
+                    json!({ "count": dp.count, "sum": dp.sum }),
+                    &dp.attributes,
+                    "histogram",
+                );
+                push_metric_doc(&doc, dp.time_unix_nano, &mut messages);
+            }
+        }
+        Some(metric::Data::ExponentialHistogram(eh)) => {
+            for dp in &eh.data_points {
+                let doc = base(
+                    dp.time_unix_nano,
+                    json!({ "count": dp.count, "sum": dp.sum, "scale": dp.scale }),
+                    &dp.attributes,
+                    "exponential_histogram",
+                );
+                push_metric_doc(&doc, dp.time_unix_nano, &mut messages);
+            }
+        }
+        Some(metric::Data::Summary(summary)) => {
+            for dp in &summary.data_points {
+                let doc = base(
+                    dp.time_unix_nano,
+                    json!({ "count": dp.count, "sum": dp.sum }),
+                    &dp.attributes,
+                    "summary",
+                );
+                push_metric_doc(&doc, dp.time_unix_nano, &mut messages);
+            }
+        }
+        None => {}
+    }
+
+    messages
+}
+
+fn push_metric_doc(doc: &MetricDoc<'_>, time_ns: u64, messages: &mut Vec<ProducedMessage>) {
+    match serde_json::to_vec(doc) {
+        Ok(payload) => messages.push(ProducedMessage {
+            id: None,
+            checksum: None,
+            timestamp: Some(time_ns),
+            origin_timestamp: None,
+            headers: None,
+            payload,
+        }),
+        Err(err) => warn!("Failed to serialize metric data point: {err}"),
+    }
+}
+
+fn number_dp_value(value: &Option<number_data_point::Value>) -> Value {
+    match value {
+        Some(number_data_point::Value::AsDouble(d)) => json!(d),
+        Some(number_data_point::Value::AsInt(i)) => json!(i),
+        None => Value::Null,
+    }
+}
+
+pub fn extract_resource_attrs(resource: Option<&Resource>) -> Map<String, Value> {
+    resource
+        .map(|r| extract_attrs(&r.attributes))
+        .unwrap_or_default()
+}
+
+pub fn extract_attrs(attrs: &[KeyValue]) -> Map<String, Value> {
+    attrs
+        .iter()
+        .map(|kv| {
+            let value = match kv.value.as_ref() {
+                Some(av) if matches!(av.value, Some(any_value::Value::StringValueStrindex(_))) => {
+                    warn!(key = %kv.key, "dropping attribute with unrecognized AnyValue variant");
+                    Value::Null
+                }
+                Some(av) => any_value_to_json(av),
+                None => Value::Null,
+            };
+            (kv.key.clone(), value)
+        })
+        .collect()
+}
+
+pub fn any_value_to_json(value: &AnyValue) -> Value {
+    match &value.value {
+        Some(any_value::Value::StringValue(s)) => Value::String(s.clone()),
+        Some(any_value::Value::BoolValue(b)) => Value::Bool(*b),
+        Some(any_value::Value::IntValue(i)) => json!(i),
+        Some(any_value::Value::DoubleValue(d)) => json!(d),
+        Some(any_value::Value::ArrayValue(arr)) => {
+            Value::Array(arr.values.iter().map(any_value_to_json).collect())
+        }
+        Some(any_value::Value::KvlistValue(kvlist)) => Value::Object(extract_attrs(&kvlist.values)),
+        Some(any_value::Value::BytesValue(bytes)) => Value::String(bytes_to_hex(bytes)),
+        Some(any_value::Value::StringValueStrindex(_)) | None => Value::Null,
+    }
+}
+
+pub fn bytes_to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn severity_number_to_text(number: i32) -> &'static str {
+    match number {
+        1..=4 => "TRACE",
+        5..=8 => "DEBUG",
+        9..=12 => "INFO",
+        13..=16 => "WARN",
+        17..=20 => "ERROR",
+        21..=24 => "FATAL",
+        _ => "UNSPECIFIED",
+    }
+}
+
+fn status_code_to_text(code: i32) -> &'static str {
+    match code {
+        1 => "ok",
+        2 => "error",
+        _ => "unset",
+    }
+}
+
+fn span_kind_to_text(kind: i32) -> &'static str {
+    match kind {
+        1 => "internal",
+        2 => "server",
+        3 => "client",
+        4 => "producer",
+        5 => "consumer",
+        _ => "unspecified",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_proto::tonic::common::v1::{AnyValue, ArrayValue, KeyValueList};
+    use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+    use opentelemetry_proto::tonic::metrics::v1::{
+        Gauge, Histogram, HistogramDataPoint, Metric, NumberDataPoint, ResourceMetrics,
+        ScopeMetrics, Sum,
+    };
+    use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span, Status};
+
+    fn string_value(value: &str) -> AnyValue {
+        AnyValue {
+            value: Some(any_value::Value::StringValue(value.to_owned())),
+        }
+    }
+
+    fn attribute(key: &str, value: AnyValue) -> KeyValue {
+        KeyValue {
+            key: key.to_owned(),
+            value: Some(value),
+            ..Default::default()
+        }
+    }
+
+    fn service_resource(name: &str) -> Resource {
+        Resource {
+            attributes: vec![attribute("service.name", string_value(name))],
+            ..Default::default()
+        }
+    }
+
+    fn payload_of(message: &ProducedMessage) -> Value {
+        serde_json::from_slice(&message.payload).expect("payload is valid JSON")
+    }
+
+    fn logs_request(
+        resource: Option<Resource>,
+        records: Vec<LogRecord>,
+    ) -> ExportLogsServiceRequest {
+        ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                resource,
+                scope_logs: vec![ScopeLogs {
+                    log_records: records,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    fn traces_request(resource: Option<Resource>, spans: Vec<Span>) -> ExportTraceServiceRequest {
+        ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource,
+                scope_spans: vec![ScopeSpans {
+                    spans,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    fn metrics_request(
+        resource: Option<Resource>,
+        metrics: Vec<Metric>,
+    ) -> ExportMetricsServiceRequest {
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                resource,
+                scope_metrics: vec![ScopeMetrics {
+                    metrics,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn given_log_record_should_produce_json_message() {
+        let record = LogRecord {
+            time_unix_nano: 1_700_000_000_000_000_000,
+            observed_time_unix_nano: 1_700_000_000_000_000_001,
+            severity_number: 9,
+            severity_text: "INFO".to_owned(),
+            body: Some(string_value("hello")),
+            attributes: vec![attribute("http.method", string_value("GET"))],
+            trace_id: vec![0x01, 0x02],
+            span_id: vec![0xab],
+            ..Default::default()
+        };
+
+        let messages =
+            export_logs_to_messages(logs_request(Some(service_resource("api")), vec![record]));
+
+        assert_eq!(messages.len(), 1);
+        let doc = payload_of(&messages[0]);
+        assert_eq!(doc["signal"], "log");
+        assert_eq!(doc["timestamp_ns"], 1_700_000_000_000_000_000u64);
+        assert_eq!(doc["severity"], "INFO");
+        assert_eq!(doc["body"], "hello");
+        assert_eq!(doc["trace_id"], "0102");
+        assert_eq!(doc["span_id"], "ab");
+        assert_eq!(doc["service_name"], "api");
+        assert_eq!(doc["resource"]["service.name"], "api");
+        assert_eq!(doc["attributes"]["http.method"], "GET");
+        assert_eq!(
+            messages[0].timestamp,
+            Some(1_700_000_000_000_000_000),
+            "non-zero record time is carried onto the message"
+        );
+    }
+
+    #[test]
+    fn given_log_record_with_empty_fields_should_prune_them() {
+        let record = LogRecord {
+            severity_number: 9,
+            body: Some(string_value("hello")),
+            ..Default::default()
+        };
+
+        let messages = export_logs_to_messages(logs_request(None, vec![record]));
+
+        let doc = payload_of(&messages[0]);
+        let obj = doc.as_object().expect("document is an object");
+        assert!(!obj.contains_key("severity_text"), "empty string is pruned");
+        assert!(!obj.contains_key("trace_id"), "empty hex string is pruned");
+        assert!(!obj.contains_key("service_name"), "empty string is pruned");
+        assert_eq!(doc["body"], "hello");
+    }
+
+    #[test]
+    fn given_zero_log_timestamp_should_leave_message_timestamp_unset() {
+        let record = LogRecord {
+            time_unix_nano: 0,
+            body: Some(string_value("hello")),
+            ..Default::default()
+        };
+
+        let messages = export_logs_to_messages(logs_request(None, vec![record]));
+
+        assert_eq!(
+            messages[0].timestamp, None,
+            "proto default 0 must not become the Unix epoch"
+        );
+    }
+
+    #[test]
+    fn given_shared_resource_should_repeat_it_in_every_record() {
+        let record = || LogRecord {
+            body: Some(string_value("hello")),
+            ..Default::default()
+        };
+
+        let messages = export_logs_to_messages(logs_request(
+            Some(service_resource("api")),
+            vec![record(), record(), record()],
+        ));
+
+        assert_eq!(messages.len(), 3);
+        for message in &messages {
+            assert_eq!(payload_of(message)["resource"]["service.name"], "api");
+        }
+    }
+
+    #[test]
+    fn given_span_should_produce_json_message() {
+        let span = Span {
+            trace_id: vec![0xde, 0xad],
+            span_id: vec![0xbe, 0xef],
+            parent_span_id: vec![0x01],
+            name: "GET /users".to_owned(),
+            kind: 2,
+            start_time_unix_nano: 100,
+            end_time_unix_nano: 200,
+            status: Some(Status {
+                code: 2,
+                message: "boom".to_owned(),
+            }),
+            attributes: vec![attribute("http.route", string_value("/users"))],
+            ..Default::default()
+        };
+
+        let messages =
+            export_traces_to_messages(traces_request(Some(service_resource("api")), vec![span]));
+
+        let doc = payload_of(&messages[0]);
+        assert_eq!(doc["signal"], "trace");
+        assert_eq!(doc["trace_id"], "dead");
+        assert_eq!(doc["span_id"], "beef");
+        assert_eq!(doc["parent_span_id"], "01");
+        assert_eq!(doc["name"], "GET /users");
+        assert_eq!(doc["kind"], "server");
+        assert_eq!(doc["status"], "error");
+        assert_eq!(doc["status_message"], "boom");
+        assert_eq!(doc["resource"]["service.name"], "api");
+        assert_eq!(doc["attributes"]["http.route"], "/users");
+        assert_eq!(messages[0].timestamp, Some(100));
+    }
+
+    #[test]
+    fn given_span_without_status_should_report_unset() {
+        let span = Span {
+            name: "work".to_owned(),
+            start_time_unix_nano: 1,
+            ..Default::default()
+        };
+
+        let messages = export_traces_to_messages(traces_request(None, vec![span]));
+
+        assert_eq!(payload_of(&messages[0])["status"], "unset");
+    }
+
+    #[test]
+    fn given_zero_span_start_time_should_leave_message_timestamp_unset() {
+        let span = Span {
+            name: "work".to_owned(),
+            start_time_unix_nano: 0,
+            ..Default::default()
+        };
+
+        let messages = export_traces_to_messages(traces_request(None, vec![span]));
+
+        assert_eq!(messages[0].timestamp, None);
+    }
+
+    #[test]
+    fn given_gauge_metric_should_produce_data_point_message() {
+        let metric = Metric {
+            name: "cpu.usage".to_owned(),
+            unit: "1".to_owned(),
+            data: Some(metric::Data::Gauge(Gauge {
+                data_points: vec![NumberDataPoint {
+                    time_unix_nano: 42,
+                    value: Some(number_data_point::Value::AsDouble(0.75)),
+                    attributes: vec![attribute("cpu", string_value("0"))],
+                    ..Default::default()
+                }],
+            })),
+            ..Default::default()
+        };
+
+        let messages = export_metrics_to_messages(metrics_request(
+            Some(service_resource("api")),
+            vec![metric],
+        ));
+
+        assert_eq!(messages.len(), 1);
+        let doc = payload_of(&messages[0]);
+        assert_eq!(doc["signal"], "metric");
+        assert_eq!(doc["name"], "cpu.usage");
+        assert_eq!(doc["type"], "gauge");
+        assert_eq!(doc["unit"], "1");
+        assert_eq!(doc["value"], 0.75);
+        assert_eq!(doc["service_name"], "api");
+        assert_eq!(doc["resource"]["service.name"], "api");
+        assert_eq!(doc["attributes"]["cpu"], "0");
+        assert_eq!(messages[0].timestamp, Some(42));
+    }
+
+    #[test]
+    fn given_sum_metric_should_include_is_monotonic() {
+        let metric = Metric {
+            name: "requests.total".to_owned(),
+            data: Some(metric::Data::Sum(Sum {
+                data_points: vec![NumberDataPoint {
+                    time_unix_nano: 7,
+                    value: Some(number_data_point::Value::AsInt(12)),
+                    ..Default::default()
+                }],
+                is_monotonic: true,
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let messages = export_metrics_to_messages(metrics_request(None, vec![metric]));
+
+        let doc = payload_of(&messages[0]);
+        assert_eq!(doc["type"], "sum");
+        assert_eq!(doc["value"], 12);
+        assert_eq!(doc["is_monotonic"], true);
+    }
+
+    #[test]
+    fn given_histogram_metric_should_produce_count_and_sum() {
+        let metric = Metric {
+            name: "latency".to_owned(),
+            data: Some(metric::Data::Histogram(Histogram {
+                data_points: vec![HistogramDataPoint {
+                    time_unix_nano: 9,
+                    count: 3,
+                    sum: Some(1.5),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let messages = export_metrics_to_messages(metrics_request(None, vec![metric]));
+
+        let doc = payload_of(&messages[0]);
+        assert_eq!(doc["type"], "histogram");
+        assert_eq!(doc["value"]["count"], 3);
+        assert_eq!(doc["value"]["sum"], 1.5);
+    }
+
+    #[test]
+    fn given_metric_without_data_should_produce_no_messages() {
+        let metric = Metric {
+            name: "empty".to_owned(),
+            data: None,
+            ..Default::default()
+        };
+
+        let messages = export_metrics_to_messages(metrics_request(None, vec![metric]));
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn given_bytes_should_convert_to_lowercase_hex() {
+        assert_eq!(bytes_to_hex(&[0x00, 0x0f, 0xff]), "000fff");
+        assert_eq!(bytes_to_hex(&[]), "");
+    }
+
+    #[test]
+    fn given_nested_any_value_should_convert_to_json() {
+        let nested = AnyValue {
+            value: Some(any_value::Value::KvlistValue(KeyValueList {
+                values: vec![attribute("inner", string_value("value"))],
+            })),
+        };
+        let array = AnyValue {
+            value: Some(any_value::Value::ArrayValue(ArrayValue {
+                values: vec![string_value("a"), string_value("b")],
+            })),
+        };
+
+        assert_eq!(any_value_to_json(&nested)["inner"], "value");
+        assert_eq!(any_value_to_json(&array), json!(["a", "b"]));
+    }
+
+    #[test]
+    fn given_bytes_any_value_should_convert_to_hex_string() {
+        let bytes = AnyValue {
+            value: Some(any_value::Value::BytesValue(vec![0xa0, 0x0b])),
+        };
+
+        assert_eq!(any_value_to_json(&bytes), "a00b");
+    }
+
+    #[test]
+    fn given_unrecognized_any_value_variant_should_map_to_null() {
+        let unknown = AnyValue {
+            value: Some(any_value::Value::StringValueStrindex(3)),
+        };
+
+        assert_eq!(any_value_to_json(&unknown), Value::Null);
+        assert_eq!(
+            extract_attrs(&[attribute("k", unknown)])["k"],
+            Value::Null,
+            "unknown variants are dropped to null rather than silently skipped"
+        );
+    }
+
+    #[test]
+    fn given_missing_resource_should_extract_empty_attributes() {
+        assert!(extract_resource_attrs(None).is_empty());
+    }
+
+    #[test]
+    fn given_severity_number_should_map_to_text() {
+        assert_eq!(severity_number_to_text(1), "TRACE");
+        assert_eq!(severity_number_to_text(9), "INFO");
+        assert_eq!(severity_number_to_text(17), "ERROR");
+        assert_eq!(severity_number_to_text(24), "FATAL");
+        assert_eq!(severity_number_to_text(0), "UNSPECIFIED");
+        assert_eq!(severity_number_to_text(99), "UNSPECIFIED");
+    }
+
+    #[test]
+    fn given_span_kind_should_map_to_text() {
+        assert_eq!(span_kind_to_text(1), "internal");
+        assert_eq!(span_kind_to_text(5), "consumer");
+        assert_eq!(span_kind_to_text(0), "unspecified");
+    }
+
+    #[test]
+    fn given_status_code_should_map_to_text() {
+        assert_eq!(status_code_to_text(1), "ok");
+        assert_eq!(status_code_to_text(2), "error");
+        assert_eq!(status_code_to_text(0), "unset");
+    }
+}

--- a/core/connectors/sources/otlp_source/src/lib.rs
+++ b/core/connectors/sources/otlp_source/src/lib.rs
@@ -1,0 +1,242 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use async_trait::async_trait;
+use iggy_connector_sdk::{
+    ConnectorState, Error, ProducedMessage, ProducedMessages, Schema, Source, source_connector,
+};
+use serde::Deserialize;
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tonic::transport::server::TcpIncoming;
+use tracing::info;
+
+pub(crate) mod convert;
+pub(crate) mod server;
+
+source_connector!(OtlpSource);
+
+/// How messages are stored in the Iggy topic.
+///
+/// `Json` (default): each OTLP signal item (span / data-point / log record)
+/// is stored as a flat JSON document. Human-readable but verbose.
+///
+/// `Proto`: the entire `Export*ServiceRequest` proto is stored as raw bytes
+/// per gRPC call. Typically 4-5x smaller than JSON and zero-copy on the sink
+/// side when paired with `otlp_sink`'s `format = "proto"`.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StorageFormat {
+    #[default]
+    Json,
+    Proto,
+}
+
+#[derive(Debug)]
+pub struct OtlpSource {
+    id: u32,
+    config: OtlpSourceConfig,
+    rx: Mutex<Option<mpsc::Receiver<ProducedMessage>>>,
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    server_task: Mutex<Option<JoinHandle<()>>>,
+}
+
+/// Configuration for the OTLP source connector, deserialized from
+/// `[plugin_config]` in config.toml.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OtlpSourceConfig {
+    /// Address the gRPC server binds to, e.g. `0.0.0.0:4317`.
+    pub listen_addr: String,
+    /// In-process buffer between the gRPC server and `poll()` (default: 50000).
+    /// Must be greater than 0. Overflowing exports are reported back to the
+    /// client through `partial_success` rather than failing the whole batch.
+    #[serde(default = "default_channel_capacity")]
+    pub channel_capacity: usize,
+    /// Maximum messages returned by a single `poll()` (default: 1000).
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// How records are stored, see [`StorageFormat`] (default: `json`).
+    #[serde(default)]
+    pub format: StorageFormat,
+}
+
+fn default_channel_capacity() -> usize {
+    50_000
+}
+
+fn default_batch_size() -> usize {
+    1_000
+}
+
+impl OtlpSource {
+    pub fn new(id: u32, config: OtlpSourceConfig, _state: Option<ConnectorState>) -> Self {
+        OtlpSource {
+            id,
+            config,
+            rx: Mutex::new(None),
+            shutdown_tx: Mutex::new(None),
+            server_task: Mutex::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl Source for OtlpSource {
+    async fn open(&mut self) -> Result<(), Error> {
+        if self.rx.lock().await.is_some() {
+            return Err(Error::InitError(
+                "OTLP source connector is already open".to_string(),
+            ));
+        }
+
+        // tokio::sync::mpsc::channel panics on a zero capacity, which would take
+        // down the whole runtime process on a typo in the connector TOML.
+        if self.config.channel_capacity == 0 {
+            return Err(Error::InvalidConfigValue(
+                "channel_capacity must be greater than 0".to_string(),
+            ));
+        }
+
+        let addr = self
+            .config
+            .listen_addr
+            .parse()
+            .map_err(|err| Error::InitError(format!("Invalid listen address: {err}")))?;
+
+        let incoming = TcpIncoming::bind(addr).map_err(|err| {
+            Error::InitError(format!("Failed to bind {}: {err}", self.config.listen_addr))
+        })?;
+
+        info!(
+            "OTLP source connector with ID: {} listening on {}",
+            self.id, self.config.listen_addr
+        );
+
+        let (tx, rx) = mpsc::channel(self.config.channel_capacity);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let handle = tokio::spawn(server::run_grpc_server(
+            incoming,
+            tx,
+            shutdown_rx,
+            self.config.format,
+        ));
+
+        *self.rx.lock().await = Some(rx);
+        *self.shutdown_tx.lock().await = Some(shutdown_tx);
+        *self.server_task.lock().await = Some(handle);
+
+        Ok(())
+    }
+
+    async fn poll(&self) -> Result<ProducedMessages, Error> {
+        let mut rx_guard = self.rx.lock().await;
+        let rx = rx_guard.as_mut().ok_or_else(|| {
+            Error::InitError("OTLP source connector is not initialized".to_string())
+        })?;
+
+        let first = match rx.recv().await {
+            Some(msg) => msg,
+            None => {
+                return Err(Error::Connection(
+                    "OTLP gRPC server terminated unexpectedly".to_string(),
+                ));
+            }
+        };
+
+        let mut messages = Vec::with_capacity(self.config.batch_size);
+        messages.push(first);
+
+        while messages.len() < self.config.batch_size {
+            match rx.try_recv() {
+                Ok(msg) => messages.push(msg),
+                Err(_) => break,
+            }
+        }
+
+        let schema = match self.config.format {
+            StorageFormat::Json => Schema::Json,
+            StorageFormat::Proto => Schema::Raw,
+        };
+
+        Ok(ProducedMessages {
+            schema,
+            messages,
+            state: None,
+        })
+    }
+
+    async fn close(&mut self) -> Result<(), Error> {
+        if let Some(tx) = self.shutdown_tx.lock().await.take() {
+            let _ = tx.send(());
+        }
+        let task = self.server_task.lock().await.take();
+        if let Some(task) = task {
+            task.abort();
+            let _ = task.await;
+        }
+        *self.rx.lock().await = None;
+        info!("OTLP source connector with ID: {} closed.", self.id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn given_minimal_config_should_apply_defaults() {
+        let config: OtlpSourceConfig =
+            serde_json::from_str(r#"{"listen_addr": "0.0.0.0:4317"}"#).expect("config parses");
+
+        assert_eq!(config.channel_capacity, 50_000);
+        assert_eq!(config.batch_size, 1_000);
+        assert!(matches!(config.format, StorageFormat::Json));
+    }
+
+    #[test]
+    fn given_lowercase_format_should_deserialize() {
+        let config: OtlpSourceConfig =
+            serde_json::from_str(r#"{"listen_addr": "0.0.0.0:4317", "format": "proto"}"#)
+                .expect("config parses");
+
+        assert!(matches!(config.format, StorageFormat::Proto));
+    }
+
+    #[test]
+    fn given_unknown_config_field_should_fail_deserialization() {
+        // Without deny_unknown_fields a typo would silently fall back to the
+        // default and the connector would run on a configuration nobody wrote.
+        let result: Result<OtlpSourceConfig, _> =
+            serde_json::from_str(r#"{"listen_addr": "0.0.0.0:4317", "batch_sise": 10}"#);
+
+        let error = result.expect_err("unknown field is rejected");
+        assert!(
+            error.to_string().contains("batch_sise"),
+            "error names the offending key, got: {error}"
+        );
+    }
+
+    #[test]
+    fn given_missing_listen_addr_should_fail_deserialization() {
+        let result: Result<OtlpSourceConfig, _> = serde_json::from_str("{}");
+
+        assert!(result.is_err(), "listen_addr has no default");
+    }
+}

--- a/core/connectors/sources/otlp_source/src/server.rs
+++ b/core/connectors/sources/otlp_source/src/server.rs
@@ -1,0 +1,406 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::StorageFormat;
+use crate::convert;
+use iggy_connector_sdk::ProducedMessage;
+use opentelemetry_proto::tonic::collector::logs::v1::{
+    ExportLogsPartialSuccess, ExportLogsServiceRequest, ExportLogsServiceResponse,
+    logs_service_server::{LogsService, LogsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsPartialSuccess, ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+    metrics_service_server::{MetricsService, MetricsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTracePartialSuccess, ExportTraceServiceRequest, ExportTraceServiceResponse,
+    trace_service_server::{TraceService, TraceServiceServer},
+};
+use opentelemetry_proto::tonic::metrics::v1::metric;
+use prost::Message as ProstMessage;
+use tokio::sync::{mpsc, oneshot};
+use tonic::codec::CompressionEncoding;
+use tonic::transport::server::TcpIncoming;
+use tonic::{Request, Response, Status};
+use tracing::{error, info, warn};
+
+pub async fn run_grpc_server(
+    incoming: TcpIncoming,
+    tx: mpsc::Sender<ProducedMessage>,
+    shutdown: oneshot::Receiver<()>,
+    format: StorageFormat,
+) {
+    let logs_svc = LogsServiceImpl {
+        tx: tx.clone(),
+        format,
+    };
+    let metrics_svc = MetricsServiceImpl {
+        tx: tx.clone(),
+        format,
+    };
+    let trace_svc = TraceServiceImpl { tx, format };
+
+    // OTel SDKs and the Collector's OTLP exporter gzip-compress payloads by
+    // default, so every service must accept gzip on the wire. Send-side gzip is
+    // deliberately not advertised: an export response carries at most a
+    // partial_success and serializes to a couple of bytes, where the gzip header
+    // alone outweighs the body.
+    let logs_server = LogsServiceServer::new(logs_svc).accept_compressed(CompressionEncoding::Gzip);
+    let metrics_server =
+        MetricsServiceServer::new(metrics_svc).accept_compressed(CompressionEncoding::Gzip);
+    let trace_server =
+        TraceServiceServer::new(trace_svc).accept_compressed(CompressionEncoding::Gzip);
+
+    if let Err(err) = tonic::transport::Server::builder()
+        .add_service(logs_server)
+        .add_service(metrics_server)
+        .add_service(trace_server)
+        .serve_with_incoming_shutdown(incoming, async {
+            let _ = shutdown.await;
+            info!("OTLP gRPC server received shutdown signal");
+        })
+        .await
+    {
+        error!("OTLP gRPC server error: {err}");
+    }
+}
+
+struct LogsServiceImpl {
+    tx: mpsc::Sender<ProducedMessage>,
+    format: StorageFormat,
+}
+
+struct MetricsServiceImpl {
+    tx: mpsc::Sender<ProducedMessage>,
+    format: StorageFormat,
+}
+
+struct TraceServiceImpl {
+    tx: mpsc::Sender<ProducedMessage>,
+    format: StorageFormat,
+}
+
+#[tonic::async_trait]
+impl LogsService for LogsServiceImpl {
+    async fn export(
+        &self,
+        request: Request<ExportLogsServiceRequest>,
+    ) -> Result<Response<ExportLogsServiceResponse>, Status> {
+        let batch = encode_or_convert(request.into_inner(), self.format, "logs");
+        let rejected = send_messages(&self.tx, batch, "logs");
+        let partial_success = (rejected > 0).then(|| ExportLogsPartialSuccess {
+            rejected_log_records: rejected,
+            error_message: "channel full; records dropped".to_string(),
+        });
+        Ok(Response::new(ExportLogsServiceResponse { partial_success }))
+    }
+}
+
+#[tonic::async_trait]
+impl MetricsService for MetricsServiceImpl {
+    async fn export(
+        &self,
+        request: Request<ExportMetricsServiceRequest>,
+    ) -> Result<Response<ExportMetricsServiceResponse>, Status> {
+        let batch = encode_or_convert(request.into_inner(), self.format, "metrics");
+        let rejected = send_messages(&self.tx, batch, "metrics");
+        let partial_success = (rejected > 0).then(|| ExportMetricsPartialSuccess {
+            rejected_data_points: rejected,
+            error_message: "channel full; data points dropped".to_string(),
+        });
+        Ok(Response::new(ExportMetricsServiceResponse {
+            partial_success,
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl TraceService for TraceServiceImpl {
+    async fn export(
+        &self,
+        request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        let batch = encode_or_convert(request.into_inner(), self.format, "traces");
+        let rejected = send_messages(&self.tx, batch, "traces");
+        let partial_success = (rejected > 0).then(|| ExportTracePartialSuccess {
+            rejected_spans: rejected,
+            error_message: "channel full; spans dropped".to_string(),
+        });
+        Ok(Response::new(ExportTraceServiceResponse {
+            partial_success,
+        }))
+    }
+}
+
+trait OtlpBatch {
+    fn into_json_messages(self) -> Vec<ProducedMessage>;
+
+    /// Number of individual OTLP records in the request. The `rejected_*` fields
+    /// of `partial_success` are defined per record, so proto mode (one blob for
+    /// the whole request) cannot report the message count.
+    fn record_count(&self) -> i64;
+}
+
+impl OtlpBatch for ExportLogsServiceRequest {
+    fn into_json_messages(self) -> Vec<ProducedMessage> {
+        convert::export_logs_to_messages(self)
+    }
+
+    fn record_count(&self) -> i64 {
+        self.resource_logs
+            .iter()
+            .flat_map(|resource| &resource.scope_logs)
+            .map(|scope| scope.log_records.len() as i64)
+            .sum()
+    }
+}
+
+impl OtlpBatch for ExportMetricsServiceRequest {
+    fn into_json_messages(self) -> Vec<ProducedMessage> {
+        convert::export_metrics_to_messages(self)
+    }
+
+    fn record_count(&self) -> i64 {
+        self.resource_metrics
+            .iter()
+            .flat_map(|resource| &resource.scope_metrics)
+            .flat_map(|scope| &scope.metrics)
+            .map(|metric| match &metric.data {
+                Some(metric::Data::Gauge(gauge)) => gauge.data_points.len() as i64,
+                Some(metric::Data::Sum(sum)) => sum.data_points.len() as i64,
+                Some(metric::Data::Histogram(histogram)) => histogram.data_points.len() as i64,
+                Some(metric::Data::ExponentialHistogram(histogram)) => {
+                    histogram.data_points.len() as i64
+                }
+                Some(metric::Data::Summary(summary)) => summary.data_points.len() as i64,
+                None => 0,
+            })
+            .sum()
+    }
+}
+
+impl OtlpBatch for ExportTraceServiceRequest {
+    fn into_json_messages(self) -> Vec<ProducedMessage> {
+        convert::export_traces_to_messages(self)
+    }
+
+    fn record_count(&self) -> i64 {
+        self.resource_spans
+            .iter()
+            .flat_map(|resource| &resource.scope_spans)
+            .map(|scope| scope.spans.len() as i64)
+            .sum()
+    }
+}
+
+/// A request turned into messages, plus what each message is worth in OTLP
+/// records so drops can be reported in the units the spec expects.
+struct EncodedBatch {
+    messages: Vec<ProducedMessage>,
+    records_per_message: i64,
+    /// Records lost before anything reached the channel, i.e. a proto encode
+    /// failure. Reported as rejected so the client does not read a dropped
+    /// batch as a full success.
+    rejected: i64,
+}
+
+fn encode_or_convert<R>(req: R, format: StorageFormat, signal: &str) -> EncodedBatch
+where
+    R: ProstMessage + OtlpBatch,
+{
+    match format {
+        StorageFormat::Json => EncodedBatch {
+            messages: req.into_json_messages(),
+            records_per_message: 1,
+            rejected: 0,
+        },
+        StorageFormat::Proto => {
+            let records = req.record_count();
+            let mut buf = Vec::with_capacity(req.encoded_len());
+            if let Err(e) = req.encode(&mut buf) {
+                warn!("Failed to encode {signal} proto, rejecting {records} records: {e}");
+                return EncodedBatch {
+                    messages: vec![],
+                    records_per_message: records,
+                    rejected: records,
+                };
+            }
+            EncodedBatch {
+                messages: vec![ProducedMessage {
+                    id: None,
+                    checksum: None,
+                    timestamp: None,
+                    origin_timestamp: None,
+                    headers: None,
+                    payload: buf,
+                }],
+                records_per_message: records,
+                rejected: 0,
+            }
+        }
+    }
+}
+
+fn send_messages(tx: &mpsc::Sender<ProducedMessage>, batch: EncodedBatch, signal: &str) -> i64 {
+    let total = batch.messages.len() as i64;
+    let mut dropped: i64 = 0;
+    for message in batch.messages {
+        if tx.try_send(message).is_err() {
+            dropped += 1;
+        }
+    }
+    if dropped > 0 {
+        warn!("OTLP channel full, dropped {dropped}/{total} {signal} messages");
+    }
+    batch.rejected + dropped * batch.records_per_message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+    use opentelemetry_proto::tonic::metrics::v1::{
+        Gauge, Histogram, HistogramDataPoint, Metric, NumberDataPoint, ResourceMetrics,
+        ScopeMetrics, Sum,
+    };
+    use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+
+    fn logs_request(records: usize) -> ExportLogsServiceRequest {
+        ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![LogRecord::default(); records],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    fn traces_request(spans: usize) -> ExportTraceServiceRequest {
+        ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    spans: vec![Span::default(); spans],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    fn metrics_request(metrics: Vec<Metric>) -> ExportMetricsServiceRequest {
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn given_log_request_should_count_every_record() {
+        assert_eq!(logs_request(7).record_count(), 7);
+        assert_eq!(logs_request(0).record_count(), 0);
+    }
+
+    #[test]
+    fn given_trace_request_should_count_every_span() {
+        assert_eq!(traces_request(4).record_count(), 4);
+    }
+
+    #[test]
+    fn given_metric_request_should_count_data_points_not_metrics() {
+        let request = metrics_request(vec![
+            Metric {
+                data: Some(metric::Data::Gauge(Gauge {
+                    data_points: vec![NumberDataPoint::default(); 3],
+                })),
+                ..Default::default()
+            },
+            Metric {
+                data: Some(metric::Data::Sum(Sum {
+                    data_points: vec![NumberDataPoint::default(); 2],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            Metric {
+                data: Some(metric::Data::Histogram(Histogram {
+                    data_points: vec![HistogramDataPoint::default(); 1],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            Metric {
+                data: None,
+                ..Default::default()
+            },
+        ]);
+
+        assert_eq!(request.record_count(), 6);
+    }
+
+    #[tokio::test]
+    async fn given_json_format_should_reject_one_record_per_dropped_message() {
+        let (tx, _rx) = mpsc::channel(1);
+        let batch = encode_or_convert(logs_request(3), StorageFormat::Json, "logs");
+        assert_eq!(batch.messages.len(), 3);
+        assert_eq!(batch.records_per_message, 1);
+
+        let rejected = send_messages(&tx, batch, "logs");
+
+        assert_eq!(rejected, 2, "one message fits the channel, two are dropped");
+    }
+
+    #[tokio::test]
+    async fn given_proto_format_should_reject_the_whole_batch_when_dropped() {
+        let (tx, _rx) = mpsc::channel(1);
+        // Fill the single slot so the proto blob cannot be enqueued.
+        tx.try_send(ProducedMessage {
+            id: None,
+            checksum: None,
+            timestamp: None,
+            origin_timestamp: None,
+            headers: None,
+            payload: vec![],
+        })
+        .expect("channel has one free slot");
+
+        let batch = encode_or_convert(traces_request(500), StorageFormat::Proto, "traces");
+        assert_eq!(batch.messages.len(), 1, "proto mode emits a single blob");
+        assert_eq!(batch.records_per_message, 500);
+
+        let rejected = send_messages(&tx, batch, "traces");
+
+        assert_eq!(
+            rejected, 500,
+            "rejected_* counts records, not the one dropped message"
+        );
+    }
+
+    #[tokio::test]
+    async fn given_proto_format_should_report_no_rejects_when_enqueued() {
+        let (tx, _rx) = mpsc::channel(1);
+        let batch = encode_or_convert(traces_request(500), StorageFormat::Proto, "traces");
+
+        assert_eq!(send_messages(&tx, batch, "traces"), 0);
+    }
+}


### PR DESCRIPTION
## Which issue does this PR address?

Closes #3815
Relates to #2753

## Rationale

OTLP is listed as a P0 source and sink on the connector roadmap. Collectors and
SDKs already speak OTLP/gRPC, so today the only way to get telemetry into Iggy
is to run a separate bridge process in front of it. This terminates the OTLP
gRPC service inside the connectors runtime instead.

## What changed?

New `iggy_connector_otlp_source` plugin. One listener on port 4317 serves all
three collector services, since standard OTLP deployments expose a single
endpoint and splitting them would force operators to configure three addresses
that match no existing tooling.

Requests are decoded with `opentelemetry-proto`, which already ships the
generated tonic stubs, so there is no `build.rs` or `protoc` in the build.
`format = "json"` emits one queryable document per record; `format = "proto"`
forwards the raw request bytes as a single message, roughly 4-5x smaller and
zero-copy with `otlp_sink`'s proto format.

Backpressure does not fail the export. When the channel fills, whatever fits is
enqueued and the rest is reported in `partial_success`, counted in OTLP records
rather than internal messages, so a client retries only what was actually
rejected instead of resending a batch that was half-delivered.

## Local Execution

- Passed

```
cargo fmt --all
cargo sort --check --no-format --workspace
cargo clippy -p iggy_connector_otlp_source --all-features --all-targets -- -D warnings
cargo test -p iggy_connector_otlp_source                        # 29 passed
./scripts/ci/taplo.sh --check
./scripts/ci/markdownlint.sh --check
./scripts/ci/license-headers.sh
./scripts/ci/trailing-whitespace.sh
./scripts/ci/trailing-newline.sh
```

29 unit tests cover the OTLP to JSON conversion for all three signals, the
`partial_success` record accounting in both storage formats, and config
deserialization including unknown-key rejection. There is no integration suite
for this connector yet; it has been exercised against a live OpenTelemetry
Collector, with logs, metrics and traces all landing in their topics.

- Pre-commit hooks ran

## AI Usage

1. Claude Code.
2. Used throughout: drafting the connector, the proto-to-JSON conversion, and
   the test suite, and auditing the diff against reviewer comments.
3. Verified by running the full local check list above and by pointing a live
   OpenTelemetry Collector at the connector and checking the resulting messages
   in each topic.
4. Yes.