### PR TITLE
fix(connectors): bring quickwit_sink up to convention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7137,9 +7137,10 @@ name = "iggy_connector_quickwit_sink"
 version = "0.4.1-edge.1"
 dependencies = [
  "async-trait",
- "dashmap",
+ "base64",
  "iggy_connector_sdk",
  "reqwest 0.13.4",
+ "reqwest-middleware",
  "serde",
  "serde_yaml_ng",
  "simd-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7349,9 +7349,10 @@ name = "iggy_connector_quickwit_sink"
 version = "0.5.0-edge.4"
 dependencies = [
  "async-trait",
- "dashmap",
+ "base64",
  "iggy_connector_sdk",
  "reqwest 0.13.4",
+ "reqwest-middleware",
  "serde",
  "serde_yaml_ng",
  "simd-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7349,13 +7349,15 @@ name = "iggy_connector_quickwit_sink"
 version = "0.5.0-edge.4"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.1",
+ "humantime",
  "iggy_connector_sdk",
  "reqwest 0.13.4",
  "reqwest-middleware",
  "serde",
  "serde_yaml_ng",
  "simd-json",
+ "tokio",
  "tracing",
 ]
 

--- a/core/connectors/runtime/example_config/connectors/quickwit_sink.toml
+++ b/core/connectors/runtime/example_config/connectors/quickwit_sink.toml
@@ -53,6 +53,13 @@ fields = ["email", "created_at"]
 
 [plugin_config]
 url = "http://localhost:7280"
+verbose_logging = false
+# max_retries = 3
+# retry_delay = "200ms"
+# retry_max_delay = "5s"
+# max_open_retries = 5
+# open_retry_max_delay = "30s"
+# timeout = "30s"
 index = """
 version: 0.9
 

--- a/core/connectors/runtime/example_config/connectors/quickwit_sink.toml
+++ b/core/connectors/runtime/example_config/connectors/quickwit_sink.toml
@@ -21,8 +21,6 @@ enabled = true
 version = 0
 name = "Quickwit sink 1"
 path = "target/release/libiggy_connector_quickwit_sink"
-# Set the format here. The PLUGIN_CONFIG_FORMAT env override also injects an
-# unsupported plugin_config.format field and prevents Quickwit initialization.
 plugin_config_format = "yaml"
 verbose = false
 

--- a/core/connectors/runtime/example_config/connectors/quickwit_sink.toml
+++ b/core/connectors/runtime/example_config/connectors/quickwit_sink.toml
@@ -21,6 +21,8 @@ enabled = true
 version = 0
 name = "Quickwit sink 1"
 path = "target/release/libiggy_connector_quickwit_sink"
+# Set the format here. The PLUGIN_CONFIG_FORMAT env override also injects an
+# unsupported plugin_config.format field and prevents Quickwit initialization.
 plugin_config_format = "yaml"
 verbose = false
 
@@ -54,10 +56,12 @@ fields = ["email", "created_at"]
 [plugin_config]
 url = "http://localhost:7280"
 verbose_logging = false
+# Total attempts including the first; 1 disables retries.
 # max_retries = 3
-# retry_delay = "200ms"
+# retry_delay = "1s"
 # retry_max_delay = "5s"
-# max_open_retries = 5
+# Total readiness probes including the first; 1 disables retries.
+# max_open_retries = 10
 # open_retry_max_delay = "30s"
 # timeout = "30s"
 index = """
@@ -66,7 +70,7 @@ version: 0.9
 index_id: events
 
 doc_mapping:
-  mode: strict
+  mode: dynamic
   field_mappings:
     - name: timestamp
       type: datetime
@@ -100,12 +104,15 @@ doc_mapping:
       type: text
       tokenizer: default
 
-  timestamp_field: timestamp
+  # Enable timestamp sharding only when every document contains timestamp.
+  # Raw/text wrappers do not acquire fields from the add_fields transform.
+  # timestamp_field: timestamp
 
 indexing_settings:
   commit_timeout_secs: 10
 
-retention:
-  period: 7 days
-  schedule: daily
+# Retention requires timestamp_field above.
+# retention:
+#   period: 7 days
+#   schedule: daily
 """

--- a/core/connectors/runtime/src/configs/connectors/local_provider.rs
+++ b/core/connectors/runtime/src/configs/connectors/local_provider.rs
@@ -32,6 +32,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use tracing::{debug, info, warn};
 
+const PLUGIN_CONFIG_FORMAT_ENV_SUFFIX: &str = "FORMAT";
+
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
 struct ConnectorId {
     key: String,
@@ -355,6 +357,10 @@ impl<S: ProviderState> LocalConnectorsConfigProvider<S> {
             }
 
             let field_path = &env_key_upper[prefix.len()..];
+            // ConfigEnv handles plugin_config_format on the connector itself.
+            if field_path == PLUGIN_CONFIG_FORMAT_ENV_SUFFIX {
+                continue;
+            }
             let field_name = field_path.to_lowercase();
             let parsed_value = ::configs::parse_env_value_to_json(&env_value);
 
@@ -855,8 +861,12 @@ impl Provider for ConnectorEnvProvider {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::process::Command;
+
     use tempfile::TempDir;
+
+    use super::*;
+    use crate::configs::connectors::ConfigFormat;
 
     #[tokio::test]
     async fn given_valid_key_when_creating_source_config_should_write_prefixed_file() {
@@ -879,5 +889,129 @@ mod tests {
             .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
             .collect();
         assert_eq!(entries, vec!["source_random_0.toml"]);
+    }
+
+    #[test]
+    fn given_runtime_format_env_when_loading_configs_should_preserve_plugin_overrides() {
+        const CHILD_PROCESS_ENV: &str = "IGGY_CONNECTORS_FORMAT_OVERRIDE_TEST";
+        const CONNECTOR_KEY: &str = "format_override_test";
+        const FORMAT_ONLY_KEY: &str = "format_only_test";
+
+        if std::env::var_os(CHILD_PROCESS_ENV).is_none() {
+            // Environment overrides stay in a child process to avoid racing other tests.
+            let mut command = Command::new(
+                std::env::current_exe().expect("Test binary path should be available"),
+            );
+            command
+                .arg("--exact")
+                .arg(
+                    std::thread::current()
+                        .name()
+                        .expect("Test thread should have a name"),
+                )
+                .env_clear()
+                .env(CHILD_PROCESS_ENV, "1");
+            for connector_type in ["SINK", "SOURCE"] {
+                let prefix = format!(
+                    "IGGY_CONNECTORS_{connector_type}_{}_PLUGIN_CONFIG_",
+                    CONNECTOR_KEY.to_uppercase()
+                );
+                command
+                    .env(format!("{prefix}FORMAT"), "yaml")
+                    .env(format!("{prefix}URL"), "http://overridden.test")
+                    .env(format!("{prefix}FORMAT_OPTIONS"), r#"["compact","json"]"#)
+                    .env(
+                        format!(
+                            "IGGY_CONNECTORS_{connector_type}_{}_PLUGIN_CONFIG_FORMAT",
+                            FORMAT_ONLY_KEY.to_uppercase()
+                        ),
+                        "yaml",
+                    );
+            }
+            let output = command.output().expect("Config override test should run");
+            assert!(
+                output.status.success(),
+                "Config override test failed:\n{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        let dir = TempDir::new().expect("Config directory should be created");
+        for connector_type in ["sink", "source"] {
+            for key in [CONNECTOR_KEY, FORMAT_ONLY_KEY] {
+                let mut config = format!(
+                    r#"
+type = "{connector_type}"
+key = "{key}"
+enabled = true
+version = 0
+name = "format override test"
+path = "unused"
+streams = []
+plugin_config_format = "json"
+"#
+                );
+                if key == CONNECTOR_KEY {
+                    config.push_str(
+                        r#"
+[plugin_config]
+url = "http://original.test"
+format_options = ["original"]
+[plugin_config.headers]
+content_type = "application/json"
+"#,
+                    );
+                }
+                std::fs::write(
+                    dir.path().join(format!("{connector_type}_{key}.toml")),
+                    config,
+                )
+                .expect("Connector config should be written");
+            }
+        }
+
+        let runtime = tokio::runtime::Runtime::new().expect("Test runtime should be created");
+        runtime.block_on(async {
+            let provider = LocalConnectorsConfigProvider::new(
+                dir.path()
+                    .to_str()
+                    .expect("Config directory should be UTF-8"),
+            )
+            .init()
+            .await
+            .expect("Connector configs should load");
+
+            for key in [CONNECTOR_KEY, FORMAT_ONLY_KEY] {
+                let sink = provider
+                    .get_sink_config(key, None)
+                    .await
+                    .expect("Sink config should be available")
+                    .expect("Sink config should exist");
+                let source = provider
+                    .get_source_config(key, None)
+                    .await
+                    .expect("Source config should be available")
+                    .expect("Source config should exist");
+                let expected_plugin_config = (key == CONNECTOR_KEY).then(|| {
+                    serde_json::json!({
+                        "url": "http://overridden.test",
+                        "headers": {"content_type": "application/json"},
+                        "format_options": ["compact", "json"]
+                    })
+                });
+                for (connector_type, format, plugin_config) in [
+                    ("sink", sink.plugin_config_format, sink.plugin_config),
+                    ("source", source.plugin_config_format, source.plugin_config),
+                ] {
+                    assert_eq!(format, Some(ConfigFormat::Yaml), "{connector_type} {key}");
+                    assert_eq!(
+                        plugin_config, expected_plugin_config,
+                        "{connector_type} {key}"
+                    );
+                }
+            }
+        });
     }
 }

--- a/core/connectors/sinks/quickwit_sink/Cargo.toml
+++ b/core/connectors/sinks/quickwit_sink/Cargo.toml
@@ -29,17 +29,15 @@ repository = "https://github.com/apache/iggy"
 readme = "../../README.md"
 publish = false
 
-[package.metadata.cargo-machete]
-ignored = ["dashmap"]
-
 [lib]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
 async-trait = { workspace = true }
-dashmap = { workspace = true }
+base64 = { workspace = true }
 iggy_connector_sdk = { workspace = true }
 reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
 serde = { workspace = true }
 serde_yaml_ng = { workspace = true }
 simd-json = { workspace = true }

--- a/core/connectors/sinks/quickwit_sink/Cargo.toml
+++ b/core/connectors/sinks/quickwit_sink/Cargo.toml
@@ -35,6 +35,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
+humantime = { workspace = true }
 iggy_connector_sdk = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
@@ -42,6 +43,9 @@ serde = { workspace = true }
 serde_yaml_ng = { workspace = true }
 simd-json = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/core/connectors/sinks/quickwit_sink/README.md
+++ b/core/connectors/sinks/quickwit_sink/README.md
@@ -18,7 +18,7 @@ The Quickwit connector sends data to the Quickwit API using HTTP. It checks read
 
 Duration values require units, such as `250ms` or `30s`. Invalid or zero durations prevent initialization. Unknown plugin configuration keys are rejected.
 
-Set `plugin_config_format` in the connector TOML. The runtime also treats `IGGY_CONNECTORS_SINK_QUICKWIT_PLUGIN_CONFIG_FORMAT` as a plugin configuration override, injecting an unsupported `format` key. Setting that environment variable therefore prevents initialization.
+Set `plugin_config_format` in the connector TOML or with the `IGGY_CONNECTORS_SINK_QUICKWIT_PLUGIN_CONFIG_FORMAT` environment variable.
 
 ```toml
 [plugin_config]

--- a/core/connectors/sinks/quickwit_sink/README.md
+++ b/core/connectors/sinks/quickwit_sink/README.md
@@ -1,22 +1,44 @@
 # Quickwit Sink
 
-The Quickwit connector allows you to send data to the Quickwit API using HTTP. This sink will ensure that the index exists (create it if it doesn't) and will append the data to the index using the same batch size as specified in the Iggy configuration.
+The Quickwit connector sends data to the Quickwit API using HTTP. It checks readiness when opening, creates the index if needed, and appends messages as NDJSON. Requests are split at 8 MiB, including the newline after each document. A larger individual document is logged and rejected while other documents continue.
 
 ## Configuration
 
-- `url`: The URL of the Quickwit server.
-- `index`: The index configuration using YAML, as described in the [Quickwit index configuration docs](https://quickwit.io/docs/configuration/index-config)
+| Key | Default | Description |
+| --- | --- | --- |
+| `url` | Required | Quickwit base URL with an `http` or `https` scheme and host. Path prefixes and a trailing slash are supported; query strings and fragments are rejected. |
+| `index` | Required | Index configuration as YAML, with a nonempty `index_id`. See the [Quickwit index configuration docs](https://quickwit.io/docs/configuration/index-config). |
+| `verbose_logging` | `false` | Log received and ingested message counts at `info` instead of `debug`. |
+| `max_retries` | `3` | Total HTTP attempts including the first; `1` disables retries. |
+| `retry_delay` | `"1s"` | Base exponential delay for HTTP retries and readiness probes. |
+| `retry_max_delay` | `"5s"` | Maximum delay between HTTP retry attempts. |
+| `max_open_retries` | `10` | Total readiness probes including the first; `1` disables retries. |
+| `open_retry_max_delay` | `"30s"` | Maximum delay between readiness probes. |
+| `timeout` | `"30s"` | Timeout for each HTTP request. |
+
+Duration values require units, such as `250ms` or `30s`. Invalid or zero durations prevent initialization. Unknown plugin configuration keys are rejected.
+
+Set `plugin_config_format` in the connector TOML. The runtime also treats `IGGY_CONNECTORS_SINK_QUICKWIT_PLUGIN_CONFIG_FORMAT` as a plugin configuration override, injecting an unsupported `format` key. Setting that environment variable therefore prevents initialization.
 
 ```toml
 [plugin_config]
 url = "http://localhost:7280"
+verbose_logging = false
+# Total attempts including the first; 1 disables retries.
+max_retries = 3
+retry_delay = "1s"
+retry_max_delay = "5s"
+# Total readiness probes including the first; 1 disables retries.
+max_open_retries = 10
+open_retry_max_delay = "30s"
+timeout = "30s"
 index = """
 version: 0.9
 
 index_id: events
 
 doc_mapping:
-  mode: strict
+  mode: dynamic
   field_mappings:
     - name: timestamp
       type: datetime
@@ -50,13 +72,39 @@ doc_mapping:
       type: text
       tokenizer: default
 
-  timestamp_field: timestamp
+  # Enable only when every document contains timestamp.
+  # timestamp_field: timestamp
 
 indexing_settings:
   commit_timeout_secs: 10
 
-retention:
-  period: 7 days
-  schedule: daily
+# Retention requires timestamp_field above.
+# retention:
+#   period: 7 days
+#   schedule: daily
 """
 ```
+
+## Document shapes
+
+The stream's `schema` selects the runtime decoder. The sink sends JSON objects using these shapes:
+
+| Payload | Example document |
+| --- | --- |
+| JSON object, including an object parsed from raw bytes | `{"message":"ready"}` |
+| JSON array or scalar | `{"data":[1,2],"data_type":"json"}` or `{"data":42,"data_type":"json"}` |
+| Raw UTF-8 that is not a JSON object | `{"data":"ready","data_type":"raw","data_encoding":"utf8"}` |
+| Raw non-UTF-8 bytes | `{"data":"/wCA","data_type":"raw","data_encoding":"base64"}` |
+| Text | `{"text":"ready","data_type":"text"}` |
+
+Raw JSON arrays and scalars remain UTF-8 strings in the raw wrapper. Malformed JSON also preserves the original bytes. `data_encoding` distinguishes literal text from base64. The sink handles `Payload::Avro` and `Payload::FlatBuffer` with the raw path, and `Payload::Proto` with the text wrapper. Runtime decoder settings determine which payload variant reaches the sink.
+
+The examples use `mode: dynamic` to retain wrapper fields. With `mode: strict`, map every field emitted by the selected payload shape or Quickwit rejects the document during indexing, even after a successful HTTP response. Timestamp sharding and retention are optional here: raw/text wrappers have no `timestamp`, and the `add_fields` transform only enriches JSON payloads. Configure them only when every document supplies the required timestamp.
+
+## Delivery semantics
+
+Transient HTTP failures, including 429, can retry a request that Quickwit already accepted. Quickwit ingest has no deduplication key, so these retries can produce duplicate documents. Set `max_retries = 1` to disable HTTP retries and use at-most-once request submission.
+
+The sink cannot guarantee at-least-once delivery. The runtime commits offsets when polling and ignores the plugin's consume return code. A permanent error or exhausted retry budget is logged, but affected messages are not redelivered. The runtime's processed-message count does not prove successful indexing. These runtime limitations are tracked in [#2927](https://github.com/apache/iggy/issues/2927) and [#2928](https://github.com/apache/iggy/issues/2928).
+
+Chunks are independent: successful writes remain committed if another chunk fails. The sink continues later chunks and returns the last error. A successful ingest response acknowledges submission for indexing, not that every document passed the index mapping. This sink has no circuit breaker.

--- a/core/connectors/sinks/quickwit_sink/config.toml
+++ b/core/connectors/sinks/quickwit_sink/config.toml
@@ -34,3 +34,12 @@ consumer_group = "quickwit_sink"
 [plugin_config]
 url = ""
 index = ""
+verbose_logging = true
+# Total attempts including the first; 1 disables retries.
+max_retries = 2
+retry_delay = "250ms"
+retry_max_delay = "2s"
+# Total readiness probes including the first; 1 disables retries.
+max_open_retries = 8
+open_retry_max_delay = "10s"
+timeout = "10s"

--- a/core/connectors/sinks/quickwit_sink/src/lib.rs
+++ b/core/connectors/sinks/quickwit_sink/src/lib.rs
@@ -16,29 +16,65 @@
 // under the License.
 
 use async_trait::async_trait;
-use iggy_connector_sdk::{
-    ConsumedMessage, Error, MessagesMetadata, Payload, Sink, TopicMetadata, sink_connector,
+use base64::{Engine as _, engine::general_purpose};
+use iggy_connector_sdk::retry::{
+    ConnectivityConfig, build_retry_client, check_connectivity_with_retry, parse_duration,
 };
-use serde::{Deserialize, Serialize};
-use tracing::{error, info, warn};
+use iggy_connector_sdk::{
+    ConsumedMessage, Error, MessagesMetadata, Payload, Schema, Sink, TopicMetadata, sink_connector,
+};
+use reqwest::StatusCode;
+use reqwest::Url;
+use reqwest_middleware::ClientWithMiddleware;
+use serde::Deserialize;
+use simd_json::OwnedValue;
+use tracing::{debug, error, info, warn};
 
 sink_connector!(QuickwitSink);
+
+const DEFAULT_MAX_RETRIES: u32 = 3;
+const DEFAULT_RETRY_DELAY: &str = "200ms";
+const DEFAULT_RETRY_MAX_DELAY: &str = "5s";
+const DEFAULT_MAX_OPEN_RETRIES: u32 = 5;
+const DEFAULT_OPEN_RETRY_MAX_DELAY: &str = "30s";
+const DEFAULT_TIMEOUT: &str = "30s";
 
 #[derive(Debug)]
 pub struct QuickwitSink {
     id: u32,
     config: QuickwitSinkConfig,
-    client: reqwest::Client,
+    client: Option<ClientWithMiddleware>,
+    verbose: bool,
     index_id: String,
+    base_url: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// Configuration for the Quickwit sink connector, deserialized from [plugin_config] in config.toml.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct QuickwitSinkConfig {
-    url: String,
-    index: String,
+    /// Target URL for the Quickwit service.
+    pub url: String,
+    /// Full Quickwit index config YAML, passed to `POST /api/v1/indexes` on first open.
+    /// `index_id` is extracted from this YAML to build ingest URLs.
+    pub index: String,
+    /// Enable verbose logging for ingested messages (default: false).
+    pub verbose_logging: Option<bool>,
+    /// Maximum number of retries for transient ingest errors (default: 3).
+    pub max_retries: Option<u32>,
+    /// Initial retry delay as a human-readable duration string, e.g. "200ms" (default: 200ms).
+    pub retry_delay: Option<String>,
+    /// Maximum retry delay cap as a human-readable duration string, e.g. "5s" (default: 5s).
+    pub retry_max_delay: Option<String>,
+    /// Maximum number of connectivity retries when opening the sink (default: 5).
+    pub max_open_retries: Option<u32>,
+    /// Maximum retry delay cap when opening the sink, e.g. "30s" (default: 30s).
+    pub open_retry_max_delay: Option<String>,
+    /// HTTP request timeout as a human-readable duration string, e.g. "30s" (default: 30s).
+    pub timeout: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 struct IndexConfig {
     index_id: String,
 }
@@ -47,127 +83,265 @@ impl QuickwitSink {
     pub fn new(id: u32, config: QuickwitSinkConfig) -> Self {
         let index_config =
             serde_yaml_ng::from_str::<IndexConfig>(&config.index).expect("Invalid index config.");
-        QuickwitSink {
+        let verbose = config.verbose_logging.unwrap_or(false);
+        let base_url = config.url.trim_end_matches('/').to_owned();
+        Self {
             id,
             config,
+            client: None,
+            verbose,
             index_id: index_config.index_id,
-            client: reqwest::Client::new(),
+            base_url,
         }
     }
 
+    fn client(&self) -> Result<&ClientWithMiddleware, Error> {
+        self.client
+            .as_ref()
+            .ok_or_else(|| Error::InitError("Quickwit sink client not initialized".into()))
+    }
+
     async fn has_index(&self) -> Result<bool, Error> {
-        let url = format!("{}/api/v1/indexes/{}", self.config.url, self.index_id);
-        let response = self.client.get(&url).send().await.map_err(|error| {
-            error!(
-                "Failed to send HTTP request to check if index with ID: {} exists. {error}",
-                self.index_id
-            );
-            Error::HttpRequestFailed(error.to_string())
-        })?;
+        let client = self.client()?;
+        let url = format!("{}/api/v1/indexes/{}", self.base_url, self.index_id);
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| Error::HttpRequestFailed(e.to_string()))?;
         let status = response.status();
         if status.is_success() {
             Ok(true)
-        } else if status == reqwest::StatusCode::NOT_FOUND {
+        } else if status == StatusCode::NOT_FOUND {
             Ok(false)
         } else {
             Err(Error::HttpRequestFailed(format!(
-                "Unexpected status code: {status}",
+                "Unexpected status checking Quickwit index: {status}"
             )))
         }
     }
 
     async fn create_index(&self) -> Result<(), Error> {
-        info!("Creating index: {}", self.index_id);
-        let url = format!("{}/api/v1/indexes", self.config.url);
-        let response = self
-            .client
+        info!(
+            "Creating Quickwit index: {} for connector ID: {}",
+            self.index_id, self.id
+        );
+        let client = self.client()?;
+        let url = format!("{}/api/v1/indexes", self.base_url);
+        let response = client
             .post(&url)
-            .header("content-type", "application/yaml")
-            .body(self.config.index.to_owned())
+            .header("Content-Type", "application/yaml")
+            .body(self.config.index.clone())
             .send()
             .await
-            .map_err(|error| {
+            .map_err(|e| {
                 error!(
-                    "Failed to send HTTP request to create index: {}. {error}",
-                    self.index_id
+                    "Failed to create Quickwit index: {} for connector ID: {}. {e}",
+                    self.index_id, self.id
                 );
-                Error::HttpRequestFailed(error.to_string())
+                Error::HttpRequestFailed(e.to_string())
             })?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let reason = response.text().await.unwrap_or_default();
-            error!(
-                "Received an invalid HTTP response when creating index: {}. Status code: {status}, reason: {reason}",
-                self.index_id
+        let status = response.status();
+        if status.is_success() {
+            info!(
+                "Created Quickwit index: {} for connector ID: {}",
+                self.index_id, self.id
             );
-            return Err(Error::InitError(format!(
-                "Failed to create index: {}. {reason}",
-                self.index_id
-            )));
+            Ok(())
+        } else {
+            let reason = response.text().await.unwrap_or_default();
+            if status == StatusCode::CONFLICT
+                || (status == StatusCode::BAD_REQUEST
+                    && reason.to_lowercase().contains("already exists"))
+            {
+                info!(
+                    "Quickwit index already exists ({status}): {} for connector ID: {}",
+                    self.index_id, self.id
+                );
+                Ok(())
+            } else {
+                error!(
+                    "Failed creating Quickwit index: {} for connector ID: {}. status: {status}, reason: {reason}",
+                    self.index_id, self.id
+                );
+                Err(Error::InitError(format!(
+                    "Failed to create index '{0}': {status} {reason}",
+                    self.index_id
+                )))
+            }
         }
-
-        info!("Created index: {}", self.index_id);
-        Ok(())
     }
 
     pub async fn ingest(&self, messages: Vec<simd_json::OwnedValue>) -> Result<(), Error> {
+        let client = self.client()?;
+        // At-least-once during transient retries, but at-most-once on final failure:
+        // Quickwit ingest carries no dedup key, so a retry after a transient 5xx/timeout
+        // that actually committed double-writes those rows. Conversely, if a batch permanently
+        // fails (e.g. 4xx client error or retries exhausted), the offset was already committed
+        // at poll, so the batch is silently dropped and never redelivered.
         let url = format!(
             "{}/api/v1/{}/ingest?commit=auto",
-            self.config.url, self.index_id
+            self.base_url, self.index_id
         );
-        info!("Ingesting messages for index: {}...", self.index_id);
-        let messages_count = messages.len();
-        let messages = messages
-            .into_iter()
-            .filter_map(|record| simd_json::to_string(&record).ok())
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let response = self
-            .client
-            .post(&url)
-            .body(messages)
-            .send()
-            .await
-            .map_err(|error| {
-                error!(
-                    "Failed to send HTTP request to ingest messages for index: {}. {error}",
-                    self.index_id
-                );
-                Error::HttpRequestFailed(error.to_string())
-            })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_default();
-            error!(
-                "Received an invalid HTTP response when ingesting messages for index: {}. Status code: {status}, reason: {text}",
-                self.index_id
-            );
-            return Err(Error::HttpRequestFailed(format!(
-                "Status code: {status}, reason: {text}"
-            )));
+        let mut ndjson = String::with_capacity(messages.len() * 512);
+        let mut messages_count = 0;
+        for record in messages {
+            if let Ok(json_str) = simd_json::to_string(&record) {
+                if !ndjson.is_empty() {
+                    ndjson.push('\n');
+                }
+                ndjson.push_str(&json_str);
+                messages_count += 1;
+            }
         }
 
-        info!(
-            "Ingested {messages_count} messages for index: {}",
-            self.index_id
-        );
-        Ok(())
+        if messages_count == 0 {
+            return Ok(());
+        }
+
+        let response = client
+            .post(&url)
+            .header("Content-Type", "application/x-ndjson")
+            .body(ndjson)
+            .send()
+            .await
+            .map_err(|e| {
+                error!(
+                    "Failed to ingest {messages_count} messages into Quickwit index: {} for connector ID: {}. {e}",
+                    self.index_id, self.id
+                );
+                Error::HttpRequestFailed(e.to_string())
+            })?;
+
+        let status = response.status();
+        if status.is_success() {
+            debug!(
+                "Ingested {messages_count} messages into Quickwit index: {} for connector ID: {}",
+                self.index_id, self.id
+            );
+            Ok(())
+        } else if status.is_client_error() && status != StatusCode::TOO_MANY_REQUESTS {
+            let text = response.text().await.unwrap_or_default();
+            error!(
+                "Permanent error ingesting into Quickwit index: {} for connector ID: {}. status: {status}, reason: {text}",
+                self.index_id, self.id
+            );
+            Err(Error::PermanentHttpError(format!(
+                "status: {status}, reason: {text}"
+            )))
+        } else {
+            let text = response.text().await.unwrap_or_default();
+            error!(
+                "Transient error ingesting into Quickwit index: {} for connector ID: {}. status: {status}, reason: {text}",
+                self.index_id, self.id
+            );
+            Err(Error::HttpRequestFailed(format!(
+                "status: {status}, reason: {text}"
+            )))
+        }
+    }
+
+    fn extract_json_payloads(
+        &self,
+        messages: Vec<ConsumedMessage>,
+        schema: Schema,
+    ) -> Vec<OwnedValue> {
+        let mut json_payloads = Vec::with_capacity(messages.len());
+        for message in messages {
+            let val = match message.payload {
+                Payload::Json(value) => value,
+                Payload::Raw(bytes) => {
+                    let mut bytes_copy = bytes.clone();
+                    match simd_json::from_slice::<OwnedValue>(&mut bytes_copy) {
+                        Ok(value) => value,
+                        Err(_) => match String::from_utf8(bytes) {
+                            Ok(text) => simd_json::json!({
+                                "data": text,
+                                "data_type": "raw"
+                            }),
+                            Err(err) => simd_json::json!({
+                                "data": general_purpose::STANDARD.encode(err.into_bytes()),
+                                "data_type": "raw"
+                            }),
+                        },
+                    }
+                }
+                Payload::Text(text) => simd_json::json!({
+                    "text": text,
+                    "data_type": "text"
+                }),
+                _ => {
+                    warn!(
+                        "Quickwit sink connector ID: {} unsupported payload schema: {}",
+                        self.id, schema
+                    );
+                    continue;
+                }
+            };
+            json_payloads.push(val);
+        }
+        json_payloads
     }
 }
 
 #[async_trait]
 impl Sink for QuickwitSink {
     async fn open(&mut self) -> Result<(), Error> {
-        info!(
-            "Opened Quickwit sink connector with ID: {} for URL: {}",
-            self.id, self.config.url
+        let retry_delay = parse_duration(self.config.retry_delay.as_deref(), DEFAULT_RETRY_DELAY);
+        let retry_max_delay = parse_duration(
+            self.config.retry_max_delay.as_deref(),
+            DEFAULT_RETRY_MAX_DELAY,
         );
+        let max_open_retries = self
+            .config
+            .max_open_retries
+            .unwrap_or(DEFAULT_MAX_OPEN_RETRIES);
+        let open_retry_max_delay = parse_duration(
+            self.config.open_retry_max_delay.as_deref(),
+            DEFAULT_OPEN_RETRY_MAX_DELAY,
+        );
+
+        let timeout = parse_duration(self.config.timeout.as_deref(), DEFAULT_TIMEOUT);
+        let raw_client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| Error::InitError(format!("reqwest client: {e}")))?;
+        let health_url = Url::parse(&format!("{}/health/readyz", self.base_url))
+            .map_err(|e| Error::InvalidConfigValue(format!("url: {e}")))?;
+
+        check_connectivity_with_retry(
+            &raw_client,
+            health_url,
+            "Quickwit sink connector",
+            self.id,
+            &ConnectivityConfig {
+                max_open_retries,
+                open_retry_max_delay,
+                retry_delay,
+            },
+        )
+        .await?;
+
+        self.client = Some(build_retry_client(
+            raw_client,
+            self.config
+                .max_retries
+                .unwrap_or(DEFAULT_MAX_RETRIES)
+                .max(1),
+            retry_delay,
+            retry_max_delay,
+            "Quickwit",
+        ));
+
         if !self.has_index().await? {
             self.create_index().await?;
         }
+
+        info!(
+            "Opened Quickwit sink connector ID: {}, index: {}",
+            self.id, self.index_id
+        );
         Ok(())
     }
 
@@ -177,33 +351,172 @@ impl Sink for QuickwitSink {
         messages_metadata: MessagesMetadata,
         messages: Vec<ConsumedMessage>,
     ) -> Result<(), Error> {
-        info!(
-            "Quickwit sink with ID: {} received: {} messages, format: {}",
-            self.id,
-            messages.len(),
-            messages_metadata.schema
-        );
-
-        let mut json_payloads = Vec::with_capacity(messages.len());
-        for message in messages {
-            match message.payload {
-                Payload::Json(value) => json_payloads.push(value),
-                _ => {
-                    warn!("Unsupported payload format: {}", messages_metadata.schema);
-                }
-            }
+        let total = messages.len();
+        if self.verbose {
+            info!(
+                "Quickwit sink connector ID: {} received {total} messages, schema: {}",
+                self.id, messages_metadata.schema
+            );
+        } else {
+            debug!(
+                "Quickwit sink connector ID: {} received {total} messages, schema: {}",
+                self.id, messages_metadata.schema
+            );
         }
 
+        let json_payloads = self.extract_json_payloads(messages, messages_metadata.schema);
         if json_payloads.is_empty() {
             return Ok(());
         }
 
-        self.ingest(json_payloads).await?;
-        Ok(())
+        self.ingest(json_payloads).await
     }
 
     async fn close(&mut self) -> Result<(), Error> {
-        info!("Quickwit sink connector with ID: {} is closed.", self.id);
+        let _ = self.client.take();
+        info!("Closed Quickwit sink connector ID: {}", self.id);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> QuickwitSinkConfig {
+        QuickwitSinkConfig {
+            url: "http://localhost:7280".to_string(),
+            index: "index_id: test\nversion: 0.8\n".to_string(),
+            verbose_logging: None,
+            max_retries: None,
+            retry_delay: None,
+            retry_max_delay: None,
+            max_open_retries: None,
+            open_retry_max_delay: None,
+            timeout: None,
+        }
+    }
+
+    #[test]
+    fn given_default_config_verbose_should_be_false() {
+        let sink = QuickwitSink::new(1, test_config());
+        assert!(!sink.verbose);
+    }
+
+    #[test]
+    fn given_verbose_logging_enabled_should_set_verbose_flag() {
+        let mut config = test_config();
+        config.verbose_logging = Some(true);
+        let sink = QuickwitSink::new(1, config);
+        assert!(sink.verbose);
+    }
+
+    #[test]
+    fn given_verbose_logging_disabled_should_not_set_verbose_flag() {
+        let mut config = test_config();
+        config.verbose_logging = Some(false);
+        let sink = QuickwitSink::new(1, config);
+        assert!(!sink.verbose);
+    }
+
+    #[test]
+    fn given_new_sink_client_should_not_be_initialized() {
+        let sink = QuickwitSink::new(1, test_config());
+        assert!(sink.client.is_none());
+    }
+
+    #[test]
+    fn given_index_yaml_should_extract_index_id() {
+        let sink = QuickwitSink::new(1, test_config());
+        assert_eq!(sink.index_id, "test");
+    }
+
+    fn test_message(payload: Payload) -> ConsumedMessage {
+        ConsumedMessage {
+            id: 1,
+            offset: 0,
+            checksum: 0,
+            timestamp: 0,
+            origin_timestamp: 0,
+            headers: None,
+            payload,
+        }
+    }
+
+    #[test]
+    fn given_json_payload_should_extract_it_directly() {
+        let sink = QuickwitSink::new(1, test_config());
+        let val = simd_json::json!({"key": "value"});
+        let msg = test_message(Payload::Json(val.clone()));
+        let extracted = sink.extract_json_payloads(vec![msg], Schema::Json);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(extracted[0], val);
+    }
+
+    #[test]
+    fn given_raw_json_payload_should_parse_and_extract_it() {
+        let sink = QuickwitSink::new(1, test_config());
+        let val = simd_json::json!({"key": "value"});
+        let raw_bytes = simd_json::to_vec(&val).unwrap();
+        let msg = test_message(Payload::Raw(raw_bytes));
+        let extracted = sink.extract_json_payloads(vec![msg], Schema::Raw);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(extracted[0], val);
+    }
+
+    #[test]
+    fn given_raw_invalid_json_text_should_wrap_in_raw_object() {
+        let sink = QuickwitSink::new(1, test_config());
+        let raw_text = "invalid json text";
+        let msg = test_message(Payload::Raw(raw_text.as_bytes().to_vec()));
+        let extracted = sink.extract_json_payloads(vec![msg], Schema::Raw);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(
+            extracted[0],
+            simd_json::json!({
+                "data": raw_text,
+                "data_type": "raw"
+            })
+        );
+    }
+
+    #[test]
+    fn given_raw_binary_should_encode_base64_in_raw_object() {
+        let sink = QuickwitSink::new(1, test_config());
+        let binary_data = vec![0, 15, 255];
+        let msg = test_message(Payload::Raw(binary_data.clone()));
+        let extracted = sink.extract_json_payloads(vec![msg], Schema::Raw);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(
+            extracted[0],
+            simd_json::json!({
+                "data": general_purpose::STANDARD.encode(&binary_data),
+                "data_type": "raw"
+            })
+        );
+    }
+
+    #[test]
+    fn given_text_payload_should_wrap_in_text_object() {
+        let sink = QuickwitSink::new(1, test_config());
+        let text = "hello quickwit";
+        let msg = test_message(Payload::Text(text.to_string()));
+        let extracted = sink.extract_json_payloads(vec![msg], Schema::Text);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(
+            extracted[0],
+            simd_json::json!({
+                "text": text,
+                "data_type": "text"
+            })
+        );
+    }
+
+    #[test]
+    fn given_unsupported_payload_should_ignore_it() {
+        let sink = QuickwitSink::new(1, test_config());
+        let msg = test_message(Payload::FlatBuffer(vec![1, 2, 3]));
+        let extracted = sink.extract_json_payloads(vec![msg], Schema::FlatBuffer);
+        assert!(extracted.is_empty());
     }
 }

--- a/core/connectors/sinks/quickwit_sink/src/lib.rs
+++ b/core/connectors/sinks/quickwit_sink/src/lib.rs
@@ -15,29 +15,33 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose};
 use iggy_connector_sdk::retry::{
-    ConnectivityConfig, build_retry_client, check_connectivity_with_retry, parse_duration,
+    ConnectivityConfig, build_retry_client, check_connectivity_with_retry, is_transient_status,
 };
 use iggy_connector_sdk::{
-    ConsumedMessage, Error, MessagesMetadata, Payload, Schema, Sink, TopicMetadata, sink_connector,
+    ConsumedMessage, Error, MessagesMetadata, Payload, Sink, TopicMetadata, sink_connector,
 };
 use reqwest::StatusCode;
 use reqwest::Url;
 use reqwest_middleware::ClientWithMiddleware;
 use serde::Deserialize;
 use simd_json::OwnedValue;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 sink_connector!(QuickwitSink);
 
 const DEFAULT_MAX_RETRIES: u32 = 3;
-const DEFAULT_RETRY_DELAY: &str = "200ms";
+const DEFAULT_RETRY_DELAY: &str = "1s";
 const DEFAULT_RETRY_MAX_DELAY: &str = "5s";
-const DEFAULT_MAX_OPEN_RETRIES: u32 = 5;
+const DEFAULT_MAX_OPEN_RETRIES: u32 = 10;
 const DEFAULT_OPEN_RETRY_MAX_DELAY: &str = "30s";
 const DEFAULT_TIMEOUT: &str = "30s";
+const MAX_INGEST_BODY_BYTES: usize = 8 * 1024 * 1024;
+const ESTIMATED_RECORD_BYTES: usize = 512;
 
 #[derive(Debug)]
 pub struct QuickwitSink {
@@ -46,10 +50,12 @@ pub struct QuickwitSink {
     client: Option<ClientWithMiddleware>,
     verbose: bool,
     index_id: String,
-    base_url: String,
+    indexes_url: String,
+    index_url: String,
+    ingest_url: String,
 }
 
-/// Configuration for the Quickwit sink connector, deserialized from [plugin_config] in config.toml.
+/// Configuration for the Quickwit sink connector, deserialized from `[plugin_config]` in config.toml.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct QuickwitSinkConfig {
@@ -60,13 +66,13 @@ pub struct QuickwitSinkConfig {
     pub index: String,
     /// Enable verbose logging for ingested messages (default: false).
     pub verbose_logging: Option<bool>,
-    /// Maximum number of retries for transient ingest errors (default: 3).
+    /// Total HTTP attempts including the first (default: 3). 1 disables retries.
     pub max_retries: Option<u32>,
-    /// Initial retry delay as a human-readable duration string, e.g. "200ms" (default: 200ms).
+    /// Initial retry delay as a human-readable duration string, e.g. "1s" (default: 1s).
     pub retry_delay: Option<String>,
     /// Maximum retry delay cap as a human-readable duration string, e.g. "5s" (default: 5s).
     pub retry_max_delay: Option<String>,
-    /// Maximum number of connectivity retries when opening the sink (default: 5).
+    /// Total readiness attempts including the first (default: 10). 1 disables retries.
     pub max_open_retries: Option<u32>,
     /// Maximum retry delay cap when opening the sink, e.g. "30s" (default: 30s).
     pub open_retry_max_delay: Option<String>,
@@ -81,17 +87,16 @@ struct IndexConfig {
 
 impl QuickwitSink {
     pub fn new(id: u32, config: QuickwitSinkConfig) -> Self {
-        let index_config =
-            serde_yaml_ng::from_str::<IndexConfig>(&config.index).expect("Invalid index config.");
         let verbose = config.verbose_logging.unwrap_or(false);
-        let base_url = config.url.trim_end_matches('/').to_owned();
         Self {
             id,
             config,
             client: None,
             verbose,
-            index_id: index_config.index_id,
-            base_url,
+            index_id: String::new(),
+            indexes_url: String::new(),
+            index_url: String::new(),
+            ingest_url: String::new(),
         }
     }
 
@@ -103,9 +108,8 @@ impl QuickwitSink {
 
     async fn has_index(&self) -> Result<bool, Error> {
         let client = self.client()?;
-        let url = format!("{}/api/v1/indexes/{}", self.base_url, self.index_id);
         let response = client
-            .get(&url)
+            .get(&self.index_url)
             .send()
             .await
             .map_err(|e| Error::HttpRequestFailed(e.to_string()))?;
@@ -115,8 +119,13 @@ impl QuickwitSink {
         } else if status == StatusCode::NOT_FOUND {
             Ok(false)
         } else {
-            Err(Error::HttpRequestFailed(format!(
-                "Unexpected status checking Quickwit index: {status}"
+            let reason = response
+                .text()
+                .await
+                .unwrap_or_else(|error| format!("failed to read response: {error}"));
+            Err(Error::InitError(format!(
+                "Checking Quickwit index '{}': {status}, {reason}",
+                self.index_id
             )))
         }
     }
@@ -127,20 +136,13 @@ impl QuickwitSink {
             self.index_id, self.id
         );
         let client = self.client()?;
-        let url = format!("{}/api/v1/indexes", self.base_url);
         let response = client
-            .post(&url)
+            .post(&self.indexes_url)
             .header("Content-Type", "application/yaml")
             .body(self.config.index.clone())
             .send()
             .await
-            .map_err(|e| {
-                error!(
-                    "Failed to create Quickwit index: {} for connector ID: {}. {e}",
-                    self.index_id, self.id
-                );
-                Error::HttpRequestFailed(e.to_string())
-            })?;
+            .map_err(|error| Error::HttpRequestFailed(error.to_string()))?;
 
         let status = response.status();
         if status.is_success() {
@@ -150,21 +152,18 @@ impl QuickwitSink {
             );
             Ok(())
         } else {
-            let reason = response.text().await.unwrap_or_default();
-            if status == StatusCode::CONFLICT
-                || (status == StatusCode::BAD_REQUEST
-                    && reason.to_lowercase().contains("already exists"))
-            {
+            let reason = response
+                .text()
+                .await
+                .unwrap_or_else(|error| format!("failed to read response: {error}"));
+            // A competing creator or a retried POST may already have created the index.
+            if self.has_index().await? {
                 info!(
                     "Quickwit index already exists ({status}): {} for connector ID: {}",
                     self.index_id, self.id
                 );
                 Ok(())
             } else {
-                error!(
-                    "Failed creating Quickwit index: {} for connector ID: {}. status: {status}, reason: {reason}",
-                    self.index_id, self.id
-                );
                 Err(Error::InitError(format!(
                     "Failed to create index '{0}': {status} {reason}",
                     self.index_id
@@ -173,37 +172,63 @@ impl QuickwitSink {
         }
     }
 
-    pub async fn ingest(&self, messages: Vec<simd_json::OwnedValue>) -> Result<(), Error> {
-        let client = self.client()?;
-        // At-least-once during transient retries, but at-most-once on final failure:
-        // Quickwit ingest carries no dedup key, so a retry after a transient 5xx/timeout
-        // that actually committed double-writes those rows. Conversely, if a batch permanently
-        // fails (e.g. 4xx client error or retries exhausted), the offset was already committed
-        // at poll, so the batch is silently dropped and never redelivered.
-        let url = format!(
-            "{}/api/v1/{}/ingest?commit=auto",
-            self.base_url, self.index_id
-        );
-        let mut ndjson = String::with_capacity(messages.len() * 512);
+    async fn ingest(&self, messages: Vec<OwnedValue>) -> Result<(), Error> {
+        let capacity = messages
+            .len()
+            .saturating_mul(ESTIMATED_RECORD_BYTES)
+            .min(MAX_INGEST_BODY_BYTES);
+        let mut body = Vec::with_capacity(capacity);
         let mut messages_count = 0;
-        for record in messages {
-            if let Ok(json_str) = simd_json::to_string(&record) {
-                if !ndjson.is_empty() {
-                    ndjson.push('\n');
-                }
-                ndjson.push_str(&json_str);
-                messages_count += 1;
+        let mut last_error = None;
+        for (position, record) in messages.into_iter().enumerate() {
+            let previous_len = body.len();
+            if let Err(error) = simd_json::to_writer(&mut body, &record) {
+                body.truncate(previous_len);
+                error!(
+                    "Quickwit sink connector ID: {} failed to serialize record {position}: {error}",
+                    self.id
+                );
+                last_error = Some(Error::Serialization(error.to_string()));
+                continue;
             }
+            body.push(b'\n');
+            let record_len = body.len() - previous_len;
+            if record_len > MAX_INGEST_BODY_BYTES {
+                body.truncate(previous_len);
+                let reason = format!(
+                    "record {position} is {record_len} bytes, exceeding the {MAX_INGEST_BODY_BYTES}-byte ingest limit"
+                );
+                error!("Quickwit sink connector ID: {}: {reason}", self.id);
+                last_error = Some(Error::InvalidRecordValue(reason));
+                continue;
+            }
+            if body.len() > MAX_INGEST_BODY_BYTES {
+                let next_body = body.split_off(previous_len);
+                let completed_body = std::mem::replace(&mut body, next_body);
+                if let Err(error) = self.ingest_batch(completed_body, messages_count).await {
+                    last_error = Some(error);
+                }
+                messages_count = 0;
+            }
+            messages_count += 1;
         }
-
-        if messages_count == 0 {
-            return Ok(());
+        if messages_count > 0
+            && let Err(error) = self.ingest_batch(body, messages_count).await
+        {
+            last_error = Some(error);
         }
+        last_error.map_or(Ok(()), Err)
+    }
 
+    async fn ingest_batch(&self, body: Vec<u8>, messages_count: usize) -> Result<(), Error> {
+        let client = self.client()?;
+        // Retries can duplicate accepted documents. Final failures are logged but
+        // not redelivered because the runtime commits offsets when polling.
+        // Error classification remains diagnostic across the sink FFI boundary.
         let response = client
-            .post(&url)
+            .post(&self.ingest_url)
             .header("Content-Type", "application/x-ndjson")
-            .body(ndjson)
+            .body(body)
             .send()
             .await
             .map_err(|e| {
@@ -216,68 +241,75 @@ impl QuickwitSink {
 
         let status = response.status();
         if status.is_success() {
-            debug!(
-                "Ingested {messages_count} messages into Quickwit index: {} for connector ID: {}",
-                self.index_id, self.id
-            );
-            Ok(())
-        } else if status.is_client_error() && status != StatusCode::TOO_MANY_REQUESTS {
-            let text = response.text().await.unwrap_or_default();
-            error!(
-                "Permanent error ingesting into Quickwit index: {} for connector ID: {}. status: {status}, reason: {text}",
-                self.index_id, self.id
-            );
-            Err(Error::PermanentHttpError(format!(
-                "status: {status}, reason: {text}"
-            )))
+            if self.verbose {
+                info!(
+                    "Ingested {messages_count} messages into Quickwit index: {} for connector ID: {}",
+                    self.index_id, self.id
+                );
+            } else {
+                debug!(
+                    "Ingested {messages_count} messages into Quickwit index: {} for connector ID: {}",
+                    self.index_id, self.id
+                );
+            }
+            return Ok(());
+        }
+
+        let reason = response
+            .text()
+            .await
+            .unwrap_or_else(|error| format!("failed to read response: {error}"));
+        let transient = is_transient_status(status);
+        let category = if transient { "Transient" } else { "Permanent" };
+        error!(
+            "{category} error ingesting into Quickwit index: {} for connector ID: {}. status: {status}, reason: {reason}",
+            self.index_id, self.id
+        );
+        let reason = format!("status: {status}, reason: {reason}");
+        if transient {
+            Err(Error::HttpRequestFailed(reason))
         } else {
-            let text = response.text().await.unwrap_or_default();
-            error!(
-                "Transient error ingesting into Quickwit index: {} for connector ID: {}. status: {status}, reason: {text}",
-                self.index_id, self.id
-            );
-            Err(Error::HttpRequestFailed(format!(
-                "status: {status}, reason: {text}"
-            )))
+            Err(Error::PermanentHttpError(reason))
         }
     }
 
-    fn extract_json_payloads(
-        &self,
-        messages: Vec<ConsumedMessage>,
-        schema: Schema,
-    ) -> Vec<OwnedValue> {
+    fn extract_json_payloads(&self, messages: Vec<ConsumedMessage>) -> Vec<OwnedValue> {
         let mut json_payloads = Vec::with_capacity(messages.len());
         for message in messages {
             let val = match message.payload {
-                Payload::Json(value) => value,
-                Payload::Raw(bytes) => {
-                    let mut bytes_copy = bytes.clone();
-                    match simd_json::from_slice::<OwnedValue>(&mut bytes_copy) {
-                        Ok(value) => value,
-                        Err(_) => match String::from_utf8(bytes) {
-                            Ok(text) => simd_json::json!({
-                                "data": text,
-                                "data_type": "raw"
-                            }),
-                            Err(err) => simd_json::json!({
-                                "data": general_purpose::STANDARD.encode(err.into_bytes()),
-                                "data_type": "raw"
-                            }),
-                        },
+                Payload::Json(value @ OwnedValue::Object(_)) => value,
+                Payload::Json(value) => simd_json::json!({
+                    "data": value,
+                    "data_type": "json"
+                }),
+                Payload::Raw(bytes) | Payload::Avro(bytes) | Payload::FlatBuffer(bytes) => {
+                    if bytes.iter().find(|byte| !byte.is_ascii_whitespace()) == Some(&b'{') {
+                        // SIMD parsing mutates its input, even on failure. Preserve the fallback.
+                        let mut json_bytes = bytes.clone();
+                        if let Ok(value @ OwnedValue::Object(_)) =
+                            simd_json::from_slice::<OwnedValue>(&mut json_bytes)
+                        {
+                            json_payloads.push(value);
+                            continue;
+                        }
                     }
+                    let (data, encoding) = match String::from_utf8(bytes) {
+                        Ok(text) => (text, "utf8"),
+                        Err(error) => (
+                            general_purpose::STANDARD.encode(error.into_bytes()),
+                            "base64",
+                        ),
+                    };
+                    simd_json::json!({
+                        "data": data,
+                        "data_type": "raw",
+                        "data_encoding": encoding
+                    })
                 }
-                Payload::Text(text) => simd_json::json!({
+                Payload::Text(text) | Payload::Proto(text) => simd_json::json!({
                     "text": text,
                     "data_type": "text"
                 }),
-                _ => {
-                    warn!(
-                        "Quickwit sink connector ID: {} unsupported payload schema: {}",
-                        self.id, schema
-                    );
-                    continue;
-                }
             };
             json_payloads.push(val);
         }
@@ -288,54 +320,95 @@ impl QuickwitSink {
 #[async_trait]
 impl Sink for QuickwitSink {
     async fn open(&mut self) -> Result<(), Error> {
-        let retry_delay = parse_duration(self.config.retry_delay.as_deref(), DEFAULT_RETRY_DELAY);
-        let retry_max_delay = parse_duration(
-            self.config.retry_max_delay.as_deref(),
-            DEFAULT_RETRY_MAX_DELAY,
-        );
-        let max_open_retries = self
-            .config
-            .max_open_retries
-            .unwrap_or(DEFAULT_MAX_OPEN_RETRIES);
-        let open_retry_max_delay = parse_duration(
-            self.config.open_retry_max_delay.as_deref(),
-            DEFAULT_OPEN_RETRY_MAX_DELAY,
-        );
+        let result = async {
+            let index_config = serde_yaml_ng::from_str::<IndexConfig>(&self.config.index)
+                .map_err(|error| Error::InvalidConfigValue(format!("index: {error}")))?;
+            if index_config.index_id.trim().is_empty() {
+                return Err(Error::InvalidConfigValue(
+                    "index_id must not be empty".into(),
+                ));
+            }
+            let base_url = Url::parse(self.config.url.trim_end_matches('/'))
+                .map_err(|error| Error::InvalidConfigValue(format!("url: {error}")))?;
+            if !matches!(base_url.scheme(), "http" | "https")
+                || !base_url.has_host()
+                || base_url.query().is_some()
+                || base_url.fragment().is_some()
+            {
+                return Err(Error::InvalidConfigValue(
+                    "url must be an HTTP(S) base URL with a host and no query or fragment".into(),
+                ));
+            }
+            let retry_delay = parse_duration(
+                self.config.retry_delay.as_deref(),
+                DEFAULT_RETRY_DELAY,
+                "retry_delay",
+            )?;
+            let retry_max_delay = parse_duration(
+                self.config.retry_max_delay.as_deref(),
+                DEFAULT_RETRY_MAX_DELAY,
+                "retry_max_delay",
+            )?;
+            let open_retry_max_delay = parse_duration(
+                self.config.open_retry_max_delay.as_deref(),
+                DEFAULT_OPEN_RETRY_MAX_DELAY,
+                "open_retry_max_delay",
+            )?;
+            let timeout =
+                parse_duration(self.config.timeout.as_deref(), DEFAULT_TIMEOUT, "timeout")?;
 
-        let timeout = parse_duration(self.config.timeout.as_deref(), DEFAULT_TIMEOUT);
-        let raw_client = reqwest::Client::builder()
-            .timeout(timeout)
-            .build()
-            .map_err(|e| Error::InitError(format!("reqwest client: {e}")))?;
-        let health_url = Url::parse(&format!("{}/health/readyz", self.base_url))
-            .map_err(|e| Error::InvalidConfigValue(format!("url: {e}")))?;
+            self.index_id = index_config.index_id;
+            self.indexes_url = endpoint_url(&base_url, &["api", "v1", "indexes"])?.into();
+            self.index_url =
+                endpoint_url(&base_url, &["api", "v1", "indexes", &self.index_id])?.into();
+            let mut ingest_url = endpoint_url(&base_url, &["api", "v1", &self.index_id, "ingest"])?;
+            ingest_url.set_query(Some("commit=auto"));
+            self.ingest_url = ingest_url.into();
 
-        check_connectivity_with_retry(
-            &raw_client,
-            health_url,
-            "Quickwit sink connector",
-            self.id,
-            &ConnectivityConfig {
-                max_open_retries,
-                open_retry_max_delay,
+            let raw_client = reqwest::Client::builder()
+                .timeout(timeout)
+                .build()
+                .map_err(|error| Error::InitError(format!("reqwest client: {error}")))?;
+            check_connectivity_with_retry(
+                &raw_client,
+                endpoint_url(&base_url, &["health", "readyz"])?,
+                "Quickwit sink",
+                self.id,
+                &ConnectivityConfig {
+                    max_open_retries: self
+                        .config
+                        .max_open_retries
+                        .unwrap_or(DEFAULT_MAX_OPEN_RETRIES)
+                        .max(1),
+                    open_retry_max_delay,
+                    retry_delay,
+                },
+            )
+            .await?;
+
+            self.client = Some(build_retry_client(
+                raw_client,
+                self.config
+                    .max_retries
+                    .unwrap_or(DEFAULT_MAX_RETRIES)
+                    .max(1),
                 retry_delay,
-            },
-        )
-        .await?;
-
-        self.client = Some(build_retry_client(
-            raw_client,
-            self.config
-                .max_retries
-                .unwrap_or(DEFAULT_MAX_RETRIES)
-                .max(1),
-            retry_delay,
-            retry_max_delay,
-            "Quickwit",
-        ));
-
-        if !self.has_index().await? {
-            self.create_index().await?;
+                retry_max_delay,
+                "Quickwit",
+            ));
+            if !self.has_index().await? {
+                self.create_index().await?;
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(error) = result {
+            self.client = None;
+            error!(
+                "Failed to open Quickwit sink connector ID: {}: {error}",
+                self.id
+            );
+            return Err(error);
         }
 
         info!(
@@ -364,7 +437,7 @@ impl Sink for QuickwitSink {
             );
         }
 
-        let json_payloads = self.extract_json_payloads(messages, messages_metadata.schema);
+        let json_payloads = self.extract_json_payloads(messages);
         if json_payloads.is_empty() {
             return Ok(());
         }
@@ -379,56 +452,53 @@ impl Sink for QuickwitSink {
     }
 }
 
+fn parse_duration(value: Option<&str>, default: &str, field: &str) -> Result<Duration, Error> {
+    let duration = humantime::parse_duration(value.unwrap_or(default))
+        .map_err(|error| Error::InvalidConfigValue(format!("{field}: {error}")))?;
+    if duration.is_zero() {
+        return Err(Error::InvalidConfigValue(format!(
+            "{field} must be greater than zero"
+        )));
+    }
+    Ok(duration)
+}
+
+fn endpoint_url(base_url: &Url, segments: &[&str]) -> Result<Url, Error> {
+    let mut url = base_url.clone();
+    url.path_segments_mut()
+        .map_err(|()| Error::InvalidConfigValue("url cannot be used as a base URL".into()))?
+        .pop_if_empty()
+        .extend(segments);
+    Ok(url)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use iggy_connector_sdk::Schema;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::task::JoinHandle;
+    use tokio::time::timeout;
+
     use super::*;
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+    const HTTP_READ_BUFFER_BYTES: usize = 8192;
 
     fn test_config() -> QuickwitSinkConfig {
         QuickwitSinkConfig {
             url: "http://localhost:7280".to_string(),
             index: "index_id: test\nversion: 0.8\n".to_string(),
             verbose_logging: None,
-            max_retries: None,
-            retry_delay: None,
+            max_retries: Some(1),
+            retry_delay: Some("1ms".to_string()),
             retry_max_delay: None,
-            max_open_retries: None,
+            max_open_retries: Some(1),
             open_retry_max_delay: None,
-            timeout: None,
+            timeout: Some("1s".to_string()),
         }
-    }
-
-    #[test]
-    fn given_default_config_verbose_should_be_false() {
-        let sink = QuickwitSink::new(1, test_config());
-        assert!(!sink.verbose);
-    }
-
-    #[test]
-    fn given_verbose_logging_enabled_should_set_verbose_flag() {
-        let mut config = test_config();
-        config.verbose_logging = Some(true);
-        let sink = QuickwitSink::new(1, config);
-        assert!(sink.verbose);
-    }
-
-    #[test]
-    fn given_verbose_logging_disabled_should_not_set_verbose_flag() {
-        let mut config = test_config();
-        config.verbose_logging = Some(false);
-        let sink = QuickwitSink::new(1, config);
-        assert!(!sink.verbose);
-    }
-
-    #[test]
-    fn given_new_sink_client_should_not_be_initialized() {
-        let sink = QuickwitSink::new(1, test_config());
-        assert!(sink.client.is_none());
-    }
-
-    #[test]
-    fn given_index_yaml_should_extract_index_id() {
-        let sink = QuickwitSink::new(1, test_config());
-        assert_eq!(sink.index_id, "test");
     }
 
     fn test_message(payload: Payload) -> ConsumedMessage {
@@ -444,79 +514,439 @@ mod tests {
     }
 
     #[test]
-    fn given_json_payload_should_extract_it_directly() {
-        let sink = QuickwitSink::new(1, test_config());
-        let val = simd_json::json!({"key": "value"});
-        let msg = test_message(Payload::Json(val.clone()));
-        let extracted = sink.extract_json_payloads(vec![msg], Schema::Json);
-        assert_eq!(extracted.len(), 1);
-        assert_eq!(extracted[0], val);
+    fn given_invalid_index_config_when_opened_should_return_config_error() {
+        let runtime = test_runtime();
+        runtime.block_on(async {
+            for index in [
+                "",
+                "index_id: [",
+                "version: 0.8",
+                "index_id: ''",
+                "index_id: '  '",
+            ] {
+                let mut config = test_config();
+                config.index = index.to_string();
+                let mut sink = QuickwitSink::new(1, config);
+                assert!(
+                    matches!(sink.open().await, Err(Error::InvalidConfigValue(_))),
+                    "invalid index config should fail open: {index:?}"
+                );
+                assert!(sink.client.is_none());
+            }
+        });
     }
 
     #[test]
-    fn given_raw_json_payload_should_parse_and_extract_it() {
-        let sink = QuickwitSink::new(1, test_config());
-        let val = simd_json::json!({"key": "value"});
-        let raw_bytes = simd_json::to_vec(&val).unwrap();
-        let msg = test_message(Payload::Raw(raw_bytes));
-        let extracted = sink.extract_json_payloads(vec![msg], Schema::Raw);
-        assert_eq!(extracted.len(), 1);
-        assert_eq!(extracted[0], val);
+    fn given_invalid_url_when_opened_should_return_config_error() {
+        let runtime = test_runtime();
+        runtime.block_on(async {
+            for url in [
+                "localhost:7280",
+                "ftp://localhost:7280",
+                "http://",
+                "http://localhost:7280/?token=value",
+                "http://localhost:7280/#fragment",
+            ] {
+                let mut config = test_config();
+                config.url = url.to_string();
+                let mut sink = QuickwitSink::new(1, config);
+                assert!(
+                    matches!(sink.open().await, Err(Error::InvalidConfigValue(_))),
+                    "invalid URL should fail before probing: {url}"
+                );
+            }
+        });
     }
 
     #[test]
-    fn given_raw_invalid_json_text_should_wrap_in_raw_object() {
+    fn given_invalid_duration_when_opened_should_return_config_error() {
+        let runtime = test_runtime();
+        runtime.block_on(async {
+            for field in ["retry_delay", "retry_max_delay", "open_retry_max_delay", "timeout"] {
+                for value in ["30", "0s"] {
+                    let mut config = test_config();
+                    let setting = match field {
+                        "retry_delay" => &mut config.retry_delay,
+                        "retry_max_delay" => &mut config.retry_max_delay,
+                        "open_retry_max_delay" => &mut config.open_retry_max_delay,
+                        "timeout" => &mut config.timeout,
+                        _ => unreachable!(),
+                    };
+                    *setting = Some(value.to_string());
+                    let mut sink = QuickwitSink::new(1, config);
+                    assert!(
+                        matches!(sink.open().await, Err(Error::InvalidConfigValue(reason)) if reason.contains(field)),
+                        "invalid {field} should fail before probing: {value}"
+                    );
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn given_unknown_config_key_when_deserialized_should_reject_it() {
+        let config = "url: http://localhost:7280\nindex: 'index_id: test'\nmax_retires: 1";
+        assert!(serde_yaml_ng::from_str::<QuickwitSinkConfig>(config).is_err());
+    }
+
+    #[test]
+    fn given_payload_variants_when_extracted_should_preserve_object_and_text_documents() {
         let sink = QuickwitSink::new(1, test_config());
-        let raw_text = "invalid json text";
-        let msg = test_message(Payload::Raw(raw_text.as_bytes().to_vec()));
-        let extracted = sink.extract_json_payloads(vec![msg], Schema::Raw);
-        assert_eq!(extracted.len(), 1);
+        let object = simd_json::json!({"key": "value"});
+        let raw_object = b" \n{\"key\": \"value\"}".to_vec();
+        let messages = vec![
+            test_message(Payload::Json(object.clone())),
+            test_message(Payload::Raw(raw_object.clone())),
+            test_message(Payload::Avro(raw_object.clone())),
+            test_message(Payload::FlatBuffer(raw_object)),
+            test_message(Payload::Text("hello quickwit".to_string())),
+            test_message(Payload::Proto("hello quickwit".to_string())),
+        ];
+        let extracted = sink.extract_json_payloads(messages);
         assert_eq!(
-            extracted[0],
-            simd_json::json!({
-                "data": raw_text,
-                "data_type": "raw"
-            })
+            &extracted[..4],
+            &[object.clone(), object.clone(), object.clone(), object]
+        );
+        let text = simd_json::json!({"text": "hello quickwit", "data_type": "text"});
+        assert_eq!(&extracted[4..], &[text.clone(), text]);
+    }
+
+    #[test]
+    fn given_raw_nonobjects_when_extracted_should_preserve_original_bytes() {
+        let sink = QuickwitSink::new(1, test_config());
+        for raw_text in [
+            "42",
+            "\"text\"",
+            "[1,2]",
+            "null",
+            "true",
+            "",
+            "plain text",
+            r#"{"message":"escaped\ntext","broken":}"#,
+        ] {
+            let extracted = sink.extract_json_payloads(vec![test_message(Payload::Raw(
+                raw_text.as_bytes().to_vec(),
+            ))]);
+            assert_eq!(
+                extracted,
+                vec![simd_json::json!({
+                    "data": raw_text,
+                    "data_type": "raw",
+                    "data_encoding": "utf8"
+                })],
+                "raw input should remain unchanged: {raw_text:?}"
+            );
+        }
+        let binary = vec![0, 15, 255];
+        let extracted =
+            sink.extract_json_payloads(vec![test_message(Payload::Raw(binary.clone()))]);
+        assert_eq!(
+            extracted,
+            vec![simd_json::json!({
+                "data": general_purpose::STANDARD.encode(binary),
+                "data_type": "raw",
+                "data_encoding": "base64"
+            })]
         );
     }
 
     #[test]
-    fn given_raw_binary_should_encode_base64_in_raw_object() {
+    fn given_json_nonobjects_when_extracted_should_wrap_original_values() {
         let sink = QuickwitSink::new(1, test_config());
-        let binary_data = vec![0, 15, 255];
-        let msg = test_message(Payload::Raw(binary_data.clone()));
-        let extracted = sink.extract_json_payloads(vec![msg], Schema::Raw);
-        assert_eq!(extracted.len(), 1);
-        assert_eq!(
-            extracted[0],
-            simd_json::json!({
-                "data": general_purpose::STANDARD.encode(&binary_data),
-                "data_type": "raw"
-            })
-        );
+        for value in [
+            simd_json::json!(42),
+            simd_json::json!("text"),
+            simd_json::json!([1, 2]),
+            simd_json::json!(null),
+            simd_json::json!(true),
+        ] {
+            let extracted =
+                sink.extract_json_payloads(vec![test_message(Payload::Json(value.clone()))]);
+            assert_eq!(
+                extracted,
+                vec![simd_json::json!({"data": value, "data_type": "json"})]
+            );
+        }
     }
 
     #[test]
-    fn given_text_payload_should_wrap_in_text_object() {
-        let sink = QuickwitSink::new(1, test_config());
-        let text = "hello quickwit";
-        let msg = test_message(Payload::Text(text.to_string()));
-        let extracted = sink.extract_json_payloads(vec![msg], Schema::Text);
-        assert_eq!(extracted.len(), 1);
-        assert_eq!(
-            extracted[0],
-            simd_json::json!({
-                "text": text,
-                "data_type": "text"
-            })
-        );
+    fn given_index_creation_race_when_opened_should_verify_the_existing_index() {
+        let runtime = test_runtime();
+        runtime.block_on(async {
+            for status in [400, 409, 503] {
+                let (url, server) = start_test_server(vec![
+                    ("GET /prefix/health/readyz HTTP/1.1", 200, ""),
+                    ("GET /prefix/api/v1/indexes/test HTTP/1.1", 404, ""),
+                    (
+                        "POST /prefix/api/v1/indexes HTTP/1.1",
+                        status,
+                        "index `test` already exist(s)",
+                    ),
+                    ("GET /prefix/api/v1/indexes/test HTTP/1.1", 200, "{}"),
+                ])
+                .await;
+                let mut config = test_config();
+                config.url = format!("{url}/prefix///");
+                let mut sink = QuickwitSink::new(1, config);
+                sink.open()
+                    .await
+                    .expect("index creation race should recover");
+                assert_eq!(sink.index_id, "test");
+                assert_eq!(
+                    sink.ingest_url,
+                    format!("{url}/prefix/api/v1/test/ingest?commit=auto")
+                );
+                let requests = server.await.expect("test server should finish");
+                assert_eq!(requests[2], sink.config.index.as_bytes());
+            }
+        });
     }
 
     #[test]
-    fn given_unsupported_payload_should_ignore_it() {
-        let sink = QuickwitSink::new(1, test_config());
-        let msg = test_message(Payload::FlatBuffer(vec![1, 2, 3]));
-        let extracted = sink.extract_json_payloads(vec![msg], Schema::FlatBuffer);
-        assert!(extracted.is_empty());
+    fn given_failed_index_creation_when_index_still_absent_should_fail_open() {
+        let runtime = test_runtime();
+        runtime.block_on(async {
+            let (url, server) = start_test_server(vec![
+                ("GET /health/readyz HTTP/1.1", 200, ""),
+                ("GET /api/v1/indexes/test HTTP/1.1", 404, ""),
+                (
+                    "POST /api/v1/indexes HTTP/1.1",
+                    409,
+                    "index creation failed",
+                ),
+                ("GET /api/v1/indexes/test HTTP/1.1", 404, ""),
+            ])
+            .await;
+            let mut config = test_config();
+            config.url = url;
+            let mut sink = QuickwitSink::new(1, config);
+            assert!(matches!(sink.open().await, Err(Error::InitError(_))));
+            assert!(sink.client.is_none());
+            server.await.expect("test server should finish");
+        });
+    }
+
+    #[test]
+    fn given_ingest_failure_when_consumed_should_classify_http_errors() {
+        let runtime = test_runtime();
+        runtime.block_on(async {
+            for status in [400, 429, 503] {
+                let (url, server) = start_test_server(vec![
+                    ("GET /health/readyz HTTP/1.1", 200, ""),
+                    ("GET /api/v1/indexes/test HTTP/1.1", 200, "{}"),
+                    (
+                        "POST /api/v1/test/ingest?commit=auto HTTP/1.1",
+                        status,
+                        "rejected",
+                    ),
+                ])
+                .await;
+                let mut config = test_config();
+                config.url = url;
+                let mut sink = QuickwitSink::new(1, config);
+                sink.open().await.expect("sink should open");
+                let result =
+                    consume_payloads(&sink, vec![Payload::Text("message".to_string())]).await;
+                if status == 400 {
+                    assert!(matches!(result, Err(Error::PermanentHttpError(_))));
+                } else {
+                    assert!(matches!(result, Err(Error::HttpRequestFailed(_))));
+                }
+                let requests = server.await.expect("test server should finish");
+                let mut body = requests
+                    .into_iter()
+                    .last()
+                    .expect("ingest request should exist");
+                assert_eq!(
+                    simd_json::from_slice::<OwnedValue>(&mut body)
+                        .expect("ingest body should be JSON"),
+                    simd_json::json!({"text": "message", "data_type": "text"})
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn given_full_chunk_when_consumed_should_split_and_continue_after_http_failure() {
+        let runtime = test_runtime();
+        runtime.block_on(async {
+            let (url, server) = start_test_server(vec![
+                ("GET /health/readyz HTTP/1.1", 200, ""),
+                ("GET /api/v1/indexes/test HTTP/1.1", 200, "{}"),
+                (
+                    "POST /api/v1/test/ingest?commit=auto HTTP/1.1",
+                    503,
+                    "unavailable",
+                ),
+                ("POST /api/v1/test/ingest?commit=auto HTTP/1.1", 200, "{}"),
+            ])
+            .await;
+            let mut config = test_config();
+            config.url = url;
+            let mut sink = QuickwitSink::new(1, config);
+            sink.open().await.expect("sink should open");
+            let overhead = simd_json::to_vec(&simd_json::json!({"data": ""}))
+                .expect("empty document should serialize")
+                .len()
+                + 1;
+            let full_record =
+                simd_json::json!({"data": "x".repeat(MAX_INGEST_BODY_BYTES - overhead)});
+            let last_record = simd_json::json!({"sequence": 2});
+            let result = consume_payloads(
+                &sink,
+                vec![
+                    Payload::Json(full_record),
+                    Payload::Json(last_record.clone()),
+                ],
+            )
+            .await;
+            assert!(matches!(result, Err(Error::HttpRequestFailed(_))));
+            let requests = server.await.expect("test server should finish");
+            assert_eq!(requests[2].len(), MAX_INGEST_BODY_BYTES);
+            assert_eq!(requests[2].last(), Some(&b'\n'));
+            let mut last_body = requests
+                .into_iter()
+                .last()
+                .expect("last chunk should exist");
+            assert_eq!(
+                simd_json::from_slice::<OwnedValue>(&mut last_body)
+                    .expect("last chunk should be JSON"),
+                last_record
+            );
+        });
+    }
+
+    #[test]
+    fn given_oversized_record_when_consumed_should_report_it_and_send_other_records() {
+        let runtime = test_runtime();
+        runtime.block_on(async {
+            let (url, server) = start_test_server(vec![
+                ("GET /health/readyz HTTP/1.1", 200, ""),
+                ("GET /api/v1/indexes/test HTTP/1.1", 200, "{}"),
+                ("POST /api/v1/test/ingest?commit=auto HTTP/1.1", 200, "{}"),
+            ])
+            .await;
+            let mut config = test_config();
+            config.url = url;
+            let mut sink = QuickwitSink::new(1, config);
+            sink.open().await.expect("sink should open");
+            let result = consume_payloads(
+                &sink,
+                vec![
+                    Payload::Json(simd_json::json!({"sequence": 1})),
+                    Payload::Json(simd_json::json!({"data": "x".repeat(MAX_INGEST_BODY_BYTES)})),
+                    Payload::Json(simd_json::json!({"sequence": 3})),
+                ],
+            )
+            .await;
+            assert!(matches!(result, Err(Error::InvalidRecordValue(_))));
+            let requests = server.await.expect("test server should finish");
+            assert_eq!(requests[2], b"{\"sequence\":1}\n{\"sequence\":3}\n");
+        });
+    }
+
+    fn test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should start")
+    }
+
+    async fn consume_payloads(sink: &QuickwitSink, payloads: Vec<Payload>) -> Result<(), Error> {
+        sink.consume(
+            &TopicMetadata {
+                stream: "test".to_string(),
+                topic: "test".to_string(),
+            },
+            MessagesMetadata {
+                partition_id: 1,
+                current_offset: 0,
+                schema: Schema::Raw,
+            },
+            payloads.into_iter().map(test_message).collect(),
+        )
+        .await
+    }
+
+    async fn start_test_server(
+        responses: Vec<(&'static str, u16, &'static str)>,
+    ) -> (String, JoinHandle<Vec<Vec<u8>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let url = format!(
+            "http://{}",
+            listener
+                .local_addr()
+                .expect("test server should have address")
+        );
+        let server = tokio::spawn(async move {
+            let mut bodies = Vec::with_capacity(responses.len());
+            for (expected_request, status, response_body) in responses {
+                let (mut stream, _) = timeout(TEST_TIMEOUT, listener.accept())
+                    .await
+                    .expect("request should arrive before timeout")
+                    .expect("request should connect");
+                let (request_line, body) = timeout(TEST_TIMEOUT, read_http_request(&mut stream))
+                    .await
+                    .expect("request should finish before timeout");
+                assert_eq!(request_line, expected_request);
+                bodies.push(body);
+                let response = format!(
+                    "HTTP/1.1 {status} Test\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("response should be written");
+            }
+            bodies
+        });
+        (url, server)
+    }
+
+    async fn read_http_request(stream: &mut TcpStream) -> (String, Vec<u8>) {
+        let mut buffer = Vec::new();
+        let mut chunk = [0u8; HTTP_READ_BUFFER_BYTES];
+        let headers_end = loop {
+            let read = stream.read(&mut chunk).await.expect("request should read");
+            assert_ne!(read, 0, "request should include headers");
+            buffer.extend_from_slice(&chunk[..read]);
+            if let Some(position) = buffer
+                .windows(b"\r\n\r\n".len())
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break position;
+            }
+        };
+        let headers = std::str::from_utf8(&buffer[..headers_end]).expect("headers should be UTF-8");
+        let request_line = headers
+            .lines()
+            .next()
+            .expect("request line should exist")
+            .to_string();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length").then(|| {
+                    value
+                        .trim()
+                        .parse::<usize>()
+                        .expect("content length should be valid")
+                })
+            })
+            .unwrap_or(0);
+        let body_start = headers_end + b"\r\n\r\n".len();
+        while buffer.len() < body_start + content_length {
+            let read = stream.read(&mut chunk).await.expect("body should read");
+            assert_ne!(read, 0, "request should include declared body");
+            buffer.extend_from_slice(&chunk[..read]);
+        }
+        (
+            request_line,
+            buffer[body_start..body_start + content_length].to_vec(),
+        )
     }
 }

--- a/core/integration/tests/connectors/fixtures/mod.rs
+++ b/core/integration/tests/connectors/fixtures/mod.rs
@@ -83,7 +83,10 @@ pub use postgres::{
     PostgresSourceJsonFixture, PostgresSourceJsonbFixture, PostgresSourceMarkFixture,
     PostgresSourceOps,
 };
-pub use quickwit::{QuickwitFixture, QuickwitOps, QuickwitPreCreatedFixture};
+pub use quickwit::{
+    QuickwitFixture, QuickwitOps, QuickwitPreCreatedFixture, QuickwitRawFixture,
+    QuickwitTextFixture,
+};
 pub use rabbitmq::{
     RabbitMqOps, RabbitMqSinkDirectFixture, RabbitMqSinkFanoutFixture, RabbitMqSinkFixture,
     RabbitMqSinkHeadersFixture, RabbitMqSinkRawSchemaFixture, RabbitMqSinkUnroutableFixture,

--- a/core/integration/tests/connectors/fixtures/quickwit/container.rs
+++ b/core/integration/tests/connectors/fixtures/quickwit/container.rs
@@ -129,6 +129,10 @@ pub trait QuickwitOps: Sync {
     fn container(&self) -> &QuickwitContainer;
     fn http_client(&self) -> &HttpClient;
 
+    fn timestamp_field(&self) -> Option<&str> {
+        Some(INDEX_TIMESTAMP_FIELD)
+    }
+
     fn create_index(
         &self,
         index_config: &str,
@@ -176,6 +180,7 @@ pub trait QuickwitOps: Sync {
                 .http_client()
                 .post(&ingest_url)
                 .query(&[("commit", "force")])
+                // A scalar forces a commit without adding a searchable document.
                 .json("{}")
                 .send()
                 .await
@@ -204,13 +209,12 @@ pub trait QuickwitOps: Sync {
     {
         async move {
             let search_url = format!("{}/api/v1/{}/search", self.container().base_url(), index_id);
-            let descending = "-";
+            let mut request = self.http_client().get(&search_url).query(&[("query", "")]);
+            if let Some(timestamp_field) = self.timestamp_field() {
+                request = request.query(&[("sort_by", format!("-{timestamp_field}"))]);
+            }
 
-            let response = self
-                .http_client()
-                .get(&search_url)
-                .query(&[("query", "")])
-                .query(&[("sort_by", format!("{descending}{INDEX_TIMESTAMP_FIELD}"))])
+            let response = request
                 .send()
                 .await
                 .map_err(|e| TestBinaryError::InvalidState {
@@ -326,6 +330,7 @@ fn build_connector_envs(base_url: &str) -> HashMap<String, String> {
 pub struct QuickwitFixture {
     container: QuickwitContainer,
     http_client: HttpClient,
+    timestamp_field: Option<&'static str>,
 }
 
 impl QuickwitOps for QuickwitFixture {
@@ -335,6 +340,10 @@ impl QuickwitOps for QuickwitFixture {
 
     fn http_client(&self) -> &HttpClient {
         &self.http_client
+    }
+
+    fn timestamp_field(&self) -> Option<&str> {
+        self.timestamp_field
     }
 }
 
@@ -347,6 +356,7 @@ impl TestFixture for QuickwitFixture {
         Ok(Self {
             container,
             http_client,
+            timestamp_field: Some(INDEX_TIMESTAMP_FIELD),
         })
     }
 
@@ -386,6 +396,7 @@ impl TestFixture for QuickwitPreCreatedFixture {
         let inner = QuickwitFixture {
             container,
             http_client,
+            timestamp_field: Some(INDEX_TIMESTAMP_FIELD),
         };
 
         let index_config = get_index_config(seeds::names::TOPIC);
@@ -396,5 +407,66 @@ impl TestFixture for QuickwitPreCreatedFixture {
 
     fn connectors_runtime_envs(&self) -> HashMap<String, String> {
         self.inner.connectors_runtime_envs()
+    }
+}
+
+pub struct QuickwitRawFixture {
+    inner: QuickwitFixture,
+}
+
+impl std::ops::Deref for QuickwitRawFixture {
+    type Target = QuickwitFixture;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl TestFixture for QuickwitRawFixture {
+    async fn setup() -> Result<Self, TestBinaryError> {
+        let mut inner = QuickwitFixture::setup().await?;
+        inner.timestamp_field = None;
+        Ok(Self { inner })
+    }
+
+    fn connectors_runtime_envs(&self) -> HashMap<String, String> {
+        let mut envs = self.inner.connectors_runtime_envs();
+        envs.insert(ENV_STREAMS_0_SCHEMA.to_string(), "raw".to_string());
+        envs.insert(
+            ENV_PLUGIN_INDEX.to_string(),
+            format!(
+                "version: 0.8\nindex_id: {}\ndoc_mapping:\n  mode: dynamic\n",
+                seeds::names::TOPIC
+            ),
+        );
+        envs
+    }
+}
+
+pub struct QuickwitTextFixture {
+    inner: QuickwitRawFixture,
+}
+
+impl std::ops::Deref for QuickwitTextFixture {
+    type Target = QuickwitRawFixture;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl TestFixture for QuickwitTextFixture {
+    async fn setup() -> Result<Self, TestBinaryError> {
+        Ok(Self {
+            inner: QuickwitRawFixture::setup().await?,
+        })
+    }
+
+    fn connectors_runtime_envs(&self) -> HashMap<String, String> {
+        let mut envs = self.inner.connectors_runtime_envs();
+        envs.insert(ENV_STREAMS_0_SCHEMA.to_string(), "text".to_string());
+        envs
     }
 }

--- a/core/integration/tests/connectors/fixtures/quickwit/container.rs
+++ b/core/integration/tests/connectors/fixtures/quickwit/container.rs
@@ -42,6 +42,7 @@ const QUICKWIT_LISTEN_ADDRESS: &str = "0.0.0.0";
 
 const ENV_PLUGIN_URL: &str = "IGGY_CONNECTORS_SINK_QUICKWIT_PLUGIN_CONFIG_URL";
 const ENV_PLUGIN_INDEX: &str = "IGGY_CONNECTORS_SINK_QUICKWIT_PLUGIN_CONFIG_INDEX";
+const ENV_PLUGIN_CONFIG_FORMAT: &str = "IGGY_CONNECTORS_SINK_QUICKWIT_PLUGIN_CONFIG_FORMAT";
 const ENV_STREAMS_0_STREAM: &str = "IGGY_CONNECTORS_SINK_QUICKWIT_STREAMS_0_STREAM";
 const ENV_STREAMS_0_TOPICS: &str = "IGGY_CONNECTORS_SINK_QUICKWIT_STREAMS_0_TOPICS";
 const ENV_STREAMS_0_SCHEMA: &str = "IGGY_CONNECTORS_SINK_QUICKWIT_STREAMS_0_SCHEMA";
@@ -306,6 +307,7 @@ retention:
 fn build_connector_envs(base_url: &str) -> HashMap<String, String> {
     HashMap::from([
         (ENV_PLUGIN_URL.to_string(), base_url.to_string()),
+        (ENV_PLUGIN_CONFIG_FORMAT.to_string(), "yaml".to_string()),
         (
             ENV_PLUGIN_INDEX.to_string(),
             get_index_config(seeds::names::TOPIC),

--- a/core/integration/tests/connectors/fixtures/quickwit/mod.rs
+++ b/core/integration/tests/connectors/fixtures/quickwit/mod.rs
@@ -17,4 +17,7 @@
 
 mod container;
 
-pub use container::{QuickwitFixture, QuickwitOps, QuickwitPreCreatedFixture};
+pub use container::{
+    QuickwitFixture, QuickwitOps, QuickwitPreCreatedFixture, QuickwitRawFixture,
+    QuickwitTextFixture,
+};

--- a/core/integration/tests/connectors/quickwit/quickwit_sink.rs
+++ b/core/integration/tests/connectors/quickwit/quickwit_sink.rs
@@ -16,12 +16,15 @@
 // under the License.
 
 use crate::connectors::create_test_messages;
-use crate::connectors::fixtures::{QuickwitFixture, QuickwitOps, QuickwitPreCreatedFixture};
+use crate::connectors::fixtures::{
+    QuickwitFixture, QuickwitOps, QuickwitPreCreatedFixture, QuickwitRawFixture,
+    QuickwitTextFixture,
+};
 use bytes::Bytes;
 use iggy::prelude::{IggyMessage, Partitioning};
 use iggy_common::Identifier;
 use iggy_common::MessageClient;
-use integration::harness::seeds;
+use integration::harness::{TestHarness, seeds};
 use integration::iggy_harness;
 use serde::{Deserialize, Serialize};
 
@@ -250,6 +253,127 @@ async fn given_invalid_messages_should_not_store(harness: &TestHarness, fixture:
         assert_eq!(
             hit,
             &serde_json::from_slice::<serde_json::Value>(payload).unwrap()
+        );
+    }
+}
+
+#[iggy_harness(
+    server(connectors_runtime(config_path = "tests/connectors/quickwit/sink.toml")),
+    seed = seeds::connector_stream
+)]
+async fn given_raw_messages_should_store_objects_and_encoded_wrappers(
+    harness: &TestHarness,
+    fixture: QuickwitRawFixture,
+) {
+    let cases = [
+        (
+            Bytes::from_static(br#"{"message":"raw JSON object"}"#),
+            serde_json::json!({"message": "raw JSON object"}),
+        ),
+        (
+            Bytes::from_static(b"YWJj"),
+            serde_json::json!({"data": "YWJj", "data_type": "raw", "data_encoding": "utf8"}),
+        ),
+        (
+            Bytes::from_static(b"\xff\x00\x80"),
+            serde_json::json!({"data": "/wCA", "data_type": "raw", "data_encoding": "base64"}),
+        ),
+        (
+            Bytes::from_static(br#"{"message":"escaped\ntext",broken}"#),
+            serde_json::json!({
+                "data": r#"{"message":"escaped\ntext",broken}"#,
+                "data_type": "raw",
+                "data_encoding": "utf8"
+            }),
+        ),
+        (
+            Bytes::from_static(b"42"),
+            serde_json::json!({"data": "42", "data_type": "raw", "data_encoding": "utf8"}),
+        ),
+        (
+            Bytes::from_static(br#""text""#),
+            serde_json::json!({"data": "\"text\"", "data_type": "raw", "data_encoding": "utf8"}),
+        ),
+        (
+            Bytes::from_static(b"[1,2]"),
+            serde_json::json!({"data": "[1,2]", "data_type": "raw", "data_encoding": "utf8"}),
+        ),
+        (
+            Bytes::from_static(b"null"),
+            serde_json::json!({"data": "null", "data_type": "raw", "data_encoding": "utf8"}),
+        ),
+    ];
+
+    assert_documents_stored(harness, &fixture, &cases).await;
+}
+
+#[iggy_harness(
+    server(connectors_runtime(config_path = "tests/connectors/quickwit/sink.toml")),
+    seed = seeds::connector_stream
+)]
+async fn given_text_messages_should_store_text_wrappers(
+    harness: &TestHarness,
+    fixture: QuickwitTextFixture,
+) {
+    let cases = [
+        (
+            Bytes::from_static(b"log entry\n\"ready\""),
+            serde_json::json!({"text": "log entry\n\"ready\"", "data_type": "text"}),
+        ),
+        (
+            Bytes::from_static(br#"{"message":"text containing JSON"}"#),
+            serde_json::json!({
+                "text": r#"{"message":"text containing JSON"}"#,
+                "data_type": "text"
+            }),
+        ),
+    ];
+
+    assert_documents_stored(harness, &fixture, &cases).await;
+}
+
+async fn assert_documents_stored(
+    harness: &TestHarness,
+    fixture: &QuickwitFixture,
+    cases: &[(Bytes, serde_json::Value)],
+) {
+    let client = harness.root_client().await.expect("create Iggy client");
+    let stream_id: Identifier = seeds::names::STREAM.try_into().expect("stream identifier");
+    let topic_id: Identifier = seeds::names::TOPIC.try_into().expect("topic identifier");
+    let mut messages: Vec<IggyMessage> = cases
+        .iter()
+        .enumerate()
+        .map(|(message_index, (payload, _))| {
+            IggyMessage::builder()
+                .id(message_index as u128 + 1)
+                .payload(payload.clone())
+                .build()
+                .expect("build message")
+        })
+        .collect();
+
+    client
+        .send_messages(
+            &stream_id,
+            &topic_id,
+            &Partitioning::partition_id(0),
+            &mut messages,
+        )
+        .await
+        .expect("send messages");
+
+    let search = fixture
+        .wait_for_documents(seeds::names::TOPIC, cases.len())
+        .await
+        .expect("wait for indexed documents");
+
+    assert_eq!(search.num_hits, cases.len());
+    assert_eq!(search.hits.len(), cases.len());
+    for (_, expected) in cases {
+        assert!(
+            search.hits.contains(expected),
+            "Missing document {expected}; search hits: {:?}",
+            search.hits
         );
     }
 }


### PR DESCRIPTION
## Which issue does this PR address?

Closes #3814

## Rationale

`quickwit_sink` was written before the shared connector retry helpers existed
and never caught up with them. Compared to the other HTTP sinks it had no
request timeout, no retry middleware, no readiness probe, and no handling for
two instances racing to create the same index. It also accepted only JSON
payloads and dropped everything else. Each of those is a way for the connector
to hang or lose data in a real deployment rather than fail visibly.

## What changed?

`reqwest::Client::new()` has no timeout, so a network partition or a
slow-starting Quickwit left `has_index()` and `ingest()` hanging forever, and a
5xx during startup killed the connector outright. Two instances opening at once
both saw `has_index() == false`, both POSTed, and the loser got a 409 it treated
as a fatal `InitError`.

The client is now built in `open()` with a configurable timeout and wrapped in
the SDK's retry middleware, after `check_connectivity_with_retry` waits for
`/health/readyz`. `create_index` absorbs a 409, and a 400 whose body says the
index already exists, as success. Non-JSON payloads are wrapped instead of
discarded: raw bytes are parsed as JSON when they can be, otherwise carried as
text or base64.

## Local Execution

- Passed

```
cargo fmt --all
cargo sort --check --no-format --workspace
cargo clippy -p iggy_connector_quickwit_sink --all-features --all-targets -- -D warnings
cargo test -p iggy_connector_quickwit_sink                      # 11 passed
cargo test -p integration -- connectors::quickwit               # 4 passed
./scripts/ci/taplo.sh --check
./scripts/ci/markdownlint.sh --check
./scripts/ci/license-headers.sh
./scripts/ci/trailing-whitespace.sh
./scripts/ci/trailing-newline.sh
```

The four integration tests run against a real Quickwit container and pass. Note
for anyone reproducing them locally: on this host they only get as far as
starting the container unless `create_shard_executor` keeps a worker pool. The
unconditional `proactor.thread_pool_limit(0)` in
`core/server_common/src/executor.rs` makes `iggy-server` abort on startup with
"the thread pool is needed but no worker thread is running", which takes down
every connectors integration test, not just these. That is unrelated to this PR
and is not touched here.

- Pre-commit hooks ran

## AI Usage

1. Claude Code.
2. Used throughout: drafting the retry and payload-handling changes, writing the
   unit tests, and auditing the diff against reviewer comments.
3. Verified by running the full local check list above, including the four
   integration tests against a real Quickwit container, and by reading the diff
   against `influxdb_sink`, which this sink mirrors.
4. Yes.