### PR TITLE
chore(integration): remove stale todo and run mcp under vsr

### DIFF
--- a/core/integration/tests/mcp/mod.rs
+++ b/core/integration/tests/mcp/mod.rs
@@ -16,11 +16,12 @@
 // under the License.
 
 use iggy_common::{
-    ClientInfo, ClientInfoDetails, ClusterMetadata, ConsumerGroup, ConsumerGroupDetails,
-    ConsumerOffsetInfo, PersonalAccessTokenExpiry, PersonalAccessTokenInfo, PolledMessages,
-    RawPersonalAccessToken, Snapshot, Stats, Stream, StreamDetails, Topic, TopicDetails, UserInfo,
-    UserInfoDetails,
+    ClientInfo, ClientInfoDetails, ConsumerGroup, ConsumerGroupDetails, ConsumerOffsetInfo,
+    PersonalAccessTokenExpiry, PersonalAccessTokenInfo, PolledMessages, RawPersonalAccessToken,
+    Stats, Stream, StreamDetails, Topic, TopicDetails, UserInfo, UserInfoDetails,
 };
+#[cfg(not(feature = "vsr"))]
+use iggy_common::{ClusterMetadata, Snapshot};
 use integration::{
     harness::{McpClient, seeds},
     iggy_harness,
@@ -85,6 +86,7 @@ async fn should_handle_ping(harness: &TestHarness) {
     invoke_empty(&mcp_client, "ping", None).await;
 }
 
+#[cfg(not(feature = "vsr"))]
 #[iggy_harness(server(cluster.enabled = true, mcp))]
 async fn should_return_cluster_metadata(harness: &TestHarness) {
     let mcp_client = harness.mcp_client().await.expect("MCP client required");
@@ -359,6 +361,7 @@ async fn should_return_clients(harness: &TestHarness) {
     assert!(!clients.is_empty());
 }
 
+#[cfg(not(feature = "vsr"))]
 #[iggy_harness(server(mcp), seed = seeds::mcp_standard)]
 async fn should_handle_snapshot(harness: &TestHarness) {
     let mcp_client = harness.mcp_client().await.expect("MCP client required");

--- a/core/integration/tests/mod.rs
+++ b/core/integration/tests/mod.rs
@@ -61,13 +61,6 @@ mod connectors;
 // revocation. server-ng's rebalance is also covered by `server::cg_vsr` +
 // `stale_client_consumer_group_scenario` (both green).
 mod data_integrity;
-// TODO(vsr): un-gate once the metadata `messages_count` aggregation gap is
-// fixed (partition-plane counts aren't shared into the metadata topic/stream
-// stats under vsr -- root-caused: per-buffer left-right `Arc<TopicStats>`;
-// see `sdk::metadata_counts`) and the `delete_consumer_offset` hang is
-// addressed. Enablement scaffolding is done: the `iggy-mcp` crate has a `vsr`
-// feature and the harness `mcp()` accessor works for clusters.
-#[cfg(not(feature = "vsr"))]
 mod mcp;
 mod sdk;
 mod server;


### PR DESCRIPTION
This PR removes outdated TODO and runs mcp integration tests under `vsr` feature flag, gating two known issues -- missing `get_snapshot` and `get_cluster_metadata` APIs.