### PR TITLE
feat(go): add diagnostic event subscriptions to TCP client

### DIFF
--- a/foreign/go/client/tcp/tcp_core.go
+++ b/foreign/go/client/tcp/tcp_core.go
@@ -60,6 +60,7 @@ type IggyTcpClient struct {
 	currentServerAddress   string
 	connectedAt            time.Time
 	state                  iggcon.State
+	events                 *eventBroadcaster
 	// respHeader is the reused response-status read buffer; guarded by c.mtx.
 	respHeader [ResponseInitialBytesLength]byte
 }
@@ -220,6 +221,7 @@ func NewIggyTcpClient(logger *slog.Logger, options ...Option) *IggyTcpClient {
 		connectedAt:            time.Time{},
 		leaderRedirectionState: iggcon.LeaderRedirectionState{},
 		currentServerAddress:   opts.config.serverAddress,
+		events:                 newEventBroadcaster(),
 	}
 }
 
@@ -431,12 +433,16 @@ func (c *IggyTcpClient) sendLocked(wirePayload []byte) ([]byte, error) {
 	return buffer, nil
 }
 
-// invalidateConnLocked closes the connection and marks it as disconnected
+// invalidateConnLocked closes the connection and marks it as disconnected,
+// publishing a Disconnected event on the transition.
 func (c *IggyTcpClient) invalidateConnLocked() {
 	if c.conn != nil {
 		_ = c.conn.Close()
 	}
-	c.state = iggcon.StateDisconnected
+	if c.state != iggcon.StateDisconnected {
+		c.state = iggcon.StateDisconnected
+		c.events.publish(iggcon.DiagnosticEventDisconnected)
+	}
 }
 
 func (c *IggyTcpClient) GetConnectionInfo() *iggcon.ConnectionInfo {
@@ -548,7 +554,7 @@ func (c *IggyTcpClient) Connect(ctx context.Context) error {
 		if !c.config.reconnection.enabled {
 			c.logger.Warn("Automatic reconnection is disabled.")
 		}
-		// TODO publish event disconnected
+		c.events.publish(iggcon.DiagnosticEventDisconnected)
 		return err
 	}
 
@@ -558,6 +564,7 @@ func (c *IggyTcpClient) Connect(ctx context.Context) error {
 	c.connectedAt = time.Now()
 	c.logger.Info("Iggy client has connected to the Iggy server", slog.String("client_address", c.clientAddress), slog.String("server_address", c.currentServerAddress))
 	c.mtx.Unlock()
+	c.events.publish(iggcon.DiagnosticEventConnected)
 	return nil
 }
 
@@ -624,7 +631,7 @@ func (c *IggyTcpClient) disconnect() error {
 	}
 
 	c.logger.Info("Iggy client has disconnected from server.", slog.String("client_address", c.clientAddress))
-	// TODO event pushing logic
+	c.events.publish(iggcon.DiagnosticEventDisconnected)
 	return nil
 }
 
@@ -646,10 +653,18 @@ func (c *IggyTcpClient) shutdown() error {
 
 	c.state = iggcon.StateShutdown
 	c.logger.Info("Iggy TCP client has been shutdown.", slog.String("client_address", c.clientAddress))
-	// TODO push shutdown event
+	c.events.publish(iggcon.DiagnosticEventShutdown)
+	c.events.close()
 	return nil
 }
 
 func (c *IggyTcpClient) Close() error {
 	return c.shutdown()
+}
+
+// SubscribeEvents returns an independent channel of client lifecycle events
+// and an unsubscribe function. The channel is closed on shutdown, after the
+// final DiagnosticEventShutdown.
+func (c *IggyTcpClient) SubscribeEvents() (<-chan iggcon.DiagnosticEvent, func()) {
+	return c.events.subscribe()
 }

