### PR TITLE
feat(io_uring): diagnose shard panic from unsupported opcode

### DIFF
--- a/core/server-ng/src/bootstrap.rs
+++ b/core/server-ng/src/bootstrap.rs
@@ -171,6 +171,10 @@ impl ShardHandles {
     /// does not need to read the trace log to discover late-failing shards.
     pub fn join_all(self) -> Result<(), ServerNgError> {
         let mut failures: Vec<ShardJoinFailure> = Vec::new();
+        // Shards run thread-per-core with compio's blocking fallback pool
+        // disabled, so an io_uring opcode the kernel lacks aborts every shard
+        // with the same panic. Surface the actionable diagnostic once.
+        let mut io_uring_diagnostic_shown = false;
         for (shard_id, handle) in self.shard_threads {
             match handle.join() {
                 Ok(Ok(())) => {
@@ -186,6 +190,13 @@ impl ShardHandles {
                 Err(panic_payload) => {
                     let message = panic_payload_to_string(&*panic_payload);
                     error!(shard_id, message = %message, "shard thread panicked");
+                    if !io_uring_diagnostic_shown
+                        && message
+                            .contains(server_common::diagnostics::ASYNCIFY_POOL_DISABLED_PANIC_MSG)
+                    {
+                        server_common::diagnostics::print_incomplete_io_uring_ops_info();
+                        io_uring_diagnostic_shown = true;
+                    }
                     failures.push(ShardJoinFailure {
                         shard_id,
                         kind: ShardJoinFailureKind::Panic { message },

--- a/core/server/src/diagnostics.rs
+++ b/core/server/src/diagnostics.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub use server_common::diagnostics::ASYNCIFY_POOL_DISABLED_PANIC_MSG;
+pub use server_common::diagnostics::print_incomplete_io_uring_ops_info;
 pub use server_common::diagnostics::print_invalid_io_uring_args_info;
 pub use server_common::diagnostics::print_io_uring_permission_info;
 pub use server_common::diagnostics::print_locked_memory_limit_info;

--- a/core/server/src/main.rs
+++ b/core/server/src/main.rs
@@ -30,6 +30,7 @@ use server::bootstrap::{
     load_metadata, resolve_persister, update_system_info,
 };
 use server::diagnostics::{
+    ASYNCIFY_POOL_DISABLED_PANIC_MSG, print_incomplete_io_uring_ops_info,
     print_invalid_io_uring_args_info, print_io_uring_permission_info,
     print_locked_memory_limit_info,
 };
@@ -63,6 +64,11 @@ const SHARDS_TABLE_CAPACITY: usize = 16384;
 static SHUTDOWN_START_TIME: AtomicU64 = AtomicU64::new(0);
 static SHUTDOWN_INITIATED: AtomicBool = AtomicBool::new(false);
 static SHARD_EXECUTOR_DIAGNOSTIC: std::sync::Once = std::sync::Once::new();
+// Separate latch from SHARD_EXECUTOR_DIAGNOSTIC: a shard that fails ring setup
+// (e.g. partial ENOMEM under a tight RLIMIT_MEMLOCK) must not consume the latch
+// and suppress the unsupported-opcode diagnostic from a sibling shard that did
+// start. Setup vs runtime io_uring failures can co-occur across shards.
+static SHARD_RUNTIME_DIAGNOSTIC: std::sync::Once = std::sync::Once::new();
 
 enum ShardExitStatus {
     Success,
@@ -506,6 +512,10 @@ fn main() -> Result<(), ServerError> {
                         }
                         ShardExitStatus::Panic(msg) => {
                             error!("Shard {shard_id} panicked: {msg}");
+                            if msg.contains(ASYNCIFY_POOL_DISABLED_PANIC_MSG) {
+                                SHARD_RUNTIME_DIAGNOSTIC
+                                    .call_once(print_incomplete_io_uring_ops_info);
+                            }
                             if failure_message.is_none() {
                                 failure_message =
                                     Some(format!("Shard {shard_id} panicked: {msg}"));

--- a/core/server_common/src/diagnostics.rs
+++ b/core/server_common/src/diagnostics.rs
@@ -15,6 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// compio's `AsyncifyPool::dispatch` panics with this exact message when a
+/// blocking fallback is required but the pool has zero worker threads. Iggy
+/// shard executors set `thread_pool_limit(0)` in `create_shard_executor`, so
+/// this panic means the kernel lacks an io_uring opcode a shard operation
+/// needed and compio could not run it natively. Shard-panic handlers match it
+/// to surface [`print_incomplete_io_uring_ops_info`] instead of the bare
+/// compio text.
+///
+/// Best-effort: if a future compio release changes the wording, matching
+/// degrades to logging the raw panic, which is still surfaced to the operator.
+pub const ASYNCIFY_POOL_DISABLED_PANIC_MSG: &str =
+    "the thread pool is needed but no worker thread is running";
+
 #[cfg(target_os = "linux")]
 const DISCORD_SUPPORT_URL: &str = "https://discord.gg/apache-iggy";
 
@@ -139,9 +152,6 @@ const SYSCTL_IO_URING_DISABLED_KERNEL_MINOR: u32 = 1;
 /// The caller is responsible for deduplication (e.g., via `std::sync::Once`).
 #[cfg(target_os = "linux")]
 pub fn print_invalid_io_uring_args_info() {
-    use nix::sys::utsname::uname;
-    use std::fs;
-
     eprintln!();
     eprintln!("=== io_uring Invalid Argument (EINVAL) ===");
     eprintln!();
@@ -156,6 +166,47 @@ pub fn print_invalid_io_uring_args_info() {
         "  These flags require Linux kernel >= {MIN_KERNEL_MAJOR}.{MIN_KERNEL_MINOR} with full io_uring support."
     );
     eprintln!();
+
+    report_io_uring_environment();
+}
+
+/// Prints diagnostic information when a shard thread panicked because compio
+/// had to run an io_uring operation on its blocking fallback pool, which Iggy
+/// disables (`thread_pool_limit(0)`).
+///
+/// Unlike [`print_invalid_io_uring_args_info`], io_uring setup succeeded here:
+/// the kernel accepted the ring flags and shards started, then at runtime
+/// compio's opcode probe (`IORING_REGISTER_PROBE`) reported an opcode a shard
+/// operation needed as unsupported. The caller is responsible for
+/// deduplication (e.g., via `std::sync::Once`).
+#[cfg(target_os = "linux")]
+pub fn print_incomplete_io_uring_ops_info() {
+    eprintln!();
+    eprintln!("=== io_uring Incomplete Opcode Support ===");
+    eprintln!();
+    eprintln!("A shard thread aborted because an io_uring operation it issued is not");
+    eprintln!("supported by this kernel. Iggy shards run thread-per-core with the");
+    eprintln!("blocking fallback pool disabled, so an unsupported opcode is fatal");
+    eprintln!("instead of being silently offloaded to a worker thread.");
+    eprintln!();
+    eprintln!("  io_uring setup succeeded (shards started), but at runtime compio");
+    eprintln!("  probed the kernel and a required opcode was absent. This is common");
+    eprintln!("  on WSL2 and on older or cut-down kernels whose io_uring support is");
+    eprintln!("  incomplete. Some opcodes need a kernel newer than the shard-setup");
+    eprintln!("  floor below.");
+    eprintln!();
+
+    report_io_uring_environment();
+}
+
+/// Probes the io_uring environment (kernel version, WSL2 detection,
+/// `kernel.io_uring_disabled` sysctl, AppArmor confinement), prints the
+/// findings plus any concrete issues, then prints the shared remediation
+/// steps. Reused by both io_uring diagnostics above.
+#[cfg(target_os = "linux")]
+fn report_io_uring_environment() {
+    use nix::sys::utsname::uname;
+    use std::fs;
 
     let mut detected_issues: Vec<String> = Vec::new();
 
@@ -194,7 +245,8 @@ pub fn print_invalid_io_uring_args_info() {
         if release_is_wsl || proc_version_is_wsl {
             eprintln!("  Environment: WSL2 (Microsoft kernel fork detected)");
             detected_issues.push(
-                "WSL2 kernel may not support IORING_SETUP_COOP_TASKRUN even if version >= 5.19"
+                "WSL2 kernels often ship incomplete io_uring: missing setup flags or \
+                 opcodes even at version >= 5.19"
                     .to_string(),
             );
         }
@@ -247,8 +299,8 @@ pub fn print_invalid_io_uring_args_info() {
     // Print detected issues
     if detected_issues.is_empty() {
         eprintln!();
-        eprintln!("  No specific issue was detected. The kernel may lack io_uring support");
-        eprintln!("  for the flags used by Iggy's shard executors.");
+        eprintln!("  No specific issue was detected. This kernel's io_uring support may be");
+        eprintln!("  incomplete for the setup flags or opcodes Iggy's shard executors require.");
     } else {
         eprintln!();
         eprintln!("  Detected issues:");
@@ -301,6 +353,9 @@ pub const fn print_io_uring_permission_info() {}
 
 #[cfg(not(target_os = "linux"))]
 pub const fn print_invalid_io_uring_args_info() {}
+
+#[cfg(not(target_os = "linux"))]
+pub const fn print_incomplete_io_uring_ops_info() {}
 
 #[cfg(all(test, target_os = "linux"))]
 mod tests {


### PR DESCRIPTION
Kernels with incomplete io_uring support (WSL2, older or
cut-down builds) can lack an opcode a shard operation needs.
compio's runtime probe then routes that op to the blocking
fallback pool, which shards disable via thread_pool_limit(0)
for thread-per-core, so every shard aborts with compio's
opaque "the thread pool is needed but no worker thread is
running". The existing io_uring diagnostics only covered
setup-time EINVAL, leaving operators with just that message.

Match the panic while draining shard threads and surface a
dedicated diagnostic that names the cause and reuses the
existing kernel/WSL2/sysctl probe and remediation steps.
Wired into both the classic server and server-ng. Kept
additive rather than installing a panic hook so unrelated
backtraces are preserved.
