### PR TITLE
fix(connectors): add support for server-ng

### DIFF
--- a/core/connectors/runtime/Cargo.toml
+++ b/core/connectors/runtime/Cargo.toml
@@ -29,6 +29,9 @@ repository = "https://github.com/apache/iggy"
 readme = "README.md"
 publish = false
 
+[features]
+vsr = ["iggy/vsr"]
+
 [dependencies]
 async-trait = { workspace = true }
 axum = { workspace = true }

--- a/core/integration/src/harness/orchestrator/harness.rs
+++ b/core/integration/src/harness/orchestrator/harness.rs
@@ -406,15 +406,10 @@ impl TestHarness {
             .await
     }
 
-    /// Get the connectors runtime handle from the primary server if configured.
-    ///
-    /// # Panics
-    /// Panics if called on a cluster (multiple servers). Use `node(i).connectors_runtime()` instead.
+    /// Get the connectors runtime handle if configured. Targets the primary's
+    /// handle, for both single-server and cluster setups (the builder attaches
+    /// the runtime to node 0, mirroring `mcp()`).
     pub fn connectors_runtime(&self) -> Option<&ConnectorsRuntimeHandle> {
-        assert!(
-            self.servers.len() <= 1,
-            "connectors_runtime() is only available for single-server setups. Use node(i).connectors_runtime() for clusters."
-        );
         self.servers.first().and_then(|s| s.connectors_runtime())
     }
 

--- a/core/integration/tests/mod.rs
+++ b/core/integration/tests/mod.rs
@@ -35,7 +35,6 @@ mod cli;
 #[cfg(not(feature = "vsr"))]
 mod cluster;
 mod config_provider;
-#[cfg(not(feature = "vsr"))]
 mod connectors;
 // TODO(vsr): enable the `data_integrity` suite under the `vsr` feature once
 // the full VSR path is done. Tier 1 (`verify_user_login_after_restart`,

--- a/core/server-ng/src/dispatch.rs
+++ b/core/server-ng/src/dispatch.rs
@@ -1367,7 +1367,10 @@ fn decode_poll_request(
         return Ok((namespace, partition_id, consumer, args));
     }
 
-    let partition_id = wire.partition_id.ok_or(IggyError::InvalidIdentifier)?;
+    // Plain-consumer poll: an omitted partition selects partition 0, matching
+    // the legacy resolver (`resolve_consumer_with_partition_id` uses
+    // `unwrap_or(0)` for `ConsumerKind::Consumer`).
+    let partition_id = wire.partition_id.unwrap_or(0);
     let namespace =
         resolve_partition_namespace(shard, &wire.stream_id, &wire.topic_id, Some(partition_id))?;
     let consumer = polling_consumer_from_wire(&wire.consumer, partition_id)?;
@@ -1380,7 +1383,9 @@ fn decode_consumer_offset_request(
 ) -> Result<(IggyNamespace, u32, PollingConsumer), IggyError> {
     let wire = GetConsumerOffsetRequest::decode_from(request_body(request))
         .map_err(|_| IggyError::InvalidCommand)?;
-    let partition_id = wire.partition_id.ok_or(IggyError::InvalidIdentifier)?;
+    // Omitted partition reads partition 0, matching the legacy resolver for
+    // both consumer kinds (`unwrap_or(0)`).
+    let partition_id = wire.partition_id.unwrap_or(0);
     let namespace =
         resolve_partition_namespace(shard, &wire.stream_id, &wire.topic_id, Some(partition_id))?;
     // A group offset is keyed by the group's monotonic id (any client may read


### PR DESCRIPTION
This PR adds support in the connectors integration testing suite to test using `server-ng`. 