--- a/foreign/go/client/tcp/tcp_core_test.go
+++ b/foreign/go/client/tcp/tcp_core_test.go
@@ -45,6 +45,7 @@ func newTestClient(t *testing.T) (*IggyTcpClient, net.Conn) {
 		conn:   clientConn,
 		state:  iggcon.StateConnected,
 		logger: slog.New(slog.DiscardHandler),
+		events: newEventBroadcaster(),
 	}
 	t.Cleanup(func() {
 		err := clientConn.Close()

--- a/foreign/go/client/tcp/tcp_events.go
+++ b/foreign/go/client/tcp/tcp_events.go
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tcp
+
+import (
+	"sync"
+
+	iggcon "github.com/apache/iggy/foreign/go/contracts"
+)
+
+// subscriberBufferSize bounds each subscriber's channel. A subscriber that
+// fails to drain within this many events will start dropping the oldest
+// events; the publisher is never blocked.
+const subscriberBufferSize = 1000
+
+// eventBroadcaster fans out diagnostic events to any number of subscribers.
+// Each call to subscribe returns an independent channel; publish delivers
+// the event to every live subscriber non-blockingly. close releases all
+// subscriber channels and is idempotent.
+type eventBroadcaster struct {
+	mu          sync.Mutex
+	subscribers []chan iggcon.DiagnosticEvent
+	closed      bool
+}
+
+func newEventBroadcaster() *eventBroadcaster {
+	return &eventBroadcaster{}
+}
+
+// subscribe returns a new subscriber channel and an unsubscribe function that
+// is idempotent and safe to call after the broadcaster is closed.
+func (b *eventBroadcaster) subscribe() (<-chan iggcon.DiagnosticEvent, func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan iggcon.DiagnosticEvent, subscriberBufferSize)
+	if b.closed {
+		close(ch)
+		return ch, func() {}
+	}
+	b.subscribers = append(b.subscribers, ch)
+
+	var once sync.Once
+	unsubscribe := func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			if b.closed {
+				return
+			}
+			for i, sub := range b.subscribers {
+				if sub == ch {
+					b.subscribers = append(b.subscribers[:i], b.subscribers[i+1:]...)
+					close(ch)
+					return
+				}
+			}
+		})
+	}
+	return ch, unsubscribe
+}
+
+func (b *eventBroadcaster) publish(event iggcon.DiagnosticEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+	for _, ch := range b.subscribers {
+		select {
+		case ch <- event:
+		default:
+			// Subscriber is not draining fast enough. Drop the oldest event
+			// to make room for the newest, preferring recency. Keeps the
+			// publisher non-blocking even with a slow subscriber.
+			select {
+			case <-ch:
+			default:
+			}
+			select {
+			case ch <- event:
+			default:
+			}
+		}
+	}
+}
+
+func (b *eventBroadcaster) close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+	b.closed = true
+	for _, ch := range b.subscribers {
+		close(ch)
+	}
+	b.subscribers = nil
+}

