### PR TITLE
chore(deps): bump python/cpp FFI SDK deps to latest

### DIFF
--- a/foreign/cpp/Cargo.toml
+++ b/foreign/cpp/Cargo.toml
@@ -27,7 +27,7 @@ ignored = ["cxx-build"]
 crate-type = ["staticlib"]
 
 [dependencies]
-bytes = "1.11.1"
+bytes = "1.12.0"
 cxx = "1.0.194"
 iggy = { path = "../../core/sdk" }
 iggy_common = { path = "../../core/common" }

--- a/foreign/python/Cargo.toml
+++ b/foreign/python/Cargo.toml
@@ -35,13 +35,13 @@ path = "src/bin/stub_gen.rs"
 doc = false
 
 [dependencies]
-bytes = "1.11.1"
+bytes = "1.12.0"
 futures = "0.3.32"
 iggy = { path = "../../core/sdk", version = "0.10.1-edge.2" }
-pyo3 = "0.28.3"
-pyo3-async-runtimes = { version = "0.28.0", features = [
+pyo3 = "0.29.0"
+pyo3-async-runtimes = { version = "0.29.0", features = [
     "attributes",
     "tokio-runtime",
 ] }
-pyo3-stub-gen = "0.22.3"
+pyo3-stub-gen = "0.23.0"
 tokio = "1.52.3"


### PR DESCRIPTION
Run cargo upgrade -i across the workspace-excluded FFI
crates. python: pyo3 0.28->0.29, pyo3-async-runtimes
0.29, pyo3-stub-gen 0.23, bytes 1.12. cpp: bytes 1.12.

The pyo3 0.29 jump is semver-incompatible but needs no
source changes - the bindings already use the current
attach/Bound idioms, and the generated .pyi is identical
after regeneration.
