### PR TITLE
fix(server): decouple asyncify thread pool from COOP_TASKRUN for old-kernel compat

### DIFF
--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -308,6 +308,19 @@ runs:
         ls -la codecov.json
       shell: bash
 
+    - name: Smoke-launch iggy-server (kernel version check)
+      if: inputs.task == 'test-1'
+      run: |
+        cargo build --locked --bin iggy-server 2>&1
+        timeout 3 ./target/debug/iggy-server 2>&1 | tee /tmp/iggy-smoke.log || true
+        if grep -q "requires Linux kernel" /tmp/iggy-smoke.log; then
+          echo "ERROR: kernel version check rejected the CI runner kernel"
+          cat /tmp/iggy-smoke.log
+          exit 1
+        fi
+        echo "Kernel check passed on this runner"
+      shell: bash
+
     - name: Backwards compatibility check
       if: inputs.task == 'compat' && (github.event_name != 'pull_request' || !contains(join(github.event.pull_request.labels.*.name, ','), 'breaking:storage'))
       run: |

--- a/core/server-ng/src/bootstrap.rs
+++ b/core/server-ng/src/bootstrap.rs
@@ -633,7 +633,8 @@ fn run_shard_thread(
     // TODO(hubcio): decouple runtime creation from the `server` crate
     // (mirrors the identical TODO in `main.rs`). Reusing legacy here so
     // server-ng and the legacy server share one io_uring tuning surface.
-    let runtime = create_shard_executor()
+    let keep_pool = config.tcp.enabled || config.http.enabled || config.websocket.enabled;
+    let runtime = create_shard_executor(keep_pool)
         .map_err(|source| ServerNgError::ShardRuntimeCreateFailed { shard_id, source })?;
 
     let result = runtime.block_on(async move {

--- a/core/server-ng/src/main.rs
+++ b/core/server-ng/src/main.rs
@@ -26,7 +26,7 @@ use server_ng::server_error::ServerNgError;
 use tracing::{error, info};
 
 fn main() -> Result<(), ServerNgError> {
-    let bootstrap_runtime = match server_common::create_shard_executor() {
+    let bootstrap_runtime = match server_common::create_shard_executor(true) {
         Ok(rt) => rt,
         Err(e) => {
             match e.kind() {

--- a/core/server-ng/src/main.rs
+++ b/core/server-ng/src/main.rs
@@ -26,6 +26,11 @@ use server_ng::server_error::ServerNgError;
 use tracing::{error, info};
 
 fn main() -> Result<(), ServerNgError> {
+    if let Err(msg) = server_common::check_kernel_version() {
+        eprintln!("iggy-server-ng requires Linux kernel >= 6.8: {msg}");
+        std::process::exit(1);
+    }
+
     let bootstrap_runtime = match server_common::create_shard_executor(true) {
         Ok(rt) => rt,
         Err(e) => {

--- a/core/server/src/main.rs
+++ b/core/server/src/main.rs
@@ -109,6 +109,11 @@ fn print_ascii_art(text: &str) {
 
 #[instrument(skip_all, name = "trace_start_server")]
 fn main() -> Result<(), ServerError> {
+    if let Err(msg) = server_common::check_kernel_version() {
+        eprintln!("iggy-server requires Linux kernel >= 6.8: {msg}");
+        std::process::exit(1);
+    }
+
     let rt = match compio::runtime::Runtime::new() {
         Ok(rt) => rt,
         Err(e) => {

--- a/core/server/src/main.rs
+++ b/core/server/src/main.rs
@@ -399,7 +399,9 @@ fn main() -> Result<(), ServerError> {
                             error!("Failed to bind memory: {e:?}");
                         }
 
-                        let rt = match create_shard_executor() {
+                        let keep_pool =
+                            config.tcp.enabled || config.http.enabled || config.websocket.enabled;
+                        let rt = match create_shard_executor(keep_pool) {
                             Ok(rt) => rt,
                             Err(e) => {
                                 match e.kind() {

--- a/core/server_common/src/executor.rs
+++ b/core/server_common/src/executor.rs
@@ -19,6 +19,7 @@ use compio::runtime::Runtime;
 
 const DEFAULT_SHARD_RUNTIME_CAPACITY: u32 = 4096;
 const SHARD_RUNTIME_CAPACITY_ENV: &str = "IGGY_SHARD_RUNTIME_CAPACITY";
+const SHARD_COOP_TASKRUN_ENV: &str = "IGGY_SHARD_RUNTIME_COOP_TASKRUN";
 
 /// Resolves the per-shard io_uring SQ/CQ capacity from `IGGY_SHARD_RUNTIME_CAPACITY`,
 /// falling back to [`DEFAULT_SHARD_RUNTIME_CAPACITY`] when the var is missing or
@@ -28,6 +29,24 @@ fn shard_capacity_from_env() -> u32 {
         .ok()
         .and_then(|v| v.parse::<u32>().ok())
         .unwrap_or(DEFAULT_SHARD_RUNTIME_CAPACITY)
+}
+
+/// Whether to request `IORING_SETUP_COOP_TASKRUN` + `IORING_SETUP_TASKRUN_FLAG`.
+///
+/// These flags require Linux >= 5.19; on older kernels (e.g. 5.15) the shard
+/// `io_uring` setup fails with `EINVAL` even though the default-flag main-thread
+/// runtime initializes fine. Defaults to `true` (recommended, lowest latency).
+/// Set `IGGY_SHARD_RUNTIME_COOP_TASKRUN=false` to drop the flags and run on a
+/// 5.10..5.19 kernel at a small latency cost.
+fn coop_taskrun_from_env() -> bool {
+    std::env::var(SHARD_COOP_TASKRUN_ENV)
+        .map(|v| {
+            !matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "false" | "0" | "no" | "off"
+            )
+        })
+        .unwrap_or(true)
 }
 
 /// Creates a compio runtime for a shard thread, with shard-specific `io_uring` flags.
@@ -43,19 +62,20 @@ fn shard_capacity_from_env() -> u32 {
 /// On `InvalidInput` the kernel rejected the required flags; on `OutOfMemory` or
 /// `PermissionDenied` the caller should print the appropriate diagnostic before panicking.
 ///
-/// Shard executors require `IORING_SETUP_COOP_TASKRUN` for predictable latency.
-/// Falling back to default flags would silently degrade shard performance -
-/// do not add a retry with reduced flags here.
+/// Shard executors request `IORING_SETUP_COOP_TASKRUN` for predictable latency.
+/// This is opt-out (not a silent fallback): the flags stay on by default and are
+/// only dropped when `IGGY_SHARD_RUNTIME_COOP_TASKRUN=false` is set explicitly,
+/// which is the documented escape hatch for kernels older than 5.19.
 pub fn create_shard_executor() -> Result<Runtime, std::io::Error> {
     // TODO: The event interval tick, could be configured based on the fact
     // How many clients we expect to have connected.
     // This roughly estimates the number of tasks we will create.
     let mut proactor = compio::driver::ProactorBuilder::new();
 
-    proactor
-        .capacity(shard_capacity_from_env())
-        .coop_taskrun(true)
-        .taskrun_flag(true);
+    proactor.capacity(shard_capacity_from_env());
+    if coop_taskrun_from_env() {
+        proactor.coop_taskrun(true).taskrun_flag(true);
+    }
 
     // FIXME(hubcio): Only set thread_pool_limit(0) on non-macOS platforms
     // This causes a freeze on macOS with compio fs operations
@@ -72,28 +92,33 @@ pub fn create_shard_executor() -> Result<Runtime, std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_SHARD_RUNTIME_CAPACITY, SHARD_RUNTIME_CAPACITY_ENV, shard_capacity_from_env,
+        DEFAULT_SHARD_RUNTIME_CAPACITY, SHARD_COOP_TASKRUN_ENV, SHARD_RUNTIME_CAPACITY_ENV,
+        coop_taskrun_from_env, shard_capacity_from_env,
     };
     use serial_test::serial;
 
-    fn with_capacity_env<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
+    fn with_env<R>(key: &str, value: Option<&str>, f: impl FnOnce() -> R) -> R {
         // SAFETY: tests in this module are #[serial], so no other thread races
         // on the process-wide environment while the guard is active.
-        let prev = std::env::var(SHARD_RUNTIME_CAPACITY_ENV).ok();
+        let prev = std::env::var(key).ok();
         unsafe {
             match value {
-                Some(v) => std::env::set_var(SHARD_RUNTIME_CAPACITY_ENV, v),
-                None => std::env::remove_var(SHARD_RUNTIME_CAPACITY_ENV),
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
             }
         }
         let out = f();
         unsafe {
             match prev {
-                Some(v) => std::env::set_var(SHARD_RUNTIME_CAPACITY_ENV, v),
-                None => std::env::remove_var(SHARD_RUNTIME_CAPACITY_ENV),
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
             }
         }
         out
+    }
+
+    fn with_capacity_env<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
+        with_env(SHARD_RUNTIME_CAPACITY_ENV, value, f)
     }
 
     #[test]
@@ -126,5 +151,33 @@ mod tests {
         with_capacity_env(Some("-1"), || {
             assert_eq!(shard_capacity_from_env(), DEFAULT_SHARD_RUNTIME_CAPACITY);
         });
+    }
+
+    #[test]
+    #[serial]
+    fn coop_taskrun_defaults_to_true_when_unset() {
+        with_env(SHARD_COOP_TASKRUN_ENV, None, || {
+            assert!(coop_taskrun_from_env());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn coop_taskrun_disabled_by_falsey_values() {
+        for value in ["false", "0", "no", "off", "OFF", "False"] {
+            with_env(SHARD_COOP_TASKRUN_ENV, Some(value), || {
+                assert!(!coop_taskrun_from_env(), "{value} should disable");
+            });
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn coop_taskrun_enabled_by_truthy_values() {
+        for value in ["true", "1", "yes", "on"] {
+            with_env(SHARD_COOP_TASKRUN_ENV, Some(value), || {
+                assert!(coop_taskrun_from_env(), "{value} should enable");
+            });
+        }
     }
 }

--- a/core/server_common/src/executor.rs
+++ b/core/server_common/src/executor.rs
@@ -71,17 +71,26 @@ pub fn create_shard_executor() -> Result<Runtime, std::io::Error> {
     // How many clients we expect to have connected.
     // This roughly estimates the number of tasks we will create.
     let mut proactor = compio::driver::ProactorBuilder::new();
+    let coop_taskrun = coop_taskrun_from_env();
 
     proactor.capacity(shard_capacity_from_env());
-    if coop_taskrun_from_env() {
+    if coop_taskrun {
         proactor.coop_taskrun(true).taskrun_flag(true);
     }
 
     // FIXME(hubcio): Only set thread_pool_limit(0) on non-macOS platforms
     // This causes a freeze on macOS with compio fs operations
     // see https://github.com/compio-rs/compio/issues/446
+    //
+    // Also keep a worker pool when COOP_TASKRUN is disabled: without it compio
+    // routes some ops (fs reads, JWT storage) through the asyncify thread pool,
+    // and a zero-worker pool then panics with "thread pool is needed but no
+    // worker thread is running". A non-zero pool is only safe to drop when the
+    // modern io_uring flags keep those ops on the ring.
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    proactor.thread_pool_limit(0);
+    if coop_taskrun {
+        proactor.thread_pool_limit(0);
+    }
 
     compio::runtime::RuntimeBuilder::new()
         .with_proactor(proactor.to_owned())

--- a/core/server_common/src/executor.rs
+++ b/core/server_common/src/executor.rs
@@ -56,6 +56,12 @@ fn coop_taskrun_from_env() -> bool {
 /// harness sets to `256` so N nodes * M shards fit under an 8 MiB
 /// `RLIMIT_MEMLOCK` budget without `ENOMEM` at ring setup.
 ///
+/// `keep_worker_pool` must be `true` when TCP, HTTP, or WebSocket transports are
+/// active: those transports dispatch blocking ops through the asyncify thread pool
+/// even when COOP_TASKRUN is on, and a zero-worker pool panics with "thread pool
+/// is needed but no worker thread is running". Pass `false` only for pure
+/// QUIC-only deployments where every op stays on the ring.
+///
 /// # Errors
 ///
 /// Returns an `std::io::Error` if the underlying `io_uring` proactor cannot be initialised.
@@ -66,7 +72,7 @@ fn coop_taskrun_from_env() -> bool {
 /// This is opt-out (not a silent fallback): the flags stay on by default and are
 /// only dropped when `IGGY_SHARD_RUNTIME_COOP_TASKRUN=false` is set explicitly,
 /// which is the documented escape hatch for kernels older than 5.19.
-pub fn create_shard_executor() -> Result<Runtime, std::io::Error> {
+pub fn create_shard_executor(keep_worker_pool: bool) -> Result<Runtime, std::io::Error> {
     // TODO: The event interval tick, could be configured based on the fact
     // How many clients we expect to have connected.
     // This roughly estimates the number of tasks we will create.
@@ -82,13 +88,14 @@ pub fn create_shard_executor() -> Result<Runtime, std::io::Error> {
     // This causes a freeze on macOS with compio fs operations
     // see https://github.com/compio-rs/compio/issues/446
     //
-    // Also keep a worker pool when COOP_TASKRUN is disabled: without it compio
-    // routes some ops (fs reads, JWT storage) through the asyncify thread pool,
-    // and a zero-worker pool then panics with "thread pool is needed but no
-    // worker thread is running". A non-zero pool is only safe to drop when the
-    // modern io_uring flags keep those ops on the ring.
+    // Keep a worker pool whenever the caller signals it (TCP/HTTP/WS active),
+    // or when COOP_TASKRUN is off: in both cases compio may dispatch blocking
+    // ops (fs reads, JWT storage, TLS handshakes) through the asyncify pool,
+    // and a zero-worker pool panics with "thread pool is needed". Dropping the
+    // pool is only safe when modern io_uring flags handle every op on-ring AND
+    // no transport needs asyncify-backed blocking calls.
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    if coop_taskrun {
+    if coop_taskrun && !keep_worker_pool {
         proactor.thread_pool_limit(0);
     }
 

--- a/core/server_common/src/executor.rs
+++ b/core/server_common/src/executor.rs
@@ -19,7 +19,42 @@ use compio::runtime::Runtime;
 
 const DEFAULT_SHARD_RUNTIME_CAPACITY: u32 = 4096;
 const SHARD_RUNTIME_CAPACITY_ENV: &str = "IGGY_SHARD_RUNTIME_CAPACITY";
-const SHARD_COOP_TASKRUN_ENV: &str = "IGGY_SHARD_RUNTIME_COOP_TASKRUN";
+
+// Minimum kernel required by IORING_SETUP_COOP_TASKRUN + full io_uring feature set.
+const MIN_KERNEL_MAJOR: u32 = 6;
+const MIN_KERNEL_MINOR: u32 = 8;
+
+/// Reads the running kernel version from `/proc/sys/kernel/osrelease` and returns
+/// `Err` with a human-readable message if the kernel is older than 6.8.
+///
+/// Call this once at process startup, before `create_shard_executor`. Both the
+/// classic server and server-ng entry points do this; tests skip it unless they
+/// intentionally exercise the check.
+pub fn check_kernel_version() -> Result<(), String> {
+    let raw = std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .map_err(|e| format!("cannot read kernel version: {e}"))?;
+
+    let version_str = raw.trim();
+    let mut parts = version_str.splitn(3, '.');
+    let major: u32 = parts
+        .next()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| format!("cannot parse kernel version: {version_str}"))?;
+    let minor: u32 = parts
+        .next()
+        .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| format!("cannot parse kernel version: {version_str}"))?;
+
+    if major > MIN_KERNEL_MAJOR || (major == MIN_KERNEL_MAJOR && minor >= MIN_KERNEL_MINOR) {
+        Ok(())
+    } else {
+        Err(format!(
+            "kernel {version_str} is below the minimum required {MIN_KERNEL_MAJOR}.{MIN_KERNEL_MINOR}; \
+             upgrade the kernel or use a supported host"
+        ))
+    }
+}
 
 /// Resolves the per-shard io_uring SQ/CQ capacity from `IGGY_SHARD_RUNTIME_CAPACITY`,
 /// falling back to [`DEFAULT_SHARD_RUNTIME_CAPACITY`] when the var is missing or
@@ -31,24 +66,6 @@ fn shard_capacity_from_env() -> u32 {
         .unwrap_or(DEFAULT_SHARD_RUNTIME_CAPACITY)
 }
 
-/// Whether to request `IORING_SETUP_COOP_TASKRUN` + `IORING_SETUP_TASKRUN_FLAG`.
-///
-/// These flags require Linux >= 5.19; on older kernels (e.g. 5.15) the shard
-/// `io_uring` setup fails with `EINVAL` even though the default-flag main-thread
-/// runtime initializes fine. Defaults to `true` (recommended, lowest latency).
-/// Set `IGGY_SHARD_RUNTIME_COOP_TASKRUN=false` to drop the flags and run on a
-/// 5.10..5.19 kernel at a small latency cost.
-fn coop_taskrun_from_env() -> bool {
-    std::env::var(SHARD_COOP_TASKRUN_ENV)
-        .map(|v| {
-            !matches!(
-                v.trim().to_ascii_lowercase().as_str(),
-                "false" | "0" | "no" | "off"
-            )
-        })
-        .unwrap_or(true)
-}
-
 /// Creates a compio runtime for a shard thread, with shard-specific `io_uring` flags.
 ///
 /// The per-ring SQ/CQ capacity defaults to `4096` and can be overridden via the
@@ -58,44 +75,36 @@ fn coop_taskrun_from_env() -> bool {
 ///
 /// `keep_worker_pool` must be `true` when TCP, HTTP, or WebSocket transports are
 /// active: those transports dispatch blocking ops through the asyncify thread pool
-/// even when COOP_TASKRUN is on, and a zero-worker pool panics with "thread pool
-/// is needed but no worker thread is running". Pass `false` only for pure
-/// QUIC-only deployments where every op stays on the ring.
+/// and a zero-worker pool panics with "thread pool is needed but no worker thread
+/// is running". Pass `false` only for pure QUIC-only deployments where every op
+/// stays on the ring.
 ///
 /// # Errors
 ///
-/// Returns an `std::io::Error` if the underlying `io_uring` proactor cannot be initialised.
-/// On `InvalidInput` the kernel rejected the required flags; on `OutOfMemory` or
-/// `PermissionDenied` the caller should print the appropriate diagnostic before panicking.
-///
-/// Shard executors request `IORING_SETUP_COOP_TASKRUN` for predictable latency.
-/// This is opt-out (not a silent fallback): the flags stay on by default and are
-/// only dropped when `IGGY_SHARD_RUNTIME_COOP_TASKRUN=false` is set explicitly,
-/// which is the documented escape hatch for kernels older than 5.19.
+/// Returns an `std::io::Error` if the underlying `io_uring` proactor cannot be
+/// initialised. On `InvalidInput` the kernel rejected the required flags; on
+/// `OutOfMemory` or `PermissionDenied` the caller should print the appropriate
+/// diagnostic before panicking.
 pub fn create_shard_executor(keep_worker_pool: bool) -> Result<Runtime, std::io::Error> {
     // TODO: The event interval tick, could be configured based on the fact
     // How many clients we expect to have connected.
     // This roughly estimates the number of tasks we will create.
     let mut proactor = compio::driver::ProactorBuilder::new();
-    let coop_taskrun = coop_taskrun_from_env();
 
-    proactor.capacity(shard_capacity_from_env());
-    if coop_taskrun {
-        proactor.coop_taskrun(true).taskrun_flag(true);
-    }
+    proactor
+        .capacity(shard_capacity_from_env())
+        .coop_taskrun(true)
+        .taskrun_flag(true);
 
     // FIXME(hubcio): Only set thread_pool_limit(0) on non-macOS platforms
     // This causes a freeze on macOS with compio fs operations
     // see https://github.com/compio-rs/compio/issues/446
     //
-    // Keep a worker pool whenever the caller signals it (TCP/HTTP/WS active),
-    // or when COOP_TASKRUN is off: in both cases compio may dispatch blocking
-    // ops (fs reads, JWT storage, TLS handshakes) through the asyncify pool,
-    // and a zero-worker pool panics with "thread pool is needed". Dropping the
-    // pool is only safe when modern io_uring flags handle every op on-ring AND
-    // no transport needs asyncify-backed blocking calls.
+    // Drop the asyncify worker pool only for pure QUIC deployments (no
+    // TCP/HTTP/WS): those transports need the pool for blocking ops such as
+    // TLS handshakes and JWT storage.
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    if coop_taskrun && !keep_worker_pool {
+    if !keep_worker_pool {
         proactor.thread_pool_limit(0);
     }
 
@@ -108,8 +117,8 @@ pub fn create_shard_executor(keep_worker_pool: bool) -> Result<Runtime, std::io:
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_SHARD_RUNTIME_CAPACITY, SHARD_COOP_TASKRUN_ENV, SHARD_RUNTIME_CAPACITY_ENV,
-        coop_taskrun_from_env, shard_capacity_from_env,
+        DEFAULT_SHARD_RUNTIME_CAPACITY, SHARD_RUNTIME_CAPACITY_ENV, check_kernel_version,
+        shard_capacity_from_env,
     };
     use serial_test::serial;
 
@@ -170,30 +179,42 @@ mod tests {
     }
 
     #[test]
-    #[serial]
-    fn coop_taskrun_defaults_to_true_when_unset() {
-        with_env(SHARD_COOP_TASKRUN_ENV, None, || {
-            assert!(coop_taskrun_from_env());
-        });
-    }
-
-    #[test]
-    #[serial]
-    fn coop_taskrun_disabled_by_falsey_values() {
-        for value in ["false", "0", "no", "off", "OFF", "False"] {
-            with_env(SHARD_COOP_TASKRUN_ENV, Some(value), || {
-                assert!(!coop_taskrun_from_env(), "{value} should disable");
-            });
+    fn check_kernel_version_accepts_current_kernel() {
+        // This test runs on the CI host; if the host is >= 6.8 the check passes.
+        // If CI runs on an older kernel the test is skipped rather than failed,
+        // because the check is a hard requirement for production, not for CI hosts.
+        let raw = std::fs::read_to_string("/proc/sys/kernel/osrelease");
+        if let Ok(raw) = raw {
+            let ver = raw.trim();
+            let mut p = ver.splitn(3, '.');
+            let major: u32 = p.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+            let minor: u32 = p
+                .next()
+                .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            if major > 6 || (major == 6 && minor >= 8) {
+                assert!(check_kernel_version().is_ok(), "kernel {ver} should pass");
+            }
         }
     }
 
     #[test]
-    #[serial]
-    fn coop_taskrun_enabled_by_truthy_values() {
-        for value in ["true", "1", "yes", "on"] {
-            with_env(SHARD_COOP_TASKRUN_ENV, Some(value), || {
-                assert!(coop_taskrun_from_env(), "{value} should enable");
-            });
-        }
+    fn check_kernel_version_rejects_old_kernel() {
+        // Directly test the parsing logic with a known-old version string.
+        // We can't call the real function because it reads /proc, so we inline
+        // the same logic with a synthetic input.
+        let version_str = "5.15.0-58-generic";
+        let mut parts = version_str.splitn(3, '.');
+        let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        let minor: u32 = parts
+            .next()
+            .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        assert!(
+            !(major > 6 || (major == 6 && minor >= 8)),
+            "5.15 should fail the >= 6.8 check"
+        );
     }
 }

--- a/core/server_common/src/executor.rs
+++ b/core/server_common/src/executor.rs
@@ -20,40 +20,49 @@ use compio::runtime::Runtime;
 const DEFAULT_SHARD_RUNTIME_CAPACITY: u32 = 4096;
 const SHARD_RUNTIME_CAPACITY_ENV: &str = "IGGY_SHARD_RUNTIME_CAPACITY";
 
-// Minimum kernel required by IORING_SETUP_COOP_TASKRUN + full io_uring feature set.
-const MIN_KERNEL_MAJOR: u32 = 6;
-const MIN_KERNEL_MINOR: u32 = 8;
+// IORING_SETUP_COOP_TASKRUN and IORING_SETUP_TASKRUN_FLAG both landed in Linux 5.19.
+// diagnostics.rs encodes the same floor; keep both in sync when changing.
+const MIN_KERNEL_MAJOR: u32 = 5;
+const MIN_KERNEL_MINOR: u32 = 19;
+
+fn parse_kernel_version(release: &str) -> Option<(u32, u32)> {
+    let mut parts = release.trim().splitn(3, '.');
+    let major: u32 = parts.next().and_then(|s| s.parse().ok())?;
+    let minor: u32 = parts
+        .next()
+        .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+        .and_then(|s| s.parse().ok())?;
+    Some((major, minor))
+}
+
+fn kernel_meets_min(major: u32, minor: u32) -> bool {
+    major > MIN_KERNEL_MAJOR || (major == MIN_KERNEL_MAJOR && minor >= MIN_KERNEL_MINOR)
+}
 
 /// Reads the running kernel version from `/proc/sys/kernel/osrelease` and returns
-/// `Err` with a human-readable message if the kernel is older than 6.8.
+/// `Err` with a human-readable message if the kernel is older than 5.19.
+///
+/// No-op on non-Linux platforms (always returns `Ok(())`).
 ///
 /// Call this once at process startup, before `create_shard_executor`. Both the
 /// classic server and server-ng entry points do this; tests skip it unless they
 /// intentionally exercise the check.
 pub fn check_kernel_version() -> Result<(), String> {
-    let raw = std::fs::read_to_string("/proc/sys/kernel/osrelease")
-        .map_err(|e| format!("cannot read kernel version: {e}"))?;
-
-    let version_str = raw.trim();
-    let mut parts = version_str.splitn(3, '.');
-    let major: u32 = parts
-        .next()
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| format!("cannot parse kernel version: {version_str}"))?;
-    let minor: u32 = parts
-        .next()
-        .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| format!("cannot parse kernel version: {version_str}"))?;
-
-    if major > MIN_KERNEL_MAJOR || (major == MIN_KERNEL_MAJOR && minor >= MIN_KERNEL_MINOR) {
-        Ok(())
-    } else {
-        Err(format!(
-            "kernel {version_str} is below the minimum required {MIN_KERNEL_MAJOR}.{MIN_KERNEL_MINOR}; \
-             upgrade the kernel or use a supported host"
-        ))
+    #[cfg(target_os = "linux")]
+    {
+        let raw = std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map_err(|e| format!("cannot read kernel version: {e}"))?;
+        let (major, minor) = parse_kernel_version(&raw)
+            .ok_or_else(|| format!("cannot parse kernel version: {}", raw.trim()))?;
+        if !kernel_meets_min(major, minor) {
+            return Err(format!(
+                "kernel {major}.{minor} is below the minimum required \
+                 {MIN_KERNEL_MAJOR}.{MIN_KERNEL_MINOR}; \
+                 upgrade the kernel or use a supported host"
+            ));
+        }
     }
+    Ok(())
 }
 
 /// Resolves the per-shard io_uring SQ/CQ capacity from `IGGY_SHARD_RUNTIME_CAPACITY`,
@@ -73,11 +82,15 @@ fn shard_capacity_from_env() -> u32 {
 /// harness sets to `256` so N nodes * M shards fit under an 8 MiB
 /// `RLIMIT_MEMLOCK` budget without `ENOMEM` at ring setup.
 ///
-/// `keep_worker_pool` must be `true` when TCP, HTTP, or WebSocket transports are
+/// Pass `keep_worker_pool = true` when TCP, HTTP, or WebSocket transports are
 /// active: those transports dispatch blocking ops through the asyncify thread pool
 /// and a zero-worker pool panics with "thread pool is needed but no worker thread
-/// is running". Pass `false` only for pure QUIC-only deployments where every op
-/// stays on the ring.
+/// is running".
+///
+/// Pass `false` only for pure QUIC-only deployments where **no** code path reaches
+/// `compio::runtime::spawn_blocking`. Currently safe because io_uring opcodes cover
+/// all fs I/O (fsync, read, write) and the QUIC server does not call DNS resolution
+/// or `compio::fs::set_permissions`. If either changes, pass `true` instead.
 ///
 /// # Errors
 ///
@@ -85,7 +98,7 @@ fn shard_capacity_from_env() -> u32 {
 /// initialised. On `InvalidInput` the kernel rejected the required flags; on
 /// `OutOfMemory` or `PermissionDenied` the caller should print the appropriate
 /// diagnostic before panicking.
-pub fn create_shard_executor(keep_worker_pool: bool) -> Result<Runtime, std::io::Error> {
+pub fn create_shard_executor(_keep_worker_pool: bool) -> Result<Runtime, std::io::Error> {
     // TODO: The event interval tick, could be configured based on the fact
     // How many clients we expect to have connected.
     // This roughly estimates the number of tasks we will create.
@@ -104,7 +117,7 @@ pub fn create_shard_executor(keep_worker_pool: bool) -> Result<Runtime, std::io:
     // TCP/HTTP/WS): those transports need the pool for blocking ops such as
     // TLS handshakes and JWT storage.
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    if !keep_worker_pool {
+    if !_keep_worker_pool {
         proactor.thread_pool_limit(0);
     }
 
@@ -117,7 +130,8 @@ pub fn create_shard_executor(keep_worker_pool: bool) -> Result<Runtime, std::io:
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_SHARD_RUNTIME_CAPACITY, SHARD_RUNTIME_CAPACITY_ENV, check_kernel_version,
+        DEFAULT_SHARD_RUNTIME_CAPACITY, MIN_KERNEL_MAJOR, MIN_KERNEL_MINOR,
+        SHARD_RUNTIME_CAPACITY_ENV, check_kernel_version, kernel_meets_min, parse_kernel_version,
         shard_capacity_from_env,
     };
     use serial_test::serial;
@@ -179,42 +193,56 @@ mod tests {
     }
 
     #[test]
-    fn check_kernel_version_accepts_current_kernel() {
-        // This test runs on the CI host; if the host is >= 6.8 the check passes.
-        // If CI runs on an older kernel the test is skipped rather than failed,
-        // because the check is a hard requirement for production, not for CI hosts.
-        let raw = std::fs::read_to_string("/proc/sys/kernel/osrelease");
-        if let Ok(raw) = raw {
-            let ver = raw.trim();
-            let mut p = ver.splitn(3, '.');
-            let major: u32 = p.next().and_then(|s| s.parse().ok()).unwrap_or(0);
-            let minor: u32 = p
-                .next()
-                .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0);
-            if major > 6 || (major == 6 && minor >= 8) {
-                assert!(check_kernel_version().is_ok(), "kernel {ver} should pass");
-            }
-        }
+    fn parse_kernel_version_accepts_plain() {
+        assert_eq!(parse_kernel_version("5.19.0"), Some((5, 19)));
+        assert_eq!(parse_kernel_version("6.8.0"), Some((6, 8)));
     }
 
     #[test]
-    fn check_kernel_version_rejects_old_kernel() {
-        // Directly test the parsing logic with a known-old version string.
-        // We can't call the real function because it reads /proc, so we inline
-        // the same logic with a synthetic input.
-        let version_str = "5.15.0-58-generic";
-        let mut parts = version_str.splitn(3, '.');
-        let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
-        let minor: u32 = parts
-            .next()
-            .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-        assert!(
-            !(major > 6 || (major == 6 && minor >= 8)),
-            "5.15 should fail the >= 6.8 check"
-        );
+    fn parse_kernel_version_accepts_distro_suffix() {
+        assert_eq!(parse_kernel_version("5.19.0-58-generic"), Some((5, 19)));
+        assert_eq!(parse_kernel_version("6.8.12-8-pve"), Some((6, 8)));
+    }
+
+    #[test]
+    fn parse_kernel_version_rejects_malformed() {
+        assert_eq!(parse_kernel_version("not-a-version"), None);
+        assert_eq!(parse_kernel_version("5"), None);
+    }
+
+    #[test]
+    fn kernel_meets_min_accepts_exact_boundary() {
+        assert!(kernel_meets_min(MIN_KERNEL_MAJOR, MIN_KERNEL_MINOR));
+    }
+
+    #[test]
+    fn kernel_meets_min_accepts_newer() {
+        assert!(kernel_meets_min(6, 8));
+        assert!(kernel_meets_min(6, 0));
+    }
+
+    #[test]
+    fn kernel_meets_min_rejects_old() {
+        assert!(!kernel_meets_min(5, 15));
+        assert!(!kernel_meets_min(5, 18));
+        assert!(!kernel_meets_min(4, 19));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn check_kernel_version_matches_host() {
+        // Only asserts when the host is >= 5.19; older CI environments are skipped
+        // rather than failed because this is a production requirement, not a CI one.
+        if let Some((major, minor)) = std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .ok()
+            .and_then(|s| parse_kernel_version(&s))
+            .filter(|&(maj, min)| kernel_meets_min(maj, min))
+        {
+            assert!(
+                check_kernel_version().is_ok(),
+                "kernel {major}.{minor} should pass the \
+                 >= {MIN_KERNEL_MAJOR}.{MIN_KERNEL_MINOR} check"
+            );
+        }
     }
 }

--- a/core/server_common/src/lib.rs
+++ b/core/server_common/src/lib.rs
@@ -53,7 +53,7 @@ pub use consensus_message::{
     MutableBacking, RequestBacking, RequestBackingKind, ResponseBacking, ResponseBackingKind,
 };
 pub use deduplication::MessageDeduplicator;
-pub use executor::create_shard_executor;
+pub use executor::{check_kernel_version, create_shard_executor};
 pub use in_flight::IggyMessagesBatchSetInFlight;
 pub use indexes_mut::IggyIndexesMut;
 pub use memory_pool::{MEMORY_POOL, MemoryPool, MemoryPoolConfigOther, memory_pool};


### PR DESCRIPTION
## Summary

`IORING_SETUP_COOP_TASKRUN` and `IORING_SETUP_TASKRUN_FLAG` landed in Linux 5.19. On older kernels the shard io_uring setup fails with `EINVAL` at ring creation, preventing server boot entirely.

This PR fixes that in two steps:

1. **Reject kernels < 5.19 at startup** (`server`, `server-ng`). Both entry points call `check_kernel_version()` as the first statement of `main()`. On kernels below 5.19 the server prints a clear error and exits with code 1 rather than crashing deeper in ring setup. The check is a no-op on non-Linux platforms (`#[cfg(target_os = "linux")]`). (`feat(server)`)

2. **Decouple `thread_pool_limit` from COOP_TASKRUN.** TCP, HTTP, and WebSocket transports dispatch blocking ops through the asyncify thread pool. Tying `thread_pool_limit(0)` to COOP_TASKRUN panics on those transports. `create_shard_executor` now takes an explicit `keep_worker_pool: bool`; both server entry points derive it from their loaded config. (`fix(server)`)

## Files changed

- `core/server_common/src/executor.rs` -- `check_kernel_version()`, `parse_kernel_version()`, `kernel_meets_min()` (pure, testable); `create_shard_executor(keep_worker_pool: bool)`
- `core/server/src/main.rs` -- startup kernel check + `keep_worker_pool` derivation
- `core/server-ng/src/main.rs`, `core/server-ng/src/bootstrap.rs` -- same
- `.github/actions/rust/pre-merge/action.yml` -- smoke-launch step in `test-1` leg

## Test plan

- [ ] `cargo clippy -p server -p server-ng -p server_common -- -D warnings` passes
- [ ] `cargo test -p server_common` passes (unit tests cover `parse_kernel_version`, `kernel_meets_min`, and call `check_kernel_version()` on the host)
- [ ] CI smoke-launch step exits without the kernel-rejection message

🤖 Generated with [Claude Code](https://claude.com/claude-code)