--- a/foreign/go/client/tcp/tcp_events_test.go
+++ b/foreign/go/client/tcp/tcp_events_test.go
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tcp
+
+import (
+	"testing"
+	"time"
+
+	iggcon "github.com/apache/iggy/foreign/go/contracts"
+)
+
+func recvWithTimeout(t *testing.T, ch <-chan iggcon.DiagnosticEvent) (iggcon.DiagnosticEvent, bool) {
+	t.Helper()
+	select {
+	case ev, ok := <-ch:
+		return ev, ok
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+		return 0, false
+	}
+}
+
+func TestEventBroadcaster_DeliversToAllSubscribers(t *testing.T) {
+	b := newEventBroadcaster()
+	a, _ := b.subscribe()
+	c, _ := b.subscribe()
+
+	b.publish(iggcon.DiagnosticEventConnected)
+
+	if ev, _ := recvWithTimeout(t, a); ev != iggcon.DiagnosticEventConnected {
+		t.Errorf("subscriber A got %v, want connected", ev)
+	}
+	if ev, _ := recvWithTimeout(t, c); ev != iggcon.DiagnosticEventConnected {
+		t.Errorf("subscriber B got %v, want connected", ev)
+	}
+}
+
+func TestEventBroadcaster_PreservesOrderForOneSubscriber(t *testing.T) {
+	b := newEventBroadcaster()
+	ch, _ := b.subscribe()
+
+	want := []iggcon.DiagnosticEvent{
+		iggcon.DiagnosticEventConnected,
+		iggcon.DiagnosticEventSignedIn,
+		iggcon.DiagnosticEventDisconnected,
+	}
+	for _, ev := range want {
+		b.publish(ev)
+	}
+	for i, w := range want {
+		got, _ := recvWithTimeout(t, ch)
+		if got != w {
+			t.Errorf("event %d: got %v, want %v", i, got, w)
+		}
+	}
+}
+
+func TestEventBroadcaster_CloseDeliversNoMoreEvents(t *testing.T) {
+	b := newEventBroadcaster()
+	ch, _ := b.subscribe()
+
+	b.close()
+
+	// channel should be closed; receive returns zero, ok=false
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected channel to be closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for closed channel")
+	}
+
+	// subsequent publish is a no-op
+	b.publish(iggcon.DiagnosticEventConnected)
+
+	// late subscribe returns an already-closed channel
+	late, _ := b.subscribe()
+	select {
+	case _, ok := <-late:
+		if ok {
+			t.Fatal("expected late-subscribe channel to be closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for closed late-subscribe channel")
+	}
+}
+
+func TestEventBroadcaster_SlowSubscriberDoesNotBlockPublisher(t *testing.T) {
+	b := newEventBroadcaster()
+	_, _ = b.subscribe() // never drained
+
+	// Publish more events than the buffer; if the publisher blocked or
+	// panicked we'd hang or fail here.
+	for range subscriberBufferSize * 2 {
+		b.publish(iggcon.DiagnosticEventConnected)
+	}
+}
+
+func TestEventBroadcaster_CloseIsIdempotent(t *testing.T) {
+	b := newEventBroadcaster()
+	b.subscribe()
+	b.close()
+	b.close() // must not panic
+}
+
+func TestEventBroadcaster_UnsubscribeStopsDelivery(t *testing.T) {
+	b := newEventBroadcaster()
+	ch, unsubscribe := b.subscribe()
+
+	unsubscribe()
+
+	if _, ok := <-ch; ok {
+		t.Fatal("expected channel to be closed after unsubscribe")
+	}
+	b.publish(iggcon.DiagnosticEventConnected)
+
+	other, _ := b.subscribe()
+	b.publish(iggcon.DiagnosticEventSignedIn)
+	if ev, _ := recvWithTimeout(t, other); ev != iggcon.DiagnosticEventSignedIn {
+		t.Errorf("remaining subscriber got %v, want signed_in", ev)
+	}
+}
+
+func TestEventBroadcaster_UnsubscribeIsIdempotentAndSafeAfterClose(t *testing.T) {
+	b := newEventBroadcaster()
+	_, unsubscribe := b.subscribe()
+
+	unsubscribe()
+	unsubscribe() // second call must not panic or double-close
+
+	b.close()
+	unsubscribe() // after close must not panic
+}

--- a/foreign/go/client/tcp/tcp_session_management.go
+++ b/foreign/go/client/tcp/tcp_session_management.go
@@ -51,6 +51,7 @@ func (c *IggyTcpClient) LoginUser(ctx context.Context, username string, password
 		}
 		return c.LoginUser(ctx, username, password)
 	}
+	c.events.publish(iggcon.DiagnosticEventSignedIn)
 	return identity, nil
 }
 
@@ -75,12 +76,16 @@ func (c *IggyTcpClient) LoginWithPersonalAccessToken(ctx context.Context, token 
 		}
 		return c.LoginWithPersonalAccessToken(ctx, token)
 	}
+	c.events.publish(iggcon.DiagnosticEventSignedIn)
 	return identity, nil
 }
 
 func (c *IggyTcpClient) LogoutUser(ctx context.Context) error {
-	_, err := c.do(ctx, &command.LogoutUser{})
-	return err
+	if _, err := c.do(ctx, &command.LogoutUser{}); err != nil {
+		return err
+	}
+	c.events.publish(iggcon.DiagnosticEventSignedOut)
+	return nil
 }
 
 func (c *IggyTcpClient) HandleLeaderRedirection(ctx context.Context) (bool, error) {
@@ -116,6 +121,8 @@ func (c *IggyTcpClient) HandleLeaderRedirection(ctx context.Context) (bool, erro
 		return false, nil
 	}
 	c.mtx.Unlock()
+
+	c.events.publish(iggcon.DiagnosticEventRedirected)
 
 	if err = c.disconnect(); err != nil {
 		return false, err

--- a/foreign/go/contracts/client.go
+++ b/foreign/go/contracts/client.go
@@ -29,6 +29,12 @@ type Client interface {
 	// GetConnectionInfo returns the current connection information including protocol and server address
 	GetConnectionInfo() *ConnectionInfo
 
+	// SubscribeEvents returns an independent channel of client lifecycle events
+	// and an unsubscribe function that removes the subscription and closes the
+	// channel. The channel is also closed on shutdown, after the final
+	// DiagnosticEventShutdown.
+	SubscribeEvents() (<-chan DiagnosticEvent, func())
+
 	// GetClusterMetadata get the metadata of the cluster including node information, roles, and status.
 	// Authentication is required.
 	GetClusterMetadata(ctx context.Context) (*ClusterMetadata, error)

--- a/foreign/go/contracts/diagnostic_event.go
+++ b/foreign/go/contracts/diagnostic_event.go
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iggcon
+
+// DiagnosticEvent describes a client-level lifecycle change that subscribers
+// can observe via Client.SubscribeEvents.
+type DiagnosticEvent int
+
+const (
+	DiagnosticEventShutdown DiagnosticEvent = iota
+	DiagnosticEventDisconnected
+	DiagnosticEventConnected
+	DiagnosticEventSignedIn
+	DiagnosticEventSignedOut
+	DiagnosticEventRedirected
+)
+
+func (e DiagnosticEvent) String() string {
+	switch e {
+	case DiagnosticEventShutdown:
+		return "shutdown"
+	case DiagnosticEventDisconnected:
+		return "disconnected"
+	case DiagnosticEventConnected:
+		return "connected"
+	case DiagnosticEventSignedIn:
+		return "signed_in"
+	case DiagnosticEventSignedOut:
+		return "signed_out"
+	case DiagnosticEventRedirected:
+		return "redirected"
+	default:
+		return "unknown"
+	}
+}

--- a/foreign/go/tests/diagnostic_events_test.go
+++ b/foreign/go/tests/diagnostic_events_test.go
@@ -1,0 +1,268 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tests_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/apache/iggy/foreign/go/client"
+	"github.com/apache/iggy/foreign/go/client/tcp"
+	iggcon "github.com/apache/iggy/foreign/go/contracts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// sharedServerAddr is the address of the Iggy server started once for the
+// whole package by TestMain and reused by every diagnostic-event test.
+var sharedServerAddr string
+
+// TestMain starts one Iggy server container for the whole package, runs the
+// tests against it, and tears it down.
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	container, addr, err := startPlainContainer(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "diagnostic_events_test: failed to start Iggy container: %v\n", err)
+		os.Exit(1)
+	}
+	sharedServerAddr = addr
+
+	code := m.Run()
+
+	_ = container.Terminate(ctx)
+	os.Exit(code)
+}
+
+// startPlainContainer starts a non-TLS Iggy server container and returns it
+// along with its mapped address.
+func startPlainContainer(ctx context.Context) (testcontainers.Container, string, error) {
+	dockerImage := os.Getenv("IGGY_SERVER_DOCKER_IMAGE")
+	if dockerImage == "" {
+		dockerImage = "apache/iggy:edge"
+	}
+
+	req := testcontainers.ContainerRequest{
+		Image:        dockerImage,
+		ExposedPorts: []string{"8090/tcp"},
+		Env: map[string]string{
+			"IGGY_ROOT_USERNAME": "iggy",
+			"IGGY_ROOT_PASSWORD": "iggy",
+			"IGGY_TCP_ADDRESS":   "0.0.0.0:8090",
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Iggy server is running"),
+			wait.ForListeningPort("8090/tcp"),
+		),
+		Privileged: true,
+		AutoRemove: true,
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	port, err := container.MappedPort(ctx, "8090")
+	if err != nil {
+		return nil, "", err
+	}
+
+	return container, fmt.Sprintf("%s:%s", host, port.Port()), nil
+}
+
+// recvEvent reads one event from the channel with a timeout. Failing the
+// test on timeout keeps a flaky CI from hanging the whole suite.
+func recvEvent(t *testing.T, ch <-chan iggcon.DiagnosticEvent, timeout time.Duration) (iggcon.DiagnosticEvent, bool) {
+	t.Helper()
+	select {
+	case ev, ok := <-ch:
+		return ev, ok
+	case <-time.After(timeout):
+		t.Fatalf("timed out after %v waiting for diagnostic event", timeout)
+		return 0, false
+	}
+}
+
+// drainEvents collects events until the channel is closed or the timeout
+// expires. Used to assert the full sequence emitted during a scenario.
+func drainEvents(t *testing.T, ch <-chan iggcon.DiagnosticEvent, timeout time.Duration) []iggcon.DiagnosticEvent {
+	t.Helper()
+	deadline := time.After(timeout)
+	var events []iggcon.DiagnosticEvent
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return events
+			}
+			events = append(events, ev)
+		case <-deadline:
+			t.Fatalf("timed out after %v draining diagnostic events; got %v", timeout, events)
+			return events
+		}
+	}
+}
+
+func newPlainClient(t *testing.T, addr string) iggcon.Client {
+	t.Helper()
+	cli, err := client.NewIggyClient(
+		client.WithTcp(
+			tcp.WithServerAddress(addr),
+		),
+	)
+	require.NoError(t, err, "Failed to create Iggy client")
+	return cli
+}
+
+// TestDiagnosticEvents_LoginEmitsSignedIn verifies that LoginUser emits
+// a SignedIn event after a successful authentication.
+func TestDiagnosticEvents_LoginEmitsSignedIn(t *testing.T) {
+	cli := newPlainClient(t, sharedServerAddr)
+	defer func() { _ = cli.Close() }()
+
+	require.NoError(t, cli.Connect(context.Background()), "Connect should succeed")
+
+	// Subscribe after connecting so the first event we observe is SignedIn.
+	events, cancel := cli.SubscribeEvents()
+	defer cancel()
+
+	_, err := cli.LoginUser(context.Background(), defaultUsername, defaultPassword)
+	require.NoError(t, err, "Login should succeed")
+
+	ev, ok := recvEvent(t, events, 5*time.Second)
+	require.True(t, ok, "channel should not be closed")
+	assert.Equal(t, iggcon.DiagnosticEventSignedIn, ev, "expected signed_in event after LoginUser")
+}
+
+// TestDiagnosticEvents_LogoutEmitsSignedOut verifies that LogoutUser emits
+// a SignedOut event after a successful logout.
+func TestDiagnosticEvents_LogoutEmitsSignedOut(t *testing.T) {
+	cli := newPlainClient(t, sharedServerAddr)
+	defer func() { _ = cli.Close() }()
+
+	require.NoError(t, cli.Connect(context.Background()), "Connect should succeed")
+
+	_, err := cli.LoginUser(context.Background(), defaultUsername, defaultPassword)
+	require.NoError(t, err, "Login should succeed")
+
+	// Subscribe after login so the first event we observe is SignedOut.
+	events, cancel := cli.SubscribeEvents()
+	defer cancel()
+
+	err = cli.LogoutUser(context.Background())
+	require.NoError(t, err, "Logout should succeed")
+
+	ev, ok := recvEvent(t, events, 5*time.Second)
+	require.True(t, ok, "channel should not be closed")
+	assert.Equal(t, iggcon.DiagnosticEventSignedOut, ev, "expected signed_out event after LogoutUser")
+}
+
+// TestDiagnosticEvents_CloseEmitsShutdownAndClosesChannel verifies that
+// Close emits a final Shutdown event and then closes the subscriber
+// channel, so consumers can range over the channel and exit cleanly.
+func TestDiagnosticEvents_CloseEmitsShutdownAndClosesChannel(t *testing.T) {
+	cli := newPlainClient(t, sharedServerAddr)
+	require.NoError(t, cli.Connect(context.Background()), "Connect should succeed")
+
+	// Subscribe after connecting so the only event we observe is Shutdown.
+	events, cancel := cli.SubscribeEvents()
+	defer cancel()
+
+	require.NoError(t, cli.Close(), "Close should succeed")
+
+	ev, ok := recvEvent(t, events, 5*time.Second)
+	require.True(t, ok, "should receive shutdown before channel close")
+	assert.Equal(t, iggcon.DiagnosticEventShutdown, ev, "expected shutdown event on Close")
+
+	// Channel must be closed after the final Shutdown event.
+	select {
+	case _, ok := <-events:
+		assert.False(t, ok, "channel should be closed after shutdown")
+	case <-time.After(2 * time.Second):
+		t.Fatal("channel was not closed after shutdown")
+	}
+}
+
+// TestDiagnosticEvents_MultipleSubscribers verifies that two independent
+// subscribers each receive the full sequence of events.
+func TestDiagnosticEvents_MultipleSubscribers(t *testing.T) {
+	cli := newPlainClient(t, sharedServerAddr)
+	require.NoError(t, cli.Connect(context.Background()), "Connect should succeed")
+
+	// Subscribe after connecting so both subscribers observe the same
+	// login → logout → close sequence.
+	a, cancelA := cli.SubscribeEvents()
+	defer cancelA()
+	b, cancelB := cli.SubscribeEvents()
+	defer cancelB()
+
+	_, err := cli.LoginUser(context.Background(), defaultUsername, defaultPassword)
+	require.NoError(t, err)
+	require.NoError(t, cli.LogoutUser(context.Background()))
+	require.NoError(t, cli.Close())
+
+	want := []iggcon.DiagnosticEvent{
+		iggcon.DiagnosticEventSignedIn,
+		iggcon.DiagnosticEventSignedOut,
+		iggcon.DiagnosticEventShutdown,
+	}
+	assert.Equal(t, want, drainEvents(t, a, 10*time.Second), "subscriber A should receive full event sequence")
+	assert.Equal(t, want, drainEvents(t, b, 10*time.Second), "subscriber B should receive full event sequence")
+}
+
+// TestDiagnosticEvents_FullLifecycle verifies the complete event sequence
+// emitted across login → logout → close on a single subscriber.
+func TestDiagnosticEvents_FullLifecycle(t *testing.T) {
+	cli := newPlainClient(t, sharedServerAddr)
+
+	// Subscribe before connecting so the sequence includes Connected.
+	events, cancel := cli.SubscribeEvents()
+	defer cancel()
+
+	require.NoError(t, cli.Connect(context.Background()), "Connect should succeed")
+
+	_, err := cli.LoginUser(context.Background(), defaultUsername, defaultPassword)
+	require.NoError(t, err, "Login should succeed")
+
+	require.NoError(t, cli.LogoutUser(context.Background()), "Logout should succeed")
+
+	require.NoError(t, cli.Close(), "Close should succeed")
+
+	got := drainEvents(t, events, 10*time.Second)
+	want := []iggcon.DiagnosticEvent{
+		iggcon.DiagnosticEventConnected,
+		iggcon.DiagnosticEventSignedIn,
+		iggcon.DiagnosticEventSignedOut,
+		iggcon.DiagnosticEventShutdown,
+	}
+	assert.Equal(t, want, got, "expected full lifecycle event sequence")
+}


### PR DESCRIPTION

## Which issue does this PR address

Closes #3219

## Rationale

The TCP client had `// TODO publish event` stubs at the connect/disconnect/
shutdown paths with no way for callers to observe connection or auth state
changes. This fills those in and is groundwork for a high-level `IggyConsumer`
abstraction: diagnostic events let the consumer detect disconnects and
re-join consumer groups eagerly on reconnect. They're also useful on their own
for application-level observability (logging drops, health metrics).

## What changed?

- `DiagnosticEvent` enum + `String()` in `contracts/`, and `SubscribeEvents()`
  on the `Client` interface.
- A small non-blocking broadcaster in the TCP client fanning out to multiple
  independent subscribers.
- Emission wired into connect (`Connected`), disconnect/failed-connect
  (`Disconnected`), shutdown (`Shutdown`), login (`SignedIn`) and logout
  (`SignedOut`).

## Local Execution

- **Passed.** `go build ./...`, `go vet ./...`, `gofmt`, and `go mod tidy` are clean.
- Unit tests pass: `DiagnosticEvent.String`, and the broadcaster tests
  (fan-out / ordering / slow-subscriber-drop / idempotent-close).
- Integration tests pass — all 5 in `tests/diagnostic_events_test.go`
  (login → SignedIn, logout → SignedOut, close → Shutdown + channel close,
  multiple subscribers, and the full connect → login → logout → close sequence),
  run against a real `apache/iggy:edge` container via testcontainers.
- **Pre-commit hooks ran** via `prek` (pre-commit + pre-push), including
  `golangci-lint` on `foreign/go` — passed.


## AI Usage

1. **Tool:** Claude Code.
2. **Scope:** Implementation of the enum, broadcaster, and event wiring;
   rebase/conflict resolution onto latest `master`; test authoring.
3. **Verification:** Local `go build`/`go vet`/unit tests, `golangci-lint`, and
   manual review of every changed line against the surrounding code.
4. **Can I explain every line?** Yes.
