### PR TITLE
feat(server-ng): add cluster-correct HTTP listener + per-op RBAC

### DIFF
--- a/core/binary_protocol/src/consensus/header.rs
+++ b/core/binary_protocol/src/consensus/header.rs
@@ -151,7 +151,13 @@ pub struct RequestHeader {
     pub operation_padding: [u8; 7],
     pub namespace: u64,
     pub session: u64,
-    pub reserved: [u8; 56],
+    /// Acting user id, stamped by the metadata primary at admission for every
+    /// gated client op so the in-apply RBAC gate resolves the same identity on
+    /// every replica; on `Register` it carries the freshly authenticated user.
+    /// The submitter's wire value is never trusted. Zero for `Logout`,
+    /// partition-plane, and server-internal ops.
+    pub user_id: u32,
+    pub reserved: [u8; 52],
 }
 const _: () = {
     assert!(size_of::<RequestHeader>() == HEADER_SIZE);
@@ -159,7 +165,10 @@ const _: () = {
         offset_of!(RequestHeader, client)
             == offset_of!(RequestHeader, reserved_frame) + size_of::<[u8; 66]>()
     );
-    assert!(offset_of!(RequestHeader, reserved) + size_of::<[u8; 56]>() == HEADER_SIZE);
+    assert!(
+        offset_of!(RequestHeader, user_id) == offset_of!(RequestHeader, session) + size_of::<u64>()
+    );
+    assert!(offset_of!(RequestHeader, reserved) + size_of::<[u8; 52]>() == HEADER_SIZE);
 };
 
 impl Default for RequestHeader {
@@ -182,7 +191,8 @@ impl Default for RequestHeader {
             operation_padding: [0; 7],
             namespace: 0,
             session: 0,
-            reserved: [0; 56],
+            user_id: 0,
+            reserved: [0; 52],
         }
     }
 }
@@ -272,7 +282,20 @@ pub struct ReplyHeader {
     pub operation: Operation,
     pub operation_padding: [u8; 7],
     pub namespace: u64,
-    pub reserved: [u8; 32],
+    /// Request-level status: 0 = ok; nonzero = the `IggyError` code for a
+    /// failure decided before commit (e.g. a dispatch-time authorization
+    /// denial, or the partition primary rejecting a consumer-offset op).
+    ///
+    /// Contract: this is nonzero ONLY on a pre-commit denial, and a deny
+    /// reply always carries an EMPTY body. So this header channel and the
+    /// committed per-sub-op results in the metadata result section are mutually
+    /// exclusive by construction: a reply either commits (status 0, result
+    /// section present) or is denied before commit (status set, no body), and a
+    /// consumer never reconciles the two. Carved from `reserved` exactly like
+    /// `user_id` in `RequestHeader` / `PrepareHeader`; no existing field offset
+    /// moves and `validate` does not inspect it.
+    pub status: u32,
+    pub reserved: [u8; 28],
 }
 const _: () = {
     assert!(size_of::<ReplyHeader>() == HEADER_SIZE);
@@ -280,7 +303,10 @@ const _: () = {
         offset_of!(ReplyHeader, request_checksum)
             == offset_of!(ReplyHeader, reserved_frame) + size_of::<[u8; 66]>()
     );
-    assert!(offset_of!(ReplyHeader, reserved) + size_of::<[u8; 32]>() == HEADER_SIZE);
+    assert!(
+        offset_of!(ReplyHeader, status) == offset_of!(ReplyHeader, namespace) + size_of::<u64>()
+    );
+    assert!(offset_of!(ReplyHeader, reserved) + size_of::<[u8; 28]>() == HEADER_SIZE);
 };
 
 impl Default for ReplyHeader {
@@ -305,7 +331,8 @@ impl Default for ReplyHeader {
             operation: Operation::Reserved,
             operation_padding: [0; 7],
             namespace: 0,
-            reserved: [0; 32],
+            status: 0,
+            reserved: [0; 28],
         }
     }
 }
@@ -591,7 +618,10 @@ pub struct PrepareHeader {
     pub operation: Operation,
     pub operation_padding: [u8; 7],
     pub namespace: u64,
-    pub reserved: [u8; 32],
+    /// Acting user id, copied verbatim from the admitted `RequestHeader`; see
+    /// that field for the stamping contract.
+    pub user_id: u32,
+    pub reserved: [u8; 28],
 }
 const _: () = {
     assert!(size_of::<PrepareHeader>() == HEADER_SIZE);
@@ -599,7 +629,11 @@ const _: () = {
         offset_of!(PrepareHeader, client)
             == offset_of!(PrepareHeader, reserved_frame) + size_of::<[u8; 66]>()
     );
-    assert!(offset_of!(PrepareHeader, reserved) + size_of::<[u8; 32]>() == HEADER_SIZE);
+    assert!(
+        offset_of!(PrepareHeader, user_id)
+            == offset_of!(PrepareHeader, namespace) + size_of::<u64>()
+    );
+    assert!(offset_of!(PrepareHeader, reserved) + size_of::<[u8; 28]>() == HEADER_SIZE);
 };
 
 impl Default for PrepareHeader {
@@ -624,7 +658,8 @@ impl Default for PrepareHeader {
             operation: Operation::Reserved,
             operation_padding: [0; 7],
             namespace: 0,
-            reserved: [0; 32],
+            user_id: 0,
+            reserved: [0; 28],
         }
     }
 }
@@ -989,8 +1024,8 @@ impl ConsensusHeader for StartViewHeader {
 mod tests {
     use super::{
         Command2, CommitHeader, ConsensusHeader, DoViewChangeHeader, EvictionHeader,
-        EvictionReason, GenericHeader, Operation, PrepareHeader, PrepareOkHeader, ReplyHeader,
-        RequestHeader, StartViewChangeHeader, StartViewHeader,
+        EvictionReason, GenericHeader, HEADER_SIZE, Operation, PrepareHeader, PrepareOkHeader,
+        ReplyHeader, RequestHeader, StartViewChangeHeader, StartViewHeader,
     };
     use aligned_vec::{AVec, ConstAlign};
 
@@ -1109,6 +1144,34 @@ mod tests {
         buf[60] = Command2::Reply as u8;
         let header: &ReplyHeader = bytemuck::checked::try_from_bytes(&buf).unwrap();
         assert_eq!(header.command, Command2::Reply);
+        assert!(header.validate().is_ok());
+    }
+
+    // `status` is carved from the reserved tail; the SDK reply funnel peeks it
+    // at this offset before any body decode, so a layout drift must trip here.
+    #[test]
+    fn reply_header_status_offset_and_size_pinned() {
+        use std::mem::offset_of;
+        assert_eq!(size_of::<ReplyHeader>(), HEADER_SIZE);
+        assert_eq!(
+            offset_of!(ReplyHeader, status),
+            offset_of!(ReplyHeader, namespace) + size_of::<u64>()
+        );
+        assert_eq!(
+            offset_of!(ReplyHeader, reserved) + size_of::<[u8; 28]>(),
+            HEADER_SIZE
+        );
+    }
+
+    // A nonzero status rides the reserved region, which reply `validate` does
+    // not inspect: a status-bearing reply stays valid so the SDK can peek it.
+    #[test]
+    fn reply_header_nonzero_status_still_validates() {
+        let header = ReplyHeader {
+            command: Command2::Reply,
+            status: 41,
+            ..ReplyHeader::default()
+        };
         assert!(header.validate().is_ok());
     }
 

--- a/core/common/src/error/eviction.rs
+++ b/core/common/src/error/eviction.rs
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shared grading of a wire [`EvictionReason`] to the typed [`IggyError`] an
+//! evicted session surfaces. The SDK's binary-transport Eviction-frame decoder
+//! (TCP / QUIC / WebSocket) and the server-ng HTTP write path both call this,
+//! so every transport sees one status per reason.
+
+use iggy_binary_protocol::consensus::EvictionReason;
+use iggy_binary_protocol::version::IGGY_PROTOCOL_VERSION;
+
+use super::iggy_error::IggyError;
+
+/// Map a session-terminal [`EvictionReason`], plus the accepted protocol window
+/// an `IncompatibleProtocol` frame carries, to the [`IggyError`] the caller
+/// renders. Session-terminal reasons collapse to re-authentication statuses;
+/// `IncompatibleProtocol` reports the exact window unless it is degenerate (a
+/// zero minimum or an inverted range), which also falls back to
+/// re-authentication.
+///
+/// The two callers extract the fields differently - server-ng from an aligned
+/// `EvictionHeader`, the SDK by wire offset off an unaligned buffer - then grade
+/// through here so the mappings cannot drift apart.
+#[must_use]
+pub fn eviction_reason_to_error(
+    reason: EvictionReason,
+    server_protocol_version: u32,
+    server_protocol_version_min: u32,
+) -> IggyError {
+    match reason {
+        EvictionReason::InvalidCredentials => IggyError::InvalidCredentials,
+        EvictionReason::InvalidToken => IggyError::InvalidPersonalAccessToken,
+        EvictionReason::UserInactive
+        | EvictionReason::SessionError
+        | EvictionReason::NoSession
+        | EvictionReason::SessionTooLow
+        | EvictionReason::SessionReleaseMismatch => IggyError::Unauthenticated,
+        EvictionReason::StaleClient => IggyError::StaleClient,
+        EvictionReason::IncompatibleProtocol => {
+            if server_protocol_version_min == 0
+                || server_protocol_version < server_protocol_version_min
+            {
+                IggyError::Unauthenticated
+            } else {
+                IggyError::IncompatibleProtocolVersion(
+                    IGGY_PROTOCOL_VERSION,
+                    server_protocol_version_min,
+                    server_protocol_version,
+                )
+            }
+        }
+        EvictionReason::MalformedLogin => IggyError::InvalidFormat,
+        _ => IggyError::InvalidCommand,
+    }
+}

--- a/core/common/src/error/mod.rs
+++ b/core/common/src/error/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 pub(crate) mod client_error;
+pub mod eviction;
 pub(crate) mod iggy_error;
 
 // preserves existing internal import paths across

--- a/core/common/src/lib.rs
+++ b/core/common/src/lib.rs
@@ -26,6 +26,7 @@ mod utils;
 pub mod wire_conversions;
 
 pub use error::client_error::ClientError;
+pub use error::eviction::eviction_reason_to_error;
 pub use error::iggy_error::{IggyError, IggyErrorDiscriminants};
 // Locking is feature gated, thus only mod level re-export.
 pub mod locking;

--- a/core/common/src/traits/binary_impls/mod.rs
+++ b/core/common/src/traits/binary_impls/mod.rs
@@ -31,6 +31,8 @@ use crate::IggyError;
 use crate::http::users::defaults::{
     MAX_PASSWORD_LENGTH, MAX_USERNAME_LENGTH, MIN_PASSWORD_LENGTH, MIN_USERNAME_LENGTH,
 };
+#[cfg(feature = "vsr")]
+use crate::{BinaryClient, ClientState};
 use iggy_binary_protocol::WireDecode;
 #[cfg(feature = "vsr")]
 use iggy_binary_protocol::{ClientVersionInfo, IGGY_PROTOCOL_VERSION, WireName};
@@ -50,6 +52,23 @@ pub(crate) fn rust_sdk_version_info(sdk_version: &str) -> Result<ClientVersionIn
         sdk_name: WireName::new(RUST_SDK_NAME).expect("RUST_SDK_NAME is 1-255 bytes"),
         sdk_version: WireName::new(sdk_version).map_err(|_| IggyError::InvalidFormat)?,
     })
+}
+
+/// Release a live session before a fresh login on the same connection.
+///
+/// server-ng binds a connection to one `(client, session)` and resolves the
+/// acting user from that binding, not the wire header. A re-login on a still-
+/// bound connection is served as an idempotent replay that keeps the old
+/// identity, so switching users on a live connection requires logging out
+/// first: the committed Logout unbinds the connection cluster-wide, so the
+/// following Register takes the full register path and rebinds the newly
+/// authenticated user. No-op when the client is not authenticated.
+#[cfg(feature = "vsr")]
+pub(crate) async fn logout_before_relogin<B: BinaryClient>(client: &B) -> Result<(), IggyError> {
+    if client.get_state().await == ClientState::Authenticated {
+        client.logout_user().await?;
+    }
+    Ok(())
 }
 
 /// Same bounds and error every server (HTTP and binary) enforces, applied

--- a/core/common/src/traits/binary_impls/personal_access_tokens.rs
+++ b/core/common/src/traits/binary_impls/personal_access_tokens.rs
@@ -105,6 +105,7 @@ impl<B: BinaryClient> PersonalAccessTokenClient for B {
     ) -> Result<IdentityInfo, IggyError> {
         #[cfg(feature = "vsr")]
         {
+            super::logout_before_relogin(self).await?;
             // Same bounds the non-vsr branch gets from `WireName::new(token)`;
             // the request stores a `SecretString`, so enforce them here to keep
             // the u8 length prefix consistent with the realized bytes.

--- a/core/common/src/traits/binary_impls/users.rs
+++ b/core/common/src/traits/binary_impls/users.rs
@@ -189,6 +189,7 @@ impl<B: BinaryClient> UserClient for B {
         super::validate_password(password)?;
         #[cfg(feature = "vsr")]
         {
+            super::logout_before_relogin(self).await?;
             let wire_name = WireName::new(username).map_err(|_| IggyError::InvalidFormat)?;
             let response = match self
                 .send_raw_with_response(

--- a/core/common/src/types/consumer/consumer_kind.rs
+++ b/core/common/src/types/consumer/consumer_kind.rs
@@ -42,7 +42,7 @@ pub struct Consumer {
 }
 
 /// `ConsumerKind` is an enum that represents the type of consumer.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Default, Copy, Clone, ValueEnum)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Default, Copy, Clone, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum ConsumerKind {
     /// `Consumer` represents a regular consumer.

--- a/core/consensus/src/client_table.rs
+++ b/core/consensus/src/client_table.rs
@@ -79,6 +79,9 @@ pub struct ClientEntry {
     /// Session number = commit op of the register. Monotonic across
     /// registrations; new register always gets a higher session.
     pub session: u64,
+    /// Acting user id captured at register. Fixed for the entry's lifetime;
+    /// lets every replica resolve session -> user without a metadata lookup.
+    pub user_id: u32,
     /// Cached reply for client's latest committed request.
     pub reply: CachedReply,
 }
@@ -241,8 +244,13 @@ impl ClientTable {
     /// # Panics
     /// If `client_id == 0`, `session == 0`, or `client_id != reply.header().client`.
     /// Session mismatch does NOT panic.
-    pub fn commit_register<F>(&mut self, client_id: u128, reply: Message<ReplyHeader>, in_flight: F)
-    where
+    pub fn commit_register<F>(
+        &mut self,
+        client_id: u128,
+        user_id: u32,
+        reply: Message<ReplyHeader>,
+        in_flight: F,
+    ) where
         F: Fn(u128) -> bool,
     {
         assert!(client_id != 0, "client_id 0 is reserved for internal use");
@@ -291,6 +299,7 @@ impl ClientTable {
             let slot_idx = self.first_free_slot().expect("eviction must free a slot");
             self.slots[slot_idx] = Some(ClientEntry {
                 session,
+                user_id,
                 reply: cached,
             });
             self.index.insert(client_id, slot_idx);
@@ -462,6 +471,13 @@ impl ClientTable {
         self.slots[slot_idx].as_ref().map(|entry| entry.session)
     }
 
+    /// Acting user id captured when the client registered.
+    #[must_use]
+    pub fn get_user_id(&self, client_id: u128) -> Option<u32> {
+        let &slot_idx = self.index.get(&client_id)?;
+        self.slots[slot_idx].as_ref().map(|entry| entry.user_id)
+    }
+
     /// Active committed entries.
     #[must_use]
     pub fn count(&self) -> usize {
@@ -473,6 +489,10 @@ impl ClientTable {
 mod tests {
     use super::*;
     use iggy_binary_protocol::{Command2, Operation};
+
+    /// Arbitrary non-zero user id for register fixtures; most tests don't
+    /// assert on it (see `register_stores_user_id` for the accessor check).
+    const TEST_USER_ID: u32 = 7;
 
     fn make_register_reply(client: u128, commit: u64) -> Message<ReplyHeader> {
         let header_size = std::mem::size_of::<ReplyHeader>();
@@ -519,7 +539,12 @@ mod tests {
     fn table_with_client() -> (ClientTable, u64) {
         let mut table = ClientTable::new(10);
         let session = 10;
-        table.commit_register(1, make_register_reply(1, session), no_in_flight());
+        table.commit_register(
+            1,
+            TEST_USER_ID,
+            make_register_reply(1, session),
+            no_in_flight(),
+        );
         (table, session)
     }
 
@@ -528,9 +553,25 @@ mod tests {
     #[test]
     fn register_creates_session() {
         let mut table = ClientTable::new(10);
-        table.commit_register(1, make_register_reply(1, 42), no_in_flight());
+        table.commit_register(1, TEST_USER_ID, make_register_reply(1, 42), no_in_flight());
         assert_eq!(table.get_session(1), Some(42));
+        assert_eq!(table.get_user_id(1), Some(TEST_USER_ID));
         assert_eq!(table.count(), 1);
+    }
+
+    // Each entry keeps the user id it registered with; lookups are per-client.
+    #[test]
+    fn register_stores_user_id() {
+        let mut table = ClientTable::new(10);
+        table.commit_register(1, 11, make_register_reply(1, 10), no_in_flight());
+        table.commit_register(2, 22, make_register_reply(2, 20), no_in_flight());
+        assert_eq!(table.get_user_id(1), Some(11));
+        assert_eq!(table.get_user_id(2), Some(22));
+        assert_eq!(
+            table.get_user_id(3),
+            None,
+            "unregistered client has no user"
+        );
     }
 
     #[test]
@@ -696,9 +737,24 @@ mod tests {
     #[test]
     fn eviction_removes_oldest_commit() {
         let mut table = ClientTable::new(2);
-        table.commit_register(100, make_register_reply(100, 10), no_in_flight());
-        table.commit_register(200, make_register_reply(200, 20), no_in_flight());
-        table.commit_register(300, make_register_reply(300, 30), no_in_flight());
+        table.commit_register(
+            100,
+            TEST_USER_ID,
+            make_register_reply(100, 10),
+            no_in_flight(),
+        );
+        table.commit_register(
+            200,
+            TEST_USER_ID,
+            make_register_reply(200, 20),
+            no_in_flight(),
+        );
+        table.commit_register(
+            300,
+            TEST_USER_ID,
+            make_register_reply(300, 30),
+            no_in_flight(),
+        );
         assert!(table.get_reply(100).is_none());
         assert!(table.get_reply(200).is_some());
         assert!(table.get_reply(300).is_some());
@@ -708,9 +764,24 @@ mod tests {
     #[test]
     fn eviction_is_deterministic_by_slot_index() {
         let mut table = ClientTable::new(2);
-        table.commit_register(100, make_register_reply(100, 10), no_in_flight());
-        table.commit_register(200, make_register_reply(200, 10), no_in_flight());
-        table.commit_register(300, make_register_reply(300, 30), no_in_flight());
+        table.commit_register(
+            100,
+            TEST_USER_ID,
+            make_register_reply(100, 10),
+            no_in_flight(),
+        );
+        table.commit_register(
+            200,
+            TEST_USER_ID,
+            make_register_reply(200, 10),
+            no_in_flight(),
+        );
+        table.commit_register(
+            300,
+            TEST_USER_ID,
+            make_register_reply(300, 30),
+            no_in_flight(),
+        );
         assert!(table.get_reply(100).is_none());
         assert!(table.get_reply(200).is_some());
         assert!(table.get_reply(300).is_some());
@@ -719,8 +790,18 @@ mod tests {
     #[test]
     fn slot_reuse_after_eviction() {
         let mut table = ClientTable::new(1);
-        table.commit_register(100, make_register_reply(100, 10), no_in_flight());
-        table.commit_register(200, make_register_reply(200, 20), no_in_flight());
+        table.commit_register(
+            100,
+            TEST_USER_ID,
+            make_register_reply(100, 10),
+            no_in_flight(),
+        );
+        table.commit_register(
+            200,
+            TEST_USER_ID,
+            make_register_reply(200, 20),
+            no_in_flight(),
+        );
         assert!(table.get_reply(100).is_none());
         assert!(table.get_reply(200).is_some());
         assert_eq!(table.count(), 1);
@@ -732,11 +813,21 @@ mod tests {
     #[test]
     fn eviction_skips_in_flight_clients() {
         let mut table = ClientTable::new(2);
-        table.commit_register(100, make_register_reply(100, 10), no_in_flight());
-        table.commit_register(200, make_register_reply(200, 20), no_in_flight());
+        table.commit_register(
+            100,
+            TEST_USER_ID,
+            make_register_reply(100, 10),
+            no_in_flight(),
+        );
+        table.commit_register(
+            200,
+            TEST_USER_ID,
+            make_register_reply(200, 20),
+            no_in_flight(),
+        );
         // 100 in-flight; eviction must pick 200.
         let in_flight = |c: u128| c == 100;
-        table.commit_register(300, make_register_reply(300, 30), in_flight);
+        table.commit_register(300, TEST_USER_ID, make_register_reply(300, 30), in_flight);
         assert!(
             table.get_reply(100).is_some(),
             "in-flight client must survive"
@@ -753,10 +844,25 @@ mod tests {
     #[test]
     fn eviction_falls_back_to_oldest_when_all_in_flight() {
         let mut table = ClientTable::new(2);
-        table.commit_register(100, make_register_reply(100, 10), no_in_flight());
-        table.commit_register(200, make_register_reply(200, 20), no_in_flight());
+        table.commit_register(
+            100,
+            TEST_USER_ID,
+            make_register_reply(100, 10),
+            no_in_flight(),
+        );
+        table.commit_register(
+            200,
+            TEST_USER_ID,
+            make_register_reply(200, 20),
+            no_in_flight(),
+        );
         let all_in_flight = |_| true;
-        table.commit_register(300, make_register_reply(300, 30), all_in_flight);
+        table.commit_register(
+            300,
+            TEST_USER_ID,
+            make_register_reply(300, 30),
+            all_in_flight,
+        );
         assert!(
             table.get_reply(100).is_none(),
             "100 evicted (oldest fallback)"
@@ -770,9 +876,9 @@ mod tests {
     #[test]
     fn commit_register_idempotent_on_replay() {
         let mut table = ClientTable::new(10);
-        table.commit_register(1, make_register_reply(1, 10), no_in_flight());
+        table.commit_register(1, TEST_USER_ID, make_register_reply(1, 10), no_in_flight());
         // Same client_id + session = idempotent (WAL replay).
-        table.commit_register(1, make_register_reply(1, 10), no_in_flight());
+        table.commit_register(1, TEST_USER_ID, make_register_reply(1, 10), no_in_flight());
         assert_eq!(table.get_session(1), Some(10));
         assert_eq!(table.count(), 1);
     }
@@ -783,12 +889,12 @@ mod tests {
     #[test]
     fn commit_register_different_session_logs_and_skips() {
         let mut table = ClientTable::new(10);
-        table.commit_register(1, make_register_reply(1, 10), no_in_flight());
+        table.commit_register(1, TEST_USER_ID, make_register_reply(1, 10), no_in_flight());
         // existing=10, replay=20.
-        table.commit_register(1, make_register_reply(1, 20), no_in_flight());
+        table.commit_register(1, TEST_USER_ID, make_register_reply(1, 20), no_in_flight());
         assert_eq!(table.get_session(1), Some(10), "first session stays");
         // Smaller replay session: same skip.
-        table.commit_register(1, make_register_reply(1, 5), no_in_flight());
+        table.commit_register(1, TEST_USER_ID, make_register_reply(1, 5), no_in_flight());
         assert_eq!(table.get_session(1), Some(10));
     }
 
@@ -814,8 +920,8 @@ mod tests {
     #[test]
     fn different_clients_independent_sessions() {
         let mut table = ClientTable::new(10);
-        table.commit_register(1, make_register_reply(1, 10), no_in_flight());
-        table.commit_register(2, make_register_reply(2, 20), no_in_flight());
+        table.commit_register(1, TEST_USER_ID, make_register_reply(1, 10), no_in_flight());
+        table.commit_register(2, TEST_USER_ID, make_register_reply(2, 20), no_in_flight());
         assert_eq!(table.get_session(1), Some(10));
         assert_eq!(table.get_session(2), Some(20));
         assert!(matches!(table.check_request(1, 10, 1), RequestStatus::New));

--- a/core/consensus/src/impls.rs
+++ b/core/consensus/src/impls.rs
@@ -2108,6 +2108,10 @@ where
                 timestamp,
                 operation: old.operation,
                 namespace: old.namespace,
+                // Copied verbatim: carries the stamped acting user for client
+                // ops (and the authenticated user on Register), so the in-apply
+                // RBAC gate resolves the same identity on every backup.
+                user_id: old.user_id,
                 ..Default::default()
             }
         })

--- a/core/consensus/src/metadata_helpers.rs
+++ b/core/consensus/src/metadata_helpers.rs
@@ -414,6 +414,10 @@ mod tests {
     use iggy_binary_protocol::{Command2, Operation, ReplyHeader};
     use message_bus::SendError;
 
+    /// Acting user for register fixtures; these tests exercise preflight /
+    /// replay, not user resolution, so the exact value is immaterial.
+    const ACTING_USER_ID: u32 = 1;
+
     /// Production-sized `ClientTable`.
     fn fresh_client_table() -> RefCell<ClientTable> {
         RefCell::new(ClientTable::new(CLIENTS_TABLE_MAX))
@@ -475,7 +479,7 @@ mod tests {
         let original_checksum = initial_reply.header().checksum;
         client_table
             .borrow_mut()
-            .commit_register(client_id, initial_reply, |_| false);
+            .commit_register(client_id, ACTING_USER_ID, initial_reply, |_| false);
 
         let result =
             futures::executor::block_on(register_preflight(&consensus, &client_table, client_id));
@@ -511,7 +515,7 @@ mod tests {
         let initial_reply = synthesize_register_reply(&consensus, client_id, session);
         client_table
             .borrow_mut()
-            .commit_register(client_id, initial_reply, |_| false);
+            .commit_register(client_id, ACTING_USER_ID, initial_reply, |_| false);
 
         // SendMessages commits -> cached is no longer the register reply.
         let app_reply = synthesize_send_messages_reply(&consensus, client_id, session, 1, 18);
@@ -579,7 +583,7 @@ mod tests {
         let initial_reply = synthesize_register_reply(&consensus, client_id, real_session);
         client_table
             .borrow_mut()
-            .commit_register(client_id, initial_reply, |_| false);
+            .commit_register(client_id, ACTING_USER_ID, initial_reply, |_| false);
 
         // Older retry (17 < 99): stale-session case.
         let result = futures::executor::block_on(apply_preflight_consensus_plane(
@@ -615,7 +619,7 @@ mod tests {
         let initial_reply = synthesize_register_reply(&consensus, client_id, real_session);
         client_table
             .borrow_mut()
-            .commit_register(client_id, initial_reply, |_| false);
+            .commit_register(client_id, ACTING_USER_ID, initial_reply, |_| false);
 
         // Client claims newer session (99 > 17), client bug.
         let result = futures::executor::block_on(apply_preflight_consensus_plane(
@@ -677,7 +681,7 @@ mod tests {
         let initial_reply = synthesize_register_reply(&consensus, client_id, session);
         client_table
             .borrow_mut()
-            .commit_register(client_id, initial_reply, |_| false);
+            .commit_register(client_id, ACTING_USER_ID, initial_reply, |_| false);
         // Cache at request 5 -> request 3 is stale.
         let advanced = synthesize_send_messages_reply(&consensus, client_id, session, 5, 100);
         client_table

--- a/core/consensus/src/plane_helpers.rs
+++ b/core/consensus/src/plane_helpers.rs
@@ -298,9 +298,7 @@ where
     let total_size = header_size + body_len;
     let mut buffer = bytes::BytesMut::zeroed(total_size);
 
-    let header = bytemuck::checked::try_from_bytes_mut::<ReplyHeader>(&mut buffer[..header_size])
-        .expect("zeroed bytes are valid");
-    *header = ReplyHeader {
+    let header = ReplyHeader {
         checksum: 0,
         checksum_body: 0,
         cluster: prepare_header.cluster,
@@ -325,6 +323,8 @@ where
         namespace: prepare_header.namespace,
         ..Default::default()
     };
+    // `BytesMut` makes no alignment guarantee, so never cast into it.
+    buffer[..header_size].copy_from_slice(bytemuck::bytes_of(&header));
 
     fill(&mut buffer[header_size..]);
 
@@ -341,9 +341,9 @@ where
 /// request that could not be committed *right now* (not-caught-up / in-flight
 /// / pipeline-full / view-change cancel); the SDK decodes it and replays the
 /// same `request_id` immediately instead of waiting out its response
-/// read-timeout. Any other code is a TERMINAL rejection (e.g.
-/// `ConsumerOffsetNotFound` / `InvalidOffset` from partition-plane admission)
-/// that the SDK surfaces as the typed error.
+/// read-timeout. Any other code is a TERMINAL rejection (e.g. a committed
+/// metadata rejection like `UserAlreadyExists`) that the SDK surfaces as the
+/// typed error.
 ///
 /// Stamped from the request header (no prepare exists for a rejected op).
 /// `commit` is the primary's current commit position and is informational
@@ -366,9 +366,7 @@ pub fn build_result_rejection_reply(
     let total_size = header_size + RESULT_BODY_LEN;
     let mut buffer = bytes::BytesMut::zeroed(total_size);
 
-    let header = bytemuck::checked::try_from_bytes_mut::<ReplyHeader>(&mut buffer[..header_size])
-        .expect("zeroed bytes are valid");
-    *header = ReplyHeader {
+    let header = ReplyHeader {
         cluster: request_header.cluster,
         size: total_size as u32,
         view: request_header.view,
@@ -388,6 +386,7 @@ pub fn build_result_rejection_reply(
         namespace: request_header.namespace,
         ..Default::default()
     };
+    buffer[..header_size].copy_from_slice(bytemuck::bytes_of(&header));
 
     let body = &mut buffer[header_size..];
     body[0..4].copy_from_slice(&1u32.to_le_bytes());
@@ -420,9 +419,7 @@ where
     let mut buffer = bytes::BytesMut::zeroed(total_size);
 
     let commit = consensus.commit_max();
-    let header = bytemuck::checked::try_from_bytes_mut::<ReplyHeader>(&mut buffer[..header_size])
-        .expect("zeroed bytes are valid");
-    *header = ReplyHeader {
+    let header = ReplyHeader {
         checksum: 0,
         checksum_body: 0,
         cluster: consensus.cluster(),
@@ -443,6 +440,7 @@ where
         namespace: request_header.namespace,
         ..Default::default()
     };
+    buffer[..header_size].copy_from_slice(bytemuck::bytes_of(&header));
 
     if !body.is_empty() {
         buffer[header_size..].copy_from_slice(&body);
@@ -450,6 +448,37 @@ where
 
     Message::try_from(Owned::<4096>::copy_from_slice(buffer.as_ref()))
         .expect("reply buffer must contain a valid reply message")
+}
+
+/// Reply that denies a request on the primary before it enters the VSR
+/// pipeline.
+///
+/// The request's frame with an empty body and a nonzero `ReplyHeader.status`
+/// (the request-level error channel the SDK peeks before body decode).
+/// Nothing is prepared or replicated, so backups never see the denied
+/// request; `op` stays 0, the shape reply consumers already read as "nothing
+/// committed".
+///
+/// # Panics
+/// If the constructed message buffer is not valid.
+pub fn build_deny_reply_from_request<B, P>(
+    consensus: &VsrConsensus<B, P>,
+    request_header: &RequestHeader,
+    status: u32,
+) -> Message<ReplyHeader>
+where
+    B: MessageBus,
+    P: Pipeline<Entry = PipelineEntry>,
+{
+    let mut reply = build_reply_from_request(consensus, request_header, bytes::Bytes::new());
+    let header_size = std::mem::size_of::<ReplyHeader>();
+    let header_bytes = &mut reply.as_mut_slice()[..header_size];
+    let mut header = bytemuck::checked::try_pod_read_unaligned::<ReplyHeader>(header_bytes)
+        .expect("freshly built reply header is valid");
+    header.status = status;
+    header.op = 0;
+    header_bytes.copy_from_slice(bytemuck::bytes_of(&header));
+    reply
 }
 
 /// Verify hash chain would not break if we add this header.
@@ -539,7 +568,7 @@ pub async fn send_prepare_ok<B, P>(
 mod tests {
     use super::*;
     use crate::{Consensus, LocalPipeline, VsrAction};
-    use iggy_binary_protocol::StartViewChangeHeader;
+    use iggy_binary_protocol::{ConsensusHeader, Operation, StartViewChangeHeader};
     use message_bus::SendError;
     use server_common::{MESSAGE_ALIGN, iobuf::Frozen};
 
@@ -983,5 +1012,43 @@ mod tests {
                 .map(|entry| entry.header.op),
             Some(7)
         );
+    }
+
+    // A deny echoes the request frame with an empty body, carries the error
+    // code in `status`, and keeps `op` at 0 even when the group has committed
+    // ops -- reply consumers read `op == 0` as "nothing committed", and the
+    // deny must never be mistaken for a committed reply.
+    #[test]
+    fn deny_reply_from_request_stamps_status_and_commits_nothing() {
+        let consensus = VsrConsensus::new(1, 0, 3, 0, NoopBus, LocalPipeline::new());
+        consensus.init();
+        consensus.advance_commit_max(4);
+
+        let request = RequestHeader {
+            command: Command2::Request,
+            operation: Operation::DeleteConsumerOffset2,
+            client: 42,
+            request: 7,
+            namespace: 9,
+            ..Default::default()
+        };
+        let status = 3021;
+        let reply = build_deny_reply_from_request(&consensus, &request, status);
+
+        let header = reply.header();
+        assert_eq!(header.command, Command2::Reply);
+        assert_eq!(header.status, status);
+        assert_eq!(header.op, 0, "a deny commits nothing");
+        assert_eq!(header.commit, 4);
+        assert_eq!(header.client, 42);
+        assert_eq!(header.request, 7);
+        assert_eq!(header.namespace, 9);
+        assert_eq!(header.operation, Operation::DeleteConsumerOffset2);
+        assert_eq!(
+            header.size as usize,
+            std::mem::size_of::<ReplyHeader>(),
+            "deny reply body must be empty"
+        );
+        assert!(header.validate().is_ok());
     }
 }

--- a/core/harness_derive/src/codegen.rs
+++ b/core/harness_derive/src/codegen.rs
@@ -124,16 +124,11 @@ fn generate_variants(attrs: &IggyTestAttrs) -> Vec<TestVariant> {
     variants
 }
 
-/// HTTP is not served by the next-gen (VSR) server, so HTTP transport variants
-/// must not compile into the test binary under `--features vsr`. The proc macro
-/// cannot read the consuming crate's feature flags at expansion time, so it
-/// emits this `cfg` gate on HTTP variants; the `integration` crate resolves it.
-fn vsr_transport_cfg(transport: Transport) -> TokenStream {
-    if matches!(transport, Transport::Http) {
-        quote!(#[cfg(not(feature = "vsr"))])
-    } else {
-        quote!()
-    }
+/// No transport is gated out of the VSR test matrix. Retained as the single
+/// seam where a transport could be excluded from `--features vsr` if one is
+/// ever unsupported by the next-gen server again.
+fn vsr_transport_cfg(_transport: Transport) -> TokenStream {
+    quote!()
 }
 
 /// Generate test code from attributes and input function.

--- a/core/integration/tests/data_integrity/mod.rs
+++ b/core/integration/tests/data_integrity/mod.rs
@@ -21,9 +21,12 @@
 #[cfg(not(feature = "vsr"))]
 mod verify_after_server_restart;
 #[cfg(not(feature = "vsr"))]
-mod verify_no_plaintext_credentials_on_disk;
-#[cfg(not(feature = "vsr"))]
 mod verify_user_login_after_restart;
+
+// Not restart-based: it creates a user + PAT, stops the server, and greps the
+// data dir for plaintext. No replica catch-up needed, and server-ng hashes the
+// password / PAT before either reaches the WAL, so it runs under vsr too.
+mod verify_no_plaintext_credentials_on_disk;
 
 // The cooperative-rebalance matrix runs under vsr too: it exercises server-ng's
 // consumer-group rebalancing (a VSR feature) and never restarts the cluster, so
@@ -33,3 +36,8 @@ mod verify_consumer_group_partition_assignment;
 // Cross-replica on-disk data identity is VSR-only.
 #[cfg(feature = "vsr")]
 mod verify_cluster_replica_data_identical;
+
+// Auto-commit offset replication is inherently a multi-node (VSR) property: the
+// backup only holds the offset if the poll's auto-commit rode consensus.
+#[cfg(feature = "vsr")]
+mod verify_auto_commit_offset_replicates;

--- a/core/integration/tests/data_integrity/verify_auto_commit_offset_replicates.rs
+++ b/core/integration/tests/data_integrity/verify_auto_commit_offset_replicates.rs
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! A poll with `auto_commit = true` must replicate the consumer offset through
+//! the partition consensus, not merely persist it on the serving node -- else a
+//! failover to a backup silently loses the committed offset.
+//!
+//! Discriminator: drive the poll+auto_commit on the primary (node 0) and read
+//! the offset from a backup's (node 1) on-disk store. The backup holds it only
+//! if the commit rode consensus; the pre-fix node-local persist never reaches
+//! it, so the file stays absent until the deadline and the test fails.
+
+use iggy::prelude::*;
+use integration::harness::TestHarness;
+use integration::iggy_harness;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::time::sleep;
+
+const STREAM_NAME: &str = "auto-commit-repl-stream";
+const TOPIC_NAME: &str = "auto-commit-repl-topic";
+const PARTITION_ID: u32 = 0;
+// Explicit numeric consumer id shared by the poll and the offset read;
+// `Consumer::default()` would carry id 0.
+const CONSUMER_ID: u32 = 7;
+const MESSAGE_COUNT: u32 = 10;
+// Offset of the last message after polling all of `0..MESSAGE_COUNT` from 0.
+const EXPECTED_OFFSET: u64 = (MESSAGE_COUNT - 1) as u64;
+// The primary answers the poll before the auto-commit replicates, so allow the
+// backup a bounded window to catch up rather than a fixed settle sleep.
+const REPLICATION_TIMEOUT: Duration = Duration::from_secs(15);
+const REPLICATION_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_cluster_when_poll_auto_commits_then_offset_replicates_to_backup(
+    harness: &TestHarness,
+) {
+    run(harness).await;
+}
+
+async fn run(harness: &TestHarness) {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let topic = Identifier::named(TOPIC_NAME).unwrap();
+    let consumer = Consumer::new(Identifier::numeric(CONSUMER_ID).unwrap());
+
+    // Primary (node 0, the view-0 primary): create the topic, produce, then poll
+    // with auto_commit so the offset is committed server-side.
+    let primary = harness.tcp_root_client().await.unwrap();
+    primary.create_stream(STREAM_NAME).await.unwrap();
+    primary
+        .create_topic(
+            &stream,
+            TOPIC_NAME,
+            1,
+            CompressionAlgorithm::None,
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+
+    let mut messages: Vec<IggyMessage> = (0..MESSAGE_COUNT)
+        .map(|i| {
+            IggyMessage::builder()
+                .payload(format!("auto-commit-{i}").into())
+                .build()
+                .unwrap()
+        })
+        .collect();
+    primary
+        .send_messages(
+            &stream,
+            &topic,
+            &Partitioning::partition_id(PARTITION_ID),
+            &mut messages,
+        )
+        .await
+        .unwrap();
+
+    let polled = primary
+        .poll_messages(
+            &stream,
+            &topic,
+            Some(PARTITION_ID),
+            &consumer,
+            &PollingStrategy::offset(0),
+            MESSAGE_COUNT,
+            true,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        polled.messages.len(),
+        MESSAGE_COUNT as usize,
+        "poll must return every produced message so the auto-commit has an offset to store",
+    );
+
+    // Sanity: the serving node holds its own committed offset (eager in-memory
+    // apply). Passes on both the buggy and fixed paths -- the discriminator is
+    // the backup below.
+    let on_primary = primary
+        .get_consumer_offset(&consumer, &stream, &topic, Some(PARTITION_ID))
+        .await
+        .unwrap();
+    assert_eq!(
+        on_primary.map(|info| info.stored_offset),
+        Some(EXPECTED_OFFSET),
+        "the serving node must hold the auto-committed offset",
+    );
+
+    // Discriminator: the backup's on-disk consumer-offset store. A backup does
+    // not serve client logins (Register is a primary-only metadata op), so read
+    // its data dir directly. Only a consensus-replicated auto-commit lands there
+    // -- the pre-fix node-local persist never reaches the backup, so the file
+    // stays absent until the deadline and the test fails.
+    let backup_dir = harness.node(1).data_path();
+    let deadline = tokio::time::Instant::now() + REPLICATION_TIMEOUT;
+    loop {
+        if let Some(stored) = read_replicated_consumer_offset(&backup_dir) {
+            assert_eq!(
+                stored, EXPECTED_OFFSET,
+                "backup replicated a wrong auto-commit offset",
+            );
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "auto-commit offset never replicated to the backup within {REPLICATION_TIMEOUT:?}; \
+             it stayed node-local (the bug)",
+        );
+        sleep(REPLICATION_POLL_INTERVAL).await;
+    }
+}
+
+/// The u64 offset persisted under any `offsets/consumers/<id>` file in a node's
+/// data dir, or `None` when no such file has been written yet. Walks the tree so
+/// it is robust to the stream/topic/partition id layout; the test drives exactly
+/// one consumer, so at most one such file exists. A zero-length read (persist
+/// truncates before writing the 8 bytes) is treated as not-yet-written.
+fn read_replicated_consumer_offset(data_dir: &Path) -> Option<u64> {
+    let mut stack: Vec<PathBuf> = vec![data_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let is_consumer_offset = path
+                .parent()
+                .and_then(Path::file_name)
+                .is_some_and(|name| name == "consumers")
+                && path
+                    .parent()
+                    .and_then(Path::parent)
+                    .and_then(Path::file_name)
+                    .is_some_and(|name| name == "offsets");
+            if is_consumer_offset
+                && let Ok(bytes) = std::fs::read(&path)
+                && let Ok(array) = <[u8; 8]>::try_from(bytes.as_slice())
+            {
+                return Some(u64::from_le_bytes(array));
+            }
+        }
+    }
+    None
+}

--- a/core/integration/tests/mcp/mod.rs
+++ b/core/integration/tests/mcp/mod.rs
@@ -16,12 +16,11 @@
 // under the License.
 
 use iggy_common::{
-    ClientInfo, ClientInfoDetails, ConsumerGroup, ConsumerGroupDetails, ConsumerOffsetInfo,
-    PersonalAccessTokenExpiry, PersonalAccessTokenInfo, PolledMessages, RawPersonalAccessToken,
-    Stats, Stream, StreamDetails, Topic, TopicDetails, UserInfo, UserInfoDetails,
+    ClientInfo, ClientInfoDetails, ClusterMetadata, ConsumerGroup, ConsumerGroupDetails,
+    ConsumerOffsetInfo, PersonalAccessTokenExpiry, PersonalAccessTokenInfo, PolledMessages,
+    RawPersonalAccessToken, Snapshot, Stats, Stream, StreamDetails, Topic, TopicDetails, UserInfo,
+    UserInfoDetails,
 };
-#[cfg(not(feature = "vsr"))]
-use iggy_common::{ClusterMetadata, Snapshot};
 use integration::{
     harness::{McpClient, seeds},
     iggy_harness,
@@ -86,8 +85,10 @@ async fn should_handle_ping(harness: &TestHarness) {
     invoke_empty(&mcp_client, "ping", None).await;
 }
 
-#[cfg(not(feature = "vsr"))]
-#[iggy_harness(server(cluster.enabled = true, mcp))]
+// Pins two nodes: the default vsr harness spawns three, but this test asserts a
+// two-node roster. Exercises the binary GetClusterMetadata roster end-to-end
+// over MCP (MCP server -> TCP -> iggy).
+#[iggy_harness(cluster_nodes = 2, server(mcp))]
 async fn should_return_cluster_metadata(harness: &TestHarness) {
     let mcp_client = harness.mcp_client().await.expect("MCP client required");
     let cluster: ClusterMetadata = invoke(&mcp_client, "get_cluster_metadata", None).await;
@@ -361,7 +362,6 @@ async fn should_return_clients(harness: &TestHarness) {
     assert!(!clients.is_empty());
 }
 
-#[cfg(not(feature = "vsr"))]
 #[iggy_harness(server(mcp), seed = seeds::mcp_standard)]
 async fn should_handle_snapshot(harness: &TestHarness) {
     let mcp_client = harness.mcp_client().await.expect("MCP client required");

--- a/core/integration/tests/server/cluster_metadata_vsr.rs
+++ b/core/integration/tests/server/cluster_metadata_vsr.rs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Binary `GetClusterMetadata` over a real VSR cluster. The reply must carry
+//! the full configured roster with real client ports and live leader/follower
+//! roles - not a single synthesized self node with zeroed ports.
+
+use iggy::prelude::*;
+use integration::iggy_harness;
+
+/// One shard per node so the client connection is always served by shard 0,
+/// where the metadata consensus that marks the leader lives. A request
+/// round-robined to a peer shard would still get the full roster but with no
+/// leader marked, since peer shards run no consensus.
+#[iggy_harness(cluster_nodes = 2, server(system.sharding.cpu_allocation = "0..1"))]
+async fn given_two_node_cluster_when_getting_cluster_metadata_should_return_full_roster(
+    harness: &TestHarness,
+) {
+    let client = harness
+        .node(0)
+        .tcp_client()
+        .expect("tcp client")
+        .with_root_login()
+        .connect()
+        .await
+        .expect("connect to node 0");
+
+    let metadata = client
+        .get_cluster_metadata()
+        .await
+        .expect("get cluster metadata");
+
+    assert_eq!(
+        metadata.nodes.len(),
+        harness.cluster_size(),
+        "every configured node must appear in the roster, got {metadata}"
+    );
+    for node in &metadata.nodes {
+        assert_ne!(
+            node.endpoints.tcp, 0,
+            "node {} must report its real tcp port, not the stub's 0",
+            node.name
+        );
+    }
+
+    let leaders = metadata
+        .nodes
+        .iter()
+        .filter(|node| node.role == ClusterNodeRole::Leader)
+        .count();
+    let followers = metadata
+        .nodes
+        .iter()
+        .filter(|node| node.role == ClusterNodeRole::Follower)
+        .count();
+    assert_eq!(leaders, 1, "exactly one node must lead, got {metadata}");
+    assert_eq!(
+        followers,
+        harness.cluster_size() - 1,
+        "every other node must follow, got {metadata}"
+    );
+}

--- a/core/integration/tests/server/concurrent_addition.rs
+++ b/core/integration/tests/server/concurrent_addition.rs
@@ -37,19 +37,12 @@ use test_case::test_matrix;
     quic.max_idle_timeout = "500s",
     quic.keep_alive_interval = "15s"
 ))]
-// vsr excludes HTTP only (server-ng exposes no HTTP listener).
-#[cfg_attr(not(feature = "vsr"), test_matrix(
+#[test_matrix(
     [tcp(), http(), quic(), websocket()],
     [user(), stream(), topic(), partition(), consumer_group()],
     [hot(), cold()],
     [barrier_on(), barrier_off()]
-))]
-#[cfg_attr(feature = "vsr", test_matrix(
-    [tcp(), quic(), websocket()],
-    [user(), stream(), topic(), partition(), consumer_group()],
-    [hot(), cold()],
-    [barrier_on(), barrier_off()]
-))]
+)]
 async fn matrix(
     harness: &TestHarness,
     transport: TransportProtocol,
@@ -64,7 +57,6 @@ fn tcp() -> TransportProtocol {
     TransportProtocol::Tcp
 }
 
-#[cfg(not(feature = "vsr"))]
 fn http() -> TransportProtocol {
     TransportProtocol::Http
 }

--- a/core/integration/tests/server/flush_vsr.rs
+++ b/core/integration/tests/server/flush_vsr.rs
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Flush contract against server-ng (vsr): the server has no on-demand flush
+//! primitive, so `FLUSH_UNSAVED_BUFFER` must surface a typed
+//! `FeatureUnavailable` over the SDK rather than the non-replicated catch-all's
+//! empty-ok, which would fake a durability guarantee.
+
+use iggy::prelude::*;
+use integration::iggy_harness;
+
+// server-ng partition ids are 0-based (CreateTopic assigns them from 0).
+const PARTITION_ID: u32 = 0;
+
+#[iggy_harness(
+    test_client_transport = [Tcp],
+    server(tcp.socket.override_defaults = true, tcp.socket.nodelay = true)
+)]
+async fn given_valid_partition_when_flushing_should_reject_feature_unavailable(
+    harness: &TestHarness,
+) {
+    let client = harness.tcp_root_client().await.expect("tcp root client");
+    client
+        .create_stream("flush-stream")
+        .await
+        .expect("create stream");
+    let stream_id = Identifier::from_str_value("flush-stream").expect("stream identifier");
+    client
+        .create_topic(
+            &stream_id,
+            "flush-topic",
+            1,
+            CompressionAlgorithm::None,
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .expect("create topic");
+    let topic_id = Identifier::from_str_value("flush-topic").expect("topic identifier");
+
+    // A valid, existing partition proves the deny is feature-unavailable, not a
+    // target-not-found in disguise; fsync makes it the strongest durability ask.
+    let result = client
+        .flush_unsaved_buffer(&stream_id, &topic_id, PARTITION_ID, true)
+        .await;
+
+    assert!(
+        matches!(&result, Err(error) if error.as_code() == IggyError::FeatureUnavailable.as_code()),
+        "flush over TCP-ng must surface Err(FeatureUnavailable), got {result:?}"
+    );
+}

--- a/core/integration/tests/server/general.rs
+++ b/core/integration/tests/server/general.rs
@@ -15,14 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#[cfg(not(feature = "vsr"))]
+use crate::server::scenarios::bench_scenario;
 use crate::server::scenarios::{
     authentication_scenario, consumer_timestamp_polling_scenario, create_message_payload,
-    invalid_consumer_offset_scenario, message_headers_scenario, stream_size_validation_scenario,
-    system_scenario,
-};
-#[cfg(not(feature = "vsr"))]
-use crate::server::scenarios::{
-    bench_scenario, permissions_scenario, snapshot_scenario, user_scenario,
+    invalid_consumer_offset_scenario, message_headers_scenario, permissions_scenario,
+    snapshot_scenario, stream_size_validation_scenario, system_scenario, user_scenario,
 };
 use integration::iggy_harness;
 
@@ -53,14 +51,6 @@ async fn system(harness: &TestHarness) {
     system_scenario::run(harness).await;
 }
 
-// Blocked under vsr: the startup-hang is fixed and root `created_at` now
-// resolves, but the scenario issues several sequential `login_user` calls on
-// one connection. Under vsr login == register, and the SDK's one-shot
-// `ConsensusSession` only resets on the reconnect/replay path, so the second
-// deliberate re-login panics `register_request_id already called`
-// (sdk/src/session.rs). Needs an SDK login-lifecycle fix (reset the session
-// on each fresh login).
-#[cfg(not(feature = "vsr"))]
 #[iggy_harness(
     test_client_transport = [Tcp, Http, Quic, WebSocket],
     server(
@@ -74,14 +64,6 @@ async fn user(harness: &TestHarness) {
     user_scenario::run(harness).await;
 }
 
-// Blocked under vsr: password hashing and the metadata journal-append
-// race are now fixed, so the scenario runs deep into its permission
-// matrix. Remaining blocker is per-operation authorization: server-ng
-// does not enforce the caller's permissions on metadata ops, so a
-// `read_streams`-only user calling `create_stream` gets `InvalidFormat`
-// instead of `Unauthorized`. Needs the permission-enforcement subsystem
-// wired on the metadata plane.
-#[cfg(not(feature = "vsr"))]
 #[iggy_harness(
     test_client_transport = [Tcp, Http, Quic, WebSocket],
     server(
@@ -164,9 +146,6 @@ async fn consumer_timestamp_polling(harness: &TestHarness) {
     consumer_timestamp_polling_scenario::run(harness).await;
 }
 
-// Blocked under vsr: the snapshot-file feature (GET_SNAPSHOT_FILE) is
-// not implemented in server-ng.
-#[cfg(not(feature = "vsr"))]
 #[iggy_harness(
     test_client_transport = [Tcp, Http, Quic, WebSocket],
     server(

--- a/core/integration/tests/server/http_client.rs
+++ b/core/integration/tests/server/http_client.rs
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shared HTTP transport plumbing for the server-ng REST suites (`http_vsr`,
+//! `http_rbac`): one authenticated `reqwest` session with the login-retry gate
+//! and the generic verb helpers. Each suite keeps its own request shapes and
+//! assertions as extension methods on [`HttpClient`], so the wire-contract and
+//! listener-behavior separation between the suites stays intact.
+
+use std::time::{Duration, Instant};
+
+use iggy::prelude::*;
+use integration::harness::TestHarness;
+use reqwest::Response;
+use serde_json::{Value, json};
+use tokio::time::sleep;
+
+/// The harness readiness gate waits for the dumped runtime config, which the
+/// server writes before binding the HTTP listener; a bounded login retry
+/// bridges that gap plus single-node consensus warmup.
+pub const LOGIN_TIMEOUT: Duration = Duration::from_secs(15);
+pub const LOGIN_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// One authenticated HTTP session against the test server's shard-0 listener: a
+/// `reqwest` client, the listener base URL, and the bearer to send. The bearer
+/// is either a login JWT or a raw personal access token (server-ng resolves
+/// either on the `Authorization: Bearer` header).
+pub struct HttpClient {
+    pub client: reqwest::Client,
+    pub base_url: String,
+    pub token: String,
+}
+
+impl HttpClient {
+    /// Log in as root, retrying while the listener binds and consensus warms up.
+    pub async fn login_root(harness: &TestHarness) -> Self {
+        let addr = harness
+            .server()
+            .http_addr()
+            .expect("HTTP transport not configured on test server");
+        let base_url = format!("http://{addr}");
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .expect("build reqwest client");
+
+        let body = json!({
+            "username": DEFAULT_ROOT_USERNAME,
+            "password": DEFAULT_ROOT_PASSWORD,
+        });
+        let deadline = Instant::now() + LOGIN_TIMEOUT;
+        loop {
+            let attempt = client
+                .post(format!("{base_url}/users/login"))
+                .json(&body)
+                .send()
+                .await;
+            match attempt {
+                Ok(response) if response.status().is_success() => {
+                    return Self {
+                        client,
+                        base_url,
+                        token: access_token(response).await,
+                    };
+                }
+                // Listener not bound yet or consensus still warming up; any
+                // non-5xx rejection (e.g. 401) is a real failure.
+                Ok(response) if response.status().is_server_error() => {}
+                Ok(response) => panic!("root login rejected: {}", response.status()),
+                Err(error) if error.is_connect() => {}
+                Err(error) => panic!("root login request failed: {error}"),
+            }
+            assert!(
+                Instant::now() < deadline,
+                "HTTP root login did not succeed within {LOGIN_TIMEOUT:?}"
+            );
+            sleep(LOGIN_RETRY_INTERVAL).await;
+        }
+    }
+
+    /// Log in as an already-created user; single attempt (the server is warm
+    /// once root exists). Reuses this session's client and base URL.
+    pub async fn login(&self, username: &str, password: &str) -> Self {
+        let body = json!({ "username": username, "password": password });
+        let response = self
+            .client
+            .post(self.url("/users/login"))
+            .json(&body)
+            .send()
+            .await
+            .expect("login request");
+        assert!(
+            response.status().is_success(),
+            "login for {username} failed: {}",
+            response.status()
+        );
+        Self {
+            client: self.client.clone(),
+            base_url: self.base_url.clone(),
+            token: access_token(response).await,
+        }
+    }
+
+    /// A view of this session bound to a different bearer (a refreshed JWT or a
+    /// PAT), reusing the same client and base URL.
+    pub fn with_token(&self, token: String) -> Self {
+        Self {
+            client: self.client.clone(),
+            base_url: self.base_url.clone(),
+            token,
+        }
+    }
+
+    pub fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    pub async fn get(&self, path: &str) -> Response {
+        self.client
+            .get(self.url(path))
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .expect("get request")
+    }
+
+    /// Unauthenticated GET (no bearer) for the public `/ping` probe.
+    pub async fn get_anonymous(&self, path: &str) -> Response {
+        self.client
+            .get(self.url(path))
+            .send()
+            .await
+            .expect("anonymous get request")
+    }
+
+    pub async fn post_json(&self, path: &str, body: &Value) -> Response {
+        self.client
+            .post(self.url(path))
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await
+            .expect("post request")
+    }
+
+    pub async fn put_json(&self, path: &str, body: &Value) -> Response {
+        self.client
+            .put(self.url(path))
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await
+            .expect("put request")
+    }
+
+    pub async fn delete(&self, path: &str) -> Response {
+        self.client
+            .delete(self.url(path))
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .expect("delete request")
+    }
+}
+
+/// Extract the JWT from a successful login response.
+pub async fn access_token(response: Response) -> String {
+    let identity: IdentityInfo = response.json().await.expect("decode IdentityInfo");
+    identity
+        .access_token
+        .expect("login must return an access token")
+        .token
+}

--- a/core/integration/tests/server/http_rbac.rs
+++ b/core/integration/tests/server/http_rbac.rs
@@ -1,0 +1,532 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! HTTP wire-contract residue for server-ng's shard-0 REST listener. The RBAC
+//! authorization matrix itself (who may do what, over every transport) lives in
+//! the cross-transport `permissions_scenario` suite; this file keeps only what
+//! the SDK abstracts away and only raw HTTP can show:
+//!
+//! - exact HTTP status codes paired with the typed `{id, code}` JSON error body
+//!   (the SDK collapses every non-401/403/404 status into a generic error);
+//! - the SDK-hidden success codes (produce 201, reads 200, mutations 204, and
+//!   the server-assigned id in a 200 create-stream body);
+//! - HTTP-only route shapes: the `/users/me` self alias, the caller-scoped
+//!   name-sorted PAT-list array, auth-only cluster metadata, and the public ping;
+//! - the change-password status/body shape: a wrong current password renders a
+//!   typed 400 `InvalidCredentials` and a missing target a 404 `ResourceNotFound`,
+//!   both bodies the SDK hides. Change-password commits over every transport, so
+//!   its authz is covered in `permissions_scenario`; only the wire shape is here.
+//!
+//! Each test owns its own server (one spawn per `#[iggy_harness]` fn).
+
+use crate::server::http_client::HttpClient;
+use iggy::prelude::*;
+use iggy_common::IggyMessagesBatch;
+use iggy_common::create_stream::CreateStream;
+use iggy_common::create_topic::CreateTopic;
+use integration::iggy_harness;
+use reqwest::{Response, StatusCode};
+use serde_json::{Value, json};
+
+// server-ng partition ids are 0-based (CreateTopic assigns them from 0).
+const PARTITION_ID: u32 = 0;
+// Explicit consumer id in the poll query (`Consumer::default()` is numeric 0).
+const CONSUMER_ID: u32 = 1;
+
+// `IggyError` discriminants (== the numeric `id` in the JSON error body).
+const UNAUTHORIZED_ID: u64 = 41;
+const INVALID_CREDENTIALS_ID: u64 = 42;
+const CANNOT_DELETE_USER_ID: u64 = 48;
+const CANNOT_CHANGE_PERMISSIONS_ID: u64 = 49;
+// The apply's `ChangePasswordResult::UserNotFound` maps to `ResourceNotFound`.
+const RESOURCE_NOT_FOUND_ID: u64 = 20;
+// Snake-case `IggyError` names (== the `code` string in the JSON error body).
+const UNAUTHORIZED_CODE: &str = "unauthorized";
+const INVALID_CREDENTIALS_CODE: &str = "invalid_credentials";
+const CANNOT_DELETE_USER_CODE: &str = "cannot_delete_user";
+const CANNOT_CHANGE_PERMISSIONS_CODE: &str = "cannot_change_permissions";
+const RESOURCE_NOT_FOUND_CODE: &str = "resource_not_found";
+
+/// Root is the first user (slab id 0) and is undeletable / permission-locked.
+const ROOT_USER_PATH: &str = "0";
+
+/// Wire-contract request shapes layered on the shared [`HttpClient`]: this suite
+/// pins raw HTTP status codes and typed `{id, code}` error bodies, so its
+/// helpers return the raw [`Response`] for the caller to assert on.
+trait ClientExt {
+    async fn create_stream(&self, name: &str) -> u64;
+    async fn create_topic(&self, stream: &str, topic: &str, partitions: u32);
+    async fn create_user(&self, username: &str, password: &str, permissions: Value) -> Response;
+    async fn change_password(&self, user_id: &str, current: &str, new: &str) -> Response;
+    async fn login_attempt(&self, username: &str, password: &str) -> Response;
+    async fn produce(
+        &self,
+        stream: &str,
+        topic: &str,
+        partition_id: u32,
+        messages: Vec<IggyMessage>,
+    ) -> Response;
+    async fn poll(&self, stream: &str, topic: &str, partition_id: u32) -> Response;
+}
+
+impl ClientExt for HttpClient {
+    /// Create a stream and return its server-assigned numeric id (proves the
+    /// SDK-hidden `id` field of a 200 create-stream body).
+    async fn create_stream(&self, name: &str) -> u64 {
+        let response = self
+            .post_json(
+                "/streams",
+                &serde_json::to_value(CreateStream { name: name.into() }).unwrap(),
+            )
+            .await;
+        assert!(
+            response.status().is_success(),
+            "root create stream {name} failed: {}",
+            response.status()
+        );
+        let details: Value = response.json().await.expect("stream details json");
+        details["id"]
+            .as_u64()
+            .expect("stream id in create response")
+    }
+
+    async fn create_topic(&self, stream: &str, topic: &str, partitions: u32) {
+        let command = CreateTopic {
+            stream_id: Identifier::default(),
+            partitions_count: partitions,
+            compression_algorithm: CompressionAlgorithm::None,
+            message_expiry: IggyExpiry::NeverExpire,
+            max_topic_size: MaxTopicSize::ServerDefault,
+            replication_factor: None,
+            name: topic.to_string(),
+        };
+        let response = self
+            .post_json(
+                &format!("/streams/{stream}/topics"),
+                &serde_json::to_value(command).unwrap(),
+            )
+            .await;
+        assert!(
+            response.status().is_success(),
+            "root create topic {topic} failed: {}",
+            response.status()
+        );
+    }
+
+    /// Create a user with the given permissions (`Value::Null` = no grants).
+    async fn create_user(&self, username: &str, password: &str, permissions: Value) -> Response {
+        self.post_json(
+            "/users",
+            &json!({
+                "username": username,
+                "password": password,
+                "status": "active",
+                "permissions": permissions,
+            }),
+        )
+        .await
+    }
+
+    /// Change a user's password via `PUT /users/{user_id}/password`.
+    async fn change_password(&self, user_id: &str, current: &str, new: &str) -> Response {
+        self.put_json(
+            &format!("/users/{user_id}/password"),
+            &json!({ "current_password": current, "new_password": new }),
+        )
+        .await
+    }
+
+    /// Anonymous login attempt returning the raw response, for exercising a
+    /// rejected login (the asserting [`HttpClient::login`] cannot express failure).
+    async fn login_attempt(&self, username: &str, password: &str) -> Response {
+        self.client
+            .post(self.url("/users/login"))
+            .json(&json!({ "username": username, "password": password }))
+            .send()
+            .await
+            .expect("login request")
+    }
+
+    async fn produce(
+        &self,
+        stream: &str,
+        topic: &str,
+        partition_id: u32,
+        messages: Vec<IggyMessage>,
+    ) -> Response {
+        let body = SendMessages {
+            metadata_length: 0,
+            stream_id: Identifier::default(),
+            topic_id: Identifier::default(),
+            partitioning: Partitioning::partition_id(partition_id),
+            batch: IggyMessagesBatch::from(&messages),
+        };
+        self.client
+            .post(self.url(&format!("/streams/{stream}/topics/{topic}/messages")))
+            .bearer_auth(&self.token)
+            .json(&body)
+            .send()
+            .await
+            .expect("produce request")
+    }
+
+    async fn poll(&self, stream: &str, topic: &str, partition_id: u32) -> Response {
+        let path = format!(
+            "/streams/{stream}/topics/{topic}/messages\
+             ?consumer_id={CONSUMER_ID}&partition_id={partition_id}\
+             &kind=offset&value=0&count=10&auto_commit=false"
+        );
+        self.get(&path).await
+    }
+}
+
+fn text_message(id: u128, payload: &str) -> IggyMessage {
+    IggyMessage::builder()
+        .id(id)
+        .payload(payload.to_string().into())
+        .build()
+        .expect("message build")
+}
+
+/// No permissions at all: the permissioner holds no entry, so every rule denies.
+fn no_permissions() -> Value {
+    Value::Null
+}
+
+/// Assert a JSON error body carries the expected typed `id` + `code`. Proves the
+/// error crossed the wire as a real `IggyError` code, not a bare status.
+async fn assert_error_body(response: Response, expected_id: u64, expected_code: &str, ctx: &str) {
+    let body: Value = response.json().await.expect("error body json");
+    assert_eq!(
+        body["id"].as_u64(),
+        Some(expected_id),
+        "{ctx}: error id (body={body})"
+    );
+    assert_eq!(
+        body["code"].as_str(),
+        Some(expected_code),
+        "{ctx}: error code (body={body})"
+    );
+}
+
+/// Decode a PAT-list response body into its token names, asserting 200 first.
+async fn pat_names(response: Response) -> Vec<String> {
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "PAT list must be 200 for an authenticated caller"
+    );
+    let body: Value = response.json().await.expect("PAT list body must be JSON");
+    body.as_array()
+        .expect("PAT list must be a JSON array")
+        .iter()
+        .map(|token| {
+            token["name"]
+                .as_str()
+                .expect("every token must carry a name")
+                .to_owned()
+        })
+        .collect()
+}
+
+// === Denials carry the exact HTTP status + typed JSON error body ============
+
+/// The SDK reconstructs only 401/403/404 as typed errors and collapses every
+/// other status; raw HTTP is the only place the paired status + `{id, code}`
+/// body is observable. Covers both denial gates and both root-protection rules.
+#[iggy_harness]
+async fn given_http_requests_when_denied_should_carry_typed_status_and_body(harness: &TestHarness) {
+    let root = HttpClient::login_root(harness).await;
+    // A populated stream so the read gate denies over a real listing surface.
+    root.create_stream("rbac-s1").await;
+    root.create_user("alice", "alice-pass", no_permissions())
+        .await;
+    let alice = root.login("alice", "alice-pass").await;
+
+    // Dispatch read gate: an ungranted read is 403 with a typed Unauthorized body.
+    let read = alice.get("/streams").await;
+    assert_eq!(
+        read.status(),
+        StatusCode::FORBIDDEN,
+        "alice GET /streams must be 403"
+    );
+    assert_error_body(
+        read,
+        UNAUTHORIZED_ID,
+        UNAUTHORIZED_CODE,
+        "alice GET /streams",
+    )
+    .await;
+
+    // In-apply control gate: the denial rides the metadata result section back as
+    // a typed Unauthorized body, still under a 403.
+    let create = alice
+        .post_json("/streams", &json!({ "name": "alice-stream" }))
+        .await;
+    assert_eq!(
+        create.status(),
+        StatusCode::FORBIDDEN,
+        "alice POST /streams must be 403"
+    );
+    assert_error_body(
+        create,
+        UNAUTHORIZED_ID,
+        UNAUTHORIZED_CODE,
+        "alice POST /streams",
+    )
+    .await;
+
+    // Business-rule rejections fire in the STM apply AFTER RBAC admits root
+    // (both guards are target-based on slab id 0). The typed code rides the body
+    // and the `IggyError` map yields 400, not 403.
+    let delete_root = root.delete(&format!("/users/{ROOT_USER_PATH}")).await;
+    assert_eq!(
+        delete_root.status(),
+        StatusCode::BAD_REQUEST,
+        "delete root status"
+    );
+    assert_error_body(
+        delete_root,
+        CANNOT_DELETE_USER_ID,
+        CANNOT_DELETE_USER_CODE,
+        "delete root",
+    )
+    .await;
+
+    let change_root = root
+        .put_json(
+            &format!("/users/{ROOT_USER_PATH}/permissions"),
+            &json!({ "permissions": no_permissions() }),
+        )
+        .await;
+    assert_eq!(
+        change_root.status(),
+        StatusCode::BAD_REQUEST,
+        "re-permission root status"
+    );
+    assert_error_body(
+        change_root,
+        CANNOT_CHANGE_PERMISSIONS_ID,
+        CANNOT_CHANGE_PERMISSIONS_CODE,
+        "re-permission root",
+    )
+    .await;
+}
+
+// === Authorized requests carry the SDK-hidden success status codes ==========
+
+/// Root exercises the happy path; the SDK hides these exact status codes behind
+/// `Ok(...)`, so only raw HTTP can pin produce 201 / read 200 / create-stream
+/// 200 + the id body.
+#[iggy_harness]
+async fn given_http_requests_when_authorized_should_carry_sdk_hidden_status_codes(
+    harness: &TestHarness,
+) {
+    let root = HttpClient::login_root(harness).await;
+    let stream_id = root.create_stream("root-canary").await;
+    assert!(stream_id < u64::MAX, "root create stream must return an id");
+    root.create_topic("root-canary", "canary-topic", 1).await;
+
+    assert_eq!(
+        root.produce(
+            "root-canary",
+            "canary-topic",
+            PARTITION_ID,
+            vec![text_message(1, "root-msg")],
+        )
+        .await
+        .status(),
+        StatusCode::CREATED,
+        "root produce must be 201"
+    );
+    assert_eq!(
+        root.poll("root-canary", "canary-topic", PARTITION_ID)
+            .await
+            .status(),
+        StatusCode::OK,
+        "root poll must be 200"
+    );
+    assert_eq!(
+        root.get("/stats").await.status(),
+        StatusCode::OK,
+        "root GET /stats must be 200"
+    );
+}
+
+// === HTTP-only route shapes the SDK does not expose =========================
+
+/// Routes with no SDK equivalent: the `/users/me` self alias, auth-only cluster
+/// metadata (readable by an ungranted caller, so never RBAC-gated), the public
+/// ping, and the caller-scoped name-sorted PAT-list JSON array.
+#[iggy_harness]
+async fn given_http_only_routes_when_requested_should_return_expected_shapes(
+    harness: &TestHarness,
+) {
+    let root = HttpClient::login_root(harness).await;
+    root.create_user("alice", "alice-pass", no_permissions())
+        .await;
+    let alice = root.login("alice", "alice-pass").await;
+
+    // The `me` alias resolves to the caller's own user (self-scoped, no rule).
+    let me = alice.get("/users/me").await;
+    assert_eq!(me.status(), StatusCode::OK, "GET /users/me must be 200");
+    let me_body: Value = me.json().await.expect("users/me body must be JSON");
+    assert_eq!(
+        me_body["username"], "alice",
+        "the me alias must resolve to the caller's own user"
+    );
+
+    // Cluster metadata is auth-only: an ungranted caller still reads it, proving
+    // the route is never RBAC-gated.
+    assert_eq!(
+        alice.get("/cluster/metadata").await.status(),
+        StatusCode::OK,
+        "cluster metadata is auth-only, never RBAC-gated"
+    );
+
+    // Ping is public (no bearer).
+    assert_eq!(
+        alice.get_anonymous("/ping").await.status(),
+        StatusCode::OK,
+        "ping is public"
+    );
+
+    // PAT listing is a JSON array of the caller's own tokens, name-sorted
+    // (created in reverse order to prove the sort). Create returns 200.
+    for name in ["alice-zeta", "alice-alpha"] {
+        assert_eq!(
+            alice
+                .post_json(
+                    "/personal-access-tokens",
+                    &json!({ "name": name, "expiry": 0 }),
+                )
+                .await
+                .status(),
+            StatusCode::OK,
+            "alice create PAT {name} must be 200"
+        );
+    }
+    assert_eq!(
+        pat_names(alice.get("/personal-access-tokens").await).await,
+        ["alice-alpha", "alice-zeta"],
+        "PAT list must be a name-sorted JSON array of the caller's tokens"
+    );
+}
+
+// === Change-password wire contract (status/body shape) ==========================
+
+/// The current-password check gates a self-service rotation: a wrong current
+/// password is verified against the stored hash on shard 0, commits as a
+/// rejecting no-op, and surfaces as 400 `InvalidCredentials` from the
+/// replicated apply; only the correct one rotates the credential so the old
+/// password stops working and the new one starts.
+#[iggy_harness]
+async fn given_own_password_when_current_wrong_should_reject_and_correct_should_rotate(
+    harness: &TestHarness,
+) {
+    let root = HttpClient::login_root(harness).await;
+    root.create_user("carol", "carol-pass-1", no_permissions())
+        .await;
+    let carol = root.login("carol", "carol-pass-1").await;
+
+    let wrong = carol
+        .change_password("carol", "not-my-password", "carol-pass-2")
+        .await;
+    assert_eq!(
+        wrong.status(),
+        StatusCode::BAD_REQUEST,
+        "wrong current password must be 400"
+    );
+    assert_error_body(
+        wrong,
+        INVALID_CREDENTIALS_ID,
+        INVALID_CREDENTIALS_CODE,
+        "carol change-password wrong current",
+    )
+    .await;
+
+    let correct = carol
+        .change_password("carol", "carol-pass-1", "carol-pass-2")
+        .await;
+    assert_eq!(
+        correct.status(),
+        StatusCode::NO_CONTENT,
+        "correct current password must be 204"
+    );
+
+    assert!(
+        !carol
+            .login_attempt("carol", "carol-pass-1")
+            .await
+            .status()
+            .is_success(),
+        "old password must stop working after a successful rotation"
+    );
+    assert!(
+        carol
+            .login_attempt("carol", "carol-pass-2")
+            .await
+            .status()
+            .is_success(),
+        "new password must work after a successful rotation"
+    );
+}
+
+/// Admin-initiated change (target != caller): the current password is checked
+/// against the TARGET's stored hash, so a wrong one is 400 `InvalidCredentials`;
+/// a target that does not resolve is left to the replicated apply, which
+/// answers 404 `UserNotFound` (the plaintext is still stripped + hashed first).
+#[iggy_harness]
+async fn given_admin_change_password_when_target_current_wrong_or_missing_should_reject(
+    harness: &TestHarness,
+) {
+    let root = HttpClient::login_root(harness).await;
+    root.create_user("dave", "dave-pass", no_permissions())
+        .await;
+
+    let wrong = root
+        .change_password("dave", "not-daves-password", "new-dave-pass")
+        .await;
+    assert_eq!(
+        wrong.status(),
+        StatusCode::BAD_REQUEST,
+        "admin change with the wrong target current password must be 400"
+    );
+    assert_error_body(
+        wrong,
+        INVALID_CREDENTIALS_ID,
+        INVALID_CREDENTIALS_CODE,
+        "admin change dave wrong current",
+    )
+    .await;
+
+    let missing = root
+        .change_password("ghost-does-not-exist", "whatever", "whatever-else")
+        .await;
+    assert_eq!(
+        missing.status(),
+        StatusCode::NOT_FOUND,
+        "change for an unknown target must be 404 from the apply"
+    );
+    assert_error_body(
+        missing,
+        RESOURCE_NOT_FOUND_ID,
+        RESOURCE_NOT_FOUND_CODE,
+        "admin change missing target",
+    )
+    .await;
+}

--- a/core/integration/tests/server/http_vsr.rs
+++ b/core/integration/tests/server/http_vsr.rs
@@ -1,0 +1,843 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! HTTP data-plane gate for server-ng: produce, poll, and consumer-offset
+//! routes exercised over raw `reqwest` (not the SDK HTTP client) so the wire
+//! contract itself is under test - exact status codes, the
+//! `x-iggy-durability` header, the body-size cap, and cross-request isolation
+//! of concurrent produces on one login session.
+
+use crate::server::http_client::HttpClient;
+use futures::future::join_all;
+use iggy::prelude::*;
+use iggy_common::create_stream::CreateStream;
+use iggy_common::create_topic::CreateTopic;
+use iggy_common::store_consumer_offset::StoreConsumerOffset;
+use iggy_common::{ConsumerOffsetInfo, IggyMessagesBatch};
+use integration::iggy_harness;
+use reqwest::{Response, StatusCode};
+use serde_json::json;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+// server-ng partition ids are 0-based (CreateTopic assigns them from 0).
+const PARTITION_ID: u32 = 0;
+
+/// Explicit consumer id shared by the offset store body and the read/delete
+/// query, so both sides address the same offset-table key
+/// (`Consumer::default()` would carry numeric id 0, not 1).
+const CONSUMER_ID: u32 = 1;
+
+const DURABILITY_HEADER: &str = "x-iggy-durability";
+const DURABILITY_REPLICATED_MEMORY: &str = "replicated-memory";
+const DURABILITY_NONE: &str = "none";
+
+/// `?ack=none` answers before the commit; poll until visible, never unbounded.
+const ASYNC_COMMIT_TIMEOUT: Duration = Duration::from_secs(15);
+const ASYNC_COMMIT_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Data-plane request shapes layered on the shared [`HttpClient`]: this suite
+/// exercises the listener's produce / poll / consumer-offset behavior, so its
+/// helpers decode `PolledMessages` and drive multi-partition produces.
+trait HttpSessionExt {
+    async fn create_stream_and_topic(&self, stream: &str, topic: &str, partitions: u32);
+    async fn produce(
+        &self,
+        stream: &str,
+        topic: &str,
+        partition_id: u32,
+        messages: Vec<IggyMessage>,
+    ) -> Response;
+    async fn produce_with_query(
+        &self,
+        stream: &str,
+        topic: &str,
+        partition_id: u32,
+        messages: Vec<IggyMessage>,
+        query: &str,
+    ) -> Response;
+    async fn poll(
+        &self,
+        stream: &str,
+        topic: &str,
+        partition_id: u32,
+        offset: u64,
+        count: u32,
+    ) -> PolledMessages;
+    async fn create_user(&self, username: &str, password: &str);
+}
+
+impl HttpSessionExt for HttpClient {
+    async fn create_stream_and_topic(&self, stream: &str, topic: &str, partitions: u32) {
+        let response = self
+            .client
+            .post(self.url("/streams"))
+            .bearer_auth(&self.token)
+            .json(&CreateStream {
+                name: stream.to_string(),
+            })
+            .send()
+            .await
+            .expect("create stream request");
+        assert!(
+            response.status().is_success(),
+            "create stream failed: {}",
+            response.status()
+        );
+
+        let command = CreateTopic {
+            stream_id: Identifier::default(),
+            partitions_count: partitions,
+            compression_algorithm: CompressionAlgorithm::None,
+            message_expiry: IggyExpiry::NeverExpire,
+            max_topic_size: MaxTopicSize::ServerDefault,
+            replication_factor: None,
+            name: topic.to_string(),
+        };
+        let response = self
+            .client
+            .post(self.url(&format!("/streams/{stream}/topics")))
+            .bearer_auth(&self.token)
+            .json(&command)
+            .send()
+            .await
+            .expect("create topic request");
+        assert!(
+            response.status().is_success(),
+            "create topic failed: {}",
+            response.status()
+        );
+    }
+
+    async fn produce(
+        &self,
+        stream: &str,
+        topic: &str,
+        partition_id: u32,
+        messages: Vec<IggyMessage>,
+    ) -> Response {
+        self.produce_with_query(stream, topic, partition_id, messages, "")
+            .await
+    }
+
+    async fn produce_with_query(
+        &self,
+        stream: &str,
+        topic: &str,
+        partition_id: u32,
+        messages: Vec<IggyMessage>,
+        query: &str,
+    ) -> Response {
+        let body = SendMessages {
+            metadata_length: 0,
+            stream_id: Identifier::default(),
+            topic_id: Identifier::default(),
+            partitioning: Partitioning::partition_id(partition_id),
+            batch: IggyMessagesBatch::from(&messages),
+        };
+        self.client
+            .post(self.url(&format!("/streams/{stream}/topics/{topic}/messages{query}")))
+            .bearer_auth(&self.token)
+            .json(&body)
+            .send()
+            .await
+            .expect("produce request")
+    }
+
+    async fn poll(
+        &self,
+        stream: &str,
+        topic: &str,
+        partition_id: u32,
+        offset: u64,
+        count: u32,
+    ) -> PolledMessages {
+        let path = format!(
+            "/streams/{stream}/topics/{topic}/messages\
+             ?consumer_id={CONSUMER_ID}&partition_id={partition_id}\
+             &kind=offset&value={offset}&count={count}&auto_commit=false"
+        );
+        let response = self
+            .client
+            .get(self.url(&path))
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .expect("poll request");
+        assert_eq!(response.status(), StatusCode::OK, "poll must answer 200");
+        response.json().await.expect("decode PolledMessages")
+    }
+
+    /// Create an ungranted user (no permissions -> the permissioner holds no
+    /// entry, so every RBAC rule denies). Runs as this session's user.
+    async fn create_user(&self, username: &str, password: &str) {
+        let body = serde_json::json!({
+            "username": username,
+            "password": password,
+            "status": "active",
+            "permissions": null,
+        });
+        let response = self
+            .client
+            .post(self.url("/users"))
+            .bearer_auth(&self.token)
+            .json(&body)
+            .send()
+            .await
+            .expect("create user request");
+        assert!(
+            response.status().is_success(),
+            "create user failed: {}",
+            response.status()
+        );
+    }
+}
+
+fn durability(response: &Response) -> &str {
+    response
+        .headers()
+        .get(DURABILITY_HEADER)
+        .expect("produce response must carry the durability header")
+        .to_str()
+        .expect("durability header is ASCII")
+}
+
+fn text_message(id: u128, payload: String) -> IggyMessage {
+    IggyMessage::builder()
+        .id(id)
+        .payload(payload.into())
+        .build()
+        .expect("message build")
+}
+
+#[iggy_harness]
+async fn given_http_session_when_producing_and_polling_should_round_trip(harness: &TestHarness) {
+    let http = HttpClient::login_root(harness).await;
+    http.create_stream_and_topic("http-stream", "http-topic", 1)
+        .await;
+
+    let header_key = HeaderKey::try_from("trace-id").expect("header key");
+    let header_value = HeaderValue::from_str("trace-42").expect("header value");
+    let messages: Vec<IggyMessage> = (0..3u32)
+        .map(|i| {
+            let builder = IggyMessage::builder()
+                .id(u128::from(i + 1))
+                .payload(format!("round-trip-{i}").into());
+            if i == 0 {
+                let user_headers = BTreeMap::from([(header_key.clone(), header_value.clone())]);
+                builder
+                    .user_headers(user_headers)
+                    .build()
+                    .expect("message build")
+            } else {
+                builder.build().expect("message build")
+            }
+        })
+        .collect();
+
+    let response = http
+        .produce("http-stream", "http-topic", PARTITION_ID, messages)
+        .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "produce must commit"
+    );
+    assert_eq!(durability(&response), DURABILITY_REPLICATED_MEMORY);
+
+    let polled = http
+        .poll("http-stream", "http-topic", PARTITION_ID, 0, 10)
+        .await;
+    assert_eq!(polled.messages.len(), 3, "all sent messages must come back");
+    for (i, message) in polled.messages.iter().enumerate() {
+        assert_eq!(message.header.offset, i as u64, "offsets must be dense");
+        assert_eq!(
+            message.payload,
+            bytes::Bytes::from(format!("round-trip-{i}")),
+            "payload round trip for message {i}"
+        );
+    }
+    let user_headers = polled.messages[0]
+        .user_headers_map()
+        .expect("headers decode")
+        .expect("first message carries user headers");
+    assert_eq!(
+        user_headers.get(&header_key),
+        Some(&header_value),
+        "user header must survive the round trip"
+    );
+}
+
+const CONCURRENT_PRODUCES: usize = 16;
+const CONCURRENT_PARTITIONS: u32 = 4;
+
+#[iggy_harness]
+async fn given_one_session_when_producing_concurrently_should_not_cross_talk(
+    harness: &TestHarness,
+) {
+    let http = HttpClient::login_root(harness).await;
+    http.create_stream_and_topic("http-concurrent", "hammer", CONCURRENT_PARTITIONS)
+        .await;
+
+    let produces = (0..CONCURRENT_PRODUCES).map(|i| {
+        let http = &http;
+        let partition_id = (i as u32) % CONCURRENT_PARTITIONS;
+        async move {
+            let message = text_message(i as u128 + 1, format!("concurrent-{i}"));
+            let response = http
+                .produce("http-concurrent", "hammer", partition_id, vec![message])
+                .await;
+            (i, response.status(), durability(&response).to_string())
+        }
+    });
+    let outcomes = join_all(produces).await;
+
+    for (i, status, durability) in &outcomes {
+        assert_eq!(
+            *status,
+            StatusCode::CREATED,
+            "concurrent produce {i} must commit"
+        );
+        assert_eq!(
+            durability, DURABILITY_REPLICATED_MEMORY,
+            "concurrent produce {i} must attest a replicated commit"
+        );
+    }
+
+    let mut produced: HashMap<u32, HashSet<String>> = HashMap::new();
+    for i in 0..CONCURRENT_PRODUCES {
+        produced
+            .entry((i as u32) % CONCURRENT_PARTITIONS)
+            .or_default()
+            .insert(format!("concurrent-{i}"));
+    }
+
+    // Every partition must return exactly its own produced payloads: nothing
+    // lost, nothing foreign. The produce path is at-least-once, so duplicates
+    // are tolerated but must be byte-identical to a produced payload.
+    let mut polled_union: HashSet<String> = HashSet::new();
+    for partition_id in 0..CONCURRENT_PARTITIONS {
+        let polled = http
+            .poll("http-concurrent", "hammer", partition_id, 0, 100)
+            .await;
+        let expected = &produced[&partition_id];
+        let mut seen: HashSet<String> = HashSet::new();
+        for message in &polled.messages {
+            let payload = String::from_utf8(message.payload.to_vec()).expect("payload is UTF-8");
+            assert!(
+                expected.contains(&payload),
+                "partition {partition_id} returned foreign payload {payload:?}"
+            );
+            seen.insert(payload);
+        }
+        assert_eq!(
+            &seen, expected,
+            "partition {partition_id} must return exactly its own produced payloads"
+        );
+        polled_union.extend(seen);
+    }
+    assert_eq!(
+        polled_union.len(),
+        CONCURRENT_PRODUCES,
+        "every produced payload must be polled back"
+    );
+}
+
+#[iggy_harness]
+async fn given_consumer_offset_when_stored_and_deleted_should_round_trip(harness: &TestHarness) {
+    let http = HttpClient::login_root(harness).await;
+    http.create_stream_and_topic("http-offsets", "offsets", 1)
+        .await;
+
+    // Two committed messages so offset 1 names a real position.
+    let messages = (0..2u32)
+        .map(|i| text_message(u128::from(i + 1), format!("offset-fodder-{i}")))
+        .collect();
+    let response = http
+        .produce("http-offsets", "offsets", PARTITION_ID, messages)
+        .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "produce must commit"
+    );
+
+    let offsets_path = "/streams/http-offsets/topics/offsets/consumer-offsets";
+    let store = StoreConsumerOffset {
+        consumer: Consumer::new(Identifier::numeric(CONSUMER_ID).expect("consumer id")),
+        partition_id: Some(PARTITION_ID),
+        offset: 1,
+    };
+    let response = http
+        .client
+        .put(http.url(offsets_path))
+        .bearer_auth(&http.token)
+        .json(&store)
+        .send()
+        .await
+        .expect("store offset request");
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "store must commit"
+    );
+
+    let get_path = format!("{offsets_path}?consumer_id={CONSUMER_ID}&partition_id={PARTITION_ID}");
+    let response = http
+        .client
+        .get(http.url(&get_path))
+        .bearer_auth(&http.token)
+        .send()
+        .await
+        .expect("get offset request");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "stored offset must be readable"
+    );
+    let info: ConsumerOffsetInfo = response.json().await.expect("decode ConsumerOffsetInfo");
+    assert_eq!(info.stored_offset, 1, "stored offset must round trip");
+    assert_eq!(info.partition_id, PARTITION_ID);
+
+    let delete_path = format!("{offsets_path}/{CONSUMER_ID}?partition_id={PARTITION_ID}");
+    let response = http
+        .client
+        .delete(http.url(&delete_path))
+        .bearer_auth(&http.token)
+        .send()
+        .await
+        .expect("delete offset request");
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "delete must commit"
+    );
+
+    let response = http
+        .client
+        .get(http.url(&get_path))
+        .bearer_auth(&http.token)
+        .send()
+        .await
+        .expect("get offset request after delete");
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "deleted offset must be gone"
+    );
+}
+
+/// A DELETE of a never-stored consumer offset is denied by the partition
+/// primary before consensus (`ReplyHeader.status`), so the route must answer
+/// a typed 404 immediately - not wait out the 10s partition-write reply
+/// timeout into a 504 - and the deny gate must not break a store-then-delete
+/// of an offset that does exist.
+#[iggy_harness]
+async fn given_missing_consumer_offset_when_deleting_should_reject_404_fast(harness: &TestHarness) {
+    /// Well under the partition-write reply timeout: a deny is a single
+    /// round trip, a silent drop only answers at the full 10s.
+    const DENY_LATENCY_BUDGET: Duration = Duration::from_secs(5);
+
+    let http = HttpClient::login_root(harness).await;
+    http.create_stream_and_topic("http-missing-offset", "offsets", 1)
+        .await;
+
+    let offsets_path = "/streams/http-missing-offset/topics/offsets/consumer-offsets";
+    let delete_path = format!("{offsets_path}/{CONSUMER_ID}?partition_id={PARTITION_ID}");
+    let started = Instant::now();
+    let response = http
+        .client
+        .delete(http.url(&delete_path))
+        .bearer_auth(&http.token)
+        .send()
+        .await
+        .expect("delete missing offset request");
+    let elapsed = started.elapsed();
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "missing offset delete must reject 404"
+    );
+    assert!(
+        elapsed < DENY_LATENCY_BUDGET,
+        "deny must answer fast, not ride the reply timeout (took {elapsed:?})"
+    );
+    // The typed deny body, not the generic pre-dispatch not-found shape.
+    let body: serde_json::Value = response.json().await.expect("decode error body");
+    assert_eq!(
+        body["code"], "consumer_offset_not_found",
+        "deny must carry the typed error code, got {body}"
+    );
+
+    // The deny gate must not reject offsets that exist: store, then delete.
+    let messages = vec![text_message(1, "offset-fodder".to_string())];
+    let response = http
+        .produce("http-missing-offset", "offsets", PARTITION_ID, messages)
+        .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "produce must commit"
+    );
+    let store = StoreConsumerOffset {
+        consumer: Consumer::new(Identifier::numeric(CONSUMER_ID).expect("consumer id")),
+        partition_id: Some(PARTITION_ID),
+        offset: 0,
+    };
+    let response = http
+        .client
+        .put(http.url(offsets_path))
+        .bearer_auth(&http.token)
+        .json(&store)
+        .send()
+        .await
+        .expect("store offset request");
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "store must commit"
+    );
+    let response = http
+        .client
+        .delete(http.url(&delete_path))
+        .bearer_auth(&http.token)
+        .send()
+        .await
+        .expect("delete stored offset request");
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "existing offset delete must commit"
+    );
+}
+
+/// A store of an out-of-range consumer offset is denied by the partition
+/// primary at admission and must answer a typed 400, NOT a silent 204.
+/// Regression guard: the deny once rode the result-body result section with
+/// `status = 0`; the status-only `classify_partition_reply` read that as a
+/// committed success on a non-empty partition (`op = commit_max >= 1`) and
+/// returned 204 for a rejected store, dropping the offset silently. The two
+/// committed messages below make the partition non-empty so that `op != 0`
+/// path is exercised - an empty partition would only surface a different 404.
+#[iggy_harness]
+async fn given_out_of_range_consumer_offset_when_storing_should_reject_400_fast(
+    harness: &TestHarness,
+) {
+    /// Well under the partition-write reply timeout: an admission deny is a
+    /// single round trip, never the full reply timeout.
+    const DENY_LATENCY_BUDGET: Duration = Duration::from_secs(5);
+
+    let http = HttpClient::login_root(harness).await;
+    http.create_stream_and_topic("http-store-range", "offsets", 1)
+        .await;
+
+    // Two committed messages so the partition is non-empty (current_offset == 1,
+    // commit_max >= 1); the silent-204 path only appears once op != 0.
+    let messages = (0..2u32)
+        .map(|i| text_message(u128::from(i + 1), format!("offset-fodder-{i}")))
+        .collect();
+    let response = http
+        .produce("http-store-range", "offsets", PARTITION_ID, messages)
+        .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "produce must commit"
+    );
+
+    // Offset 5 runs past the committed tail (offset 1), so it is out of range.
+    let offsets_path = "/streams/http-store-range/topics/offsets/consumer-offsets";
+    let store = StoreConsumerOffset {
+        consumer: Consumer::new(Identifier::numeric(CONSUMER_ID).expect("consumer id")),
+        partition_id: Some(PARTITION_ID),
+        offset: 5,
+    };
+    let started = Instant::now();
+    let response = http
+        .client
+        .put(http.url(offsets_path))
+        .bearer_auth(&http.token)
+        .json(&store)
+        .send()
+        .await
+        .expect("store out-of-range offset request");
+    let elapsed = started.elapsed();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "out-of-range store must reject 400, not silently accept as 204"
+    );
+    assert!(
+        elapsed < DENY_LATENCY_BUDGET,
+        "deny must answer fast, not ride the reply timeout (took {elapsed:?})"
+    );
+    // The typed deny body carried in `ReplyHeader.status`, not a swallowed code.
+    let body: serde_json::Value = response.json().await.expect("decode error body");
+    assert_eq!(
+        body["code"], "invalid_offset",
+        "deny must carry the typed error code, got {body}"
+    );
+}
+
+#[iggy_harness]
+async fn given_oversized_body_when_producing_should_reject_413(harness: &TestHarness) {
+    let http = HttpClient::login_root(harness).await;
+    http.create_stream_and_topic("http-oversized", "big", 1)
+        .await;
+
+    // 3 MiB payload -> ~4 MiB JSON after base64: over the 2 MB body cap under
+    // either decimal or binary megabyte semantics.
+    let oversized = IggyMessage::builder()
+        .payload(vec![0x42u8; 3 * 1024 * 1024].into())
+        .build()
+        .expect("message build");
+    let response = http
+        .produce("http-oversized", "big", PARTITION_ID, vec![oversized])
+        .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "oversized body must be rejected"
+    );
+
+    // The rejection must not poison the listener: a normal produce still commits.
+    let normal = text_message(1, "small-after-large".to_string());
+    let response = http
+        .produce("http-oversized", "big", PARTITION_ID, vec![normal])
+        .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "server must stay healthy after a 413"
+    );
+    let polled = http
+        .poll("http-oversized", "big", PARTITION_ID, 0, 10)
+        .await;
+    assert_eq!(polled.messages.len(), 1, "normal produce must be pollable");
+    assert_eq!(
+        polled.messages[0].payload,
+        bytes::Bytes::from("small-after-large")
+    );
+}
+
+#[iggy_harness]
+async fn given_ack_none_when_producing_should_return_202_and_commit(harness: &TestHarness) {
+    let http = HttpClient::login_root(harness).await;
+    http.create_stream_and_topic("http-ack-none", "fire", 1)
+        .await;
+
+    let message = text_message(1, "fire-and-forget".to_string());
+    let response = http
+        .produce_with_query(
+            "http-ack-none",
+            "fire",
+            PARTITION_ID,
+            vec![message],
+            "?ack=none",
+        )
+        .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::ACCEPTED,
+        "ack=none must answer before the commit"
+    );
+    assert_eq!(durability(&response), DURABILITY_NONE);
+
+    // The commit still happens, just asynchronously: poll bounded until the
+    // message becomes visible.
+    let deadline = Instant::now() + ASYNC_COMMIT_TIMEOUT;
+    loop {
+        let polled = http
+            .poll("http-ack-none", "fire", PARTITION_ID, 0, 10)
+            .await;
+        if !polled.messages.is_empty() {
+            assert_eq!(polled.messages.len(), 1, "exactly one message was produced");
+            assert_eq!(
+                polled.messages[0].payload,
+                bytes::Bytes::from("fire-and-forget"),
+                "ack=none payload must round trip"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "ack=none produce did not become pollable within {ASYNC_COMMIT_TIMEOUT:?}"
+        );
+        sleep(ASYNC_COMMIT_RETRY_INTERVAL).await;
+    }
+}
+
+/// End-to-end RBAC proof: an ungranted user is 403 on a metadata read and on a
+/// data-plane produce, root stays 200/201, and the auth-only cluster-metadata
+/// route is never gated. Exercises the HTTP per-op gates (read + partition
+/// write) and the in-apply control gate (user creation as root) in one path.
+#[iggy_harness]
+async fn given_ungranted_user_when_reading_or_producing_should_be_forbidden(harness: &TestHarness) {
+    let root = HttpClient::login_root(harness).await;
+    root.create_stream_and_topic("rbac-stream", "rbac-topic", 1)
+        .await;
+    // Root provisions a user with no permissions, then we log in as them.
+    root.create_user("rbac-nobody", "rbac-nobody-pass").await;
+    let nobody = root.login("rbac-nobody", "rbac-nobody-pass").await;
+
+    // A metadata read: 403 for the ungranted user, 200 for root.
+    assert_eq!(
+        nobody.get("/streams").await.status(),
+        StatusCode::FORBIDDEN,
+        "ungranted read must be 403"
+    );
+    assert_eq!(
+        root.get("/streams").await.status(),
+        StatusCode::OK,
+        "root read must be 200"
+    );
+
+    // A data-plane produce: 403 for the ungranted user, 201 for root.
+    let denied = nobody
+        .produce(
+            "rbac-stream",
+            "rbac-topic",
+            PARTITION_ID,
+            vec![text_message(1, "denied".to_string())],
+        )
+        .await;
+    assert_eq!(
+        denied.status(),
+        StatusCode::FORBIDDEN,
+        "ungranted produce must be 403"
+    );
+    let allowed = root
+        .produce(
+            "rbac-stream",
+            "rbac-topic",
+            PARTITION_ID,
+            vec![text_message(2, "allowed".to_string())],
+        )
+        .await;
+    assert_eq!(
+        allowed.status(),
+        StatusCode::CREATED,
+        "root produce must commit"
+    );
+
+    // The auth-only cluster-metadata route carries no rule: any authenticated
+    // user reaches it, ungranted included.
+    assert_eq!(
+        nobody.get("/cluster/metadata").await.status(),
+        StatusCode::OK,
+        "cluster metadata is auth-only, never RBAC-gated"
+    );
+}
+
+/// The unauthenticated `POST /users/refresh-token` route: the current token
+/// travels in the JSON body, sent with no bearer header.
+trait RefreshExt {
+    async fn refresh(&self, token: &str) -> Response;
+}
+
+impl RefreshExt for HttpClient {
+    async fn refresh(&self, token: &str) -> Response {
+        self.client
+            .post(self.url("/users/refresh-token"))
+            .json(&json!({ "token": token }))
+            .send()
+            .await
+            .expect("refresh-token request")
+    }
+}
+
+#[iggy_harness]
+async fn given_valid_access_token_when_refreshing_should_issue_working_token_without_revoking_old(
+    harness: &TestHarness,
+) {
+    let http = HttpClient::login_root(harness).await;
+
+    // Baseline identity carrying both a token and its expiry; `login_root` keeps
+    // only the token string, so log in once more for the full `IdentityInfo`.
+    let old: IdentityInfo = http
+        .client
+        .post(http.url("/users/login"))
+        .json(&json!({
+            "username": DEFAULT_ROOT_USERNAME,
+            "password": DEFAULT_ROOT_PASSWORD,
+        }))
+        .send()
+        .await
+        .expect("login request")
+        .json()
+        .await
+        .expect("decode IdentityInfo");
+    let old_user_id = old.user_id;
+    let old_token = old.access_token.expect("login returns a token");
+
+    let response = http.refresh(&old_token.token).await;
+    assert_eq!(response.status(), StatusCode::OK, "refresh must answer 200");
+    let refreshed: IdentityInfo = response.json().await.expect("decode IdentityInfo");
+    let new_token = refreshed.access_token.expect("refresh returns a token");
+
+    assert_eq!(
+        refreshed.user_id, old_user_id,
+        "refresh must re-issue for the same user"
+    );
+    assert_ne!(
+        new_token.token, old_token.token,
+        "a fresh jti must yield a different token"
+    );
+    assert!(
+        new_token.expiry >= old_token.expiry,
+        "the refreshed token must not expire earlier than the one it replaced"
+    );
+
+    // The fresh token authenticates: its new jti lazily Registers a session on
+    // first authed use.
+    assert_eq!(
+        http.with_token(new_token.token)
+            .get("/streams")
+            .await
+            .status(),
+        StatusCode::OK,
+        "the refreshed token must authenticate"
+    );
+
+    // Stateless by design: server-ng has no replicated revocation list (P3), so
+    // refreshing never invalidates the token it was minted from - the old token
+    // lives to its natural exp. Deliberate, not a bug; the same posture as
+    // logout, which ends a session without revoking its bearer.
+    assert_eq!(
+        http.with_token(old_token.token)
+            .get("/streams")
+            .await
+            .status(),
+        StatusCode::OK,
+        "the pre-refresh token stays valid (no revocation by design)"
+    );
+}
+
+#[iggy_harness]
+async fn given_garbage_or_empty_token_when_refreshing_should_reject_401(harness: &TestHarness) {
+    let http = HttpClient::login_root(harness).await;
+    for token in ["not-a-jwt", ""] {
+        let response = http.refresh(token).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "refresh with an invalid token ({token:?}) must be 401"
+        );
+    }
+}

--- a/core/integration/tests/server/legacy_login_vsr.rs
+++ b/core/integration/tests/server/legacy_login_vsr.rs
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Legacy login codes against server-ng (vsr). server-ng authenticates only
+//! through the Register handshake, so the pre-register `LOGIN_USER` (38) and
+//! `LOGIN_WITH_PERSONAL_ACCESS_TOKEN` (44) codes -- which the vsr SDK never
+//! emits (its typed login methods send the register codes, its raw path
+//! rejects session-control codes) -- must be rejected with a typed
+//! `MalformedLogin` eviction, instead of the misleading `NoSession` eviction
+//! the pre-auth guard would send unbound, or the silent empty-ok reply the
+//! bound non-replicated path would send.
+//! Since the SDK cannot send these codes, the frames are hand-crafted on a raw
+//! TCP socket: a header-only non-replicated frame carrying the code in the
+//! reserved command slot.
+
+#![cfg(feature = "vsr")]
+
+use iggy_binary_protocol::HEADER_SIZE;
+use iggy_binary_protocol::codes::{LOGIN_USER_CODE, LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE};
+use iggy_binary_protocol::consensus::{Command2, Operation, RequestHeader};
+use iggy_binary_protocol::namespace::METADATA_CONSENSUS_NAMESPACE;
+use integration::harness::TestHarness;
+use integration::iggy_harness;
+use std::mem::offset_of;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+// Wire byte pinned to `EvictionReason::MalformedLogin` in consensus::header.
+const EVICTION_REASON_MALFORMED_LOGIN: u8 = 15;
+
+#[iggy_harness]
+async fn given_legacy_login_user_code_when_sent_raw_should_evict_malformed_login(
+    harness: &TestHarness,
+) {
+    assert_legacy_login_code_evicted(harness, LOGIN_USER_CODE).await;
+}
+
+#[iggy_harness]
+async fn given_legacy_pat_login_code_when_sent_raw_should_evict_malformed_login(
+    harness: &TestHarness,
+) {
+    assert_legacy_login_code_evicted(harness, LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE).await;
+}
+
+/// Send a header-only non-replicated frame carrying `code` in the reserved
+/// command slot and assert the server answers with a `MalformedLogin`
+/// eviction. The reject runs before the session gate, so this unbound socket
+/// exercises the same path a bound connection would.
+async fn assert_legacy_login_code_evicted(harness: &TestHarness, code: u32) {
+    let mut header = RequestHeader {
+        command: Command2::Request,
+        operation: Operation::NonReplicated,
+        size: u32::try_from(HEADER_SIZE).unwrap(),
+        // NonReplicated leaves session / request unchecked, but the header
+        // validator still requires a nonzero client id.
+        client: 0xC0FFEE,
+        session: 0,
+        request: 0,
+        namespace: METADATA_CONSENSUS_NAMESPACE,
+        ..Default::default()
+    };
+    // A non-replicated command code travels in the first 4 reserved bytes.
+    header.reserved[..4].copy_from_slice(&code.to_le_bytes());
+
+    let addr = harness
+        .server()
+        .tcp_addr()
+        .expect("server must expose a TCP address");
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    stream.write_all(bytemuck::bytes_of(&header)).await.unwrap();
+
+    // Eviction is header-only: exactly 256 bytes. The timeout makes the
+    // fail-fast contract explicit -- a regression that silently drops the
+    // frame trips this instead of hanging until the test wall clock.
+    let mut reply = [0u8; HEADER_SIZE];
+    timeout(Duration::from_secs(5), stream.read_exact(&mut reply))
+        .await
+        .expect("server must answer a legacy login code within 5s, not stall")
+        .expect("reading the eviction frame must succeed");
+
+    let command_offset = offset_of!(RequestHeader, command);
+    assert_eq!(
+        reply[command_offset],
+        Command2::Eviction as u8,
+        "expected an Eviction frame for legacy login code {code}, not a Reply"
+    );
+    assert_eq!(
+        reply[HEADER_SIZE - 1],
+        EVICTION_REASON_MALFORMED_LOGIN,
+        "legacy login code {code} must evict with MalformedLogin"
+    );
+}

--- a/core/integration/tests/server/mod.rs
+++ b/core/integration/tests/server/mod.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// a2a_jwt is HTTP-only (JWT against the HTTP transport); vsr has no HTTP.
+// a2a_jwt exercises trusted-issuer (JWKS) tokens; server-ng's HTTP JWT
+// verifier has no trusted-issuer path.
 #[cfg(not(feature = "vsr"))]
 mod a2a_jwt;
 // Polling-based consumer-group scenarios are not implemented under vsr yet.
@@ -24,6 +25,27 @@ mod cg;
 // The ported round-robin membership join scenario runs against server-ng.
 #[cfg(feature = "vsr")]
 mod cg_vsr;
+// Flush (FLUSH_UNSAVED_BUFFER) has no server-ng primitive; it must deny typed.
+#[cfg(feature = "vsr")]
+mod flush_vsr;
+// Legacy login codes (LOGIN_USER / LOGIN_WITH_PAT) have no server-ng handler;
+// they must evict typed (MalformedLogin), not stall or reply empty-ok.
+#[cfg(feature = "vsr")]
+mod legacy_login_vsr;
+// Shared HTTP transport plumbing (session + verb helpers) for the raw-HTTP
+// server-ng suites below.
+#[cfg(feature = "vsr")]
+mod http_client;
+// Raw-HTTP data-plane contract against server-ng's shard-0 listener.
+#[cfg(feature = "vsr")]
+mod http_vsr;
+// Raw-HTTP wire-contract residue against server-ng (status codes + typed error
+// bodies); the RBAC matrix lives in permissions_scenario.
+#[cfg(feature = "vsr")]
+mod http_rbac;
+// Binary GetClusterMetadata must serve the real roster from a VSR cluster.
+#[cfg(feature = "vsr")]
+mod cluster_metadata_vsr;
 // 80-case race matrix with hardcoded HTTP variants (test_matrix bypasses
 // the harness transport filter).
 mod concurrent_addition;
@@ -34,8 +56,8 @@ mod message_cleanup;
 mod message_retrieval;
 // Server restarts, consumer-group barriers, and DeleteSegments maintenance.
 // `should_delete_segments_without_consumers` is framing-agnostic + async-aware
-// and runs under server-ng; the consumer-group / restart variants stay
-// legacy-shaped (cg polling has its own vsr gaps) and are filtered out there.
+// and runs fully (both restart variants) under server-ng; the consumer-group
+// variants stay legacy-shaped or vsr-gated (cg polling has its own vsr gaps).
 mod purge_delete;
 mod scenarios;
 mod specific;

--- a/core/integration/tests/server/purge_delete.rs
+++ b/core/integration/tests/server/purge_delete.rs
@@ -46,12 +46,9 @@ async fn should_delete_segments_and_validate_filesystem(
 ))]
 // Recovery on restart is fixed -- server-ng reads its own 24-byte segment index
 // via `segment_recovery` (no more "Index data must be exactly 16 bytes" panic;
-// the server restarts + re-meshes cleanly). restart_on stays vsr-gated on a
-// CLIENT blocker: the SDK `ConsensusSession` cannot reconnect after restart --
-// `register_request_id already called` (core/sdk/src/session.rs:121), the same
-// reconnect/re-register lifecycle `user_scenario` hits. Re-enable once that lands.
-#[cfg_attr(not(feature = "vsr"), test_matrix([restart_off(), restart_on()]))]
-#[cfg_attr(feature = "vsr", test_matrix([restart_off()]))]
+// the server restarts + re-meshes cleanly). The SDK reconnect-after-restart
+// re-login lifecycle is fixed too, so restart_on runs under vsr.
+#[test_matrix([restart_off(), restart_on()])]
 async fn should_delete_segments_without_consumers(harness: &mut TestHarness, restart_server: bool) {
     purge_delete_scenario::run_no_consumers(harness, restart_server).await;
 }
@@ -101,9 +98,12 @@ async fn should_block_deletion_until_all_consumers_pass_segment(
 ))]
 // The scenario asserts the exact [0, 7, 14, 21] layout only on the legacy path;
 // under vsr it verifies the framing-agnostic purge outcome (offsets cleared,
-// files deleted, partition reset to a single segment at offset 0). restart_on
-// stays vsr-gated on the SDK reconnect-after-restart lifecycle (see
-// `should_delete_segments_without_consumers`).
+// files deleted, partition reset to a single segment at offset 0). The SDK
+// re-login panic is fixed, but restart_on stays vsr-gated on a separate
+// consumer-group blocker: after restart the heartbeat's group-assignment
+// refresh reconnect path re-binds an already-bound VSR session and fails
+// `AlreadyAuthenticated` (the consumerless `should_delete_segments_without_consumers`
+// restart_on passes, so this is CG-reconnect specific, not the login re-arm).
 #[cfg_attr(not(feature = "vsr"), test_matrix([restart_off(), restart_on()]))]
 #[cfg_attr(feature = "vsr", test_matrix([restart_off()]))]
 async fn should_purge_topic_and_clear_consumer_offsets(
@@ -117,9 +117,6 @@ fn restart_off() -> bool {
     false
 }
 
-// Only the `not(vsr)` matrix cell uses restart_on (restart is vsr-gated on the
-// SDK reconnect lifecycle above), so it is unused under the vsr feature.
-#[cfg(not(feature = "vsr"))]
 fn restart_on() -> bool {
     true
 }

--- a/core/integration/tests/server/scenarios/mod.rs
+++ b/core/integration/tests/server/scenarios/mod.rs
@@ -31,7 +31,10 @@ pub mod consumer_group_with_multiple_clients_polling_messages_scenario;
 pub mod consumer_group_with_single_client_polling_messages_scenario;
 pub mod consumer_timestamp_polling_scenario;
 pub mod create_message_payload;
-#[cfg(not(feature = "vsr"))]
+// Cross-protocol PAT visibility (create via HTTP, list via TCP across shards,
+// and the reverse). Runs under vsr too: server-ng serves the PAT routes on its
+// shard-0 HTTP listener and the create/delete commit through the metadata STM,
+// so the token replicates to every shard a TCP client may land on.
 pub mod cross_protocol_pat_scenario;
 #[cfg(not(feature = "vsr"))]
 pub mod encryption_scenario;
@@ -45,7 +48,6 @@ pub mod message_cleanup_scenario;
 pub mod message_headers_scenario;
 pub mod message_size_scenario;
 pub mod offset_scenario;
-#[cfg(not(feature = "vsr"))]
 pub mod permissions_scenario;
 pub mod purge_delete_scenario;
 pub mod read_during_persistence_scenario;
@@ -55,7 +57,6 @@ pub mod reconnect_after_restart_scenario;
 pub mod restart_offset_skip_scenario;
 pub mod segment_rotation_race_scenario;
 pub mod single_message_per_batch_scenario;
-#[cfg(not(feature = "vsr"))]
 pub mod snapshot_scenario;
 pub mod stale_client_consumer_group_scenario;
 pub mod stream_size_validation_scenario;
@@ -64,7 +65,6 @@ pub mod stress_produce_consume_scenario;
 pub mod system_scenario;
 pub mod tcp_tls_scenario;
 pub mod timestamp_scenario;
-#[cfg(not(feature = "vsr"))]
 pub mod user_scenario;
 pub mod websocket_tls_scenario;
 

--- a/core/integration/tests/server/scenarios/permissions_scenario.rs
+++ b/core/integration/tests/server/scenarios/permissions_scenario.rs
@@ -69,6 +69,15 @@ pub async fn run(harness: &TestHarness) {
     // Missing resource behavior tests
     test_missing_resource_behavior(harness, &root_client).await;
 
+    // RBAC surface ported from the raw-HTTP server-ng suite (server::http_rbac),
+    // asserting the exact typed IggyError over every transport.
+    test_consumer_offset_permissions(harness, &root_client).await;
+    test_change_password_reply_path(harness, &root_client).await;
+    test_root_user_is_protected(harness, &root_client).await;
+    test_live_permission_revocation(harness, &root_client).await;
+    test_deleted_user_session_denied(harness, &root_client).await;
+    test_personal_access_token_lifecycle(harness, &root_client).await;
+
     cleanup(&root_client).await;
 }
 
@@ -2436,8 +2445,372 @@ async fn test_missing_resource_behavior(harness: &TestHarness, root_client: &Igg
 }
 
 // =============================================================================
+// Test: Consumer-offset ops honor RBAC (ported from server::http_rbac).
+// A no-permission user is denied on the writes (store/delete surface the exact
+// Unauthorized); the GET is an enumeration-safe read the legacy server answers
+// with Ok(None), so it stays on the lenient helper.
+// =============================================================================
+
+async fn test_consumer_offset_permissions(harness: &TestHarness, root_client: &IggyClient) {
+    const USER: &str = "offset-no-perms-user";
+    create_test_user(root_client, USER, Some(no_permissions())).await;
+    let client = login_user(harness, USER).await;
+
+    let stream_id = Identifier::named(STREAM_1).unwrap();
+    let topic_id = Identifier::named(TOPIC_1).unwrap();
+    let consumer = Consumer::default();
+
+    assert_error_code(
+        client
+            .store_consumer_offset(&consumer, &stream_id, &topic_id, Some(0), 0)
+            .await,
+        IggyError::Unauthorized,
+        "no perms: store_consumer_offset",
+    );
+    assert_error_code(
+        client
+            .delete_consumer_offset(&consumer, &stream_id, &topic_id, Some(0))
+            .await,
+        IggyError::Unauthorized,
+        "no perms: delete_consumer_offset",
+    );
+    // GET is enumeration-safe: legacy answers Ok(None), server-ng denies typed.
+    assert_unauthorized(
+        client
+            .get_consumer_offset(&consumer, &stream_id, &topic_id, Some(0))
+            .await,
+        "no perms: get_consumer_offset",
+    );
+
+    delete_test_user(root_client, USER).await;
+}
+
+// =============================================================================
+// Test: Root (user id 0) is business-rule protected even from a manage_users
+// admin: delete -> CannotDeleteUser, re-permission -> CannotChangePermissions.
+// Both fire AFTER the RBAC gate admits the acting admin.
+// =============================================================================
+
+async fn test_root_user_is_protected(harness: &TestHarness, root_client: &IggyClient) {
+    const ADMIN: &str = "root-guard-admin";
+    create_test_user(
+        root_client,
+        ADMIN,
+        Some(Permissions {
+            global: GlobalPermissions {
+                manage_users: true,
+                ..Default::default()
+            },
+            streams: None,
+        }),
+    )
+    .await;
+    let admin = login_user(harness, ADMIN).await;
+    let root_id = Identifier::numeric(0).unwrap();
+
+    assert_error_code(
+        admin.delete_user(&root_id).await,
+        IggyError::CannotDeleteUser(0),
+        "admin delete root",
+    );
+    assert_error_code(
+        admin
+            .update_permissions(&root_id, Some(no_permissions()))
+            .await,
+        IggyError::CannotChangePermissions(0),
+        "admin re-permission root",
+    );
+
+    delete_test_user(root_client, ADMIN).await;
+}
+
+// =============================================================================
+// Test: Live revocation on a single node. Stripping send from a granted user
+// denies the next send immediately (exact Unauthorized) while the retained poll
+// grant still succeeds.
+// =============================================================================
+
+async fn test_live_permission_revocation(harness: &TestHarness, root_client: &IggyClient) {
+    const USER: &str = "revocation-user";
+    create_test_user(
+        root_client,
+        USER,
+        Some(Permissions {
+            global: GlobalPermissions {
+                poll_messages: true,
+                send_messages: true,
+                ..Default::default()
+            },
+            streams: None,
+        }),
+    )
+    .await;
+    let client = login_user(harness, USER).await;
+
+    let stream_id = Identifier::named(STREAM_1).unwrap();
+    let topic_id = Identifier::named(TOPIC_1).unwrap();
+
+    let mut msgs = test_messages();
+    client
+        .send_messages(
+            &stream_id,
+            &topic_id,
+            &Partitioning::partition_id(0),
+            &mut msgs,
+        )
+        .await
+        .expect("send must work before revocation");
+
+    root_client
+        .update_permissions(
+            &Identifier::named(USER).unwrap(),
+            Some(Permissions {
+                global: GlobalPermissions {
+                    poll_messages: true,
+                    send_messages: false,
+                    ..Default::default()
+                },
+                streams: None,
+            }),
+        )
+        .await
+        .expect("root re-permission (strip send)");
+
+    let mut msgs = test_messages();
+    assert_error_code(
+        client
+            .send_messages(
+                &stream_id,
+                &topic_id,
+                &Partitioning::partition_id(0),
+                &mut msgs,
+            )
+            .await,
+        IggyError::Unauthorized,
+        "send must be denied after send is stripped",
+    );
+    client
+        .poll_messages(
+            &stream_id,
+            &topic_id,
+            Some(0),
+            &Consumer::default(),
+            &PollingStrategy::offset(0),
+            1,
+            false,
+        )
+        .await
+        .expect("poll must still work (poll grant retained)");
+
+    delete_test_user(root_client, USER).await;
+}
+
+// =============================================================================
+// Test: Deleting a user with a live session denies that session's next read.
+// A read_servers grant makes the pre-delete read a real Ok (get_stats is not
+// enumeration-safe), so the post-delete denial is unambiguous. The binary
+// transports may answer Unauthenticated (session eviction) rather than
+// Unauthorized, so accept either.
+// =============================================================================
+
+async fn test_deleted_user_session_denied(harness: &TestHarness, root_client: &IggyClient) {
+    const USER: &str = "deleted-session-user";
+    create_test_user(
+        root_client,
+        USER,
+        Some(Permissions {
+            global: GlobalPermissions {
+                read_servers: true,
+                ..Default::default()
+            },
+            streams: None,
+        }),
+    )
+    .await;
+    let client = login_user(harness, USER).await;
+    client
+        .get_stats()
+        .await
+        .expect("read_servers get_stats must work before deletion");
+
+    root_client
+        .delete_user(&Identifier::named(USER).unwrap())
+        .await
+        .expect("root delete user");
+
+    let result = client.get_stats().await;
+    assert!(
+        matches!(&result, Err(e)
+            if e.as_code() == IggyError::Unauthorized.as_code()
+                || e.as_code() == IggyError::Unauthenticated.as_code()),
+        "deleted user's live session must be denied (Unauthorized or Unauthenticated), got {result:?}"
+    );
+}
+
+// =============================================================================
+// Test: PAT lifecycle over the SDK. A no-permission user self-manages PATs
+// (create/list/delete bypass RBAC); a fresh session authenticating WITH the raw
+// PAT inherits the owner's empty rule set, so a subsequent op is denied; and the
+// listing is caller-scoped (only the caller's own tokens).
+// =============================================================================
+
+async fn test_personal_access_token_lifecycle(harness: &TestHarness, root_client: &IggyClient) {
+    const USER: &str = "pat-lifecycle-user";
+    const OTHER: &str = "pat-other-user";
+    create_test_user(root_client, USER, Some(no_permissions())).await;
+    create_test_user(root_client, OTHER, Some(no_permissions())).await;
+    let client = login_user(harness, USER).await;
+    let other = login_user(harness, OTHER).await;
+
+    // Self-scoped create/delete bypass RBAC even with no permissions.
+    client
+        .create_personal_access_token("pat-to-delete", PersonalAccessTokenExpiry::NeverExpire)
+        .await
+        .expect("no perms: create own PAT should work");
+    client
+        .delete_personal_access_token("pat-to-delete")
+        .await
+        .expect("no perms: delete own PAT should work");
+
+    // A PAT resolves to its owner, inheriting the owner's (empty) rules.
+    let raw = client
+        .create_personal_access_token("pat-identity", PersonalAccessTokenExpiry::NeverExpire)
+        .await
+        .expect("no perms: create identity PAT should work");
+    let via_pat = create_client(harness).await;
+    via_pat
+        .login_with_personal_access_token(&raw.token)
+        .await
+        .expect("PAT login should succeed");
+    assert_unauthorized(
+        via_pat.get_streams().await,
+        "PAT-bound session inherits the owner's empty rules",
+    );
+
+    // Listing is caller-scoped: OTHER never sees USER's tokens.
+    other
+        .create_personal_access_token("other-pat", PersonalAccessTokenExpiry::NeverExpire)
+        .await
+        .expect("other: create own PAT should work");
+    let owner_tokens: Vec<String> = client
+        .get_personal_access_tokens()
+        .await
+        .expect("owner PAT list")
+        .into_iter()
+        .map(|token| token.name)
+        .collect();
+    assert_eq!(
+        owner_tokens,
+        vec!["pat-identity".to_string()],
+        "owner must list exactly their own live token"
+    );
+    let other_tokens: Vec<String> = other
+        .get_personal_access_tokens()
+        .await
+        .expect("other PAT list")
+        .into_iter()
+        .map(|token| token.name)
+        .collect();
+    assert_eq!(
+        other_tokens,
+        vec!["other-pat".to_string()],
+        "other must never see the owner's tokens"
+    );
+
+    delete_test_user(root_client, USER).await;
+    delete_test_user(root_client, OTHER).await;
+}
+
+// =============================================================================
+// Test: change-password over the consensus reply path (every transport).
+//
+// A wrong current password returns the typed `InvalidCredentials` and a missing
+// target returns `ResourceNotFound`, and in EVERY case the caller's connection
+// stays usable for the next replicated op. Regression guard: the binary
+// transports used to deny a wrong current password pre-consensus, consuming the
+// client's request id without advancing the replicated `ClientTable`, so the
+// next replicated request hit a `RequestGap` and was silently dropped until the
+// socket timed out. The rejection now commits as a no-op, keeping the sequence
+// contiguous.
+// =============================================================================
+
+async fn test_change_password_reply_path(harness: &TestHarness, root_client: &IggyClient) {
+    const USER: &str = "change-password-user";
+    const ADMIN: &str = "change-password-admin";
+    create_test_user(root_client, USER, Some(no_permissions())).await;
+    create_test_user(root_client, ADMIN, Some(manage_users_permissions())).await;
+
+    let user_id = Identifier::named(USER).unwrap();
+    let client = login_user(harness, USER).await;
+
+    // Wrong current password: typed rejection, connection still usable.
+    assert_error_code(
+        client
+            .change_password(&user_id, "wrong-current", "password456")
+            .await,
+        IggyError::InvalidCredentials,
+        "self change with a wrong current password",
+    );
+    client
+        .create_personal_access_token(
+            "change-password-probe-1",
+            PersonalAccessTokenExpiry::NeverExpire,
+        )
+        .await
+        .expect("connection stays usable after a wrong-current rejection");
+
+    // Correct current password: succeeds, session stays live.
+    client
+        .change_password(&user_id, "password123", "password456")
+        .await
+        .expect("self change with the correct current password");
+    client
+        .create_personal_access_token(
+            "change-password-probe-2",
+            PersonalAccessTokenExpiry::NeverExpire,
+        )
+        .await
+        .expect("connection stays usable after a successful self rotation");
+
+    // Admin changing a missing target: typed not-found, connection still usable.
+    let admin = login_user(harness, ADMIN).await;
+    assert_error_code(
+        admin
+            .change_password(
+                &Identifier::named("change-password-ghost").unwrap(),
+                "irrelevant",
+                "password456",
+            )
+            .await,
+        IggyError::ResourceNotFound(String::new()),
+        "admin change for a non-existent target",
+    );
+    admin
+        .create_personal_access_token(
+            "change-password-probe-3",
+            PersonalAccessTokenExpiry::NeverExpire,
+        )
+        .await
+        .expect("connection stays usable after a missing-target rejection");
+
+    delete_test_user(root_client, USER).await;
+    delete_test_user(root_client, ADMIN).await;
+}
+
+// =============================================================================
 // Helpers
 // =============================================================================
+
+fn manage_users_permissions() -> Permissions {
+    Permissions {
+        global: GlobalPermissions {
+            manage_users: true,
+            read_users: true,
+            ..GlobalPermissions::default()
+        },
+        streams: None,
+    }
+}
 
 fn test_messages() -> Vec<IggyMessage> {
     vec![
@@ -2473,6 +2846,35 @@ fn assert_unauthorized<T: std::fmt::Debug>(result: Result<T, IggyError>, context
             // All protocols return Ok(None) for unauthorized/not-found to prevent resource enumeration
         }
     }
+}
+
+/// Assert an exact typed `IggyError`. Ported RBAC cases assert the precise code
+/// the server returns, not the enumeration-safe set of [`assert_unauthorized`].
+///
+/// The HTTP SDK reconstructs only 401/403/404 as typed errors and collapses
+/// every other status (notably the 400s carrying `InvalidCredentials`,
+/// `CannotDeleteUser`, and `CannotChangePermissions`) into a generic
+/// `HttpResponseError` wrapping the typed JSON body. Read the exact code back
+/// from that body's `id` so the assertion stays exact over HTTP as well.
+fn assert_error_code<T: std::fmt::Debug>(
+    result: Result<T, IggyError>,
+    expected: IggyError,
+    context: &str,
+) {
+    let expected_code = expected.as_code();
+    match &result {
+        Err(e) if e.as_code() == expected_code => {}
+        Err(IggyError::HttpResponseError(_, body))
+            if http_error_id(body) == Some(expected_code) => {}
+        _ => panic!("{context}: expected error code {expected_code}, got {result:?}"),
+    }
+}
+
+/// The `id` field of an HTTP `ErrorResponse` body is the wire `IggyError` code,
+/// so a status-collapsed `HttpResponseError` can still be matched exactly.
+fn http_error_id(body: &str) -> Option<u32> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    value.get("id")?.as_u64().map(|id| id as u32)
 }
 
 fn assert_not_found_or_related<T: std::fmt::Debug>(result: Result<T, IggyError>, context: &str) {

--- a/core/message_bus/src/lib.rs
+++ b/core/message_bus/src/lib.rs
@@ -95,13 +95,14 @@ pub use installer::conn_info::{
 };
 pub use lifecycle::{
     BusMessage, BusReceiver, BusSender, ConnectionRegistry, DrainOutcome, FusedShutdown,
-    ReplicaRegistry, Shutdown, ShutdownToken,
+    InstanceToken, ReplicaRegistry, ReplyRoute, ReplySlotError, ReplySlotGuard, Shutdown,
+    ShutdownToken,
 };
 pub use transports::tls::TlsServerCredentials;
 
 pub use compio::runtime::JoinHandle;
 use configs::server_ng::ServerNgConfig;
-use iggy_binary_protocol::GenericHeader;
+use iggy_binary_protocol::{GenericHeader, ReplyHeader};
 use server_common::{MESSAGE_ALIGN, Message, iobuf::Frozen};
 use std::array;
 use std::cell::{Cell, OnceCell, RefCell};
@@ -1225,13 +1226,21 @@ impl MessageBus for IggyMessageBus {
         // Owning shard is encoded in the top 16 bits of client_id.
         let owning_shard = client_id_owning_shard(client_id);
         if owning_shard == self.shard_id {
-            // Fast path: move `message` straight into `try_send`. On no-slot
-            // the registry hands it back; we drop it and surface
-            // ClientNotFound (matches prior behaviour: SendError did not
-            // preserve payload either).
+            // Route by the entry's reply target. Socket is the unchanged
+            // fast path and never decodes. InProcess resolves the waiting
+            // request id from the reply header and fires its oneshot; that
+            // decode stays off the socket path. No slot surfaces
+            // ClientNotFound (prior behaviour: SendError did not preserve
+            // the payload either).
             return match self.clients.try_send_or_return(client_id, message) {
-                Ok(send_result) => send_result.map_err(map_try_send_err),
-                Err(_msg) => Err(SendError::ClientNotFound(client_id)),
+                ReplyRoute::Delivered(send_result) => send_result.map_err(map_try_send_err),
+                ReplyRoute::InProcess(message) => {
+                    let request = reply_request_id(&message);
+                    self.clients
+                        .fire_in_process(client_id, request, message)
+                        .map_err(|_| SendError::ClientNotFound(client_id))
+                }
+                ReplyRoute::NoSlot(_message) => Err(SendError::ClientNotFound(client_id)),
             };
         }
         let forward = self
@@ -1313,6 +1322,22 @@ pub const fn client_id_owning_shard(client_id: u128) -> u16 {
     (client_id >> 112) as u16
 }
 
+/// Reserved client id stamped on server-generated auto-commit
+/// `StoreConsumerOffset2` ops (a poll's `auto_commit` replicated for failover).
+///
+/// Never belongs to a live connection: `mint_client_id` produces
+/// `(shard << 112) | seq` and no real shard is `u16::MAX`, so `u128::MAX` is
+/// unreachable. The commit path recognises it and skips the (unwaited) reply,
+/// keeping an unrequested frame off a real client's lockstep stream. Nonzero,
+/// so it still satisfies the wire header's `client != 0` validation.
+pub const AUTO_COMMIT_CLIENT_ID: u128 = u128::MAX;
+
+/// Whether `client_id` is the reserved [`AUTO_COMMIT_CLIENT_ID`] sentinel.
+#[must_use]
+pub const fn is_auto_commit_client(client_id: u128) -> bool {
+    client_id == AUTO_COMMIT_CLIENT_ID
+}
+
 /// Map an `async_channel::TrySendError` onto the bus-level [`SendError`].
 ///
 /// Shape-matches `Result::map_err` (takes the error by value) so it can be
@@ -1323,6 +1348,21 @@ fn map_try_send_err(e: async_channel::TrySendError<Frozen<MESSAGE_ALIGN>>) -> Se
         async_channel::TrySendError::Full(_) => SendError::Backpressure,
         async_channel::TrySendError::Closed(_) => SendError::ConnectionClosed,
     }
+}
+
+/// Peek `ReplyHeader.request` (the originating request id) from a reply
+/// buffer at its fixed header offset. Only the in-process reply path calls
+/// this; the socket path never decodes.
+fn reply_request_id(reply: &Frozen<MESSAGE_ALIGN>) -> u64 {
+    const OFFSET: usize = std::mem::offset_of!(ReplyHeader, request);
+    reply
+        .as_slice()
+        .get(OFFSET..OFFSET + std::mem::size_of::<u64>())
+        .and_then(|bytes| bytes.try_into().ok())
+        // Native-endian is safe: this id never leaves the process, so writer and
+        // reader share endianness. A wire reader uses little-endian instead (see
+        // the SDK's `read_reply_status`).
+        .map_or(0, u64::from_ne_bytes)
 }
 
 #[cfg(test)]
@@ -1370,6 +1410,56 @@ mod tests {
         let client_id = (3u128 << 112) | 1;
         let err = bus
             .send_to_client(client_id, dummy_message().into_frozen())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SendError::ClientNotFound(_)));
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn reply_message(request: u64) -> Message<ReplyHeader> {
+        Message::<ReplyHeader>::new(HEADER_SIZE).transmute_header(|_, h: &mut ReplyHeader| {
+            h.command = Command2::Reply;
+            h.size = HEADER_SIZE as u32;
+            h.request = request;
+        })
+    }
+
+    /// Full in-process seam: entry + slot installed, `send_to_client`
+    /// resolves the request id from the reply header and fires the oneshot.
+    #[compio::test]
+    #[allow(clippy::future_not_send)]
+    async fn send_to_client_in_process_fires_matching_reply_slot() {
+        let bus = IggyMessageBus::new(0);
+        let client_id = 1u128;
+        bus.clients()
+            .insert_in_process(client_id)
+            .expect("fresh key");
+        let (_guard, reply_rx) = bus
+            .clients()
+            .install_reply_slot(client_id, 42)
+            .expect("slot installs");
+
+        bus.send_to_client(client_id, reply_message(42).into_generic().into_frozen())
+            .await
+            .expect("in-process delivery");
+
+        let received = reply_rx.await.expect("reply delivered");
+        assert_eq!(reply_request_id(&received), 42);
+    }
+
+    /// Reply whose request id has no waiter (timed-out caller already
+    /// removed its slot): shed as `ClientNotFound`, nothing panics.
+    #[compio::test]
+    #[allow(clippy::future_not_send)]
+    async fn send_to_client_in_process_sheds_reply_without_waiter() {
+        let bus = IggyMessageBus::new(0);
+        let client_id = 1u128;
+        bus.clients()
+            .insert_in_process(client_id)
+            .expect("fresh key");
+
+        let err = bus
+            .send_to_client(client_id, reply_message(42).into_generic().into_frozen())
             .await
             .unwrap_err();
         assert!(matches!(err, SendError::ClientNotFound(_)));

--- a/core/message_bus/src/lifecycle/connection_registry.rs
+++ b/core/message_bus/src/lifecycle/connection_registry.rs
@@ -33,6 +33,7 @@
 //! [`ShutdownToken`]: crate::lifecycle::ShutdownToken
 
 use compio::runtime::JoinHandle;
+use futures::channel::oneshot;
 use server_common::{MESSAGE_ALIGN, iobuf::Frozen};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -40,6 +41,7 @@ use std::collections::hash_map::Entry as HmEntry;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::time::{Duration, Instant};
+use thiserror::Error;
 use tracing::{debug, warn};
 
 /// Opaque per-insert generation token.
@@ -128,9 +130,111 @@ pub struct DrainOutcome {
     pub background_force: usize,
 }
 
+/// Where a client reply is delivered.
+///
+/// `Socket` is the wire path taken by every TCP / WS / QUIC client: the
+/// reply is pushed into the per-peer queue exactly as before. `InProcess`
+/// reifies an in-process reply target keyed by request id so a caller
+/// holding the matching [`oneshot::Receiver`] can await its reply without a
+/// socket. Both ends are shard-0-local, hence a single-threaded oneshot.
+#[derive(Debug)]
+enum ReplyTarget {
+    Socket(BusSender),
+    InProcess {
+        by_request: HashMap<u64, oneshot::Sender<BusMessage>>,
+    },
+}
+
+impl ReplyTarget {
+    /// Wire sender for socket targets; `None` for in-process targets.
+    const fn as_socket(&self) -> Option<&BusSender> {
+        match self {
+            Self::Socket(sender) => Some(sender),
+            Self::InProcess { .. } => None,
+        }
+    }
+}
+
+/// Outcome of routing a client reply through an [`Entry`]'s reply target.
+///
+/// `Delivered` is the socket fast path: `try_send` was attempted and its
+/// result is carried through unchanged. `InProcess` hands the message back
+/// so the caller can decode the request id and fire the matching oneshot
+/// via [`ConnectionRegistry::fire_in_process`], keeping that decode off the
+/// socket path. `NoSlot` means no entry exists for the key.
+#[derive(Debug)]
+#[must_use]
+pub enum ReplyRoute {
+    Delivered(Result<(), async_channel::TrySendError<BusMessage>>),
+    InProcess(BusMessage),
+    NoSlot(BusMessage),
+}
+
+/// Rejection reasons for [`ConnectionRegistry::install_reply_slot`].
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ReplySlotError {
+    /// No registry entry exists for the key: the in-process entry was
+    /// never installed or has already been torn down.
+    #[error("no registry entry for this key")]
+    EntryNotFound,
+    /// The entry is a socket target. Socket replies go through the
+    /// per-peer queue; a reply slot on such an entry could never fire.
+    #[error("registry entry is a socket target")]
+    NotInProcess,
+    /// A waiter is already registered under this request id. Replacing it
+    /// would drop the first waiter's sender and could deliver its reply
+    /// to the wrong caller, so the second install is rejected instead.
+    #[error("a reply slot for this request id is already installed")]
+    DuplicateRequest,
+}
+
+/// Cancel-safety handle for an installed in-process reply slot.
+///
+/// Dropping the guard removes the slot unless the reply already fired
+/// ([`ConnectionRegistry::fire_in_process`] consumes the slot on delivery,
+/// making the drop a no-op) or the whole entry was replaced (fenced by the
+/// entry's [`InstanceToken`], mirroring `remove_if_token_matches`). A
+/// caller that times out or is cancelled therefore never leaks its oneshot
+/// sender.
+///
+/// Contract: a request id must not be reused under the same key while a
+/// previous guard for that id is still live; the stale guard's drop would
+/// remove the new slot. Callers mint monotonically increasing request ids,
+/// which rules this out.
+#[must_use = "dropping the guard removes the reply slot"]
+#[derive(Debug)]
+pub struct ReplySlotGuard<'a, K>
+where
+    K: Eq + Hash + Copy + Debug + 'static,
+{
+    registry: &'a ConnectionRegistry<K>,
+    key: K,
+    request: u64,
+    token: InstanceToken,
+}
+
+impl<K> Drop for ReplySlotGuard<'_, K>
+where
+    K: Eq + Hash + Copy + Debug + 'static,
+{
+    fn drop(&mut self) {
+        let mut entries = self.registry.entries.borrow_mut();
+        let Some(entry) = entries.get_mut(&self.key) else {
+            return;
+        };
+        if entry.token != self.token {
+            return;
+        }
+        let ReplyTarget::InProcess { by_request } = &mut entry.reply else {
+            return;
+        };
+        by_request.remove(&self.request);
+    }
+}
+
 #[derive(Debug)]
 struct Entry {
-    sender: BusSender,
+    reply: ReplyTarget,
     writer_handle: Option<JoinHandle<()>>,
     reader_handle: Option<JoinHandle<()>>,
     /// Generation token minted by the registry on insert. Entries that
@@ -215,41 +319,103 @@ where
     /// `close_peer`.
     pub fn with_sender<R>(&self, key: K, f: impl FnOnce(&BusSender) -> R) -> Option<R> {
         let entries = self.entries.borrow();
-        entries.get(&key).map(|entry| f(&entry.sender))
+        entries
+            .get(&key)
+            .and_then(|entry| entry.reply.as_socket())
+            .map(f)
     }
 
-    /// Try to send `msg` to the per-peer queue, returning the message back
-    /// when no slot exists.
+    /// Route `msg` to the entry's reply target, handing it back when no
+    /// live target accepts it.
     ///
-    /// Lets `send_to_*` skip the unconditional `Frozen::clone()` the
-    /// `with_sender` shape forced (closure consumes a clone, outer caller
-    /// retains the original for the slow path the borrow checker cannot
-    /// prove unreachable). The consuming variant moves `msg` into
-    /// `try_send` on the fast path; on no-slot the message is handed back
-    /// so the caller can route it via the slow path or drop it.
+    /// Lets `send_to_client` skip the unconditional `Frozen::clone()` the
+    /// `with_sender` shape forced. Socket targets move `msg` straight into
+    /// `try_send`; in-process targets hand it back via
+    /// [`ReplyRoute::InProcess`] so the caller can resolve the request id
+    /// and fire the oneshot without decoding on the socket path.
     ///
     /// Returns:
-    /// - `Ok(Ok(()))`: slot exists and the queue accepted `msg`.
-    /// - `Ok(Err(TrySendError))`: slot exists but `try_send` failed
-    ///   (`Full` or `Closed`); the inner error carries `msg` back per
-    ///   `async_channel`'s contract.
-    /// - `Err(msg)`: no slot for `key`; `msg` returned to the caller.
+    /// - [`ReplyRoute::Delivered`]: socket target; carries the `try_send`
+    ///   result (`Full` / `Closed` errors carry `msg` back per
+    ///   `async_channel`'s contract).
+    /// - [`ReplyRoute::InProcess`]: in-process target; `msg` handed back.
+    /// - [`ReplyRoute::NoSlot`]: no entry for `key`; `msg` handed back.
+    pub fn try_send_or_return(&self, key: K, msg: BusMessage) -> ReplyRoute {
+        let entries = self.entries.borrow();
+        let Some(entry) = entries.get(&key) else {
+            return ReplyRoute::NoSlot(msg);
+        };
+        match &entry.reply {
+            ReplyTarget::Socket(sender) => ReplyRoute::Delivered(sender.try_send(msg)),
+            ReplyTarget::InProcess { .. } => ReplyRoute::InProcess(msg),
+        }
+    }
+
+    /// Fire the in-process reply registered under `request` for `key`.
+    ///
+    /// Companion to [`ReplyRoute::InProcess`]; the socket path never reaches
+    /// here. Removes the matching oneshot and delivers `msg` on it.
     ///
     /// # Errors
     ///
-    /// The outer `Err(msg)` reports that no entry exists for `key`. The
-    /// inner `Err(TrySendError)` reports that the entry's queue is full
-    /// or closed.
-    pub fn try_send_or_return(
-        &self,
-        key: K,
-        msg: BusMessage,
-    ) -> Result<Result<(), async_channel::TrySendError<BusMessage>>, BusMessage> {
-        let entries = self.entries.borrow();
-        match entries.get(&key) {
-            Some(entry) => Ok(entry.sender.try_send(msg)),
+    /// Hands `msg` back when `key` has no in-process target or no waiter is
+    /// registered for `request`, so the caller surfaces the same not-found
+    /// outcome as a missing socket.
+    pub fn fire_in_process(&self, key: K, request: u64, msg: BusMessage) -> Result<(), BusMessage> {
+        let mut entries = self.entries.borrow_mut();
+        let Some(entry) = entries.get_mut(&key) else {
+            return Err(msg);
+        };
+        let ReplyTarget::InProcess { by_request } = &mut entry.reply else {
+            return Err(msg);
+        };
+        match by_request.remove(&request) {
+            Some(reply_tx) => reply_tx.send(msg),
             None => Err(msg),
         }
+    }
+
+    /// Register a oneshot waiter for the reply to `request` on `key`'s
+    /// in-process entry.
+    ///
+    /// The returned receiver resolves when `send_to_client` routes a reply
+    /// carrying this request id (via [`Self::fire_in_process`]), or with
+    /// `Canceled` when the entry is torn down first. The guard removes the
+    /// slot on drop; see [`ReplySlotGuard`] for the exact semantics.
+    ///
+    /// # Errors
+    ///
+    /// [`ReplySlotError::EntryNotFound`] when `key` has no entry,
+    /// [`ReplySlotError::NotInProcess`] when the entry is a socket target,
+    /// [`ReplySlotError::DuplicateRequest`] when a waiter is already
+    /// registered under `request`.
+    pub fn install_reply_slot(
+        &self,
+        key: K,
+        request: u64,
+    ) -> Result<(ReplySlotGuard<'_, K>, oneshot::Receiver<BusMessage>), ReplySlotError> {
+        let mut entries = self.entries.borrow_mut();
+        let Some(entry) = entries.get_mut(&key) else {
+            return Err(ReplySlotError::EntryNotFound);
+        };
+        let token = entry.token;
+        let ReplyTarget::InProcess { by_request } = &mut entry.reply else {
+            return Err(ReplySlotError::NotInProcess);
+        };
+        let HmEntry::Vacant(slot) = by_request.entry(request) else {
+            return Err(ReplySlotError::DuplicateRequest);
+        };
+        let (reply_tx, reply_rx) = oneshot::channel();
+        slot.insert(reply_tx);
+        Ok((
+            ReplySlotGuard {
+                registry: self,
+                key,
+                request,
+                token,
+            },
+            reply_rx,
+        ))
     }
 
     /// Register a new connection. Stores the producer side of the per-peer
@@ -294,7 +460,7 @@ where
         entries.insert(
             key,
             Entry {
-                sender,
+                reply: ReplyTarget::Socket(sender),
                 writer_handle: Some(writer_handle),
                 reader_handle: Some(reader_handle),
                 token,
@@ -302,6 +468,38 @@ where
             },
         );
         Ok(token)
+    }
+
+    /// Register an in-process reply target for `key`.
+    ///
+    /// In-process peers have no socket and no reader / writer tasks:
+    /// replies routed to `key` resolve request-keyed oneshots installed
+    /// via [`Self::install_reply_slot`]. Teardown goes through
+    /// [`Self::remove`] / [`Self::remove_if_token_matches`]; dropping the
+    /// entry drops every pending sender, so all outstanding receivers
+    /// resolve `Canceled`.
+    ///
+    /// Returns `None` when `key` is already registered (socket or
+    /// in-process); the caller must tear the existing entry down first.
+    pub fn insert_in_process(&self, key: K) -> Option<InstanceToken> {
+        let mut entries = self.entries.borrow_mut();
+        let HmEntry::Vacant(slot) = entries.entry(key) else {
+            return None;
+        };
+        let token = self.mint_token();
+        // Nothing ever waits on this shutdown (no reader to wake); it
+        // exists only because every entry owns one.
+        let (conn_shutdown, _) = super::Shutdown::new();
+        slot.insert(Entry {
+            reply: ReplyTarget::InProcess {
+                by_request: HashMap::new(),
+            },
+            writer_handle: None,
+            reader_handle: None,
+            token,
+            _conn_shutdown: conn_shutdown,
+        });
+        Some(token)
     }
 
     /// Unregister a connection without awaiting its tasks.
@@ -360,7 +558,9 @@ where
         let Some(mut entry) = self.entries.borrow_mut().remove(&key) else {
             return;
         };
-        entry.sender.close();
+        if let Some(sender) = entry.reply.as_socket() {
+            sender.close();
+        }
         if let Some(writer_handle) = entry.writer_handle.take() {
             let _ = compio::time::timeout(timeout, writer_handle).await;
         }
@@ -389,7 +589,9 @@ where
             }
             slot.remove()
         };
-        entry.sender.close();
+        if let Some(sender) = entry.reply.as_socket() {
+            sender.close();
+        }
         if let Some(writer_handle) = entry.writer_handle.take() {
             let _ = compio::time::timeout(timeout, writer_handle).await;
         }
@@ -447,7 +649,9 @@ where
             // the shutdown token has not been triggered. Writer is
             // awaited before the reader handle is dropped so a
             // mid-writev cancellation cannot truncate a frame.
-            entry.sender.close();
+            if let Some(sender) = entry.reply.as_socket() {
+                sender.close();
+            }
             // Writer gets the full shared deadline so a legitimately-
             // flushing `write_vectored_all` never loses budget to any
             // other entry in the same drain batch.
@@ -581,22 +785,34 @@ impl ReplicaRegistry {
         let slots = self.slots.borrow();
         slots[usize::from(key)]
             .as_ref()
-            .map(|entry| f(&entry.sender))
+            .and_then(|entry| entry.reply.as_socket())
+            .map(f)
     }
 
-    /// See [`ConnectionRegistry::try_send_or_return`].
+    /// Try to send `msg` to the replica socket registered under `key`, handing
+    /// `msg` back as `Err` when no slot is present.
+    ///
+    /// Replicas only ever register socket reply targets, so unlike
+    /// [`ConnectionRegistry::try_send_or_return`] (which returns a [`ReplyRoute`]
+    /// also covering the in-process case) this stays a flat
+    /// `Result<try-send outcome, BusMessage>`.
     ///
     /// # Errors
     ///
-    /// Same as [`ConnectionRegistry::try_send_or_return`].
+    /// `Err(msg)` when `key` has no registered slot. The inner `Err` carries a
+    /// `try_send` failure (`Full` / `Closed`), which returns `msg` per
+    /// `async_channel`'s contract.
     pub fn try_send_or_return(
         &self,
         key: u8,
         msg: BusMessage,
     ) -> Result<Result<(), async_channel::TrySendError<BusMessage>>, BusMessage> {
         let slots = self.slots.borrow();
-        match slots[usize::from(key)].as_ref() {
-            Some(entry) => Ok(entry.sender.try_send(msg)),
+        match slots[usize::from(key)]
+            .as_ref()
+            .and_then(|entry| entry.reply.as_socket())
+        {
+            Some(sender) => Ok(sender.try_send(msg)),
             None => Err(msg),
         }
     }
@@ -627,7 +843,7 @@ impl ReplicaRegistry {
         }
         let token = self.mint_token();
         *slot = Some(Entry {
-            sender,
+            reply: ReplyTarget::Socket(sender),
             writer_handle: Some(writer_handle),
             reader_handle: Some(reader_handle),
             token,
@@ -672,7 +888,9 @@ impl ReplicaRegistry {
             self.len.set(self.len.get() - 1);
             entry
         };
-        entry.sender.close();
+        if let Some(sender) = entry.reply.as_socket() {
+            sender.close();
+        }
         if let Some(writer_handle) = entry.writer_handle.take() {
             let _ = compio::time::timeout(timeout, writer_handle).await;
         }
@@ -697,7 +915,9 @@ impl ReplicaRegistry {
             self.len.set(self.len.get() - 1);
             removed_entry
         };
-        entry.sender.close();
+        if let Some(sender) = entry.reply.as_socket() {
+            sender.close();
+        }
         if let Some(writer_handle) = entry.writer_handle.take() {
             let _ = compio::time::timeout(timeout, writer_handle).await;
         }
@@ -1065,7 +1285,7 @@ mod tests {
             .expect("insert ok");
 
         let outer = reg.try_send_or_return(1u8, make_bus_msg());
-        assert!(matches!(outer, Ok(Ok(()))));
+        assert!(matches!(outer, ReplyRoute::Delivered(Ok(()))));
         // Receiver drains the message; closing the writer's rx end via
         // close_peer is not necessary for this assertion.
         let received = rx.recv().await.expect("queue had message");
@@ -1081,7 +1301,9 @@ mod tests {
         let original_len = msg.len();
 
         let outcome = reg.try_send_or_return(99u8, msg);
-        let returned = outcome.expect_err("missing slot should return msg");
+        let ReplyRoute::NoSlot(returned) = outcome else {
+            panic!("missing slot should return msg");
+        };
         assert_eq!(returned.len(), original_len);
     }
 
@@ -1104,14 +1326,16 @@ mod tests {
             .expect("insert ok");
 
         // Saturate the queue.
-        reg.try_send_or_return(1u8, make_bus_msg())
-            .expect("slot present")
-            .expect("first send accepted");
+        assert!(matches!(
+            reg.try_send_or_return(1u8, make_bus_msg()),
+            ReplyRoute::Delivered(Ok(()))
+        ));
         // Second send: slot present, queue full.
-        let outcome = reg
-            .try_send_or_return(1u8, make_bus_msg())
-            .expect("slot still present");
-        assert!(matches!(outcome, Err(async_channel::TrySendError::Full(_))));
+        let outcome = reg.try_send_or_return(1u8, make_bus_msg());
+        assert!(matches!(
+            outcome,
+            ReplyRoute::Delivered(Err(async_channel::TrySendError::Full(_)))
+        ));
     }
 
     /// Mirror of `try_send_or_return_returns_msg_when_slot_missing` for the
@@ -1126,5 +1350,153 @@ mod tests {
         let outcome = reg.try_send_or_return(7u8, msg);
         let returned = outcome.expect_err("missing slot should return msg");
         assert_eq!(returned.len(), original_len);
+    }
+
+    /// End-to-end registry seam: install entry + slot, route, fire, await.
+    #[compio::test]
+    async fn in_process_slot_receives_fired_reply() {
+        let reg: ConnectionRegistry<u8> = ConnectionRegistry::new();
+        reg.insert_in_process(1u8).expect("fresh key");
+
+        let (guard, reply_rx) = reg.install_reply_slot(1u8, 42).expect("slot installs");
+        let msg = match reg.try_send_or_return(1u8, make_bus_msg()) {
+            ReplyRoute::InProcess(msg) => msg,
+            other => panic!("expected InProcess route, got {other:?}"),
+        };
+        reg.fire_in_process(1u8, 42, msg).expect("waiter present");
+
+        let received = reply_rx.await.expect("reply delivered");
+        assert_eq!(received.len(), HEADER_SIZE);
+        drop(guard);
+        assert!(reg.contains(1u8), "guard drop must not remove the entry");
+    }
+
+    #[compio::test]
+    async fn insert_in_process_duplicate_key_returns_none() {
+        let reg: ConnectionRegistry<u8> = ConnectionRegistry::new();
+        assert!(reg.insert_in_process(1u8).is_some());
+        assert!(reg.insert_in_process(1u8).is_none());
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[compio::test]
+    async fn install_reply_slot_rejects_missing_and_socket_entries() {
+        let reg: ConnectionRegistry<u8> = ConnectionRegistry::new();
+        assert_eq!(
+            reg.install_reply_slot(1u8, 1).unwrap_err(),
+            ReplySlotError::EntryNotFound
+        );
+
+        let (_shutdown, token) = Shutdown::new();
+        let (tx, rx) = async_channel::bounded(8);
+        reg.insert(
+            1u8,
+            tx,
+            spawn_dummy_writer(rx),
+            spawn_dummy_reader(token),
+            dummy_conn_shutdown(),
+        )
+        .expect("socket insert ok");
+        assert_eq!(
+            reg.install_reply_slot(1u8, 1).unwrap_err(),
+            ReplySlotError::NotInProcess
+        );
+    }
+
+    /// Second install under a live request id must be rejected, and the
+    /// first waiter must stay wired (the reply still reaches it).
+    #[compio::test]
+    async fn install_reply_slot_rejects_duplicate_request() {
+        let reg: ConnectionRegistry<u8> = ConnectionRegistry::new();
+        reg.insert_in_process(1u8).expect("fresh key");
+
+        let (_guard, reply_rx) = reg.install_reply_slot(1u8, 42).expect("first install");
+        assert_eq!(
+            reg.install_reply_slot(1u8, 42).unwrap_err(),
+            ReplySlotError::DuplicateRequest
+        );
+
+        reg.fire_in_process(1u8, 42, make_bus_msg())
+            .expect("first waiter still registered");
+        assert_eq!(reply_rx.await.expect("reply delivered").len(), HEADER_SIZE);
+    }
+
+    /// Reply for a request id nobody waits on: handed back, no panic, and
+    /// the unrelated slot stays registered.
+    #[compio::test]
+    async fn fire_in_process_unknown_request_returns_msg() {
+        let reg: ConnectionRegistry<u8> = ConnectionRegistry::new();
+        reg.insert_in_process(1u8).expect("fresh key");
+        let (_guard, reply_rx) = reg.install_reply_slot(1u8, 42).expect("slot installs");
+
+        let msg = make_bus_msg();
+        let original_len = msg.len();
+        let returned = reg
+            .fire_in_process(1u8, 7, msg)
+            .expect_err("no waiter for request 7");
+        assert_eq!(returned.len(), original_len);
+
+        reg.fire_in_process(1u8, 42, make_bus_msg())
+            .expect("slot 42 untouched");
+        assert_eq!(reply_rx.await.expect("reply delivered").len(), HEADER_SIZE);
+    }
+
+    /// Timeout / cancellation path: dropping the guard removes the slot,
+    /// cancels the receiver, and a later reply is shed as no-waiter.
+    #[compio::test]
+    async fn dropped_guard_removes_slot_and_cancels_receiver() {
+        let reg: ConnectionRegistry<u8> = ConnectionRegistry::new();
+        reg.insert_in_process(1u8).expect("fresh key");
+
+        let (guard, reply_rx) = reg.install_reply_slot(1u8, 42).expect("slot installs");
+        drop(guard);
+
+        assert!(reply_rx.await.is_err(), "sender dropped with the slot");
+        assert!(
+            reg.fire_in_process(1u8, 42, make_bus_msg()).is_err(),
+            "late reply must be handed back, not delivered"
+        );
+        let (_guard, _reply_rx) = reg
+            .install_reply_slot(1u8, 42)
+            .expect("request id reusable after guard drop");
+    }
+
+    /// After the reply fired the slot is gone; the guard's drop is a no-op
+    /// and the request id becomes reusable.
+    #[compio::test]
+    async fn guard_drop_is_noop_after_reply_fired() {
+        let reg: ConnectionRegistry<u8> = ConnectionRegistry::new();
+        reg.insert_in_process(1u8).expect("fresh key");
+
+        let (guard, reply_rx) = reg.install_reply_slot(1u8, 42).expect("slot installs");
+        reg.fire_in_process(1u8, 42, make_bus_msg())
+            .expect("waiter present");
+        drop(guard);
+
+        assert_eq!(reply_rx.await.expect("reply delivered").len(), HEADER_SIZE);
+        let (_guard, _reply_rx) = reg
+            .install_reply_slot(1u8, 42)
+            .expect("request id reusable after fire + drop");
+    }
+
+    /// Entry teardown with a pending waiter: the receiver resolves
+    /// `Canceled` instead of hanging, and the stale guard's later drop
+    /// must not disturb a reinstalled entry's slot (token fence).
+    #[compio::test]
+    async fn entry_teardown_cancels_pending_receiver_and_fences_stale_guard() {
+        let reg: ConnectionRegistry<u8> = ConnectionRegistry::new();
+        reg.insert_in_process(1u8).expect("fresh key");
+        let (stale_guard, reply_rx) = reg.install_reply_slot(1u8, 42).expect("slot installs");
+
+        assert!(reg.remove(1u8));
+        assert!(reply_rx.await.is_err(), "teardown cancels pending waiter");
+
+        reg.insert_in_process(1u8)
+            .expect("reinstall after teardown");
+        let (_guard, reply_rx) = reg.install_reply_slot(1u8, 42).expect("slot installs");
+        drop(stale_guard);
+        reg.fire_in_process(1u8, 42, make_bus_msg())
+            .expect("stale guard must not evict the new slot");
+        assert_eq!(reply_rx.await.expect("reply delivered").len(), HEADER_SIZE);
     }
 }

--- a/core/message_bus/src/lifecycle/mod.rs
+++ b/core/message_bus/src/lifecycle/mod.rs
@@ -26,6 +26,6 @@ pub mod shutdown;
 
 pub use connection_registry::{
     BusMessage, BusReceiver, BusSender, ConnectionRegistry, DrainOutcome, InstanceToken,
-    RejectedRegistration, ReplicaRegistry,
+    RejectedRegistration, ReplicaRegistry, ReplyRoute, ReplySlotError, ReplySlotGuard,
 };
 pub use shutdown::{FusedShutdown, Shutdown, ShutdownToken};

--- a/core/metadata/src/impls/metadata.rs
+++ b/core/metadata/src/impls/metadata.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::MuxStateMachine;
+use crate::stm::authz::gated_apply;
 use crate::stm::consumer_group::CompleteConsumerGroupRevocationRequest;
 use crate::stm::snapshot::{FillSnapshot, MetadataSnapshot, Snapshot, SnapshotError};
 use crate::stm::stream::{Streams, TruncatePartitionRequest};
@@ -342,8 +343,8 @@ fn require_shard_zero<'a, T>(
     slot
 }
 
-/// Late-bound callback invoked after every successful
-/// `mux_stm.update(prepare)` on shard 0's metadata commit path.
+/// Late-bound callback invoked after every committed op on shard 0's metadata
+/// commit path (via `gated_apply`, including a gated no-op).
 ///
 /// Wired by server-ng bootstrap once the metadata bundle has broadcast;
 /// receives the committed [`Operation`] so the recipient can filter (the
@@ -376,9 +377,10 @@ pub struct IggyMetadata<C, J, S, M> {
     pub coordinator: Option<SnapshotCoordinator<M>>,
     /// Per-client session state (sessions, dedup, eviction). Metadata-only.
     pub client_table: RefCell<ClientTable>,
-    /// Late-bound post-commit notifier. Fires once per committed
-    /// operation after [`crate::stm::StateMachine::update`] succeeds in
-    /// both [`Plane::on_ack`] and [`Self::commit_journal`]. `None` until
+    /// Late-bound post-commit notifier. Fires once per committed normal op
+    /// after `gated_apply` returns (including a gated `Unauthorized` no-op that
+    /// never reaches [`crate::stm::StateMachine::update`]) in both
+    /// [`Plane::on_ack`] and [`Self::commit_journal`]. `None` until
     /// [`Self::set_commit_notifier`] runs (server-ng bootstrap on shard
     /// 0 sets it; peer shards and tests leave it `None`).
     commit_notifier: RefCell<Option<CommitNotifier>>,
@@ -825,6 +827,7 @@ where
                         |c: u128| consensus.pipeline().borrow().has_message_from_client(c);
                     self.client_table.borrow_mut().commit_register(
                         prepare_header.client,
+                        prepare_header.user_id,
                         reply.clone(),
                         in_flight,
                     );
@@ -847,7 +850,7 @@ where
                     // Normal op: apply SM, commit_reply. `Err` is decode/corruption
                     // only; a business rejection commits as a deterministic no-op
                     // whose `code` rides the reply body, replayed on retry.
-                    let apply = self.mux_stm.update(prepare).unwrap_or_else(|err| {
+                    let apply = gated_apply(&self.mux_stm, prepare).unwrap_or_else(|err| {
                         panic!(
                             "on_ack: committed metadata op={} failed to apply: {err}",
                             prepare_header.op
@@ -985,6 +988,7 @@ where
     pub async fn submit_register_in_process(
         &self,
         client_id: u128,
+        user_id: u32,
     ) -> Result<u64, MetadataSubmitError> {
         assert!(client_id != 0, "client_id 0 is reserved for internal use");
         let consensus = self
@@ -1025,7 +1029,7 @@ where
             return Err(MetadataSubmitError::PipelineFull);
         }
 
-        let request = build_register_request_message(consensus, client_id);
+        let request = build_register_request_message(consensus, client_id, user_id);
         // Wire path runs `RequestHeader::validate` at network boundary;
         // in-process skips it. debug_assert pins drift.
         debug_assert!(
@@ -1410,6 +1414,9 @@ where
             .into_generic());
         }
 
+        // The acting-user RBAC stamp lives in the shared `prepare_request`
+        // (op-guarded, fail-closed on an unknown session). `request_preflight`
+        // above proved this client's session is live, so it resolves there.
         let Ok(prepare) = self.prepare_request(message) else {
             // Structurally-invalid request. Return an eviction frame (relayed to
             // the socket by the home shard) rather than `Canceled`, which leaves
@@ -1707,10 +1714,11 @@ where
     #[allow(clippy::too_many_lines)]
     fn prepare_request(
         &self,
-        message: Message<RequestHeader>,
+        mut message: Message<RequestHeader>,
     ) -> Result<Message<PrepareHeader>, iggy_common::IggyError> {
         let consensus = self.consensus.as_ref().unwrap();
-        let header = *message.header();
+        let operation = message.header().operation;
+        let client_id = message.header().client;
         // `TruncatePartition` is server-originated (the owning shard resolves a
         // client `DeleteSegments` count to a concrete offset) but replicated AS
         // the client's own request, so the commit records the client's request
@@ -1718,10 +1726,39 @@ where
         // maps to it, so a client cannot construct one directly -- hence the
         // `is_client_allowed` gate excludes it; admit it explicitly. The default
         // match arm below projects it through unchanged.
-        if !header.operation.is_client_allowed() && header.operation != Operation::TruncatePartition
-        {
+        if !operation.is_client_allowed() && operation != Operation::TruncatePartition {
             return Err(IggyError::InvalidCommand);
         }
+
+        // Stamp the acting user id into the replicated header so the in-apply
+        // RBAC gate (`crate::stm::authz`) resolves the same identity on every
+        // replica, WAL replay included (no session table there). Every client-op
+        // prepare funnels through here, primary-only by construction, so stamping
+        // here -- not in the in-process client path alone -- also covers the
+        // wire-plane ingresses (`on_request` and the request-queue drain). The
+        // wire `user_id` is never trusted: it is overwritten for every gated
+        // client op, and a client whose session is unknown is denied here
+        // (fail-closed), never defaulted to root. `Register` / `Logout` are exempt
+        // (see `resolve_acting_user_id`); server-originated internal ops
+        // (`CompleteConsumerGroupRevocation`, the PAT-cleaner delete) build their
+        // prepare directly, bypassing this path, and keep `user_id` 0 (gate skips).
+        if let Some(acting_user_id) =
+            resolve_acting_user_id(operation, client_id, &self.client_table)?
+        {
+            let request_header = bytemuck::checked::from_bytes_mut::<RequestHeader>(
+                &mut message.as_mut_slice()[..size_of::<RequestHeader>()],
+            );
+            request_header.user_id = acting_user_id;
+        }
+
+        // Must be read AFTER the stamp: the `CreateTopic` / `CreatePartitions`
+        // arms hand this `header` copy to `build_prepare_message`, so it has to
+        // carry the stamped acting user. Reading it before the stamp would ship
+        // those prepares with the untrusted wire `user_id` (0 = root from
+        // well-behaved SDKs, attacker-chosen otherwise), silently bypassing the
+        // authz gate. The default arm projects the mutated buffer directly and
+        // is order-independent.
+        let header = *message.header();
         let body = &message.as_slice()[size_of::<RequestHeader>()..header.size as usize];
 
         match header.operation {
@@ -1893,9 +1930,12 @@ where
                 // Register: commit_register creates session, no SM.
                 let reply = build_reply_message(&header, &bytes::Bytes::new());
                 let in_flight = |c: u128| consensus.pipeline().borrow().has_message_from_client(c);
-                self.client_table
-                    .borrow_mut()
-                    .commit_register(header.client, reply, in_flight);
+                self.client_table.borrow_mut().commit_register(
+                    header.client,
+                    header.user_id,
+                    reply,
+                    in_flight,
+                );
             } else if header.operation == Operation::Logout {
                 self.client_table.borrow_mut().remove_client(header.client);
                 // Mirror the on_ack path: drop the disconnected client from
@@ -1908,7 +1948,7 @@ where
                 // Normal op: apply SM, commit_reply. `Err` is decode/corruption
                 // only; a business rejection commits as a deterministic no-op
                 // whose `code` rides the reply body, replayed on retry.
-                let apply = self.mux_stm.update(prepare).unwrap_or_else(|err| {
+                let apply = gated_apply(&self.mux_stm, prepare).unwrap_or_else(|err| {
                     panic!("commit_journal: committed metadata op={op} failed to apply: {err}");
                 });
                 // Post-commit notifier (e.g. partition reconciler
@@ -1993,6 +2033,7 @@ where
 fn build_register_request_message<B, P>(
     consensus: &VsrConsensus<B, P>,
     client_id: u128,
+    user_id: u32,
 ) -> Message<RequestHeader>
 where
     B: MessageBus,
@@ -2014,6 +2055,8 @@ where
         client: client_id,
         session: 0,
         request: 0,
+        // Replicated on the prepare so every replica resolves session -> user.
+        user_id,
         // Route through the metadata consensus group. The chain-forwarded
         // prepare is re-routed on each peer by namespace; a `0` here would
         // hash to a non-zero shard with no metadata consensus and be
@@ -2179,10 +2222,11 @@ where
     // `created_at` on every CreateStream/CreateTopic/CreatePartitions. The
     // in-process callers that bypass `Project::project` build their prepare
     // through this helper directly (the CreateTopic/CreatePartitions
-    // assignment rewrites, and the PAT-cleaner delete); the stamp is
-    // load-bearing for the creates and inert for the delete, whose apply
-    // ignores it. Shared `next_monotonic_timestamp` keeps the in-process path
-    // on the same monotonic-clock guard as the wire path.
+    // assignment rewrites, the UpdateTopic default-size rewrite, and the
+    // PAT-cleaner delete); the stamp is load-bearing for the creates and inert
+    // for the UpdateTopic rewrite and the delete, whose applies ignore it.
+    // Shared `next_monotonic_timestamp` keeps the in-process path on the same
+    // monotonic-clock guard as the wire path.
     let timestamp = consensus.next_monotonic_timestamp();
     *new_header = PrepareHeader {
         cluster: consensus.cluster(),
@@ -2200,6 +2244,13 @@ where
         timestamp,
         operation,
         namespace: request.namespace,
+        // Carry the acting user id so the in-apply RBAC gate sees the same
+        // identity on every replica. The default projection copies it (see
+        // `Project::project`); this helper builds prepares for the ops it
+        // rewrites (the CreateTopic/CreatePartitions assignment rewrites, the
+        // UpdateTopic default-size rewrite, and the PAT-cleaner delete), which
+        // would otherwise reset it to 0 via `..Default::default()`.
+        user_id: request.user_id,
         ..Default::default()
     };
 
@@ -2216,12 +2267,48 @@ const fn eviction_reason_for_invalid(operation: Operation) -> EvictionReason {
     }
 }
 
+/// Resolve the acting user id to stamp into a client op's replicated
+/// `RequestHeader`, so the in-apply RBAC gate (`crate::stm::authz`) reads the
+/// same identity on every replica (WAL replay has no session table).
+///
+/// - `Ok(Some(id))`: overwrite the header's `user_id` with the committed
+///   session's user; the wire-supplied value is never trusted.
+/// - `Ok(None)`: leave it untouched. `Register` carries the credential-verified
+///   user from login (a mid-`Register` client has no session yet, so resolution
+///   would miss and fail-close, denying every login) and `Logout` is not gated
+///   -- both keep their builder value.
+/// - `Err(Unauthenticated)`: fail-closed. A client op whose `client_id` has no
+///   session cannot be attributed, so it is denied rather than defaulted to
+///   root (`user_id` 0 is the gate's all-allow short-circuit). Every caller
+///   preflights a live session first (`request_preflight` dispatches only on
+///   `New`), so this guards a future ingress that reaches here without one.
+fn resolve_acting_user_id(
+    operation: Operation,
+    client_id: u128,
+    client_table: &RefCell<ClientTable>,
+) -> Result<Option<u32>, IggyError> {
+    if matches!(operation, Operation::Register | Operation::Logout) {
+        return Ok(None);
+    }
+    client_table
+        .borrow()
+        .get_user_id(client_id)
+        .ok_or(IggyError::Unauthenticated)
+        .map(Some)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::stm::stream::Streams;
     use crate::stm::user::Users;
+    use consensus::LocalPipeline;
+    use iggy_binary_protocol::requests::topics::CreateTopicRequest;
     use iggy_common::variadic;
+    use journal::prepare_journal::PrepareJournal;
+    use message_bus::{ClientForwardFn, ConnectionLostFn, JoinHandle, ReplicaForwardFn, SendError};
+    use server_common::MESSAGE_ALIGN;
+    use server_common::iobuf::Frozen;
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -2315,6 +2402,183 @@ mod tests {
             *second_count.borrow(),
             1,
             "cleared notifier must stay quiet"
+        );
+    }
+
+    /// Minimal committed `Register` reply for `ClientTable::commit_register`,
+    /// which reads only `client` and `commit` (the assigned session).
+    fn register_reply(client: u128, session: u64) -> Message<ReplyHeader> {
+        let header_size = size_of::<ReplyHeader>();
+        let mut reply = Message::<ReplyHeader>::new(header_size);
+        let header = bytemuck::checked::try_from_bytes_mut::<ReplyHeader>(
+            &mut reply.as_mut_slice()[..header_size],
+        )
+        .expect("zeroed bytes are a valid ReplyHeader");
+        *header = ReplyHeader {
+            client,
+            request: 0,
+            commit: session,
+            command: Command2::Reply,
+            operation: Operation::Register,
+            ..Default::default()
+        };
+        reply
+    }
+
+    #[test]
+    fn resolve_acting_user_id_skips_register_and_logout() {
+        // Session-lifecycle ops keep the user id their request builder set
+        // (Register's login identity, Logout's ungated value); the ClientTable
+        // is never consulted, so an empty table still yields `Ok(None)`.
+        let client_table = RefCell::new(ClientTable::new(CLIENTS_TABLE_MAX));
+        for operation in [Operation::Register, Operation::Logout] {
+            assert!(
+                matches!(
+                    resolve_acting_user_id(operation, 1, &client_table),
+                    Ok(None)
+                ),
+                "{operation:?} must not be stamped"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_acting_user_id_stamps_from_client_table() {
+        // A gated client op takes the acting user from the committed session,
+        // independent of any wire-supplied header value.
+        const CLIENT: u128 = 1;
+        const SESSION: u64 = 10;
+        const ACTING_USER: u32 = 7;
+        let mut table = ClientTable::new(CLIENTS_TABLE_MAX);
+        table.commit_register(CLIENT, ACTING_USER, register_reply(CLIENT, SESSION), |_| {
+            false
+        });
+        let client_table = RefCell::new(table);
+
+        match resolve_acting_user_id(Operation::CreateStream, CLIENT, &client_table) {
+            Ok(Some(user_id)) => assert_eq!(user_id, ACTING_USER),
+            other => panic!("expected Ok(Some({ACTING_USER})), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_acting_user_id_fails_closed_for_unknown_session() {
+        // A gated client op with no committed session is denied, never
+        // defaulted to root (user id 0).
+        let client_table = RefCell::new(ClientTable::new(CLIENTS_TABLE_MAX));
+        match resolve_acting_user_id(Operation::CreateStream, 999, &client_table) {
+            Err(IggyError::Unauthenticated) => {}
+            other => panic!("expected Err(Unauthenticated), got {other:?}"),
+        }
+    }
+
+    /// No-op bus: `prepare_request` builds a prepare without ever sending, so
+    /// every method is an unused stub.
+    #[derive(Debug, Default)]
+    struct NoopBus;
+
+    impl MessageBus for NoopBus {
+        fn track_background(&self, _handle: JoinHandle<()>) {}
+        async fn send_to_client(
+            &self,
+            _client_id: u128,
+            _data: Frozen<MESSAGE_ALIGN>,
+        ) -> Result<(), SendError> {
+            Ok(())
+        }
+        async fn send_to_replica(
+            &self,
+            _replica: u8,
+            _data: Frozen<MESSAGE_ALIGN>,
+        ) -> Result<(), SendError> {
+            Ok(())
+        }
+        fn set_connection_lost_fn(&self, _f: ConnectionLostFn) {}
+        fn set_replica_forward_fn(&self, _f: ReplicaForwardFn) {}
+        fn set_client_forward_fn(&self, _f: ClientForwardFn) {}
+    }
+
+    /// Single-node metadata plane whose `prepare_request` is callable. `J` is
+    /// `PrepareJournal` in name only (the value is `None`) to satisfy the
+    /// impl-block bound; no journal or snapshot is constructed.
+    fn metadata_plane() -> IggyMetadata<VsrConsensus<NoopBus>, PrepareJournal, (), TestMux> {
+        let consensus = VsrConsensus::new(
+            1,
+            0,
+            1,
+            server_common::sharding::METADATA_CONSENSUS_NAMESPACE,
+            NoopBus,
+            LocalPipeline::new(),
+        );
+        consensus.init();
+        IggyMetadata::new(Some(consensus), None, None, TestMux::default(), None)
+    }
+
+    fn create_topic_request(client: u128, wire_user_id: u32) -> Message<RequestHeader> {
+        let body = CreateTopicRequest {
+            stream_id: WireIdentifier::numeric(1),
+            partitions_count: 1,
+            compression_algorithm: 0,
+            message_expiry: 0,
+            max_topic_size: 0,
+            replication_factor: 1,
+            name: WireName::new("t").unwrap(),
+        }
+        .to_bytes();
+        let header_size = size_of::<RequestHeader>();
+        let total = header_size + body.len();
+        let mut message = Message::<RequestHeader>::new(total);
+        {
+            let slice = message.as_mut_slice();
+            slice[header_size..total].copy_from_slice(&body);
+            let header =
+                bytemuck::checked::from_bytes_mut::<RequestHeader>(&mut slice[..header_size]);
+            *header = RequestHeader {
+                command: Command2::Request,
+                operation: Operation::CreateTopic,
+                size: u32::try_from(total).unwrap(),
+                client,
+                session: 1,
+                request: 1,
+                user_id: wire_user_id,
+                namespace: server_common::sharding::METADATA_CONSENSUS_NAMESPACE,
+                ..Default::default()
+            };
+        }
+        message
+    }
+
+    #[test]
+    fn prepare_request_stamps_create_topic_from_client_table_not_wire() {
+        // `CreateTopic` is the projection that reaches `build_prepare_message`
+        // through the post-stamp `header` copy, so the built prepare must carry
+        // the ClientTable identity, not the (bogus) wire value. This pins the
+        // stamp-then-re-read ordering: a hoist would ship the untrusted wire
+        // value.
+        const CLIENT: u128 = 1;
+        const SESSION: u64 = 10;
+        const ACTING_USER: u32 = 7;
+        const WIRE_USER: u32 = 999;
+        let plane = metadata_plane();
+        plane.client_table.borrow_mut().commit_register(
+            CLIENT,
+            ACTING_USER,
+            register_reply(CLIENT, SESSION),
+            |_| false,
+        );
+
+        let prepare = plane
+            .prepare_request(create_topic_request(CLIENT, WIRE_USER))
+            .expect("CreateTopic is client-allowed");
+        assert_eq!(
+            prepare.header().operation,
+            Operation::CreateTopicWithAssignments,
+            "CreateTopic projects to the enriched form"
+        );
+        assert_eq!(
+            prepare.header().user_id,
+            ACTING_USER,
+            "prepare must carry the ClientTable identity, not the wire value"
         );
     }
 }

--- a/core/metadata/src/impls/recovery.rs
+++ b/core/metadata/src/impls/recovery.rs
@@ -17,6 +17,7 @@
 
 use crate::impls::metadata::IggySnapshot;
 use crate::stm::StateMachine;
+use crate::stm::authz::GatedApply;
 use crate::stm::snapshot::{MetadataSnapshot, RestoreSnapshot, Snapshot, SnapshotError};
 use iggy_binary_protocol::consensus::PrepareHeader;
 use iggy_common::IggyError;
@@ -107,6 +108,7 @@ pub struct RecoveredMetadata<M> {
 pub async fn recover<M>(data_dir: &Path) -> Result<RecoveredMetadata<M>, RecoveryError>
 where
     M: StateMachine<Input = Message<PrepareHeader>, Error = IggyError>
+        + GatedApply
         + RestoreSnapshot<MetadataSnapshot>
         + Default,
 {
@@ -148,7 +150,9 @@ where
                 format!("failed to read journal entry for op={}", header.op),
             ))
         })?;
-        mux_stm.update(entry)?;
+        // WAL replay must recompute authorization denials identically to the
+        // primary/backup commit paths, so it goes through the same gate.
+        mux_stm.gated_update(entry)?;
         last_applied_op = Some(header.op);
     }
 

--- a/core/metadata/src/permissioner/permissioner_rules/system.rs
+++ b/core/metadata/src/permissioner/permissioner_rules/system.rs
@@ -32,6 +32,10 @@ impl Permissioner {
         self.get_server_info(user_id)
     }
 
+    pub fn get_snapshot(&self, user_id: u32) -> Result<(), IggyError> {
+        self.get_server_info(user_id)
+    }
+
     fn get_server_info(&self, user_id: u32) -> Result<(), IggyError> {
         if let Some(global_permissions) = self.users_permissions.get(&user_id)
             && (global_permissions.manage_servers || global_permissions.read_servers)

--- a/core/metadata/src/stm/authz.rs
+++ b/core/metadata/src/stm/authz.rs
@@ -1,0 +1,760 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! In-apply control-plane authorization for the metadata state machine.
+//!
+//! Every committed client op is gated here before its `StateHandler::apply`
+//! runs. A denial returns an `Unauthorized` [`ApplyReply`] WITHOUT touching
+//! state, so the op commits as a deterministic no-op whose error rides the
+//! cached reply and replays on retry, exactly like a business rejection.
+//!
+//! Replay-determinism invariant: [`authorize`] is a pure function of the
+//! prepare header (`operation` + the acting `user_id`, stamped into the
+//! replicated header at submit time) and the committed permission/stream
+//! state as of the op immediately before this one. That state is applied in
+//! the same order on every replica, so the primary (`on_ack`), each backup
+//! (`commit_journal`), and WAL replay (`recover`) all recompute the identical
+//! decision. This is why identity must ride the header rather than being
+//! resolved from a local session table: a backup has no session for the
+//! acting client.
+
+use crate::MuxStateMachine;
+use crate::impls::metadata::StreamsFrontend;
+use crate::permissioner::Permissioner;
+use crate::stm::StateMachine;
+use crate::stm::consumer_group::{JoinConsumerGroupRequest, LeaveConsumerGroupRequest};
+use crate::stm::result::ApplyReply;
+use crate::stm::stream::{Streams, TruncatePartitionRequest};
+use crate::stm::user::Users;
+use iggy_binary_protocol::requests::consumer_groups::{
+    CreateConsumerGroupRequest, DeleteConsumerGroupRequest,
+};
+use iggy_binary_protocol::requests::partitions::{
+    CreatePartitionsWithAssignmentsRequest, DeletePartitionsRequest,
+};
+use iggy_binary_protocol::requests::streams::{
+    DeleteStreamRequest, PurgeStreamRequest, UpdateStreamRequest,
+};
+use iggy_binary_protocol::requests::topics::{
+    CreateTopicWithAssignmentsRequest, DeleteTopicRequest, PurgeTopicRequest, UpdateTopicRequest,
+};
+use iggy_binary_protocol::requests::users::ChangePasswordRequest;
+use iggy_binary_protocol::{Operation, PrepareHeader, WireDecode, WireIdentifier};
+use iggy_common::{IggyError, variadic};
+use server_common::Message;
+use std::mem::size_of;
+
+/// Gate a committed prepare, then apply it. A denial commits as an
+/// `Unauthorized` no-op (the gate never mutates state); an allow proceeds to
+/// the normal state-machine dispatch. This is the single funnel every
+/// production apply path uses, so no committed op can bypass the RBAC check.
+///
+/// The primary (`on_ack`) and backup (`commit_journal`) paths hold the concrete
+/// mux and call this directly; WAL replay (`recover`) is generic over the state
+/// machine and reaches it through [`GatedApply`].
+///
+/// # Errors
+/// Propagates the underlying [`StateMachine::update`] error (decode / corruption
+/// of a committed body), which is fatal on the commit path.
+pub(crate) fn gated_apply<M>(
+    mux: &M,
+    prepare: Message<PrepareHeader>,
+) -> Result<ApplyReply, IggyError>
+where
+    M: StreamsFrontend
+        + StateMachine<Input = Message<PrepareHeader>, Output = ApplyReply, Error = IggyError>,
+{
+    if let Some(denied) = authorize(&prepare, mux.users(), mux.streams()) {
+        return Ok(denied);
+    }
+    mux.update(prepare)
+}
+
+/// Generic entry point to [`gated_apply`] for the WAL-replay path.
+///
+/// The replay path is generic over the state machine and cannot name the
+/// concrete accessors, so it dispatches through this trait. Implemented only
+/// for the metadata mux (and, in tests, the empty state machine used by the
+/// recovery harness).
+pub trait GatedApply:
+    StateMachine<Input = Message<PrepareHeader>, Output = ApplyReply, Error = IggyError>
+{
+    /// See [`gated_apply`].
+    ///
+    /// # Errors
+    /// Propagates the underlying [`StateMachine::update`] error.
+    fn gated_update(&self, prepare: Message<PrepareHeader>) -> Result<ApplyReply, IggyError>;
+}
+
+impl GatedApply for MuxStateMachine<variadic!(Users, Streams)> {
+    fn gated_update(&self, prepare: Message<PrepareHeader>) -> Result<ApplyReply, IggyError> {
+        gated_apply(self, prepare)
+    }
+}
+
+/// The root user is always the first user created (slab id 0) and holds every
+/// grant. Short-circuited below rather than checked against the permissioner:
+/// server-originated ops carry `user_id` 0 with no session, and WAL replay
+/// gates committed ops before the unreplicated root bootstrap
+/// (`ensure_root_user`) has populated the permissioner, so the gate must not
+/// depend on permissioner contents.
+const ROOT_USER_ID: u32 = 0;
+
+/// Decides whether the acting user may run this committed op.
+///
+/// `Some(reply)` denies with a committed `Unauthorized` no-op; `None` allows
+/// the op to reach its `StateHandler::apply`. Only control-plane client ops are
+/// checked; internal / server-originated ops (which carry `user_id` 0), the
+/// self-scoped personal-access-token ops (no legacy RBAC), the pre-projection
+/// wire forms, and partition-plane ops all pass through.
+///
+/// Object ids are resolved against committed stream state first; a resolution
+/// miss passes through so `apply` produces its own `NotFound`, preserving the
+/// legacy notfound-before-permission ordering.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn authorize(
+    prepare: &Message<PrepareHeader>,
+    users: &Users,
+    streams: &Streams,
+) -> Option<ApplyReply> {
+    let header = prepare.header();
+    let user_id = header.user_id;
+
+    if user_id == ROOT_USER_ID {
+        return None;
+    }
+    let body = &prepare.as_slice()[size_of::<PrepareHeader>()..header.size as usize];
+
+    match header.operation {
+        // Streams. `create_stream` is unscoped; the rest resolve the stream id.
+        Operation::CreateStream => check(users, |perm| perm.create_stream(user_id)),
+        Operation::UpdateStream => {
+            let Ok(request) = UpdateStreamRequest::decode_from(body) else {
+                return None;
+            };
+            stream_scoped(users, streams, &request.stream_id, |perm, sid| {
+                perm.update_stream(user_id, sid)
+            })
+        }
+        Operation::DeleteStream => {
+            let Ok(request) = DeleteStreamRequest::decode_from(body) else {
+                return None;
+            };
+            stream_scoped(users, streams, &request.stream_id, |perm, sid| {
+                perm.delete_stream(user_id, sid)
+            })
+        }
+        Operation::PurgeStream => {
+            let Ok(request) = PurgeStreamRequest::decode_from(body) else {
+                return None;
+            };
+            stream_scoped(users, streams, &request.stream_id, |perm, sid| {
+                perm.purge_stream(user_id, sid)
+            })
+        }
+
+        // Topics. The wire `CreateTopic` is projected to
+        // `CreateTopicWithAssignments` before it reaches apply, so only the
+        // enriched form is gated. `create_topic` is stream-scoped.
+        Operation::CreateTopicWithAssignments => {
+            let Ok(request) = CreateTopicWithAssignmentsRequest::decode_from(body) else {
+                return None;
+            };
+            stream_scoped(users, streams, &request.request.stream_id, |perm, sid| {
+                perm.create_topic(user_id, sid)
+            })
+        }
+        Operation::UpdateTopic => {
+            let Ok(request) = UpdateTopicRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.update_topic(user_id, sid, tid),
+            )
+        }
+        Operation::DeleteTopic => {
+            let Ok(request) = DeleteTopicRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.delete_topic(user_id, sid, tid),
+            )
+        }
+        Operation::PurgeTopic => {
+            let Ok(request) = PurgeTopicRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.purge_topic(user_id, sid, tid),
+            )
+        }
+
+        // Partitions. Wire `CreatePartitions` is projected to the enriched
+        // form; `DeleteSegments` is resolved server-side to `TruncatePartition`
+        // carrying the original client's id.
+        Operation::CreatePartitionsWithAssignments => {
+            let Ok(request) = CreatePartitionsWithAssignmentsRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.request.stream_id,
+                &request.request.topic_id,
+                |perm, sid, tid| perm.create_partitions(user_id, sid, tid),
+            )
+        }
+        Operation::DeletePartitions => {
+            let Ok(request) = DeletePartitionsRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.delete_partitions(user_id, sid, tid),
+            )
+        }
+        Operation::TruncatePartition => {
+            let Ok(request) = TruncatePartitionRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.delete_segments(user_id, sid, tid),
+            )
+        }
+
+        // Consumer groups. Join/Leave carry the enriched request types that add
+        // the VSR client id; Create/Delete use the wire types.
+        Operation::CreateConsumerGroup => {
+            let Ok(request) = CreateConsumerGroupRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.create_consumer_group(user_id, sid, tid),
+            )
+        }
+        Operation::DeleteConsumerGroup => {
+            let Ok(request) = DeleteConsumerGroupRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.delete_consumer_group(user_id, sid, tid),
+            )
+        }
+        Operation::JoinConsumerGroup => {
+            let Ok(request) = JoinConsumerGroupRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.join_consumer_group(user_id, sid, tid),
+            )
+        }
+        Operation::LeaveConsumerGroup => {
+            let Ok(request) = LeaveConsumerGroupRequest::decode_from(body) else {
+                return None;
+            };
+            topic_scoped(
+                users,
+                streams,
+                &request.stream_id,
+                &request.topic_id,
+                |perm, sid, tid| perm.leave_consumer_group(user_id, sid, tid),
+            )
+        }
+
+        // Users. Unscoped `manage_users`, except `ChangePassword` which the
+        // legacy execution layer exempts when the target is the acting user.
+        Operation::CreateUser => check(users, |perm| perm.create_user(user_id)),
+        Operation::DeleteUser => check(users, |perm| perm.delete_user(user_id)),
+        Operation::UpdateUser => check(users, |perm| perm.update_user(user_id)),
+        Operation::UpdatePermissions => check(users, |perm| perm.update_permissions(user_id)),
+        Operation::ChangePassword => {
+            let Ok(request) = ChangePasswordRequest::decode_from(body) else {
+                return None;
+            };
+            match users.read(|inner| inner.resolve_user_id(&request.user_id)) {
+                // Self-service password change: allowed without `manage_users`.
+                Some(target_id) if target_id == user_id as usize => None,
+                Some(_) => check(users, |perm| perm.change_password(user_id)),
+                // Unknown target passes through to apply's `UserNotFound`.
+                None => None,
+            }
+        }
+
+        // Not gated (listed exhaustively so a new op cannot silently skip the
+        // gate): VSR-reserved ops (never reach apply as client ops),
+        // server-originated internal ops (user_id 0), self-scoped PAT ops (no
+        // legacy RBAC), the pre-projection wire forms, and every partition op.
+        Operation::Reserved
+        | Operation::Register
+        | Operation::NonReplicated
+        | Operation::Logout
+        | Operation::RemoveConsumerGroupMember
+        | Operation::CompleteConsumerGroupRevocation
+        | Operation::CreateTopic
+        | Operation::CreatePartitions
+        | Operation::DeleteSegments
+        | Operation::CreatePersonalAccessToken
+        | Operation::DeletePersonalAccessToken
+        | Operation::SendMessages
+        | Operation::StoreConsumerOffset
+        | Operation::DeleteConsumerOffset
+        | Operation::StoreConsumerOffset2
+        | Operation::DeleteConsumerOffset2 => None,
+    }
+}
+
+/// Maps a permissioner rule outcome to a gate decision: any `Err` (always
+/// `Unauthorized`) denies with a committed `Unauthorized` reply.
+fn check(
+    users: &Users,
+    rule: impl FnOnce(&Permissioner) -> Result<(), IggyError>,
+) -> Option<ApplyReply> {
+    match users.read(|inner| rule(&inner.permissioner)) {
+        Ok(()) => None,
+        Err(error) => Some(ApplyReply::err(error.as_code())),
+    }
+}
+
+/// Resolves a stream id, then runs a stream-scoped rule. A resolution miss
+/// passes through (returns `None`) so apply surfaces its own `NotFound`.
+fn stream_scoped(
+    users: &Users,
+    streams: &Streams,
+    stream_id: &WireIdentifier,
+    rule: impl FnOnce(&Permissioner, usize) -> Result<(), IggyError>,
+) -> Option<ApplyReply> {
+    let stream_id = streams.read(|inner| inner.resolve_stream_id(stream_id))?;
+    check(users, |perm| rule(perm, stream_id))
+}
+
+/// Resolves a (stream, topic) pair, then runs a topic-scoped rule. A miss on
+/// either passes through so apply surfaces its own `NotFound`.
+fn topic_scoped(
+    users: &Users,
+    streams: &Streams,
+    stream_id: &WireIdentifier,
+    topic_id: &WireIdentifier,
+    rule: impl FnOnce(&Permissioner, usize, usize) -> Result<(), IggyError>,
+) -> Option<ApplyReply> {
+    let (stream_id, topic_id) = streams.read(|inner| {
+        let stream_id = inner.resolve_stream_id(stream_id)?;
+        let topic_id = inner.resolve_topic_id(stream_id, topic_id)?;
+        Some((stream_id, topic_id))
+    })?;
+    check(users, |perm| rule(perm, stream_id, topic_id))
+}
+
+/// The recovery unit tests exercise WAL-replay mechanics with an empty state
+/// list (`MuxStateMachine<()>`), which has no permission state and so needs no
+/// gate. Production always uses the `variadic!(Users, Streams)` machine above.
+#[cfg(test)]
+impl GatedApply for MuxStateMachine<()> {
+    fn gated_update(&self, prepare: Message<PrepareHeader>) -> Result<ApplyReply, IggyError> {
+        self.update(prepare)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_possible_truncation)]
+mod tests {
+    use super::*;
+    use iggy_binary_protocol::primitives::partition_assignment::CreatedPartitionAssignment;
+    use iggy_binary_protocol::primitives::permissions::{
+        WireGlobalPermissions, WirePermissions, WireStreamPermissions,
+    };
+    use iggy_binary_protocol::requests::streams::CreateStreamRequest;
+    use iggy_binary_protocol::requests::topics::CreateTopicRequest;
+    use iggy_binary_protocol::requests::users::CreateUserRequest;
+    use iggy_binary_protocol::{Command2, WireEncode, WireName};
+    use iggy_common::UserStatus;
+    use server_common::iobuf::Owned;
+
+    const HEADER_SIZE: usize = size_of::<PrepareHeader>();
+    /// Root is the first user, so it takes slab id 0; the first user created
+    /// after it is id 1.
+    const ROOT: u32 = 0;
+    const ALICE: u32 = 1;
+
+    fn mux() -> MuxStateMachine<variadic!(Users, Streams)> {
+        let users = Users::default();
+        users.ensure_root_user("iggy", "hash");
+        let streams = Streams::default();
+        MuxStateMachine::new(variadic!(users, streams))
+    }
+
+    fn make_prepare(
+        op: u64,
+        operation: Operation,
+        user_id: u32,
+        body: &[u8],
+    ) -> Message<PrepareHeader> {
+        let total = HEADER_SIZE + body.len();
+        let mut buffer = Owned::<4096>::zeroed(total);
+        {
+            let header = bytemuck::checked::from_bytes_mut::<PrepareHeader>(
+                &mut buffer.as_mut_slice()[..HEADER_SIZE],
+            );
+            header.command = Command2::Prepare;
+            header.operation = operation;
+            header.op = op;
+            header.user_id = user_id;
+            header.size = u32::try_from(total).unwrap();
+        }
+        buffer.as_mut_slice()[HEADER_SIZE..].copy_from_slice(body);
+        Message::try_from(buffer).unwrap()
+    }
+
+    fn no_grants() -> WireGlobalPermissions {
+        WireGlobalPermissions {
+            manage_servers: false,
+            read_servers: false,
+            manage_users: false,
+            read_users: false,
+            manage_streams: false,
+            read_streams: false,
+            manage_topics: false,
+            read_topics: false,
+            poll_messages: false,
+            send_messages: false,
+        }
+    }
+
+    fn create_user_body(
+        name: &str,
+        global: WireGlobalPermissions,
+        streams: Vec<WireStreamPermissions>,
+    ) -> bytes::Bytes {
+        CreateUserRequest {
+            username: WireName::new(name).unwrap(),
+            password: "hash".to_string(),
+            status: UserStatus::Active.as_code(),
+            permissions: Some(WirePermissions { global, streams }),
+        }
+        .to_bytes()
+    }
+
+    fn create_stream_body(name: &str) -> bytes::Bytes {
+        CreateStreamRequest {
+            name: WireName::new(name).unwrap(),
+        }
+        .to_bytes()
+    }
+
+    fn create_topic_body(stream_id: u32, name: &str) -> bytes::Bytes {
+        CreateTopicWithAssignmentsRequest {
+            request: CreateTopicRequest {
+                stream_id: WireIdentifier::numeric(stream_id),
+                partitions_count: 1,
+                compression_algorithm: 0,
+                message_expiry: 0,
+                max_topic_size: 0,
+                replication_factor: 1,
+                name: WireName::new(name).unwrap(),
+            },
+            partitions: vec![CreatedPartitionAssignment {
+                partition_id: 0,
+                consensus_group_id: 1,
+            }],
+        }
+        .to_bytes()
+    }
+
+    fn change_password_body(target: &str) -> bytes::Bytes {
+        ChangePasswordRequest {
+            user_id: WireIdentifier::named(target).unwrap(),
+            current_password: String::new(),
+            new_password: "new-hash".to_string(),
+        }
+        .to_bytes()
+    }
+
+    fn stream_manage_topics(stream_id: u32) -> WireStreamPermissions {
+        WireStreamPermissions {
+            stream_id,
+            manage_stream: false,
+            read_stream: false,
+            manage_topics: true,
+            read_topics: false,
+            poll_messages: false,
+            send_messages: false,
+            topics: Vec::new(),
+        }
+    }
+
+    const UNAUTHORIZED: u32 = 41;
+
+    #[test]
+    fn given_ungranted_user_when_create_stream_should_deny_and_leave_state_unchanged() {
+        let mux = mux();
+        assert_eq!(
+            mux.gated_update(make_prepare(
+                1,
+                Operation::CreateUser,
+                ROOT,
+                &create_user_body("alice", no_grants(), Vec::new()),
+            ))
+            .unwrap()
+            .code,
+            0,
+            "root may create a user"
+        );
+
+        let reply = mux
+            .gated_update(make_prepare(
+                2,
+                Operation::CreateStream,
+                ALICE,
+                &create_stream_body("s1"),
+            ))
+            .unwrap();
+
+        assert_eq!(reply.code, UNAUTHORIZED);
+        assert_eq!(
+            mux.streams().read(|inner| inner.items.len()),
+            0,
+            "denied op must not mutate stream state"
+        );
+    }
+
+    #[test]
+    fn given_manage_streams_grant_when_create_stream_should_allow() {
+        let mux = mux();
+        let grants = WireGlobalPermissions {
+            manage_streams: true,
+            ..no_grants()
+        };
+        mux.gated_update(make_prepare(
+            1,
+            Operation::CreateUser,
+            ROOT,
+            &create_user_body("alice", grants, Vec::new()),
+        ))
+        .unwrap();
+
+        let reply = mux
+            .gated_update(make_prepare(
+                2,
+                Operation::CreateStream,
+                ALICE,
+                &create_stream_body("s1"),
+            ))
+            .unwrap();
+
+        assert_eq!(reply.code, 0);
+        assert_eq!(mux.streams().read(|inner| inner.items.len()), 1);
+    }
+
+    #[test]
+    fn given_stream_scoped_topics_grant_when_create_topic_should_allow_only_that_stream() {
+        let mux = mux();
+        // Streams 0 and 1 (StreamsInner slab is separate from the user slab).
+        mux.gated_update(make_prepare(
+            1,
+            Operation::CreateStream,
+            ROOT,
+            &create_stream_body("s0"),
+        ))
+        .unwrap();
+        mux.gated_update(make_prepare(
+            2,
+            Operation::CreateStream,
+            ROOT,
+            &create_stream_body("s1"),
+        ))
+        .unwrap();
+        // Alice may manage topics on stream 0 only.
+        mux.gated_update(make_prepare(
+            3,
+            Operation::CreateUser,
+            ROOT,
+            &create_user_body("alice", no_grants(), vec![stream_manage_topics(0)]),
+        ))
+        .unwrap();
+
+        let allowed = mux
+            .gated_update(make_prepare(
+                4,
+                Operation::CreateTopicWithAssignments,
+                ALICE,
+                &create_topic_body(0, "t"),
+            ))
+            .unwrap();
+        assert_eq!(allowed.code, 0, "grant covers stream 0");
+
+        let denied = mux
+            .gated_update(make_prepare(
+                5,
+                Operation::CreateTopicWithAssignments,
+                ALICE,
+                &create_topic_body(1, "t"),
+            ))
+            .unwrap();
+        assert_eq!(denied.code, UNAUTHORIZED, "grant does not cover stream 1");
+    }
+
+    #[test]
+    fn given_change_password_when_target_is_self_should_allow_else_deny() {
+        let mux = mux();
+        mux.gated_update(make_prepare(
+            1,
+            Operation::CreateUser,
+            ROOT,
+            &create_user_body("alice", no_grants(), Vec::new()),
+        ))
+        .unwrap();
+        mux.gated_update(make_prepare(
+            2,
+            Operation::CreateUser,
+            ROOT,
+            &create_user_body("bob", no_grants(), Vec::new()),
+        ))
+        .unwrap();
+
+        let own = mux
+            .gated_update(make_prepare(
+                3,
+                Operation::ChangePassword,
+                ALICE,
+                &change_password_body("alice"),
+            ))
+            .unwrap();
+        assert_eq!(
+            own.code, 0,
+            "self password change is exempt from manage_users"
+        );
+
+        let other = mux
+            .gated_update(make_prepare(
+                4,
+                Operation::ChangePassword,
+                ALICE,
+                &change_password_body("bob"),
+            ))
+            .unwrap();
+        assert_eq!(
+            other.code, UNAUTHORIZED,
+            "changing another user needs manage_users"
+        );
+    }
+
+    #[test]
+    fn given_internal_revocation_op_when_authorized_should_skip_the_gate() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::CompleteConsumerGroupRevocation, ROOT, &[]);
+        assert!(
+            authorize(&prepare, mux.users(), mux.streams()).is_none(),
+            "server-originated revocation must not be gated"
+        );
+    }
+
+    #[test]
+    fn given_non_root_user_when_create_pat_should_skip_the_gate() {
+        let mux = mux();
+        mux.gated_update(make_prepare(
+            1,
+            Operation::CreateUser,
+            ROOT,
+            &create_user_body("alice", no_grants(), Vec::new()),
+        ))
+        .unwrap();
+
+        let prepare = make_prepare(2, Operation::CreatePersonalAccessToken, ALICE, &[]);
+        assert!(
+            authorize(&prepare, mux.users(), mux.streams()).is_none(),
+            "PAT ops are self-scoped (parity: no legacy RBAC)"
+        );
+    }
+
+    // The linchpin: a sequence containing a denied op must produce byte-identical
+    // codes and final state whether applied once (primary on_ack) or replayed
+    // fresh (backup commit_journal / recover). Identity rides the header, so no
+    // session table is consulted.
+    #[test]
+    fn given_sequence_with_denial_when_replayed_fresh_should_be_state_identical() {
+        fn sequence() -> Vec<Message<PrepareHeader>> {
+            vec![
+                make_prepare(
+                    1,
+                    Operation::CreateUser,
+                    ROOT,
+                    &create_user_body("alice", no_grants(), Vec::new()),
+                ),
+                make_prepare(
+                    2,
+                    Operation::CreateStream,
+                    ROOT,
+                    &create_stream_body("s-root"),
+                ),
+                // Alice lacks manage_streams: denied on both passes.
+                make_prepare(
+                    3,
+                    Operation::CreateStream,
+                    ALICE,
+                    &create_stream_body("s-alice"),
+                ),
+            ]
+        }
+
+        let primary = mux();
+        let primary_codes: Vec<u32> = sequence()
+            .into_iter()
+            .map(|prepare| primary.gated_update(prepare).unwrap().code)
+            .collect();
+
+        let replay = mux();
+        let replay_codes: Vec<u32> = sequence()
+            .into_iter()
+            .map(|prepare| replay.gated_update(prepare).unwrap().code)
+            .collect();
+
+        assert_eq!(primary_codes, replay_codes, "replay must be deterministic");
+        assert_eq!(primary_codes[2], UNAUTHORIZED, "alice's create is denied");
+        assert_eq!(primary.streams().read(|inner| inner.items.len()), 1);
+        assert_eq!(replay.streams().read(|inner| inner.items.len()), 1);
+    }
+}

--- a/core/metadata/src/stm/consumer_group.rs
+++ b/core/metadata/src/stm/consumer_group.rs
@@ -505,8 +505,21 @@ impl StateHandler for CreateConsumerGroupRequest {
         state: &mut StreamsInner,
         _timestamp: iggy_common::IggyTimestamp,
     ) -> ApplyReply {
-        let Some(topic) = state.topic_mut(&self.stream_id, &self.topic_id) else {
-            return ApplyReply::ok(Bytes::new());
+        // A missing parent is a committed rejection, mirroring `CreateTopic`
+        // on a missing stream. Resolve level by level so the error names the
+        // level that missed.
+        let Some(stream_id) = state.resolve_stream_id(&self.stream_id) else {
+            return ApplyReply::err(CreateConsumerGroupResult::StreamNotFound);
+        };
+        let Some(topic_id) = state.resolve_topic_id(stream_id, &self.topic_id) else {
+            return ApplyReply::err(CreateConsumerGroupResult::TopicNotFound);
+        };
+        let Some(topic) = state
+            .items
+            .get_mut(stream_id)
+            .and_then(|stream| stream.topics.get_mut(topic_id))
+        else {
+            return ApplyReply::err(CreateConsumerGroupResult::TopicNotFound);
         };
         let name: Arc<str> = Arc::from(self.name.as_str());
         // Per-(stream,topic) name uniqueness. A same-name group already exists:
@@ -956,6 +969,41 @@ mod tests {
             u32::from(CreateConsumerGroupResult::NameAlreadyExists)
         );
         assert!(apply.body.is_empty());
+    }
+
+    #[test]
+    fn given_missing_parent_when_apply_create_consumer_group_should_return_not_found() {
+        let mut state = streams_with_topic();
+
+        let missing_stream = StateHandler::apply(
+            &CreateConsumerGroupRequest {
+                stream_id: WireIdentifier::numeric(999),
+                topic_id: WireIdentifier::numeric(0),
+                name: WireName::new("group").unwrap(),
+            },
+            &mut state,
+            IggyTimestamp::now(),
+        );
+        assert_eq!(
+            missing_stream.code,
+            u32::from(CreateConsumerGroupResult::StreamNotFound)
+        );
+        assert!(missing_stream.body.is_empty());
+
+        let missing_topic = StateHandler::apply(
+            &CreateConsumerGroupRequest {
+                stream_id: WireIdentifier::numeric(0),
+                topic_id: WireIdentifier::numeric(999),
+                name: WireName::new("group").unwrap(),
+            },
+            &mut state,
+            IggyTimestamp::now(),
+        );
+        assert_eq!(
+            missing_topic.code,
+            u32::from(CreateConsumerGroupResult::TopicNotFound)
+        );
+        assert!(missing_topic.body.is_empty());
     }
 
     #[test]

--- a/core/metadata/src/stm/mod.rs
+++ b/core/metadata/src/stm/mod.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod authz;
 pub mod consumer_group;
 pub mod mux;
 pub mod result;

--- a/core/metadata/src/stm/result.rs
+++ b/core/metadata/src/stm/result.rs
@@ -187,14 +187,27 @@ result_enum!(DeletePartitionsResult {
 
 // Users. No dedicated user-not-found code in `IggyError`; `ResourceNotFound = 20`
 // stands in until one is added (a separate `IggyError` change).
-result_enum!(CreateUserResult { UserAlreadyExists = 46 });
+result_enum!(CreateUserResult {
+    InvalidUsername = 43,
+    UserAlreadyExists = 46,
+});
 result_enum!(UpdateUserResult {
     UserNotFound = 20,
+    InvalidUsername = 43,
     UsernameAlreadyExists = 46,
 });
-result_enum!(DeleteUserResult { UserNotFound = 20 });
-result_enum!(ChangePasswordResult { UserNotFound = 20 });
-result_enum!(UpdatePermissionsResult { UserNotFound = 20 });
+result_enum!(DeleteUserResult {
+    UserNotFound = 20,
+    CannotDeleteUser = 48,
+});
+result_enum!(ChangePasswordResult {
+    UserNotFound = 20,
+    InvalidCredentials = 42,
+});
+result_enum!(UpdatePermissionsResult {
+    UserNotFound = 20,
+    CannotChangePermissions = 49,
+});
 
 // Personal access tokens.
 result_enum!(CreatePersonalAccessTokenResult {
@@ -204,17 +217,34 @@ result_enum!(CreatePersonalAccessTokenResult {
 result_enum!(DeletePersonalAccessTokenResult { NotFound = 20 });
 
 // Consumer groups.
-result_enum!(CreateConsumerGroupResult { NameAlreadyExists = 5004 });
+result_enum!(CreateConsumerGroupResult {
+    StreamNotFound = 1009,
+    TopicNotFound = 2010,
+    NameAlreadyExists = 5004,
+});
 result_enum!(DeleteConsumerGroupResult { NotFound = 5000 });
 
-/// True if `code` is one this op's result enum declares (`Ok = 0` included).
+/// `IggyError::Unauthorized`. Any control-plane op can commit as an in-apply
+/// authorization no-op, so this code is valid for every op regardless of its
+/// own result enum. Pinned to the wire discriminant in
+/// [`tests::given_result_discriminants_then_match_iggy_error_codes`].
+const UNAUTHORIZED_CODE: u32 = 41;
+
+/// True if `code` is one this op's result enum declares (`Ok = 0` included), or
+/// the global `UNAUTHORIZED_CODE`.
 ///
-/// The state machine only commits codes from the op's own enum, so an
+/// The state machine only commits codes from the op's own enum, plus the
+/// in-apply authorization gate's global `Unauthorized` denial, so an
 /// unrecognized one is a server bug, not a race (a race still yields a declared
 /// code). Enriched internal ops map to their client-op enum; ops with no result
 /// section (partition plane) return `true`.
 #[must_use]
 pub const fn result_code_recognized(operation: Operation, code: u32) -> bool {
+    // The in-apply RBAC gate can deny any control-plane op, committing an
+    // `Unauthorized` no-op, so accept it globally rather than per-op enum.
+    if code == UNAUTHORIZED_CODE {
+        return true;
+    }
     match operation {
         Operation::CreateStream => CreateStreamResult::from_u32(code).is_some(),
         Operation::UpdateStream => UpdateStreamResult::from_u32(code).is_some(),
@@ -325,6 +355,20 @@ mod tests {
         ));
         // Partition-plane ops carry no result section, so any code is accepted.
         assert!(result_code_recognized(Operation::SendMessages, 12345));
+        // `Unauthorized` commits for any control-plane op via the in-apply gate,
+        // even though no per-op result enum declares it.
+        assert!(result_code_recognized(
+            Operation::CreateStream,
+            UNAUTHORIZED_CODE
+        ));
+        assert!(result_code_recognized(
+            Operation::CreateUser,
+            UNAUTHORIZED_CODE
+        ));
+        assert!(result_code_recognized(
+            Operation::CreateConsumerGroup,
+            UNAUTHORIZED_CODE
+        ));
     }
 
     // Pins every result-enum discriminant to the `IggyError` variant its doc
@@ -377,6 +421,10 @@ mod tests {
             u32::from(DeletePartitionsResult::StreamNotFound),
             stream_not_found
         );
+        assert_eq!(
+            u32::from(CreateConsumerGroupResult::StreamNotFound),
+            stream_not_found
+        );
 
         // StreamNameAlreadyExists (1012).
         let stream_name_exists = IggyError::StreamNameAlreadyExists(String::new()).as_code();
@@ -400,6 +448,10 @@ mod tests {
         );
         assert_eq!(
             u32::from(DeletePartitionsResult::TopicNotFound),
+            topic_not_found
+        );
+        assert_eq!(
+            u32::from(CreateConsumerGroupResult::TopicNotFound),
             topic_not_found
         );
 
@@ -428,6 +480,18 @@ mod tests {
             user_exists
         );
 
+        // InvalidUsername (43) - username length outside [MIN,MAX] bytes,
+        // rejected in-apply for create and rename alike.
+        let invalid_username = IggyError::InvalidUsername.as_code();
+        assert_eq!(
+            u32::from(CreateUserResult::InvalidUsername),
+            invalid_username
+        );
+        assert_eq!(
+            u32::from(UpdateUserResult::InvalidUsername),
+            invalid_username
+        );
+
         // ResourceNotFound (20) - documented stand-in for user/PAT not-found.
         let resource_not_found = IggyError::ResourceNotFound(String::new()).as_code();
         assert_eq!(
@@ -451,6 +515,26 @@ mod tests {
             resource_not_found
         );
 
+        // CannotDeleteUser (48) - root deletion is rejected in-apply.
+        assert_eq!(
+            u32::from(DeleteUserResult::CannotDeleteUser),
+            IggyError::CannotDeleteUser(0).as_code(),
+        );
+
+        // CannotChangePermissions (49) - root permissions are immutable in-apply.
+        assert_eq!(
+            u32::from(UpdatePermissionsResult::CannotChangePermissions),
+            IggyError::CannotChangePermissions(0).as_code(),
+        );
+
+        // InvalidCredentials (42) - wrong current password on ChangePassword,
+        // committed as a rejecting no-op so the client request sequence stays
+        // contiguous (a pre-consensus deny would gap it).
+        assert_eq!(
+            u32::from(ChangePasswordResult::InvalidCredentials),
+            IggyError::InvalidCredentials.as_code(),
+        );
+
         // PersonalAccessTokenAlreadyExists (51).
         assert_eq!(
             u32::from(CreatePersonalAccessTokenResult::AlreadyExists),
@@ -472,5 +556,8 @@ mod tests {
             u32::from(DeleteConsumerGroupResult::NotFound),
             IggyError::ConsumerGroupIdNotFound(id(), id()).as_code(),
         );
+
+        // Unauthorized (41) - the global in-apply RBAC denial code.
+        assert_eq!(UNAUTHORIZED_CODE, IggyError::Unauthorized.as_code());
     }
 }

--- a/core/metadata/src/stm/stream.rs
+++ b/core/metadata/src/stm/stream.rs
@@ -628,7 +628,7 @@ impl StreamsInner {
         self.pending_revocations_count = count;
     }
 
-    fn resolve_stream_id(&self, identifier: &WireIdentifier) -> Option<usize> {
+    pub(crate) fn resolve_stream_id(&self, identifier: &WireIdentifier) -> Option<usize> {
         match identifier {
             WireIdentifier::Numeric(id) => {
                 let id = *id as usize;
@@ -642,7 +642,11 @@ impl StreamsInner {
         }
     }
 
-    fn resolve_topic_id(&self, stream_id: usize, identifier: &WireIdentifier) -> Option<usize> {
+    pub(crate) fn resolve_topic_id(
+        &self,
+        stream_id: usize,
+        identifier: &WireIdentifier,
+    ) -> Option<usize> {
         let stream = self.items.get(stream_id)?;
         match identifier {
             WireIdentifier::Numeric(id) => {

--- a/core/metadata/src/stm/user.rs
+++ b/core/metadata/src/stm/user.rs
@@ -35,8 +35,9 @@ use iggy_binary_protocol::requests::users::{
 use iggy_binary_protocol::responses::users::get_user::UserDetailsResponse;
 use iggy_binary_protocol::responses::users::user_response::UserResponse;
 use iggy_binary_protocol::{WireIdentifier, WireName};
+use iggy_common::defaults::{DEFAULT_ROOT_USER_ID, MAX_USERNAME_LENGTH, MIN_USERNAME_LENGTH};
 use iggy_common::{
-    GlobalPermissions, IggyExpiry, IggyTimestamp, Permissions, PersonalAccessToken,
+    GlobalPermissions, IggyError, IggyExpiry, IggyTimestamp, Permissions, PersonalAccessToken,
     StreamPermissions, UserId, UserStatus,
 };
 use serde::{Deserialize, Serialize};
@@ -124,7 +125,7 @@ collect_handlers! {
 }
 
 impl UsersInner {
-    fn resolve_user_id(&self, identifier: &WireIdentifier) -> Option<usize> {
+    pub(crate) fn resolve_user_id(&self, identifier: &WireIdentifier) -> Option<usize> {
         match identifier {
             WireIdentifier::Numeric(id) => {
                 let id = *id as usize;
@@ -136,6 +137,27 @@ impl UsersInner {
             }
             WireIdentifier::String(name) => self.index.get(name.as_str()).map(|&id| id as usize),
         }
+    }
+
+    /// Stored password hash of the user named by `identifier`, `None` when
+    /// the user does not resolve.
+    #[must_use]
+    pub fn password_hash_of(&self, identifier: &WireIdentifier) -> Option<Arc<str>> {
+        self.resolve_user_id(identifier)
+            .and_then(|user_id| self.items.get(user_id))
+            .map(|user| Arc::clone(&user.password_hash))
+    }
+
+    /// Clone the committed permissions of the user at slab `id`, if any.
+    ///
+    /// The permissioner is a denormalized index of `User.permissions`; both
+    /// apply paths feed it from here, reading the just-stored user so the two
+    /// never drift.
+    #[must_use]
+    fn permissions_of(&self, id: usize) -> Option<Permissions> {
+        self.items
+            .get(id)
+            .and_then(|user| user.permissions.as_deref().cloned())
     }
 
     /// Collect `(user_id, name)` for every expired personal access token.
@@ -155,6 +177,34 @@ impl UsersInner {
             .map(|(_, user_id, name)| (*user_id, Arc::clone(name)))
             .collect()
     }
+
+    /// Collect `(name, expiry_at)` for every live personal access token of
+    /// one user, sorted by name.
+    ///
+    /// Read-only accessor for the non-replicated list path (the caller lists
+    /// its own tokens). The backing per-user map is an `AHashMap`, whose
+    /// iteration order is seeded per process, so the collected list is
+    /// sorted before it is returned. Never lift this iteration into an apply
+    /// handler: apply must stay deterministic across replicas (see the
+    /// invariant on `personal_access_token_index`).
+    #[must_use]
+    pub fn personal_access_tokens_of(
+        &self,
+        user_id: UserId,
+    ) -> Vec<(Arc<str>, Option<IggyTimestamp>)> {
+        let mut tokens: Vec<_> = self
+            .personal_access_tokens
+            .get(&user_id)
+            .map(|user_tokens| {
+                user_tokens
+                    .values()
+                    .map(|pat| (Arc::clone(&pat.name), pat.expiry_at))
+                    .collect()
+            })
+            .unwrap_or_default();
+        tokens.sort_by(|(left, _), (right, _)| left.cmp(right));
+        tokens
+    }
 }
 
 impl Users {
@@ -166,15 +216,44 @@ impl Users {
         self.inner.read(f)
     }
 
+    /// Run a permissioner rule against the committed user permissions and
+    /// return its decision. The dispatch-time authorization surface for the
+    /// checks the in-apply RBAC gate cannot cover: non-replicated reads and
+    /// partition-plane ops, both decided on the connection's own shard rather
+    /// than in a replicated apply. The permissioner stays private; callers pass
+    /// the rule closure.
+    ///
+    /// # Errors
+    /// Propagates the rule's `IggyError` (always `Unauthorized`) on denial.
+    pub fn authorize(
+        &self,
+        rule: impl FnOnce(&Permissioner) -> Result<(), IggyError>,
+    ) -> Result<(), IggyError> {
+        self.read(|inner| rule(&inner.permissioner))
+    }
+
     /// Ensures a root user exists in an empty user set.
     ///
     /// # Panics
     ///
-    /// Panics if `username` is not a valid wire-format username.
+    /// Panics if `username` is not a valid wire-format username or its length is
+    /// outside `MIN_USERNAME_LENGTH..=MAX_USERNAME_LENGTH`, failing bootstrap fast
+    /// rather than letting the replicated apply reject it as a committed no-op
+    /// that would leave the server with no root user.
     pub fn ensure_root_user(&self, username: &str, password_hash: &str) {
         if self.read(|users| !users.items.is_empty()) {
             return;
         }
+
+        // Fail fast on a misconfigured `IGGY_ROOT_USERNAME`: the replicated apply
+        // enforces this same length bound and would otherwise reject the
+        // bootstrap as a committed no-op (try_apply still returns Ok), leaving the
+        // server running with no root user.
+        let length = username.len();
+        assert!(
+            (MIN_USERNAME_LENGTH..=MAX_USERNAME_LENGTH).contains(&length),
+            "root username length {length} outside {MIN_USERNAME_LENGTH}..={MAX_USERNAME_LENGTH}; fix IGGY_ROOT_USERNAME"
+        );
 
         // Boot-only invariant: server-ng calls this before listeners and
         // consensus traffic start, on shard 0 initialization. The read/apply
@@ -330,6 +409,15 @@ impl StateHandler for CreateUserRequest {
     type State = UsersInner;
     #[allow(clippy::cast_possible_truncation)]
     fn apply(&self, state: &mut UsersInner, timestamp: IggyTimestamp) -> ApplyReply {
+        // `WireName` permits 1..=255 bytes, so a raw binary client bypasses the
+        // length bound the edges (HTTP DTO, SDK, login) enforce. Re-check in the
+        // replicated apply -- the choke point every transport shares -- so state
+        // never holds a username no ingress considers valid. Rejected before any
+        // mutation, committing as a deterministic no-op.
+        if !(MIN_USERNAME_LENGTH..=MAX_USERNAME_LENGTH).contains(&self.username.as_str().len()) {
+            return ApplyReply::err(CreateUserResult::InvalidUsername);
+        }
+
         let username_arc: Arc<str> = Arc::from(self.username.as_str());
         if state.index.contains_key(&username_arc) {
             return ApplyReply::err(CreateUserResult::UserAlreadyExists);
@@ -359,6 +447,11 @@ impl StateHandler for CreateUserRequest {
         state
             .personal_access_tokens
             .insert(id as UserId, AHashMap::default());
+
+        let user_permissions = state.permissions_of(id);
+        state
+            .permissioner
+            .init_permissions_for_user(id as UserId, user_permissions);
 
         // Reply body: the SDK `create_user` decodes a `UserDetailsResponse`.
         // Serialization local to this state machine.
@@ -390,6 +483,12 @@ impl StateHandler for UpdateUserRequest {
         };
 
         if let Some(new_username) = &self.username {
+            // Same bound as CreateUser apply: a rename must not smuggle in a
+            // username the edges reject. Rejected before any mutation.
+            if !(MIN_USERNAME_LENGTH..=MAX_USERNAME_LENGTH).contains(&new_username.as_str().len()) {
+                return ApplyReply::err(UpdateUserResult::InvalidUsername);
+            }
+
             let new_username_arc: Arc<str> = Arc::from(new_username.as_str());
             if let Some(&existing_id) = state.index.get(&new_username_arc)
                 && existing_id != user_id as UserId
@@ -419,6 +518,15 @@ impl StateHandler for DeleteUserRequest {
             return ApplyReply::err(DeleteUserResult::UserNotFound);
         };
 
+        // Root (slab id 0) is undeletable, matching legacy `CannotDeleteUser`.
+        // The rejection is deterministic, so every replica keeps slab id 0 as
+        // the root user and the in-apply RBAC gate's `user_id == 0` root
+        // short-circuit can never be inherited by a recreated user (the slab
+        // reuses freed keys, so a deleted root's slot would be reclaimed).
+        if user_id == DEFAULT_ROOT_USER_ID as usize {
+            return ApplyReply::err(DeleteUserResult::CannotDeleteUser);
+        }
+
         if let Some(user) = state.items.get(user_id) {
             let username = user.username.clone();
             state.items.remove(user_id);
@@ -435,6 +543,9 @@ impl StateHandler for DeleteUserRequest {
                     }
                 }
             }
+            state
+                .permissioner
+                .delete_permissions_for_user(user_id as UserId);
         }
         ApplyReply::ok(Bytes::new())
     }
@@ -447,6 +558,16 @@ impl StateHandler for ChangePasswordRequest {
             return ApplyReply::err(ChangePasswordResult::UserNotFound);
         };
 
+        // An empty `new_password` is the primary's signal that the caller's
+        // current password did not match (see server-ng
+        // `verify_and_rewrite_change_password`): the accept path always
+        // replicates a non-empty Argon2 hash, so this is unambiguous. Rejecting
+        // here (rather than denying pre-consensus) commits the op as a no-op,
+        // keeping the client's request sequence contiguous in the ClientTable.
+        if self.new_password.is_empty() {
+            return ApplyReply::err(ChangePasswordResult::InvalidCredentials);
+        }
+
         if let Some(user) = state.items.get_mut(user_id) {
             user.password_hash = Arc::from(self.new_password.as_str());
         }
@@ -456,10 +577,19 @@ impl StateHandler for ChangePasswordRequest {
 
 impl StateHandler for UpdatePermissionsRequest {
     type State = UsersInner;
+    #[allow(clippy::cast_possible_truncation)]
     fn apply(&self, state: &mut UsersInner, _timestamp: IggyTimestamp) -> ApplyReply {
         let Some(user_id) = state.resolve_user_id(&self.user_id) else {
             return ApplyReply::err(UpdatePermissionsResult::UserNotFound);
         };
+
+        // Root (slab id 0) permissions are immutable, matching legacy
+        // `CannotChangePermissions`. Rejected before any mutation, so the op is a
+        // committed no-op: root keeps its full grants and the permissioner index
+        // is untouched.
+        if user_id == DEFAULT_ROOT_USER_ID as usize {
+            return ApplyReply::err(UpdatePermissionsResult::CannotChangePermissions);
+        }
 
         if let Some(user) = state.items.get_mut(user_id) {
             user.permissions = self
@@ -467,6 +597,10 @@ impl StateHandler for UpdatePermissionsRequest {
                 .as_ref()
                 .map(|p| Arc::new(Permissions::from(p.clone())));
         }
+        let user_permissions = state.permissions_of(user_id);
+        state
+            .permissioner
+            .update_permissions_for_user(user_id as UserId, user_permissions);
         ApplyReply::ok(Bytes::new())
     }
 }
@@ -650,43 +784,18 @@ impl Snapshotable for Users {
                     })
                     .collect();
 
+            // The permissioner is a denormalized index of `User.permissions`.
+            // Its `AHashMap`/`AHashSet` fields iterate in a per-replica-random
+            // order, so serializing them would make the snapshot bytes differ
+            // across replicas. Persist empty vecs (kept only for the positional
+            // msgpack layout) and rebuild the index from the users on restore.
             let permissioner = PermissionerSnapshot {
-                users_permissions: inner
-                    .permissioner
-                    .users_permissions
-                    .iter()
-                    .map(|(&k, v)| (k, v.clone()))
-                    .collect(),
-                users_streams_permissions: inner
-                    .permissioner
-                    .users_streams_permissions
-                    .iter()
-                    .map(|(&k, v)| (k, v.clone()))
-                    .collect(),
-                users_that_can_poll_messages_from_all_streams: inner
-                    .permissioner
-                    .users_that_can_poll_messages_from_all_streams
-                    .iter()
-                    .copied()
-                    .collect(),
-                users_that_can_send_messages_to_all_streams: inner
-                    .permissioner
-                    .users_that_can_send_messages_to_all_streams
-                    .iter()
-                    .copied()
-                    .collect(),
-                users_that_can_poll_messages_from_specific_streams: inner
-                    .permissioner
-                    .users_that_can_poll_messages_from_specific_streams
-                    .iter()
-                    .copied()
-                    .collect(),
-                users_that_can_send_messages_to_specific_streams: inner
-                    .permissioner
-                    .users_that_can_send_messages_to_specific_streams
-                    .iter()
-                    .copied()
-                    .collect(),
+                users_permissions: Vec::new(),
+                users_streams_permissions: Vec::new(),
+                users_that_can_poll_messages_from_all_streams: Vec::new(),
+                users_that_can_send_messages_to_all_streams: Vec::new(),
+                users_that_can_poll_messages_from_specific_streams: Vec::new(),
+                users_that_can_send_messages_to_specific_streams: Vec::new(),
             };
 
             UsersSnapshot {
@@ -751,38 +860,14 @@ impl Snapshotable for Users {
             personal_access_tokens.insert(user_id, token_map);
         }
 
-        let permissioner = Permissioner {
-            users_permissions: snapshot
-                .permissioner
-                .users_permissions
-                .into_iter()
-                .collect(),
-            users_streams_permissions: snapshot
-                .permissioner
-                .users_streams_permissions
-                .into_iter()
-                .collect(),
-            users_that_can_poll_messages_from_all_streams: snapshot
-                .permissioner
-                .users_that_can_poll_messages_from_all_streams
-                .into_iter()
-                .collect(),
-            users_that_can_send_messages_to_all_streams: snapshot
-                .permissioner
-                .users_that_can_send_messages_to_all_streams
-                .into_iter()
-                .collect(),
-            users_that_can_poll_messages_from_specific_streams: snapshot
-                .permissioner
-                .users_that_can_poll_messages_from_specific_streams
-                .into_iter()
-                .collect(),
-            users_that_can_send_messages_to_specific_streams: snapshot
-                .permissioner
-                .users_that_can_send_messages_to_specific_streams
-                .into_iter()
-                .collect(),
-        };
+        // Rebuild the permissioner from the restored users rather than the
+        // snapshot vecs, which are intentionally empty (see `to_snapshot`).
+        // Slab iteration is ascending by key, so the build is deterministic.
+        let mut permissioner = Permissioner::new();
+        for (user_id, user) in &items {
+            permissioner
+                .init_permissions_for_user(user_id as UserId, user.permissions.as_deref().cloned());
+        }
 
         let inner = UsersInner {
             index,
@@ -802,6 +887,8 @@ impl_fill_restore!(Users, users);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use iggy_binary_protocol::primitives::permissions::WireStreamPermissions;
+    use iggy_common::IggyError;
 
     #[test]
     fn create_pat_request_roundtrip_preserves_user_id() {
@@ -954,6 +1041,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn personal_access_tokens_of_lists_only_callers_sorted_by_name() {
+        let mut users = UsersInner::new();
+        // Insertion order deliberately not name order; a token for user 9
+        // proves the listing is caller-scoped.
+        for (user_id, name, expiry, fill) in [
+            (5u32, "zeta", 0u64, b'a'),
+            (5u32, "alpha", 1, b'b'),
+            (9u32, "other", 0, b'c'),
+        ] {
+            CreatePersonalAccessTokenRequest {
+                user_id,
+                name: WireName::new(name).unwrap(),
+                expiry,
+                token_hash: [fill; PAT_TOKEN_HASH_BYTES],
+            }
+            .apply(&mut users, IggyTimestamp::zero());
+        }
+
+        let tokens = users.personal_access_tokens_of(5);
+        let names: Vec<&str> = tokens.iter().map(|(name, _)| name.as_ref()).collect();
+        assert_eq!(names, ["alpha", "zeta"], "own tokens only, sorted by name");
+        assert!(
+            tokens[0].1.is_some(),
+            "expiring token must carry its expiry_at"
+        );
+        assert!(
+            tokens[1].1.is_none(),
+            "never-expiring token must carry no expiry_at"
+        );
+        assert!(
+            users.personal_access_tokens_of(42).is_empty(),
+            "a user without tokens lists empty"
+        );
+    }
+
     fn create_user(users: &mut UsersInner, username: &str) {
         let request = CreateUserRequest {
             username: WireName::new(username).unwrap(),
@@ -988,5 +1111,405 @@ mod tests {
         };
         let apply = StateHandler::apply(&request, &mut users, IggyTimestamp::now());
         assert_eq!(apply.code, u32::from(DeleteUserResult::UserNotFound));
+    }
+
+    #[test]
+    fn given_root_user_when_apply_delete_user_should_reject_and_keep_root() {
+        // Production seeds root at slab id 0 (`ensure_root_user`), so the first
+        // slab slot is the root user. Deleting it must be rejected in-apply, or
+        // a later `CreateUser` would reclaim slot 0 and inherit the RBAC gate's
+        // `user_id == 0` root short-circuit.
+        let mut users = UsersInner::new();
+        let root_id = create_user_with(&mut users, "iggy", None);
+        assert_eq!(root_id, DEFAULT_ROOT_USER_ID, "root takes slab id 0");
+
+        let delete_root = DeleteUserRequest {
+            user_id: WireIdentifier::numeric(root_id),
+        };
+        let reply = StateHandler::apply(&delete_root, &mut users, IggyTimestamp::now());
+        assert_eq!(reply.code, u32::from(DeleteUserResult::CannotDeleteUser));
+        assert!(
+            users.items.contains(root_id as usize),
+            "root must survive a delete attempt"
+        );
+
+        // A non-root user (slab id 1) stays deletable: the guard is scoped to
+        // root, so there is no over-block regression.
+        let alice_id = create_user_with(&mut users, "alice", None);
+        assert_ne!(alice_id, DEFAULT_ROOT_USER_ID);
+        let delete_alice = DeleteUserRequest {
+            user_id: WireIdentifier::numeric(alice_id),
+        };
+        let reply = StateHandler::apply(&delete_alice, &mut users, IggyTimestamp::now());
+        assert_eq!(reply.code, 0, "non-root deletion still succeeds");
+        assert!(!users.items.contains(alice_id as usize));
+    }
+
+    #[test]
+    fn given_root_user_when_apply_update_permissions_should_reject_and_keep_grants() {
+        // Root occupies slab id 0 (production `ensure_root_user`). Its
+        // permissions must be immutable in-apply, or a delegated manage_users
+        // admin could tamper with root's grants.
+        let mut users = UsersInner::new();
+        let mut root_global = empty_global();
+        root_global.manage_servers = true;
+        root_global.poll_messages = true;
+        let root_id = create_user_with(
+            &mut users,
+            "iggy",
+            Some(WirePermissions {
+                global: root_global,
+                streams: Vec::new(),
+            }),
+        );
+        assert_eq!(root_id, DEFAULT_ROOT_USER_ID, "root takes slab id 0");
+        assert!(users.permissioner.poll_messages(root_id, 1, 1).is_ok());
+
+        // Attempt to strip root's grants: rejected, nothing mutates.
+        let strip = UpdatePermissionsRequest {
+            user_id: WireIdentifier::numeric(root_id),
+            permissions: None,
+        };
+        let reply = StateHandler::apply(&strip, &mut users, IggyTimestamp::now());
+        assert_eq!(
+            reply.code,
+            u32::from(UpdatePermissionsResult::CannotChangePermissions)
+        );
+        assert!(
+            users
+                .items
+                .get(root_id as usize)
+                .and_then(|user| user.permissions.as_ref())
+                .is_some(),
+            "root permissions must survive"
+        );
+        assert!(
+            users.permissioner.poll_messages(root_id, 1, 1).is_ok(),
+            "root gate access unchanged"
+        );
+
+        // A non-root user's permissions can still be updated: no over-block.
+        let alice_id = create_user_with(&mut users, "alice", None);
+        assert_ne!(alice_id, DEFAULT_ROOT_USER_ID);
+        let mut alice_global = empty_global();
+        alice_global.poll_messages = true;
+        let grant = UpdatePermissionsRequest {
+            user_id: WireIdentifier::numeric(alice_id),
+            permissions: Some(WirePermissions {
+                global: alice_global,
+                streams: Vec::new(),
+            }),
+        };
+        let reply = StateHandler::apply(&grant, &mut users, IggyTimestamp::now());
+        assert_eq!(reply.code, 0, "non-root permission update still succeeds");
+        assert!(users.permissioner.poll_messages(alice_id, 1, 1).is_ok());
+    }
+
+    fn empty_global() -> WireGlobalPermissions {
+        WireGlobalPermissions {
+            manage_servers: false,
+            read_servers: false,
+            manage_users: false,
+            read_users: false,
+            manage_streams: false,
+            read_streams: false,
+            manage_topics: false,
+            read_topics: false,
+            poll_messages: false,
+            send_messages: false,
+        }
+    }
+
+    fn create_user_with(
+        users: &mut UsersInner,
+        username: &str,
+        permissions: Option<WirePermissions>,
+    ) -> UserId {
+        let request = CreateUserRequest {
+            username: WireName::new(username).unwrap(),
+            password: "hash".to_owned(),
+            status: 1,
+            permissions,
+        };
+        let reply = StateHandler::apply(&request, users, IggyTimestamp::now());
+        assert_eq!(reply.code, 0);
+        *users.index.get(username).expect("user created")
+    }
+
+    #[test]
+    fn given_global_poll_grant_when_apply_create_user_should_allow_poll_from_any_stream() {
+        let mut users = UsersInner::new();
+        let mut global = empty_global();
+        global.poll_messages = true;
+        let uid = create_user_with(
+            &mut users,
+            "poller",
+            Some(WirePermissions {
+                global,
+                streams: Vec::new(),
+            }),
+        );
+
+        // The global poll bit denormalizes into the can-poll-all set, so the
+        // user may poll any stream/topic without a stream-specific grant.
+        assert!(users.permissioner.poll_messages(uid, 7, 3).is_ok());
+        assert!(
+            users
+                .permissioner
+                .users_that_can_poll_messages_from_all_streams
+                .contains(&uid)
+        );
+    }
+
+    #[test]
+    fn given_poll_grant_when_apply_update_permissions_removes_it_should_return_unauthorized() {
+        let mut users = UsersInner::new();
+        // Occupy slab id 0 with the (immutable) root user so the poller under
+        // test is a non-root user; root permission changes are rejected in-apply.
+        create_user_with(&mut users, "iggy", None);
+        let mut global = empty_global();
+        global.poll_messages = true;
+        let uid = create_user_with(
+            &mut users,
+            "poller",
+            Some(WirePermissions {
+                global,
+                streams: Vec::new(),
+            }),
+        );
+        assert!(users.permissioner.poll_messages(uid, 1, 1).is_ok());
+
+        let update = UpdatePermissionsRequest {
+            user_id: WireIdentifier::numeric(uid),
+            permissions: None,
+        };
+        let reply = StateHandler::apply(&update, &mut users, IggyTimestamp::now());
+        assert_eq!(reply.code, 0);
+
+        assert!(matches!(
+            users.permissioner.poll_messages(uid, 1, 1),
+            Err(IggyError::Unauthorized)
+        ));
+        assert!(
+            !users
+                .permissioner
+                .users_that_can_poll_messages_from_all_streams
+                .contains(&uid)
+        );
+    }
+
+    #[test]
+    fn given_permissioned_user_when_apply_delete_user_should_clear_all_indexes() {
+        let mut users = UsersInner::new();
+        // Occupy slab id 0 with the (undeletable) root user so the victim under
+        // test is a non-root user; root deletion is rejected in-apply.
+        create_user_with(&mut users, "iggy", None);
+        let mut global = empty_global();
+        global.poll_messages = true;
+        global.send_messages = true;
+        let stream = WireStreamPermissions {
+            stream_id: 4,
+            manage_stream: false,
+            read_stream: false,
+            manage_topics: false,
+            read_topics: false,
+            poll_messages: true,
+            send_messages: true,
+            topics: Vec::new(),
+        };
+        let uid = create_user_with(
+            &mut users,
+            "victim",
+            Some(WirePermissions {
+                global,
+                streams: vec![stream],
+            }),
+        );
+        assert!(!users.permissioner.users_permissions.is_empty());
+
+        let delete = DeleteUserRequest {
+            user_id: WireIdentifier::numeric(uid),
+        };
+        let reply = StateHandler::apply(&delete, &mut users, IggyTimestamp::now());
+        assert_eq!(reply.code, 0);
+
+        let permissioner = &users.permissioner;
+        assert!(permissioner.users_permissions.is_empty());
+        assert!(permissioner.users_streams_permissions.is_empty());
+        assert!(
+            permissioner
+                .users_that_can_poll_messages_from_all_streams
+                .is_empty()
+        );
+        assert!(
+            permissioner
+                .users_that_can_send_messages_to_all_streams
+                .is_empty()
+        );
+        assert!(
+            permissioner
+                .users_that_can_poll_messages_from_specific_streams
+                .is_empty()
+        );
+        assert!(
+            permissioner
+                .users_that_can_send_messages_to_specific_streams
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn given_populated_permissions_when_snapshot_round_trip_should_rebuild_index_and_persist_empty_vecs()
+     {
+        let mut inner = UsersInner::new();
+        let mut global = empty_global();
+        global.poll_messages = true;
+        global.send_messages = true;
+        let stream = WireStreamPermissions {
+            stream_id: 2,
+            manage_stream: false,
+            read_stream: false,
+            manage_topics: false,
+            read_topics: false,
+            poll_messages: true,
+            send_messages: true,
+            topics: Vec::new(),
+        };
+        let uid = create_user_with(
+            &mut inner,
+            "alice",
+            Some(WirePermissions {
+                global,
+                streams: vec![stream],
+            }),
+        );
+        let pre_poll = inner.permissioner.poll_messages(uid, 9, 9).is_ok();
+        let pre_send = inner.permissioner.append_messages(uid, 2, 0).is_ok();
+
+        let users: Users = inner.into();
+        let snapshot = users.to_snapshot();
+
+        // The derived index is not serialized: every permissioner vec is empty.
+        let snap = &snapshot.permissioner;
+        assert!(snap.users_permissions.is_empty());
+        assert!(snap.users_streams_permissions.is_empty());
+        assert!(
+            snap.users_that_can_poll_messages_from_all_streams
+                .is_empty()
+        );
+        assert!(snap.users_that_can_send_messages_to_all_streams.is_empty());
+        assert!(
+            snap.users_that_can_poll_messages_from_specific_streams
+                .is_empty()
+        );
+        assert!(
+            snap.users_that_can_send_messages_to_specific_streams
+                .is_empty()
+        );
+
+        let restored = Users::from_snapshot(snapshot).expect("snapshot restore");
+        let (poll_ok, send_ok, in_poll_all, in_send_specific) = restored.read(|inner| {
+            let permissioner = &inner.permissioner;
+            (
+                permissioner.poll_messages(uid, 9, 9).is_ok(),
+                permissioner.append_messages(uid, 2, 0).is_ok(),
+                permissioner
+                    .users_that_can_poll_messages_from_all_streams
+                    .contains(&uid),
+                permissioner
+                    .users_that_can_send_messages_to_specific_streams
+                    .contains(&(uid, 2)),
+            )
+        });
+
+        // Rule results survive the round-trip...
+        assert_eq!(poll_ok, pre_poll);
+        assert_eq!(send_ok, pre_send);
+        // ...because the index was rebuilt from the restored user: the global
+        // poll bit repopulated the can-poll-all set and the stream send bit
+        // repopulated the specific set.
+        assert!(in_poll_all);
+        assert!(in_send_specific);
+    }
+
+    #[test]
+    fn given_root_user_when_ensure_root_after_bootstrap_should_have_root_grants() {
+        let users = Users::default();
+        users.ensure_root_user("iggy", "hash");
+        // Root carries `Permissions::root()`: full grants across every rule.
+        let (can_create_stream, can_get_stats, can_poll) = users.read(|inner| {
+            let root = *inner.index.get("iggy").expect("root user created");
+            (
+                inner.permissioner.create_stream(root).is_ok(),
+                inner.permissioner.get_stats(root).is_ok(),
+                inner.permissioner.poll_messages(root, 1, 1).is_ok(),
+            )
+        });
+        assert!(can_create_stream);
+        assert!(can_get_stats);
+        assert!(can_poll);
+    }
+
+    #[test]
+    fn given_out_of_bound_username_when_apply_create_user_should_reject_without_insert() {
+        let mut users = UsersInner::new();
+
+        // `WireName` accepts 1..=255 bytes, so a raw binary client can submit a
+        // username shorter than the edge-enforced minimum. Apply must reject it.
+        for username in [
+            "a".repeat(MIN_USERNAME_LENGTH - 1),
+            "a".repeat(MAX_USERNAME_LENGTH + 1),
+        ] {
+            let request = CreateUserRequest {
+                username: WireName::new(&username).unwrap(),
+                password: "hash".to_owned(),
+                status: 1,
+                permissions: None,
+            };
+            let reply = StateHandler::apply(&request, &mut users, IggyTimestamp::now());
+            assert_eq!(reply.code, u32::from(CreateUserResult::InvalidUsername));
+            assert!(reply.body.is_empty());
+        }
+        assert!(users.items.is_empty(), "no user inserted on reject");
+        assert!(users.index.is_empty(), "index untouched on reject");
+
+        // The minimum-length boundary is accepted.
+        let username = "a".repeat(MIN_USERNAME_LENGTH);
+        let request = CreateUserRequest {
+            username: WireName::new(&username).unwrap(),
+            password: "hash".to_owned(),
+            status: 1,
+            permissions: None,
+        };
+        let reply = StateHandler::apply(&request, &mut users, IggyTimestamp::now());
+        assert_eq!(reply.code, 0);
+        assert!(users.index.contains_key(username.as_str()));
+    }
+
+    #[test]
+    fn given_too_short_rename_when_apply_update_user_should_reject_and_keep_username() {
+        let mut users = UsersInner::new();
+        create_user_with(&mut users, "iggy", None);
+        let alice_id = create_user_with(&mut users, "alice", None);
+
+        let short = "a".repeat(MIN_USERNAME_LENGTH - 1);
+        let rename = UpdateUserRequest {
+            user_id: WireIdentifier::numeric(alice_id),
+            username: Some(WireName::new(&short).unwrap()),
+            status: None,
+        };
+        let reply = StateHandler::apply(&rename, &mut users, IggyTimestamp::now());
+        assert_eq!(reply.code, u32::from(UpdateUserResult::InvalidUsername));
+
+        assert_eq!(
+            users
+                .items
+                .get(alice_id as usize)
+                .map(|u| u.username.as_ref()),
+            Some("alice"),
+            "username must survive a rejected rename"
+        );
+        assert_eq!(users.index.get("alice"), Some(&alice_id));
+        assert!(!users.index.contains_key(short.as_str()));
     }
 }

--- a/core/partitions/src/iggy_partition.rs
+++ b/core/partitions/src/iggy_partition.rs
@@ -20,7 +20,7 @@ use crate::journal::{MessageLookup, PartitionJournal, PartitionJournalMemStorage
 use crate::log::JournalInfo;
 use crate::log::SegmentedLog;
 use crate::messages_writer::MessagesWriter;
-use crate::offset_storage::{delete_persisted_offset, persist_offset};
+use crate::offset_storage::{delete_persisted_offset, persist_offset, persist_offset_max};
 use crate::poll_plan::{
     AutoCommitCtx, AutoCommitTarget, DiskReadPlan, DiskSegment, LastPolledCtx, PollPlan, PollTier,
     ResidentTailSnapshot,
@@ -33,8 +33,8 @@ use crate::{
 use consensus::{
     CommitLogEvent, Consensus, PartitionDiagEvent, Pipeline, PipelineEntry, PlaneKind, Project,
     ReplicaLogContext, RequestLogEvent, Sequencer, SimEventKind, VsrConsensus, ack_preflight,
-    ack_quorum_reached, build_reply_from_request, build_reply_message,
-    build_result_rejection_reply, drain_committable_prefix, emit_namespace_progress_event,
+    ack_quorum_reached, build_deny_reply_from_request, build_reply_from_request,
+    build_reply_message, drain_committable_prefix, emit_namespace_progress_event,
     emit_partition_diag, emit_sim_event, fence_old_prepare_by_commit, replicate_preflight,
     replicate_to_next_in_chain, send_prepare_ok as send_prepare_ok_common,
 };
@@ -49,7 +49,7 @@ use iggy_common::{
     IggyByteSize, IggyError, IggyExpiry, IggyTimestamp, PartitionStats, PollingKind,
 };
 use journal::Journal as _;
-use message_bus::{IggyMessageBus, MessageBus};
+use message_bus::{IggyMessageBus, MessageBus, is_auto_commit_client};
 use server_common::{
     Message, SegmentStorage,
     iobuf::Frozen,
@@ -58,7 +58,9 @@ use server_common::{
     },
     sharding::IggyNamespace,
 };
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -105,6 +107,19 @@ where
     partition_dir: Option<String>,
     consumer_offset_enforce_fsync: bool,
     pending_consumer_offset_commits: HashMap<u64, PendingConsumerOffsetCommit>,
+    /// Committed-only mirror of each consumer's persisted offset file: the
+    /// last value this replica durably wrote per (kind, consumer id). Fed
+    /// exclusively by the file-writing paths (replicated commit-apply, the
+    /// primary-local `NoAck` store, purge/delete/reclaim) and never by the
+    /// eager poll-path in-memory apply, so both readers see committed state
+    /// only: the auto-commit persist gate (skip or blind-write, no per-commit
+    /// file read) and the submit-side coalesce gate
+    /// ([`Self::is_auto_commit_offset_covered`]). A cold key (first touch
+    /// after boot) folds against the file once via `persist_offset_max`, so
+    /// the tracker rebuilds from disk lazily and deterministically.
+    /// `RefCell`: mutated from `&self` paths on the single shard thread;
+    /// borrows never cross an await.
+    persisted_offsets: RefCell<HashMap<(ConsumerKind, u32), u64>>,
     observed_view: u32,
     /// Highest `PurgeTopic` generation this replica has locally applied (reset
     /// the partition to empty). The reconciler compares the committed metadata
@@ -131,6 +146,11 @@ struct PendingConsumerOffsetCommit {
     kind: ConsumerKind,
     consumer_id: u32,
     mutation: PendingConsumerOffsetMutation,
+    /// A server auto-commit (a poll's `auto_commit`, replicated via the reserved
+    /// `AUTO_COMMIT_CLIENT_ID`): the commit-apply must be monotone so it cannot
+    /// rewind the eager in-memory offset a newer poll already advanced. Explicit
+    /// client stores leave this `false` (a store may legitimately rewind).
+    auto_commit: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -145,6 +165,17 @@ impl PendingConsumerOffsetCommit {
             kind,
             consumer_id,
             mutation: PendingConsumerOffsetMutation::Upsert(offset),
+            auto_commit: false,
+        }
+    }
+
+    /// Monotone-apply variant for a server auto-commit op. See `auto_commit`.
+    const fn upsert_auto_commit(kind: ConsumerKind, consumer_id: u32, offset: u64) -> Self {
+        Self {
+            kind,
+            consumer_id,
+            mutation: PendingConsumerOffsetMutation::Upsert(offset),
+            auto_commit: true,
         }
     }
 
@@ -153,6 +184,7 @@ impl PendingConsumerOffsetCommit {
             kind,
             consumer_id,
             mutation: PendingConsumerOffsetMutation::Delete,
+            auto_commit: false,
         }
     }
 
@@ -198,6 +230,7 @@ where
             partition_dir: None,
             consumer_offset_enforce_fsync: false,
             pending_consumer_offset_commits: HashMap::new(),
+            persisted_offsets: RefCell::new(HashMap::new()),
             observed_view,
             applied_purge_generation: 0,
         }
@@ -269,8 +302,13 @@ where
         kind: ConsumerKind,
         consumer_id: u32,
         offset: u64,
+        auto_commit: bool,
     ) {
-        let pending = PendingConsumerOffsetCommit::upsert(kind, consumer_id, offset);
+        let pending = if auto_commit {
+            PendingConsumerOffsetCommit::upsert_auto_commit(kind, consumer_id, offset)
+        } else {
+            PendingConsumerOffsetCommit::upsert(kind, consumer_id, offset)
+        };
         self.pending_consumer_offset_commits.insert(op, pending);
     }
 
@@ -322,12 +360,65 @@ where
         let Some(path) = self.persisted_offset_path(pending.kind, pending.consumer_id) else {
             return Ok(());
         };
+        let key = (pending.kind, pending.consumer_id);
         match pending.mutation {
-            PendingConsumerOffsetMutation::Upsert(offset) => {
-                persist_offset(&path, offset, self.consumer_offset_enforce_fsync).await
+            // A server auto-commit persists monotonically: its op offset can
+            // trail the durably-recorded value (disk-tier polls replicate in
+            // IO-completion order), so a plain overwrite would rewind the file
+            // and re-deliver on restart. The `persisted_offsets` tracker keeps
+            // the fold off the file: a covered offset skips the write, an
+            // advancing one blind-writes, and only a cold key (first commit
+            // after boot) reads the file once. Explicit client stores
+            // overwrite, so a deliberate offset reset still holds. Mirrors the
+            // in-memory `upsert_offset_max` vs `upsert_offset` split in the
+            // commit-apply.
+            PendingConsumerOffsetMutation::Upsert(offset) if pending.auto_commit => {
+                let tracked = self.persisted_offsets.borrow().get(&key).copied();
+                let persisted = match tracked {
+                    Some(high_water) if offset <= high_water => return Ok(()),
+                    Some(_) => {
+                        persist_offset(&path, offset, self.consumer_offset_enforce_fsync).await?;
+                        offset
+                    }
+                    None => {
+                        persist_offset_max(&path, offset, self.consumer_offset_enforce_fsync)
+                            .await?
+                    }
+                };
+                self.persisted_offsets.borrow_mut().insert(key, persisted);
+                Ok(())
             }
-            PendingConsumerOffsetMutation::Delete => delete_persisted_offset(&path).await,
+            PendingConsumerOffsetMutation::Upsert(offset) => {
+                persist_offset(&path, offset, self.consumer_offset_enforce_fsync).await?;
+                self.persisted_offsets.borrow_mut().insert(key, offset);
+                Ok(())
+            }
+            PendingConsumerOffsetMutation::Delete => {
+                delete_persisted_offset(&path).await?;
+                self.persisted_offsets.borrow_mut().remove(&key);
+                Ok(())
+            }
         }
+    }
+
+    /// Whether the committed high-water for this consumer already covers
+    /// `offset`, so a poll's auto-commit submit cannot advance it and may be
+    /// skipped instead of burning a consensus op. Reads committed state only
+    /// (the tracker is fed at commit-apply, never by the eager poll-path
+    /// apply): an offset covered in memory but not yet committed keeps
+    /// resubmitting until the covering op actually lands, so a dropped
+    /// in-flight op self-heals on the next poll.
+    #[must_use]
+    pub fn is_auto_commit_offset_covered(
+        &self,
+        kind: ConsumerKind,
+        consumer_id: u32,
+        offset: u64,
+    ) -> bool {
+        self.persisted_offsets
+            .borrow()
+            .get(&(kind, consumer_id))
+            .is_some_and(|&high_water| offset <= high_water)
     }
 
     fn apply_consumer_offset_commit(
@@ -340,12 +431,19 @@ where
             {
                 let id = pending.consumer_id;
                 let key = usize::try_from(id).expect("u32 consumer id must fit usize");
-                crate::poll_plan::upsert_offset(&self.consumer_offsets, key, offset, || {
+                let create = || {
                     self.consumer_offsets_path.as_deref().map_or_else(
                         || ConsumerOffset::new(ConsumerKind::Consumer, id, 0, String::new()),
                         |path| ConsumerOffset::default_for_consumer(id, path),
                     )
-                });
+                };
+                upsert_committed_offset(
+                    &self.consumer_offsets,
+                    key,
+                    offset,
+                    pending.auto_commit,
+                    create,
+                );
                 Ok(())
             }
             PendingConsumerOffsetMutation::Upsert(offset)
@@ -355,7 +453,7 @@ where
                 let key = ConsumerGroupId(
                     usize::try_from(group_id).expect("u32 group id must fit usize"),
                 );
-                crate::poll_plan::upsert_offset(&self.consumer_group_offsets, key, offset, || {
+                let create = || {
                     self.consumer_group_offsets_path.as_deref().map_or_else(
                         || {
                             ConsumerOffset::new(
@@ -367,7 +465,14 @@ where
                         },
                         |path| ConsumerOffset::default_for_consumer_group(key, path),
                     )
-                });
+                };
+                upsert_committed_offset(
+                    &self.consumer_group_offsets,
+                    key,
+                    offset,
+                    pending.auto_commit,
+                    create,
+                );
                 Ok(())
             }
             // Commit-time apply keeps its invariant check on the PRIMARY:
@@ -443,6 +548,9 @@ where
         let mut paths = Vec::with_capacity(dead.len());
         for group_id in dead {
             pinned.remove(&ConsumerGroupId(group_id as usize));
+            self.persisted_offsets
+                .borrow_mut()
+                .remove(&(ConsumerKind::ConsumerGroup, group_id as u32));
             if let Some(path) =
                 self.persisted_offset_path(ConsumerKind::ConsumerGroup, group_id as u32)
             {
@@ -713,10 +821,11 @@ where
         }
     }
 
-    /// Capture the owned inputs for an auto-commit, if requested. The committed
-    /// offset is unknown until the poll completes, so the persist path + fsync
-    /// flag (for the disk write) and the lock-free offset-map `Arc` (for the
-    /// in-memory apply) are captured here, so both run off the partition borrow.
+    /// Capture the owned inputs for an auto-commit, if requested: the lock-free
+    /// offset-map `Arc` and the target consumer/group id, so the in-memory apply
+    /// runs off the partition borrow once the poll's served offset is known.
+    /// Durability is not captured here: the poll no longer writes the offset
+    /// file, the serving shard replicates the offset through consensus instead.
     fn auto_commit_ctx(
         &self,
         consumer: PollingConsumer,
@@ -726,7 +835,6 @@ where
             return None;
         }
         let pending = PendingConsumerOffsetCommit::try_from_polling_consumer(consumer, 0).ok()?;
-        let offset_path = self.persisted_offset_path(pending.kind, pending.consumer_id);
         let target = match pending.kind {
             ConsumerKind::Consumer => AutoCommitTarget::Consumer {
                 offsets: self.consumer_offsets.clone(),
@@ -739,11 +847,7 @@ where
                 create_path: self.consumer_group_offsets_path.clone(),
             },
         };
-        Some(AutoCommitCtx {
-            offset_path,
-            enforce_fsync: self.consumer_offset_enforce_fsync,
-            target,
-        })
+        Some(AutoCommitCtx { target })
     }
 
     /// Synchronous in-memory journal poll, for the resident tier. Never awaits
@@ -1052,30 +1156,30 @@ where
                     .with_operation(message.header().operation)
                     .with_error(error.to_string()),
                 );
-                // Reply with a terminal error instead of dropping the request:
-                // the SDK decodes any non-`TransientNotCommitted` result code as a
-                // final error, so the client gets `ConsumerOffsetNotFound` at once
-                // rather than replaying until its read-timeout (a client hang).
-                // The op is NOT admitted/replicated, so no replica ever applies a
-                // delete for an offset the primary knows is absent.
-                let reply = build_result_rejection_reply(
+                // Deny on the primary before the op enters the pipeline: nothing
+                // replicates, so backups never see the rejected delete, and the
+                // client gets a typed failure instead of waiting out its reply
+                // timeout. The code rides `ReplyHeader.status` (not the result
+                // body): the HTTP listener's `classify_partition_reply` reads the
+                // status field to render the typed 404.
+                Self::send_partition_deny_or_log(
+                    consensus,
                     message.header(),
-                    self.consensus().commit_max(),
                     error.as_code(),
-                );
-                let _ = self
-                    .consensus()
-                    .message_bus()
-                    .send_to_client(client_id, reply.into_generic().into_frozen())
-                    .await;
+                    "delete_consumer_offset deny reply send failed",
+                )
+                .await;
                 return;
             }
 
-            // Reject an out-of-range consumer-offset store at admission with a
-            // terminal `InvalidOffset` (result-framed like the delete rejection),
-            // mirroring the legacy `validate_partition_offset`: an empty partition
-            // accepts no offset, and a stored offset may not run ahead of the
-            // committed offset. Done here so the doomed op is never replicated.
+            // Reject an out-of-range consumer-offset store at admission,
+            // mirroring the legacy `validate_partition_offset`: an empty
+            // partition accepts no offset, and a stored offset may not run ahead
+            // of the committed offset. Done here so the doomed op is never
+            // replicated. Like the delete-offset deny above, the typed
+            // `InvalidOffset` rides `ReplyHeader.status` (op=0, empty body): the
+            // status-only `classify_partition_reply` would misread a result-body
+            // code on this committed-shaped frame (op=commit_max) as success.
             if matches!(
                 message.header().operation,
                 Operation::StoreConsumerOffset | Operation::StoreConsumerOffset2
@@ -1094,16 +1198,13 @@ where
                         .with_operation(message.header().operation)
                         .with_error(IggyError::InvalidOffset(requested_offset).to_string()),
                     );
-                    let reply = build_result_rejection_reply(
+                    Self::send_partition_deny_or_log(
+                        consensus,
                         message.header(),
-                        self.consensus().commit_max(),
                         IggyError::InvalidOffset(requested_offset).as_code(),
-                    );
-                    let _ = self
-                        .consensus()
-                        .message_bus()
-                        .send_to_client(client_id, reply.into_generic().into_frozen())
-                        .await;
+                        "store_consumer_offset deny reply send failed",
+                    )
+                    .await;
                     return;
                 }
             }
@@ -1578,6 +1679,7 @@ where
                             kind,
                             consumer_id,
                             offset.expect("store_consumer_offset must include offset"),
+                            is_auto_commit_client(header.client),
                         );
                     }
                     Operation::DeleteConsumerOffset | Operation::DeleteConsumerOffset2 => {
@@ -1839,7 +1941,7 @@ where
         let committed_visible_offsets = self.resolve_committed_visible_offsets(&drained).await;
         let mut messages_committed = false;
 
-        for mut entry in drained {
+        for entry in drained {
             let prepare_header = entry.header;
             if !self
                 .commit_partition_entry(
@@ -1889,20 +1991,17 @@ where
             // No reply cache: at-least-once means retries re-commit at new
             // offsets. Only primary delivers replies; backups just advance
             // commit. Session lifecycle is metadata-only.
-            let reply = build_reply_message(
-                &prepare_header,
-                &committed_reply_body(prepare_header.operation),
-            );
-
-            // TODO: no production caller yet. Partition has no in-process
-            // subscriber (only metadata uses pipeline_message_with_subscriber);
-            // wired for forward-compat. Fired AFTER local commit (slot-first
-            // ordering analog). Dropped receiver ignored.
-            if let Some(sender) = entry.take_reply_sender() {
-                let _ = sender.send(reply.clone());
-            }
-
-            if send_client_replies {
+            //
+            // A server-generated auto-commit op (a poll's `auto_commit`,
+            // replicated for failover) carries the reserved
+            // `AUTO_COMMIT_CLIENT_ID`: no client ever waits on it, so skip the
+            // reply. Emitting it would push an unrequested frame onto a real
+            // client's lockstep reply stream if the sentinel ever routed there.
+            if send_client_replies && !is_auto_commit_client(prepare_header.client) {
+                let reply = build_reply_message(
+                    &prepare_header,
+                    &committed_reply_body(prepare_header.operation),
+                );
                 let reply_buffers = reply.into_generic().into_frozen();
                 emit_sim_event(SimEventKind::ClientReplyEmitted, &event);
 
@@ -2069,6 +2168,34 @@ where
             .get(std::mem::size_of::<RequestHeader>()..total_size)
             .ok_or(IggyError::InvalidCommand)?;
         Self::parse_consumer_offset_payload(operation, body)
+    }
+
+    /// Send `header`'s deny reply with `status` on `ReplyHeader.status` (empty
+    /// body, op=0), logging a WARN under `send_fail_label` if the reply send
+    /// fails. Callers deny on the primary, before the op enters the pipeline,
+    /// so nothing replicates.
+    async fn send_partition_deny_or_log(
+        consensus: &VsrConsensus<B>,
+        header: &RequestHeader,
+        status: u32,
+        send_fail_label: &'static str,
+    ) {
+        let reply = build_deny_reply_from_request(consensus, header, status);
+        if let Err(send_error) = consensus
+            .message_bus()
+            .send_to_client(header.client, reply.into_generic().into_frozen())
+            .await
+        {
+            emit_partition_diag(
+                tracing::Level::WARN,
+                &PartitionDiagEvent::new(
+                    ReplicaLogContext::from_consensus(consensus, PlaneKind::Partitions),
+                    send_fail_label,
+                )
+                .with_operation(header.operation)
+                .with_error(send_error.to_string()),
+            );
+        }
     }
 
     fn parse_staged_consumer_offset_commit(
@@ -2680,6 +2807,10 @@ where
         for path in consumer_paths.into_iter().chain(group_paths) {
             let _ = delete_persisted_offset(&path).await;
         }
+        // The persisted-offset tracker mirrors the files unlinked above; a
+        // stale entry would make a post-purge auto-commit skip its write and
+        // lose the offset on restart.
+        self.persisted_offsets.borrow_mut().clear();
 
         // Clear the ephemeral cooperative-rebalance tracking too: after the
         // reset to offset 0 a stale `last_polled` (a high pre-purge offset)
@@ -2712,6 +2843,28 @@ where
         // to that journal before `send_prepare_ok` fires, so every op
         // that reaches here is journal-backed and ACKs as durable.
         send_prepare_ok_common(self.consensus(), header, Some(true)).await;
+    }
+}
+
+/// Commit-apply an upserted offset into a lock-free offset map. A server
+/// auto-commit already advanced this offset in memory on the serving poll and
+/// this replicated commit can land behind a newer poll, so it must be
+/// monotone (`fetch_max`) or it rewinds the map and re-serves consumed
+/// messages. An explicit client store keeps the rewinding `store` (an offset
+/// reset is a valid action).
+fn upsert_committed_offset<K>(
+    map: &papaya::HashMap<K, ConsumerOffset>,
+    key: K,
+    offset: u64,
+    auto_commit: bool,
+    create_on_miss: impl FnOnce() -> ConsumerOffset,
+) where
+    K: Hash + Eq + Clone + Send + Sync,
+{
+    if auto_commit {
+        crate::poll_plan::upsert_offset_max(map, key, offset, create_on_miss);
+    } else {
+        crate::poll_plan::upsert_offset(map, key, offset, create_on_miss);
     }
 }
 
@@ -2840,9 +2993,14 @@ mod tests {
     use bytes::Bytes;
     use compio::io::AsyncWriteAtExt;
     use consensus::LocalPipeline;
+    use iggy_binary_protocol::{Command2, ReplyHeader, WireConsumer, WireEncode};
+    use message_bus::SendError;
+    use server_common::MESSAGE_ALIGN;
     use server_common::send_messages2::{
         COMMAND_HEADER_SIZE, IggyMessage2, IggyMessage2Header, IggyMessages2, SendMessages2Owned,
     };
+    use std::cell::RefCell;
+    use std::rc::Rc;
 
     const TEST_CLUSTER: u128 = 1;
 
@@ -2863,6 +3021,317 @@ mod tests {
             IggyByteSize::from(1024 * 1024),
             false,
         )
+    }
+
+    /// Client-facing bus that records every `send_to_client` frame so tests
+    /// can assert on reply bytes without a connection registry (whose slot
+    /// guard would borrow the partition across `on_request(&mut self)`).
+    #[derive(Debug, Default)]
+    struct RecordingBus {
+        sent_to_clients: Rc<RefCell<Vec<(u128, Frozen<MESSAGE_ALIGN>)>>>,
+    }
+
+    impl MessageBus for RecordingBus {
+        fn track_background(&self, _handle: message_bus::JoinHandle<()>) {}
+
+        async fn send_to_client(
+            &self,
+            client_id: u128,
+            data: Frozen<MESSAGE_ALIGN>,
+        ) -> Result<(), SendError> {
+            self.sent_to_clients.borrow_mut().push((client_id, data));
+            Ok(())
+        }
+
+        async fn send_to_replica(
+            &self,
+            _replica: u8,
+            _data: Frozen<MESSAGE_ALIGN>,
+        ) -> Result<(), SendError> {
+            Ok(())
+        }
+
+        fn set_connection_lost_fn(&self, _f: message_bus::ConnectionLostFn) {}
+        fn set_replica_forward_fn(&self, _f: message_bus::ReplicaForwardFn) {}
+        fn set_client_forward_fn(&self, _f: message_bus::ClientForwardFn) {}
+    }
+
+    type SentFrames = Rc<RefCell<Vec<(u128, Frozen<MESSAGE_ALIGN>)>>>;
+
+    fn recording_partition() -> (IggyPartition<RecordingBus>, SentFrames) {
+        let namespace = IggyNamespace::new(1, 1, 0);
+        let bus = RecordingBus::default();
+        let sent_to_clients = bus.sent_to_clients.clone();
+        let consensus = VsrConsensus::new(
+            TEST_CLUSTER,
+            0,
+            1,
+            namespace.inner(),
+            bus,
+            LocalPipeline::new(),
+        );
+        consensus.init();
+        let partition = IggyPartition::with_in_memory_storage(
+            Arc::new(PartitionStats::default()),
+            consensus,
+            IggyByteSize::from(1024 * 1024),
+            false,
+        );
+        (partition, sent_to_clients)
+    }
+
+    fn delete_offset_request(
+        client_id: u128,
+        request_id: u64,
+        consumer_id: u32,
+    ) -> Message<RequestHeader> {
+        let body = DeleteConsumerOffset2Request {
+            consumer: WireConsumer::consumer(WireIdentifier::Numeric(consumer_id)),
+            stream_id: WireIdentifier::Numeric(1),
+            topic_id: WireIdentifier::Numeric(1),
+            partition_id: Some(0),
+            ack: AckLevel::Quorum,
+        }
+        .to_bytes();
+        let header_size = std::mem::size_of::<RequestHeader>();
+        let total = header_size + body.len();
+        let mut message = Message::<RequestHeader>::new(total);
+        message.as_mut_slice()[header_size..].copy_from_slice(&body);
+        message.transmute_header(|_, header: &mut RequestHeader| {
+            header.command = Command2::Request;
+            header.operation = Operation::DeleteConsumerOffset2;
+            header.client = client_id;
+            header.session = 1;
+            header.request = request_id;
+            header.namespace = IggyNamespace::new(1, 1, 0).inner();
+            header.size = u32::try_from(total).expect("request size fits u32");
+        })
+    }
+
+    /// Deleting a consumer offset that was never stored must answer with a
+    /// typed deny reply (empty body, `status` = `ConsumerOffsetNotFound`,
+    /// `op` 0) before consensus: nothing may enter the pipeline, and an
+    /// awaited client write must fail fast instead of waiting out its reply
+    /// timeout. Once the offset exists, the same request must pass the gate
+    /// into the pipeline without a deny.
+    #[compio::test]
+    async fn on_request_delete_of_missing_offset_replies_typed_deny() {
+        let (mut partition, sent_to_clients) = recording_partition();
+        let client_id: u128 = 42;
+        let consumer_id: u32 = 5;
+
+        partition
+            .on_request(delete_offset_request(client_id, 7, consumer_id))
+            .await;
+
+        {
+            let sent = sent_to_clients.borrow();
+            assert_eq!(sent.len(), 1, "exactly one deny reply");
+            let (reply_client, frame) = &sent[0];
+            assert_eq!(*reply_client, client_id);
+            let header = bytemuck::checked::try_from_bytes::<ReplyHeader>(
+                &frame.as_slice()[..std::mem::size_of::<ReplyHeader>()],
+            )
+            .expect("deny frame starts with a valid reply header");
+            assert_eq!(header.command, Command2::Reply);
+            assert_eq!(
+                header.status,
+                IggyError::ConsumerOffsetNotFound(0).as_code()
+            );
+            assert_eq!(header.op, 0, "a deny commits nothing");
+            assert_eq!(header.request, 7);
+            assert_eq!(
+                header.size as usize,
+                std::mem::size_of::<ReplyHeader>(),
+                "deny reply body must be empty"
+            );
+        }
+        assert_eq!(
+            partition.consensus().pipeline().borrow().len(),
+            0,
+            "denied delete must not replicate"
+        );
+        assert!(partition.pending_consumer_offset_commits.is_empty());
+
+        // Existing offset: the gate passes and the delete enters the pipeline.
+        partition.consumer_offsets.pin().insert(
+            consumer_id as usize,
+            ConsumerOffset::new(ConsumerKind::Consumer, consumer_id, 3, String::new()),
+        );
+        partition
+            .on_request(delete_offset_request(client_id, 8, consumer_id))
+            .await;
+        assert_eq!(
+            partition.consensus().pipeline().borrow().len(),
+            1,
+            "existing offset delete must replicate"
+        );
+    }
+
+    fn unique_temp_offset_dir() -> String {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "iggy-offset-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after epoch")
+                .as_nanos(),
+        ));
+        dir.to_string_lossy().into_owned()
+    }
+
+    /// A server auto-commit persists monotonically. Disk-tier polls replicate
+    /// their offsets in IO-completion order, so the last committed op can carry
+    /// a lower offset than an earlier one; the file must keep the max or a
+    /// restart reloads the rewound value and re-delivers. An explicit client
+    /// store still overwrites, so a deliberate offset reset holds.
+    #[compio::test]
+    async fn auto_commit_offset_persists_monotonically_explicit_store_rewinds() {
+        let mut partition = test_partition();
+        let dir = unique_temp_offset_dir();
+        partition.consumer_offsets_path = Some(dir.clone());
+        let consumer_id: u32 = 5;
+        let path = format!("{dir}/{consumer_id}");
+        let read_disk = |p: &str| -> u64 {
+            let bytes = std::fs::read(p).expect("offset file exists");
+            u64::from_le_bytes(bytes.try_into().expect("offset file is 8 bytes"))
+        };
+
+        // Reordered auto-commits: the later op (109) trails the earlier (114).
+        partition
+            .persist_consumer_offset_commit(PendingConsumerOffsetCommit::upsert_auto_commit(
+                ConsumerKind::Consumer,
+                consumer_id,
+                114,
+            ))
+            .await
+            .expect("auto-commit persist 114");
+        partition
+            .persist_consumer_offset_commit(PendingConsumerOffsetCommit::upsert_auto_commit(
+                ConsumerKind::Consumer,
+                consumer_id,
+                109,
+            ))
+            .await
+            .expect("auto-commit persist 109");
+        assert_eq!(
+            read_disk(&path),
+            114,
+            "auto-commit must not rewind the file on IO-completion reorder"
+        );
+
+        assert!(
+            partition.is_auto_commit_offset_covered(ConsumerKind::Consumer, consumer_id, 114),
+            "committed high-water covers the persisted offset"
+        );
+        assert!(
+            !partition.is_auto_commit_offset_covered(ConsumerKind::Consumer, consumer_id, 115),
+            "an advancing offset is not covered and must submit"
+        );
+
+        // An explicit client store may deliberately rewind.
+        partition
+            .persist_consumer_offset_commit(PendingConsumerOffsetCommit::upsert(
+                ConsumerKind::Consumer,
+                consumer_id,
+                109,
+            ))
+            .await
+            .expect("explicit store persist 109");
+        assert_eq!(read_disk(&path), 109, "explicit store may rewind the file");
+        assert!(
+            !partition.is_auto_commit_offset_covered(ConsumerKind::Consumer, consumer_id, 114),
+            "explicit rewind lowers the high-water so a later auto-commit may re-advance"
+        );
+
+        // The accepted edge: an auto-commit racing the explicit rewind
+        // re-advances the file past it.
+        partition
+            .persist_consumer_offset_commit(PendingConsumerOffsetCommit::upsert_auto_commit(
+                ConsumerKind::Consumer,
+                consumer_id,
+                114,
+            ))
+            .await
+            .expect("auto-commit persist 114 after rewind");
+        assert_eq!(
+            read_disk(&path),
+            114,
+            "auto-commit re-advances past a rewind"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The persisted-offset tracker is cold after a restart; the first
+    /// auto-commit folds against the file once (so a pre-existing higher value
+    /// wins, exactly like the old per-commit read-modify-write) and warms the
+    /// tracker with the on-disk value, not the op's. A delete drops both the
+    /// file and the tracker entry so a later auto-commit starts a fresh fold.
+    #[compio::test]
+    async fn auto_commit_cold_key_folds_against_file_once() {
+        let mut partition = test_partition();
+        let dir = unique_temp_offset_dir();
+        partition.consumer_offsets_path = Some(dir.clone());
+        let consumer_id: u32 = 5;
+        let path = format!("{dir}/{consumer_id}");
+        let read_disk = |p: &str| -> u64 {
+            let bytes = std::fs::read(p).expect("offset file exists");
+            u64::from_le_bytes(bytes.try_into().expect("offset file is 8 bytes"))
+        };
+
+        // Simulate the previous process run: the file already holds 114.
+        persist_offset(&path, 114, false)
+            .await
+            .expect("seed offset file");
+        assert!(
+            !partition.is_auto_commit_offset_covered(ConsumerKind::Consumer, consumer_id, 1),
+            "a cold key is never covered; the first submit must go through"
+        );
+
+        partition
+            .persist_consumer_offset_commit(PendingConsumerOffsetCommit::upsert_auto_commit(
+                ConsumerKind::Consumer,
+                consumer_id,
+                109,
+            ))
+            .await
+            .expect("auto-commit persist 109 on cold key");
+        assert_eq!(
+            read_disk(&path),
+            114,
+            "cold-key fold must not rewind the pre-existing on-disk value"
+        );
+        assert!(
+            partition.is_auto_commit_offset_covered(ConsumerKind::Consumer, consumer_id, 114),
+            "tracker warms with the on-disk value, not the trailing op offset"
+        );
+
+        partition
+            .persist_consumer_offset_commit(PendingConsumerOffsetCommit::delete(
+                ConsumerKind::Consumer,
+                consumer_id,
+            ))
+            .await
+            .expect("delete persisted offset");
+        assert!(!std::path::Path::new(&path).exists(), "file unlinked");
+        assert!(
+            !partition.is_auto_commit_offset_covered(ConsumerKind::Consumer, consumer_id, 1),
+            "delete drops the tracker entry with the file"
+        );
+
+        partition
+            .persist_consumer_offset_commit(PendingConsumerOffsetCommit::upsert_auto_commit(
+                ConsumerKind::Consumer,
+                consumer_id,
+                7,
+            ))
+            .await
+            .expect("auto-commit persist 7 after delete");
+        assert_eq!(read_disk(&path), 7, "post-delete auto-commit starts fresh");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// `reclaim_dead_group_offsets` must drop exactly the not-`is_live` groups

--- a/core/partitions/src/lib.rs
+++ b/core/partitions/src/lib.rs
@@ -39,7 +39,7 @@ pub use iggy_partition::IggyPartition;
 pub use iggy_partitions::IggyPartitions;
 pub use messages_writer::MessagesWriter;
 pub use offset_storage::delete_persisted_offset;
-pub use poll_plan::PollPlan;
+pub use poll_plan::{AutoCommitApplied, PollPlan};
 pub use segment::Segment;
 use server_common::Message;
 pub use server_common::send_messages2::{IggyMessage2, IggyMessage2Header, IggyMessages2};

--- a/core/partitions/src/offset_storage.rs
+++ b/core/partitions/src/offset_storage.rs
@@ -17,10 +17,12 @@
 
 use compio::{
     fs::{OpenOptions, create_dir_all, remove_file},
-    io::AsyncWriteAtExt,
+    io::{AsyncReadAtExt, AsyncWriteAtExt},
 };
 use iggy_common::IggyError;
 use std::path::Path;
+
+const OFFSET_SIZE: usize = core::mem::size_of::<u64>();
 
 pub async fn persist_offset(path: &str, offset: u64, enforce_fsync: bool) -> Result<(), IggyError> {
     if let Some(parent) = Path::new(path).parent()
@@ -53,6 +55,60 @@ pub async fn persist_offset(path: &str, offset: u64, enforce_fsync: bool) -> Res
     Ok(())
 }
 
+/// Monotone counterpart of [`persist_offset`] for a server auto-commit op:
+/// folds `max(current_on_disk, offset)` and returns the value now on disk,
+/// skipping the write when the file already holds it. Disk-tier polls
+/// replicate their auto-committed offsets in IO-completion order, so a
+/// committed op can carry a lower offset than an earlier one; a plain
+/// overwrite would leave the file rewound and a restart would reload the
+/// stale value and re-deliver. The on-disk value is committed-only (this path
+/// never writes the eager serving map), so the fold is identical on every
+/// replica applying the same op order.
+///
+/// The read makes this the cold-key path only: once the caller's
+/// persisted-offset tracker knows the file's value, warm commits persist with
+/// a blind [`persist_offset`] and skip covered offsets without any file read.
+pub async fn persist_offset_max(
+    path: &str,
+    offset: u64,
+    enforce_fsync: bool,
+) -> Result<u64, IggyError> {
+    let on_disk = read_persisted_offset(path).await?;
+    let effective = on_disk.map_or(offset, |current| current.max(offset));
+    if on_disk != Some(effective) {
+        persist_offset(path, effective, enforce_fsync).await?;
+    }
+    Ok(effective)
+}
+
+/// Read a single persisted consumer offset. `None` if the file is absent or
+/// torn (shorter than 8 bytes): a crash between `persist_offset`'s truncate
+/// and write leaves a short file, and the boot-time loader already skips such
+/// files, so the commit-path reader must agree or a torn file turns every
+/// later commit-apply into an error. Real I/O errors still propagate: mapping
+/// them to `None` would silently rewind a valid higher offset.
+async fn read_persisted_offset(path: &str) -> Result<Option<u64>, IggyError> {
+    if !Path::new(path).exists() {
+        return Ok(None);
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .open(path)
+        .await
+        .map_err(|_| IggyError::CannotOpenConsumerOffsetsFile(path.to_owned()))?;
+    let buf = vec![0u8; OFFSET_SIZE];
+    let compio::BufResult(read, buf) = file.read_exact_at(buf, 0).await;
+    match read {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(_) => return Err(IggyError::CannotReadConsumerOffsets(path.to_owned())),
+    }
+    let bytes: [u8; OFFSET_SIZE] = buf
+        .try_into()
+        .map_err(|_| IggyError::CannotReadConsumerOffsets(path.to_owned()))?;
+    Ok(Some(u64::from_le_bytes(bytes)))
+}
+
 /// Unlink a persisted consumer-offset file. A no-op if the file is absent.
 ///
 /// # Errors
@@ -65,4 +121,91 @@ pub async fn delete_persisted_offset(path: &str) -> Result<(), IggyError> {
     remove_file(path)
         .await
         .map_err(|_| IggyError::CannotDeleteConsumerOffsetFile(path.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_temp_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "iggy-offset-storage-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after epoch")
+                .as_nanos(),
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[compio::test]
+    async fn read_persisted_offset_absent_file_is_none() {
+        let dir = unique_temp_dir();
+        let path = dir.join("42").to_string_lossy().into_owned();
+
+        let read = read_persisted_offset(&path).await.expect("absent file");
+        assert_eq!(read, None);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[compio::test]
+    async fn read_persisted_offset_round_trips_persisted_value() {
+        let dir = unique_temp_dir();
+        let path = dir.join("42").to_string_lossy().into_owned();
+
+        persist_offset(&path, 114, false).await.expect("persist");
+        let read = read_persisted_offset(&path).await.expect("valid file");
+        assert_eq!(read, Some(114));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[compio::test]
+    async fn read_persisted_offset_torn_file_is_none_not_error() {
+        let dir = unique_temp_dir();
+        let path = dir.join("42").to_string_lossy().into_owned();
+        std::fs::write(&path, [0xAB, 0xCD, 0xEF]).expect("write torn file");
+
+        let read = read_persisted_offset(&path)
+            .await
+            .expect("torn file must not error the commit path");
+        assert_eq!(read, None, "short read maps to None like the boot loader");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[compio::test]
+    async fn read_persisted_offset_real_io_error_propagates() {
+        // A directory opens read-only but every read fails with EISDIR: a real
+        // I/O error, not a short read. It must surface as Err, never as None
+        // (a blanket None would silently rewind a valid higher offset).
+        let dir = unique_temp_dir();
+        let path = dir.to_string_lossy().into_owned();
+
+        let result = read_persisted_offset(&path).await;
+        assert!(
+            matches!(result, Err(IggyError::CannotReadConsumerOffsets(_))),
+            "real I/O error must propagate, got {result:?}",
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[compio::test]
+    async fn persist_offset_max_recovers_torn_file() {
+        let dir = unique_temp_dir();
+        let path = dir.join("42").to_string_lossy().into_owned();
+        std::fs::write(&path, [0xABu8; 5]).expect("write torn file");
+
+        persist_offset_max(&path, 7, false)
+            .await
+            .expect("torn file folds as absent");
+        let read = read_persisted_offset(&path).await.expect("repaired file");
+        assert_eq!(read, Some(7));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/core/partitions/src/poll_plan.rs
+++ b/core/partitions/src/poll_plan.rs
@@ -22,18 +22,17 @@
 //! `&mut` to the same namespace while a poll is parked, dangling the reference.
 //! So `IggyPartition::build_poll_plan` captures everything a poll needs
 //! synchronously under the borrow into the owned types here, drops the borrow,
-//! then [`PollPlan::execute`] runs the disk read + offset persist on owned data
-//! alone: consumer offsets are already `Arc`, the journal tail is a
-//! point-in-time `Frozen` snapshot, and segment files are re-opened by path. No
-//! value in this module holds a partition reference, so executing a plan is
-//! sound on a detached task concurrently with the pump's own writes.
+//! then [`PollPlan::execute`] runs the disk read + the in-memory auto-commit
+//! apply on owned data alone: consumer offsets are already `Arc`, the journal
+//! tail is a point-in-time `Frozen` snapshot, and segment files are re-opened
+//! by path. No value in this module holds a partition reference, so executing a
+//! plan is sound on a detached task concurrently with the pump's own writes.
 
 use crate::PollFragments;
 use crate::journal::{MessageLookup, push_selected_batch_fragments, select_batch_slice};
-use crate::offset_storage::persist_offset;
 use compio::io::AsyncReadAtExt;
 use iggy_common::{
-    ConsumerGroupId, ConsumerGroupOffsets, ConsumerKind, ConsumerOffset, ConsumerOffsets, IggyError,
+    ConsumerGroupId, ConsumerGroupOffsets, ConsumerKind, ConsumerOffset, ConsumerOffsets,
 };
 use server_common::iobuf::{Frozen, Owned};
 use server_common::send_messages2::{COMMAND_HEADER_SIZE, decode_batch_slice};
@@ -60,13 +59,25 @@ pub struct DiskSegment {
     pub(crate) persisted: u64,
 }
 
-/// Owned auto-commit inputs, applied off the partition borrow after a poll (see
-/// module docs). The committed offset is unknown until the poll completes, so
-/// the persist path + fsync flag are captured up front for the later disk write.
+/// Owned auto-commit input, applied off the partition borrow after a poll (see
+/// module docs). Only the in-memory apply happens here; durability is the
+/// replicated [`crate::iggy_partition::IggyPartition::apply_staged_consumer_offset_commit`]
+/// path's job on every node, driven by the `StoreConsumerOffset2` op the serving
+/// shard submits from [`AutoCommitApplied`]. A poll-local disk write would be
+/// node-local only and diverge on failover.
 pub struct AutoCommitCtx {
-    pub(crate) offset_path: Option<String>,
-    pub(crate) enforce_fsync: bool,
     pub(crate) target: AutoCommitTarget,
+}
+
+/// The offset an `auto_commit` poll applied in memory, surfaced for replication.
+///
+/// The serving shard replicates it through the partition consensus (the only
+/// cross-node durable path); `kind` + `consumer_id` are the offset key the
+/// submitted `StoreConsumerOffset2` op must carry.
+pub struct AutoCommitApplied {
+    pub kind: ConsumerKind,
+    pub consumer_id: u32,
+    pub offset: u64,
 }
 
 /// The lock-free offset map this auto-commit updates, captured as an owned
@@ -158,30 +169,27 @@ pub struct PollPlan {
 }
 
 impl PollPlan {
-    /// Whether executing this plan needs off-pump IO: a disk read (`Disk` tier)
-    /// or a consumer-offset persist (`auto_commit`). When `false`, the result is
-    /// fully resident and the caller can [`Self::execute_resident`] + reply on
-    /// the pump without spawning; when `true`, it must spawn [`Self::execute`]
-    /// so the pump is not blocked on file IO.
+    /// Whether executing this plan needs off-pump IO: only a `Disk` tier read.
+    /// When `false` the result is fully resident and the caller runs
+    /// [`Self::execute_resident`] + replies on the pump; when `true` it must
+    /// spawn [`Self::execute`] so the pump is not blocked on file IO.
+    ///
+    /// Auto-commit no longer forces a detached task: its in-memory apply is
+    /// synchronous and its durability rides consensus off the serving shard
+    /// (no poll-local disk write), so a fully-resident `auto_commit` poll still
+    /// replies inline.
     #[must_use]
     pub const fn needs_off_pump_io(&self) -> bool {
-        if matches!(self.tier, PollTier::Disk { .. }) {
-            return true;
-        }
-        // A resident poll only needs a detached task when its auto-commit must
-        // hit disk. With no `offset_path` (sim/dev) the apply is a sync,
-        // in-memory store the pump runs inline via `execute_resident`.
-        match &self.auto_commit {
-            Some(auto_commit) => auto_commit.needs_persist(),
-            None => false,
-        }
+        matches!(self.tier, PollTier::Disk { .. })
     }
 
     /// Execute this plan off the partition borrow: disk read (if any), straddle
-    /// splice into the owned resident-tail snapshot, then persist + apply the
-    /// auto-commit on the owned `Arc` offset map. Holds no partition reference
-    /// (see module docs), so it is safe on a detached task.
-    pub async fn execute(self) -> (PollFragments<4096>, u64) {
+    /// splice into the owned resident-tail snapshot, then apply the auto-commit
+    /// to the owned `Arc` offset map. Holds no partition reference (see module
+    /// docs), so it is safe on a detached task. Returns the served fragments,
+    /// the poll's high-water offset, and the auto-committed offset (if any) for
+    /// the serving shard to replicate through consensus.
+    pub async fn execute(self) -> (PollFragments<4096>, u64, Option<AutoCommitApplied>) {
         let commit_offset = self.commit_offset;
         let (fragments, last_matching_offset) = match self.tier {
             PollTier::Empty => (PollFragments::new(), None),
@@ -240,34 +248,21 @@ impl PollPlan {
             },
         };
 
-        if let (Some(last_polled), Some(last_offset)) = (&self.last_polled, last_matching_offset) {
-            last_polled.record(last_offset);
-        }
-
-        if let Some(auto_commit) = self.auto_commit
-            && !fragments.is_empty()
-            && let Some(last_offset) = last_matching_offset
-        {
-            match auto_commit.persist(last_offset).await {
-                // Apply to the in-memory map on the owned `Arc` (no borrow).
-                Ok(()) => auto_commit.apply(last_offset),
-                Err(err) => warn!(
-                    target: "iggy.partitions.diag",
-                    last_offset,
-                    %err,
-                    "poll_read: failed to persist consumer offset"
-                ),
-            }
-        }
-
-        (fragments, commit_offset)
+        finish(
+            self.last_polled.as_ref(),
+            self.auto_commit,
+            commit_offset,
+            fragments,
+            last_matching_offset,
+        )
     }
 
     /// Synchronous fast path for a fully-resident poll
-    /// ([`Self::needs_off_pump_io`] is `false`): no disk read, no
-    /// consumer-offset persist, so the pump can reply inline without spawning.
+    /// ([`Self::needs_off_pump_io`] is `false`): no disk read, so the pump
+    /// applies the auto-commit in memory and replies inline without spawning.
+    /// The auto-committed offset is returned for the serving shard to replicate.
     #[must_use]
-    pub fn execute_resident(self) -> (PollFragments<4096>, u64) {
+    pub fn execute_resident(self) -> (PollFragments<4096>, u64, Option<AutoCommitApplied>) {
         let commit_offset = self.commit_offset;
         let (fragments, last_matching_offset) = match self.tier {
             PollTier::Empty => (PollFragments::new(), None),
@@ -281,21 +276,59 @@ impl PollPlan {
                 unreachable!("execute_resident on Disk tier; needs_off_pump_io guards this")
             }
         };
-        if let (Some(last_polled), Some(last_offset)) = (&self.last_polled, last_matching_offset) {
-            last_polled.record(last_offset);
-        }
-        // An auto-commit reaches the resident fast path only when it needs no
-        // disk persist (`needs_off_pump_io` gate), so apply the offset to the
-        // in-memory map inline. `execute()` does the same after its persist;
-        // skipping it here would silently drop the committed offset.
-        if let Some(auto_commit) = self.auto_commit
-            && !fragments.is_empty()
-            && let Some(last_offset) = last_matching_offset
-        {
-            auto_commit.apply(last_offset);
-        }
-        (fragments, commit_offset)
+        finish(
+            self.last_polled.as_ref(),
+            self.auto_commit,
+            commit_offset,
+            fragments,
+            last_matching_offset,
+        )
     }
+}
+
+/// Common tail of [`PollPlan::execute`] and [`PollPlan::execute_resident`],
+/// factored out so the high-water record, auto-commit, and returned triple
+/// stay identical across both.
+fn finish(
+    last_polled: Option<&LastPolledCtx>,
+    auto_commit: Option<AutoCommitCtx>,
+    commit_offset: u64,
+    fragments: PollFragments<4096>,
+    last_matching_offset: Option<u64>,
+) -> (PollFragments<4096>, u64, Option<AutoCommitApplied>) {
+    if let (Some(last_polled), Some(last_offset)) = (last_polled, last_matching_offset) {
+        last_polled.record(last_offset);
+    }
+    let auto_commit_applied = apply_auto_commit(auto_commit, &fragments, last_matching_offset);
+    (fragments, commit_offset, auto_commit_applied)
+}
+
+/// Apply an `auto_commit` to the in-memory offset map (monotone) and surface
+/// the committed offset so the serving shard can replicate it through
+/// consensus. `None` when the poll served nothing (empty fragments) or no
+/// auto-commit was requested. Shared by [`PollPlan::execute`] and
+/// [`PollPlan::execute_resident`] so both apply identically.
+///
+/// The eager in-memory apply preserves read-your-own-poll for a tight
+/// `Consumer::Next` loop that reads before the replicated commit lands; the
+/// commit's apply is an idempotent monotone set, so the double-apply converges.
+fn apply_auto_commit(
+    auto_commit: Option<AutoCommitCtx>,
+    fragments: &PollFragments<4096>,
+    last_matching_offset: Option<u64>,
+) -> Option<AutoCommitApplied> {
+    let auto_commit = auto_commit?;
+    if fragments.is_empty() {
+        return None;
+    }
+    let last_offset = last_matching_offset?;
+    auto_commit.apply(last_offset);
+    let (kind, consumer_id) = auto_commit.kind_and_id();
+    Some(AutoCommitApplied {
+        kind,
+        consumer_id,
+        offset: last_offset,
+    })
 }
 
 pub enum PollTier {
@@ -512,18 +545,16 @@ impl DiskReadPlan {
 }
 
 impl AutoCommitCtx {
-    /// Whether applying this auto-commit needs a real disk persist. `false` for
-    /// sim/dev partitions with no `offset_path`, where the apply is a sync,
-    /// in-memory `papaya` store that the pump can run inline.
-    pub(crate) const fn needs_persist(&self) -> bool {
-        self.offset_path.is_some()
-    }
-
-    /// Persist the committed offset to disk, off the partition borrow.
-    pub(crate) async fn persist(&self, offset: u64) -> Result<(), IggyError> {
-        match &self.offset_path {
-            Some(path) => persist_offset(path, offset, self.enforce_fsync).await,
-            None => Ok(()),
+    /// The offset key (kind + numeric id) this auto-commit targets, for the
+    /// replicated `StoreConsumerOffset2` op the serving shard submits.
+    pub(crate) const fn kind_and_id(&self) -> (ConsumerKind, u32) {
+        match &self.target {
+            AutoCommitTarget::Consumer { consumer_id, .. } => {
+                (ConsumerKind::Consumer, *consumer_id)
+            }
+            AutoCommitTarget::ConsumerGroup { group_id, .. } => {
+                (ConsumerKind::ConsumerGroup, *group_id)
+            }
         }
     }
 
@@ -610,7 +641,12 @@ pub fn upsert_offset<K>(
 /// newer explicit `StoreConsumerOffset` cannot rewind it backward. The
 /// on-miss create branch is identical. The explicit pump path keeps
 /// [`upsert_offset`] (`store`), since an explicit store may legitimately rewind.
-fn upsert_offset_max<K>(
+///
+/// Also used by the replicated commit-apply for a server auto-commit op
+/// ([`crate::iggy_partition::IggyPartition::apply_consumer_offset_commit`]): its
+/// offset was already advanced in memory by the eager poll-path apply, and this
+/// commit can land behind a newer poll, so it must not `store` (rewind) it.
+pub fn upsert_offset_max<K>(
     map: &papaya::HashMap<K, ConsumerOffset>,
     key: K,
     offset: u64,
@@ -684,14 +720,8 @@ mod tests {
         fragments
     }
 
-    fn consumer_auto_commit(
-        offsets: Arc<ConsumerOffsets>,
-        consumer_id: u32,
-        offset_path: Option<String>,
-    ) -> AutoCommitCtx {
+    fn consumer_auto_commit(offsets: Arc<ConsumerOffsets>, consumer_id: u32) -> AutoCommitCtx {
         AutoCommitCtx {
-            offset_path,
-            enforce_fsync: false,
             target: AutoCommitTarget::Consumer {
                 offsets,
                 consumer_id,
@@ -701,15 +731,15 @@ mod tests {
     }
 
     #[test]
-    fn resident_auto_commit_without_offset_path_applies_inline() {
-        // sim/dev partition: auto_commit is requested but there is no
-        // `offset_path`, so the apply is a sync in-memory store. The plan must
-        // stay on the resident fast path (no detached task) AND still record
-        // the committed offset, which the resident path used to drop.
+    fn resident_auto_commit_applies_in_memory_and_surfaces_offset() {
+        // A resident auto_commit poll stays on the inline fast path (no detached
+        // task since the poll no longer persists), applies the committed offset
+        // to the in-memory map for read-your-own-poll, AND surfaces it so the
+        // serving shard replicates it through consensus.
         let offsets = Arc::new(ConsumerOffsets::with_capacity(1));
         let plan = PollPlan {
             commit_offset: 42,
-            auto_commit: Some(consumer_auto_commit(offsets.clone(), 7, None)),
+            auto_commit: Some(consumer_auto_commit(offsets.clone(), 7)),
             last_polled: None,
             tier: PollTier::Resident {
                 fragments: non_empty_fragments(),
@@ -719,12 +749,17 @@ mod tests {
 
         assert!(
             !plan.needs_off_pump_io(),
-            "no offset_path means the apply is sync; the pump must not spawn",
+            "a resident auto_commit no longer persists on the poll path; the pump must not spawn",
         );
 
-        let (fragments, commit_offset) = plan.execute_resident();
+        let (fragments, commit_offset, applied) = plan.execute_resident();
         assert!(!fragments.is_empty(), "resident fragments must be returned");
         assert_eq!(commit_offset, 42, "commit offset is forwarded verbatim");
+
+        let applied = applied.expect("auto_commit must surface the applied offset for replication");
+        assert!(matches!(applied.kind, ConsumerKind::Consumer));
+        assert_eq!(applied.consumer_id, 7);
+        assert_eq!(applied.offset, 5);
 
         let stored = offsets
             .pin()
@@ -738,24 +773,25 @@ mod tests {
     }
 
     #[test]
-    fn resident_auto_commit_with_offset_path_needs_off_pump_io() {
+    fn empty_resident_poll_surfaces_no_auto_commit() {
+        // Nothing served -> nothing to commit: no offset is surfaced and the
+        // in-memory map stays untouched.
         let offsets = Arc::new(ConsumerOffsets::with_capacity(1));
         let plan = PollPlan {
-            commit_offset: 0,
-            auto_commit: Some(consumer_auto_commit(
-                offsets,
-                7,
-                Some("some/path".to_owned()),
-            )),
+            commit_offset: 9,
+            auto_commit: Some(consumer_auto_commit(offsets.clone(), 7)),
             last_polled: None,
-            tier: PollTier::Resident {
-                fragments: non_empty_fragments(),
-                last_matching_offset: Some(5),
-            },
+            tier: PollTier::Empty,
         };
+        let (fragments, _commit_offset, applied) = plan.execute_resident();
+        assert!(fragments.is_empty());
         assert!(
-            plan.needs_off_pump_io(),
-            "a real offset_path persist must be spawned off the pump",
+            applied.is_none(),
+            "empty poll must not surface an auto-commit"
+        );
+        assert!(
+            offsets.pin().get(&7usize).is_none(),
+            "an empty poll must not touch the offset map",
         );
     }
 
@@ -764,7 +800,7 @@ mod tests {
         // Auto-commit must never rewind a newer offset (anti-rewind via
         // fetch_max); an explicit StoreConsumerOffset may legitimately rewind.
         let offsets = Arc::new(ConsumerOffsets::with_capacity(1));
-        let auto_commit = consumer_auto_commit(offsets.clone(), 7, None);
+        let auto_commit = consumer_auto_commit(offsets.clone(), 7);
 
         auto_commit.apply(10);
         let after_high = offsets

--- a/core/sdk/src/session.rs
+++ b/core/sdk/src/session.rs
@@ -30,15 +30,17 @@
 //!
 //! ```text
 //! new()                  - fresh client_id generated, session = None
-//! register_request_id()  - returns 0 (for the register operation, once only)
+//! begin_register()       - returns 0; re-arms a used session for a re-login
 //! bind(session)          - session assigned by server after register commits
 //! next_request_id()      - returns 1, 2, 3, ... (application requests)
 //! drop + new()           - on disconnect/crash, create a fresh session
 //! ```
 //!
-//! `ConsensusSession` is **not reusable**: on disconnect/crash drop and
-//! recreate. New `client_id` avoids ambiguous re-register; old entry
-//! stays in server `ClientTable` until evicted.
+//! A single registration is one-shot ([`ConsensusSession::register_request_id`]
+//! panics if reused), but a re-login re-arms the same value in place via
+//! [`ConsensusSession::begin_register`], which mints a fresh `client_id` and
+//! clears the binding. A new `client_id` avoids ambiguous re-register; the old
+//! entry stays in the server `ClientTable` until evicted.
 
 /// Consensus-level session state.
 ///
@@ -127,6 +129,21 @@ impl ConsensusSession {
         0
     }
 
+    /// Begin a registration, re-arming the session if it was already used.
+    ///
+    /// A re-login (fresh credentials, reconnect, or restart replay) reuses the
+    /// same `ConsensusSession`. If it is already bound or a prior register was
+    /// consumed, start a fresh session (new `client_id`, unbound) so the
+    /// Register encodes cleanly. Unlike the one-shot
+    /// [`register_request_id`](Self::register_request_id), this never panics on
+    /// a repeat login. Returns the register request id (always 0).
+    pub fn begin_register(&mut self) -> u64 {
+        if self.register_consumed || self.is_bound() {
+            *self = Self::new();
+        }
+        self.register_request_id()
+    }
+
     /// Get the next application request ID and advance the counter.
     ///
     /// Returns 1, 2, 3, ... (request 0 is reserved for register).
@@ -213,6 +230,35 @@ mod tests {
         let mut session = ConsensusSession::with_client_id(1);
         let _ = session.register_request_id();
         let _ = session.register_request_id();
+    }
+
+    #[test]
+    fn begin_register_on_fresh_session_keeps_client_id() {
+        let mut session = ConsensusSession::with_client_id(7);
+        assert_eq!(session.begin_register(), 0);
+        // The first registration keeps the session's client id; only a re-login
+        // re-arms with a fresh one.
+        assert_eq!(session.client_id(), 7);
+        assert!(!session.is_bound());
+    }
+
+    #[test]
+    fn begin_register_re_arms_after_consume_without_bind() {
+        // A prior register that never bound (failed login / dropped connection
+        // before the retry) must not panic the next login.
+        let mut session = ConsensusSession::with_client_id(1);
+        let _ = session.begin_register();
+        assert_eq!(session.begin_register(), 0);
+        assert!(!session.is_bound());
+    }
+
+    #[test]
+    fn begin_register_re_arms_after_bind() {
+        let mut session = ConsensusSession::with_client_id(1);
+        let _ = session.begin_register();
+        session.bind(42);
+        assert_eq!(session.begin_register(), 0);
+        assert!(!session.is_bound());
     }
 
     #[test]

--- a/core/sdk/src/vsr.rs
+++ b/core/sdk/src/vsr.rs
@@ -37,9 +37,8 @@ use iggy_binary_protocol::requests::consumer_offsets::{
 };
 use iggy_binary_protocol::requests::messages::SendMessagesHeader;
 use iggy_binary_protocol::requests::segments::DeleteSegmentsRequest;
-use iggy_binary_protocol::version::IGGY_PROTOCOL_VERSION;
 use iggy_binary_protocol::{WireIdentifier, WirePartitioning};
-use iggy_common::IggyError;
+use iggy_common::{IggyError, eviction_reason_to_error};
 
 const NON_REPLICATED_CODE_RANGE: std::ops::Range<usize> = 0..4;
 
@@ -72,7 +71,12 @@ pub(crate) fn encode_request_header(
 ) -> Result<(RequestHeader, usize), IggyError> {
     let (operation, request_id, session_id) = match code {
         LOGIN_REGISTER_CODE | LOGIN_REGISTER_WITH_PAT_CODE => {
-            (Operation::Register, session.register_request_id(), 0)
+            // A re-login reuses this `ConsensusSession`; `begin_register`
+            // re-arms it (fresh session) so the Register encodes cleanly instead
+            // of tripping the one-shot register guard. Safe under the transport
+            // stream lock: it is lockstep (one request in flight), so no
+            // in-flight request observes the reset.
+            (Operation::Register, session.begin_register(), 0)
         }
         _ => {
             let operation = operation_for_code(code)?;
@@ -114,7 +118,7 @@ pub(crate) fn encode_request_header(
         .checked_add(payload.len())
         .ok_or(IggyError::InvalidConfiguration)?;
     let size = u32::try_from(total_size).map_err(|_| IggyError::InvalidConfiguration)?;
-    let mut reserved = [0; 56];
+    let mut reserved = [0; 52];
     if operation == Operation::NonReplicated {
         reserved[NON_REPLICATED_CODE_RANGE].copy_from_slice(&code.to_le_bytes());
     }
@@ -179,6 +183,9 @@ pub(crate) fn decode_response(response: Bytes) -> Result<Bytes, IggyError> {
             if response.len() < total_size {
                 return Err(IggyError::InvalidCommand);
             }
+            if let Some(error) = read_reply_status(header_bytes) {
+                return Err(error);
+            }
             let operation = read_operation(header_bytes)?;
             split_metadata_result(operation, response.slice(HEADER_SIZE..total_size))
         }
@@ -206,11 +213,32 @@ pub(crate) fn decode_response_split(
             if body.len() < expected_body {
                 return Err(IggyError::InvalidCommand);
             }
+            if let Some(error) = read_reply_status(header_bytes) {
+                return Err(error);
+            }
             let operation = read_operation(header_bytes)?;
             split_metadata_result(operation, body.slice(..expected_body))
         }
         _ => Err(IggyError::InvalidCommand),
     }
+}
+
+/// Peek `ReplyHeader.status`, the pre-commit deny channel shared by every deny
+/// frame: dispatch-time denies (authorization and a malformed user-password
+/// body) via `build_deny_reply`, and partition-primary admission rejects via
+/// `consensus::build_deny_reply_from_request`. Read before any body decode:
+/// a nonzero status maps to its [`IggyError`] and fails the request, an empty
+/// or partial body notwithstanding. `None` (status 0) lets the reply flow to
+/// the body/result-section decode. Read by wire offset for the same
+/// misalignment reason as [`read_operation`]; a committed metadata reply stamps
+/// 0 here and carries its business rejection in the result section (see
+/// `split_metadata_result`).
+fn read_reply_status(header_bytes: &[u8; HEADER_SIZE]) -> Option<IggyError> {
+    const STATUS_OFFSET: usize = std::mem::offset_of!(ReplyHeader, status);
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&header_bytes[STATUS_OFFSET..STATUS_OFFSET + 4]);
+    let status = u32::from_le_bytes(bytes);
+    (status != 0).then(|| IggyError::from_code(status))
 }
 
 /// Read the [`Operation`] discriminant from a reply header by wire offset.
@@ -295,26 +323,11 @@ fn decode_eviction(header_bytes: &[u8; HEADER_SIZE]) -> IggyError {
     ) else {
         return IggyError::Unauthenticated;
     };
-    match reason {
-        EvictionReason::InvalidCredentials => IggyError::InvalidCredentials,
-        EvictionReason::InvalidToken => IggyError::InvalidPersonalAccessToken,
-        EvictionReason::UserInactive
-        | EvictionReason::SessionError
-        | EvictionReason::NoSession
-        | EvictionReason::SessionTooLow
-        | EvictionReason::SessionReleaseMismatch => IggyError::Unauthenticated,
-        EvictionReason::StaleClient => IggyError::StaleClient,
-        EvictionReason::IncompatibleProtocol => {
-            let server_max = read_window_field(header_bytes, VERSION_OFFSET);
-            let server_min = read_window_field(header_bytes, VERSION_MIN_OFFSET);
-            if server_min == 0 || server_max < server_min {
-                return IggyError::Unauthenticated;
-            }
-            IggyError::IncompatibleProtocolVersion(IGGY_PROTOCOL_VERSION, server_min, server_max)
-        }
-        EvictionReason::MalformedLogin => IggyError::InvalidFormat,
-        _ => IggyError::InvalidCommand,
-    }
+    eviction_reason_to_error(
+        reason,
+        read_window_field(header_bytes, VERSION_OFFSET),
+        read_window_field(header_bytes, VERSION_MIN_OFFSET),
+    )
 }
 
 fn read_window_field(header_bytes: &[u8; HEADER_SIZE], offset: usize) -> u32 {
@@ -450,6 +463,7 @@ mod tests {
     use iggy_binary_protocol::requests::messages::SendMessagesHeader;
     use iggy_binary_protocol::requests::streams::CreateStreamRequest;
     use iggy_binary_protocol::requests::users::LoginRegisterRequest;
+    use iggy_binary_protocol::version::IGGY_PROTOCOL_VERSION;
     use iggy_binary_protocol::{ClientVersionInfo, WireEncode, WireName};
     use secrecy::SecretString;
 
@@ -483,6 +497,35 @@ mod tests {
         // Register is routed to the metadata replica (shard 0). The router's
         // namespace==METADATA short-circuit needs the sentinel, not 0.
         assert_eq!(header.namespace, METADATA_CONSENSUS_NAMESPACE);
+    }
+
+    #[test]
+    fn second_register_on_bound_session_re_arms_instead_of_panicking() {
+        let request = LoginRegisterRequest {
+            version_info: ClientVersionInfo {
+                protocol_version: IGGY_PROTOCOL_VERSION,
+                sdk_name: WireName::new("rust-sdk").unwrap(),
+                sdk_version: WireName::new("1.0.0").unwrap(),
+            },
+            username: WireName::new("admin").unwrap(),
+            password: SecretString::from("secret"),
+            client_context: None,
+        };
+
+        let mut session = ConsensusSession::with_client_id(7);
+        encode_contiguous_request(&mut session, LOGIN_REGISTER_CODE, &request.to_bytes()).unwrap();
+        session.bind(42);
+
+        // A second login on the same bound session must encode a fresh Register
+        // (request 0, session 0), not panic in the one-shot register guard.
+        let bytes =
+            encode_contiguous_request(&mut session, LOGIN_REGISTER_CODE, &request.to_bytes())
+                .unwrap();
+        let header = decode_request_header(&bytes);
+        assert_eq!(header.operation, Operation::Register);
+        assert_eq!(header.request, 0);
+        assert_eq!(header.session, 0);
+        assert!(!session.is_bound());
     }
 
     #[test]
@@ -531,6 +574,38 @@ mod tests {
                 "window [{server_min}, {server_max}] must not surface as typed error"
             );
         }
+    }
+
+    #[test]
+    fn reply_with_nonzero_status_surfaces_as_typed_error() {
+        // A dispatch-time authorization denial rides `ReplyHeader.status`; the
+        // decode funnel surfaces it as the typed error before any body decode,
+        // even though the deny body is empty.
+        let header = ReplyHeader {
+            command: Command2::Reply,
+            size: HEADER_SIZE as u32,
+            status: IggyError::Unauthorized.as_code(),
+            ..Default::default()
+        };
+        let mut buf = [0u8; HEADER_SIZE];
+        buf.copy_from_slice(bytemuck::bytes_of(&header));
+        let result = decode_response_split(&buf, Bytes::new());
+        assert!(matches!(result, Err(IggyError::Unauthorized)));
+    }
+
+    #[test]
+    fn reply_with_zero_status_passes_body_through() {
+        // status 0 is the ok channel: a non-metadata reply returns its body.
+        let header = ReplyHeader {
+            command: Command2::Reply,
+            operation: Operation::NonReplicated,
+            size: (HEADER_SIZE + 3) as u32,
+            ..Default::default()
+        };
+        let mut buf = [0u8; HEADER_SIZE];
+        buf.copy_from_slice(bytemuck::bytes_of(&header));
+        let out = decode_response_split(&buf, Bytes::from_static(b"abc")).unwrap();
+        assert_eq!(&out[..], b"abc");
     }
 
     #[test]

--- a/core/server-ng/Cargo.toml
+++ b/core/server-ng/Cargo.toml
@@ -155,6 +155,7 @@ strum = { workspace = true }
 sysinfo = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 toml = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }

--- a/core/server-ng/server.http
+++ b/core/server-ng/server.http
@@ -34,13 +34,10 @@
 @user1_username = user1
 @user1_password = secret
 @access_token = secret
-@root_id = 1
-@user1_id = 2
+@root_id = 0
+@user1_id = 1
 @pat_name = dev_token
 @pat_raw_token = secret
-
-###
-GET {{url}}
 
 ###
 GET {{url}}/ping
@@ -63,11 +60,18 @@ Content-Type: application/json
 }
 
 ###
-GET {{url}}/metrics
-
-###
 GET {{url}}/stats
 Authorization: Bearer {{access_token}}
+
+###
+POST {{url}}/snapshot
+Authorization: Bearer {{access_token}}
+Content-Type: application/json
+
+{
+  "compression": "Deflated",
+  "snapshot_types": ["All"]
+}
 
 ###
 GET {{url}}/cluster/metadata
@@ -80,14 +84,6 @@ Authorization: Bearer {{access_token}}
 ###
 GET {{url}}/clients/{{client_id}}
 Authorization: Bearer {{access_token}}
-
-###
-POST {{url}}/users/refresh-token
-Content-Type: application/json
-
-{
-  "token": "{{access_token}}"
-}
 
 ###
 DELETE {{url}}/users/logout
@@ -154,7 +150,7 @@ Content-Type: application/json
       "send_messages": true
     },
     "streams": {
-      "1": {
+      "0": {
         "manage_stream": false,
         "read_stream": true,
         "manage_topics": false,
@@ -162,7 +158,7 @@ Content-Type: application/json
         "poll_messages": true,
         "send_messages": true,
         "topics": {
-          "1": {
+          "0": {
             "manage_topic": false,
             "read_topic": true,
             "poll_messages": true,
@@ -192,9 +188,6 @@ Content-Type: application/json
   "name": "{{pat_name}}",
   "expiry": 1000
 }
-
-###
-
 
 ###
 DELETE {{url}}/personal-access-tokens/{{pat_name}}
@@ -290,7 +283,7 @@ Authorization: Bearer {{access_token}}
 
 ###
 ### Delete segments
-DELETE {{url}}/streams/1/topics/1/partitions/1?segments_count=3
+DELETE {{url}}/streams/{{stream_id}}/topics/{{topic_id}}/partitions/{{partition_id}}?segments_count=3
 Authorization: Bearer {{access_token}}
 
 ###

--- a/core/server-ng/src/auth.rs
+++ b/core/server-ng/src/auth.rs
@@ -37,7 +37,25 @@ use metadata::impls::metadata::StreamsFrontend;
 use server_common::crypto;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::LazyLock;
 use tracing::warn;
+
+/// A well-formed Argon2 hash to verify against on the unknown-user login
+/// branch, so a missing username costs the same single `verify_password` a real
+/// user's wrong-password branch costs. Closes the username-existence timing
+/// oracle without changing the returned error. On the unknown-username branch
+/// the verify result is discarded, so even a request presenting the exact dummy
+/// plaintext cannot authenticate; the literal only needs to be a fixed input
+/// hashed by the same Argon2 hasher real users use, so the dummy verify runs an
+/// identical Argon2 KDF.
+static DUMMY_PASSWORD_HASH: LazyLock<String> =
+    LazyLock::new(|| crypto::hash_password("http-login-timing-guard"));
+
+/// Pay the one-time Argon2 cost of [`DUMMY_PASSWORD_HASH`] at boot instead of
+/// inside the first unknown-username login request.
+pub(crate) fn warm_dummy_password_hash() {
+    LazyLock::force(&DUMMY_PASSWORD_HASH);
+}
 
 pub(crate) fn verify_login_credentials(
     shard: &Rc<ServerNgShard>,
@@ -54,16 +72,25 @@ pub(crate) fn verify_login_credentials(
         return Err(LoginRegisterError::InvalidCredentials);
     }
     shard.plane.metadata().mux_stm.users().read(|users| {
-        let Some(user_id) = users.index.get(username).copied() else {
+        let user = users
+            .index
+            .get(username)
+            .copied()
+            .and_then(|user_id| users.items.get(user_id as usize));
+        let Some(user) = user else {
+            // Constant-cost path: verify against a dummy hash so a missing
+            // username is indistinguishable by response timing from a wrong
+            // password (both return InvalidCredentials).
+            let _ = crypto::verify_password(password, DUMMY_PASSWORD_HASH.as_str());
             return Err(LoginRegisterError::InvalidCredentials);
         };
-        let Some(user) = users.items.get(user_id as usize) else {
-            return Err(LoginRegisterError::InvalidCredentials);
-        };
-        if user.status != UserStatus::Active {
-            return Err(LoginRegisterError::UserInactive);
-        }
-        if !crypto::verify_password(password, user.password_hash.as_ref()) {
+        // Verify before the status check and collapse inactive to
+        // InvalidCredentials: an inactive account must answer exactly like a
+        // wrong password (same error, same Argon2 cost), or login could probe
+        // which accounts exist but are disabled.
+        if !crypto::verify_password(password, user.password_hash.as_ref())
+            || user.status != UserStatus::Active
+        {
             return Err(LoginRegisterError::InvalidCredentials);
         }
         Ok(user.id)
@@ -74,6 +101,17 @@ pub(crate) fn verify_pat_credentials(
     shard: &Rc<ServerNgShard>,
     token: &str,
 ) -> Result<u32, LoginRegisterError> {
+    verify_pat_credentials_with_expiry(shard, token).map(|(user_id, _)| user_id)
+}
+
+/// Like [`verify_pat_credentials`] but also surfaces the token's expiry (unix
+/// seconds, `u64::MAX` when the PAT never expires). The HTTP extractor keys a
+/// per-token VSR session table on this expiry for lazy eviction; the wire and
+/// login paths only need the user id and go through [`verify_pat_credentials`].
+pub(crate) fn verify_pat_credentials_with_expiry(
+    shard: &Rc<ServerNgShard>,
+    token: &str,
+) -> Result<(u32, u64), LoginRegisterError> {
     let token_hash = PersonalAccessToken::hash_token(token);
     let now = IggyTimestamp::now();
     shard.plane.metadata().mux_stm.users().read(|users| {
@@ -98,7 +136,12 @@ pub(crate) fn verify_pat_credentials(
         if user.status != UserStatus::Active {
             return Err(LoginRegisterError::UserInactive);
         }
-        Ok(user.id)
+        // `expiry_at == None` is a never-expiring PAT; map it to `u64::MAX` so
+        // the HTTP session table never expiry-evicts its entry.
+        let expiry = pat
+            .expiry_at
+            .map_or(u64::MAX, |expiry_at| expiry_at.to_secs());
+        Ok((user.id, expiry))
     })
 }
 
@@ -144,7 +187,7 @@ pub(crate) async fn complete_login_register(
     // optimistic Authenticated transition, so a transient submit failure
     // needs no rollback -- the connection stays Connected and the SDK
     // read-timeout replays.
-    let session = match submit_register_on_owner(shard, vsr_client_id).await {
+    let session = match submit_register_on_owner(shard, vsr_client_id, user_id).await {
         Ok(session) => session,
         Err(error) => {
             return Err(LoginRegisterError::Transient(error));

--- a/core/server-ng/src/bootstrap.rs
+++ b/core/server-ng/src/bootstrap.rs
@@ -15,12 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::auth::warm_dummy_password_hash;
+use crate::cluster_meta::ClusterRoster;
 use crate::config_writer::write_current_config;
 use crate::dispatch::{
     make_client_request_handler, make_deferred_client_request_handler,
     make_deferred_replica_message_handler, make_list_clients_handler, make_metadata_submit_handler,
     make_partition_read_handler,
 };
+use crate::http;
 use crate::partition_helpers::{
     configure_consumer_offsets, ensure_initial_segment, validate_namespace_bounds,
 };
@@ -519,6 +522,7 @@ pub fn bootstrap(
     config: ServerNgConfig,
     current_replica_id: Option<u8>,
 ) -> Result<ShardHandles, ServerNgError> {
+    warm_dummy_password_hash();
     let allocator = ShardAllocator::new(&config.system.sharding.cpu_allocation)
         .map_err(ServerNgError::ShardAllocator)?;
     let assignments = allocator
@@ -1048,7 +1052,8 @@ async fn shard_main(
         let coord = shard
             .coordinator()
             .expect("shard 0 always has a coordinator attached by the builder");
-        let on_client_request = make_client_request_handler(&shard, &sessions);
+        let on_client_request =
+            make_client_request_handler(&shard, &sessions, Arc::clone(&config.system));
         let (accepted_replica, dialed_replica) =
             make_replica_delegation_fns(Rc::clone(&coord), &bus);
         let accepted_client = make_shard_zero_client_accept_fns(coord, &bus, on_client_request);
@@ -1284,6 +1289,33 @@ fn spawn_shutdown_watchdog(
     watchdog.detach();
 }
 
+/// Copy the configured cluster roster plus this node's own client ports into
+/// the shared [`ClusterRoster`] so the binary `GetClusterMetadata` read serves
+/// the real topology. `self_*` back only the cluster-disabled self-synthesis;
+/// the HTTP port is read from config since HTTP binds outside this topology.
+fn build_cluster_roster(config: &ServerNgConfig, topology: &TcpTopology) -> ClusterRoster {
+    let http_port = if config.http.enabled {
+        parse_socket_addr("http.address", &config.http.address)
+            .ok()
+            .map(|addr| addr.port())
+    } else {
+        None
+    };
+    ClusterRoster {
+        enabled: config.cluster.enabled,
+        name: config.cluster.name.clone(),
+        nodes: config.cluster.nodes.clone(),
+        self_ip: topology.client_listen_addr.ip().to_string(),
+        self_ports: configs::cluster::TransportPorts {
+            tcp: Some(topology.client_listen_addr.port()),
+            quic: topology.quic_listen_addr.map(|addr| addr.port()),
+            http: http_port,
+            websocket: topology.ws_listen_addr.map(|addr| addr.port()),
+            tcp_replica: None,
+        },
+    }
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn build_shard_for_thread(
     shard_id: u16,
@@ -1401,10 +1433,19 @@ async fn build_shard_for_thread(
     let shard_handle = Rc::new(RefCell::new(None));
     // One per-shard SessionManager, shared by the client-request handler
     // (binds sessions) and the get_clients handler (reads them). Created
-    // here so both wirings reference the same instance.
+    // here so both wirings reference the same instance. It also carries this
+    // shard's cluster roster for the pre-auth GetClusterMetadata read.
     let sessions = Rc::new(RefCell::new(SessionManager::new()));
+    sessions
+        .borrow_mut()
+        .set_cluster_roster(Rc::new(build_cluster_roster(config, topology)));
     let on_replica_message = make_deferred_replica_message_handler(&shard_handle);
-    let on_client_request = make_deferred_client_request_handler(&bus, &shard_handle, &sessions);
+    let on_client_request = make_deferred_client_request_handler(
+        &bus,
+        &shard_handle,
+        &sessions,
+        Arc::clone(&config.system),
+    );
     let on_metadata_submit = make_metadata_submit_handler(&shard_handle);
     let on_list_clients = make_list_clients_handler(&sessions);
     let on_partition_read = make_partition_read_handler(&shard_handle);
@@ -1816,7 +1857,7 @@ async fn start_tcp_runtime(
     accepted_clients: LocalClientAcceptFns,
 ) -> Result<(), ServerNgError> {
     if config.tcp.enabled && !config.tcp.tls.enabled {
-        return start_via_replica_io(
+        start_via_replica_io(
             shard,
             config,
             topology,
@@ -1824,18 +1865,45 @@ async fn start_tcp_runtime(
             dialed_replica,
             accepted_clients,
         )
-        .await;
+        .await?;
+    } else {
+        start_manual_runtime(
+            shard,
+            config,
+            topology,
+            accepted_replica,
+            dialed_replica,
+            accepted_clients,
+        )
+        .await?;
     }
 
-    start_manual_runtime(
-        shard,
-        config,
-        topology,
-        accepted_replica,
-        dialed_replica,
-        accepted_clients,
-    )
-    .await
+    // HTTP is served over TCP but sits outside the replica_io / manual client
+    // reactor, so it binds independently. Shard-0 gating comes from the sole
+    // caller of this function.
+    if config.http.enabled {
+        let http_addr = parse_socket_addr("http.address", &config.http.address)?;
+        let self_ports = configs::cluster::TransportPorts {
+            tcp: config
+                .tcp
+                .enabled
+                .then(|| topology.client_listen_addr.port()),
+            quic: topology.quic_listen_addr.map(|addr| addr.port()),
+            websocket: topology.ws_listen_addr.map(|addr| addr.port()),
+            ..Default::default()
+        };
+        http::start(
+            shard,
+            http_addr,
+            &config.http,
+            &config.cluster,
+            Arc::clone(&config.system),
+            self_ports,
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 // ws/wss bindings intentionally mirror the transport names (same convention as

--- a/core/server-ng/src/cluster_meta.rs
+++ b/core/server-ng/src/cluster_meta.rs
@@ -1,0 +1,128 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Single source of cluster-metadata assembly.
+//!
+//! Both the HTTP `GET /cluster/metadata` handler and the binary
+//! `GetClusterMetadata` reply build the same view: one entry per configured
+//! roster node with its client ports, the current VSR primary marked
+//! `Leader` and the rest `Follower`. The roster is config-only data, so it is
+//! reported whenever the cluster is enabled; the leader marking is the only
+//! part that needs live consensus, and it is passed in as `primary_index` so
+//! each caller derives it from its own on-shard view (`None` when the serving
+//! shard has no consensus - peer shards - in which case no node is marked
+//! leader, but the full roster is still returned). The self-synthesized single
+//! node is the cluster-disabled fallback, shared by both callers.
+
+use configs::cluster::{ClusterNodeConfig, TransportPorts};
+use iggy_common::{
+    ClusterMetadata, ClusterNode, ClusterNodeRole, ClusterNodeStatus, TransportEndpoints,
+};
+
+/// Node name reported for the synthesized self node when no roster applies.
+const SELF_NODE_NAME: &str = "iggy-node";
+
+/// Cluster name reported when no roster is configured, matching the legacy
+/// single-node label.
+const SINGLE_NODE_CLUSTER_NAME: &str = "single-node";
+
+/// Config-derived cluster topology reported by cluster-metadata reads.
+///
+/// Copied out of `ClusterConfig` at listener/shard start so both handlers stay
+/// synchronous and never borrow live config. `self_*` describe this node and
+/// back the cluster-disabled self-synthesis only.
+pub struct ClusterRoster {
+    pub enabled: bool,
+    pub name: String,
+    pub nodes: Vec<ClusterNodeConfig>,
+    /// This node's own address, reported for the synthesized self node.
+    pub self_ip: String,
+    /// This node's own client ports for the same self node (`None` = transport
+    /// disabled).
+    pub self_ports: TransportPorts,
+}
+
+impl ClusterRoster {
+    /// A cluster-disabled roster with no self address. Used as the pre-bootstrap
+    /// default before the real roster is installed; [`Self::cluster_metadata`]
+    /// on it synthesizes a bare single node.
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            name: String::new(),
+            nodes: Vec::new(),
+            self_ip: String::new(),
+            self_ports: TransportPorts::default(),
+        }
+    }
+
+    /// Build the [`ClusterMetadata`] view. With a configured, non-empty roster
+    /// emit one node per entry, marking the node at `primary_index` the leader
+    /// and the rest followers; `None` (no on-shard consensus) leaves every node
+    /// a follower. Otherwise synthesize the single self node as the sole
+    /// leader.
+    pub fn cluster_metadata(&self, primary_index: Option<u8>) -> ClusterMetadata {
+        if self.enabled && !self.nodes.is_empty() {
+            let nodes = self
+                .nodes
+                .iter()
+                .map(|node| ClusterNode {
+                    name: node.name.clone(),
+                    ip: node.ip.clone(),
+                    endpoints: ports_to_endpoints(&node.ports),
+                    role: role_for(primary_index, node.replica_id),
+                    status: ClusterNodeStatus::Healthy,
+                })
+                .collect();
+            ClusterMetadata {
+                name: self.name.clone(),
+                nodes,
+            }
+        } else {
+            self.self_metadata()
+        }
+    }
+
+    fn self_metadata(&self) -> ClusterMetadata {
+        ClusterMetadata {
+            name: SINGLE_NODE_CLUSTER_NAME.to_owned(),
+            nodes: vec![ClusterNode {
+                name: SELF_NODE_NAME.to_owned(),
+                ip: self.self_ip.clone(),
+                endpoints: ports_to_endpoints(&self.self_ports),
+                role: ClusterNodeRole::Leader,
+                status: ClusterNodeStatus::Healthy,
+            }],
+        }
+    }
+}
+
+const fn role_for(primary_index: Option<u8>, replica_id: u8) -> ClusterNodeRole {
+    match primary_index {
+        Some(primary) if primary == replica_id => ClusterNodeRole::Leader,
+        _ => ClusterNodeRole::Follower,
+    }
+}
+
+fn ports_to_endpoints(ports: &TransportPorts) -> TransportEndpoints {
+    TransportEndpoints::new(
+        ports.tcp.unwrap_or(0),
+        ports.quic.unwrap_or(0),
+        ports.http.unwrap_or(0),
+        ports.websocket.unwrap_or(0),
+    )
+}

--- a/core/server-ng/src/dispatch.rs
+++ b/core/server-ng/src/dispatch.rs
@@ -22,59 +22,76 @@
 //! run consensus on shard 0, and the login/register, logout, and
 //! non-replicated request handlers.
 
+mod authz;
+
 use crate::auth::{
     complete_login_register, send_login_failure_reply, surface_login_failure,
     verify_login_credentials, verify_pat_credentials,
 };
 use crate::bootstrap::{ServerNgShard, ServerNgShardHandle};
+use crate::cluster_meta::ClusterRoster;
 use crate::consumer_group::{
     maybe_rewrite_consumer_group_request, maybe_rewrite_consumer_offset_request,
+};
+use crate::dispatch::authz::{
+    authorize_default_read, authorize_partition_op, authorize_partition_read, authorize_uid,
+    send_non_replicated_deny, send_partition_deny_reply,
 };
 use crate::login_register::LoginRegisterError;
 use crate::pat::maybe_rewrite_pat_request;
 use crate::responses::{
-    NonReplicatedResponse, build_consumer_offset_body, build_empty_reply, build_get_me_response,
-    build_get_personal_access_tokens_response, build_non_replicated_response,
-    build_polled_messages_body, build_raw_pat_reply, connected_client_to_response,
-    current_metadata_commit, resolve_partition_namespace, resolve_partition_request_namespace,
+    NonReplicatedResponse, build_consumer_offset_body, build_deny_reply, build_empty_reply,
+    build_get_me_response, build_get_personal_access_tokens_response,
+    build_non_replicated_response, build_polled_messages_body, build_raw_pat_reply,
+    connected_client_to_response, current_metadata_commit, resolve_partition_namespace,
+    resolve_partition_request_namespace,
 };
 use crate::session_manager::SessionManager;
+use crate::snapshot;
 use crate::users::maybe_rewrite_user_password_request;
-use crate::wire::request_body;
+use crate::wire::{request_body, usize_to_u32};
 use bytes::Bytes;
+use configs::system::SystemConfig;
 use consensus::{
-    EvictionContext, MetadataHandle, PartitionsHandle, build_eviction_message,
+    Consensus, EvictionContext, MetadataHandle, PartitionsHandle, build_eviction_message,
     build_incompatible_protocol_eviction_message,
 };
 use iggy_binary_protocol::codes::{
     GET_CLIENT_CODE, GET_CLIENTS_CODE, GET_CLUSTER_METADATA_CODE, GET_CONSUMER_OFFSET_CODE,
-    GET_ME_CODE, GET_PERSONAL_ACCESS_TOKENS_CODE, PING_CODE, POLL_MESSAGES_CODE,
-    SYNC_CONSUMER_GROUP_CODE,
+    GET_ME_CODE, GET_PERSONAL_ACCESS_TOKENS_CODE, GET_SNAPSHOT_FILE_CODE, LOGIN_USER_CODE,
+    LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, PING_CODE, POLL_MESSAGES_CODE, SYNC_CONSUMER_GROUP_CODE,
 };
 use iggy_binary_protocol::primitives::consumer::WireConsumer;
 use iggy_binary_protocol::primitives::polling_strategy::WirePollingStrategy;
 use iggy_binary_protocol::requests::consumer_groups::SyncConsumerGroupRequest;
-use iggy_binary_protocol::requests::consumer_offsets::GetConsumerOffsetRequest;
+use iggy_binary_protocol::requests::consumer_offsets::{
+    GetConsumerOffsetRequest, StoreConsumerOffset2Request,
+};
 use iggy_binary_protocol::requests::messages::PollMessagesRequest;
 use iggy_binary_protocol::requests::segments::DeleteSegmentsRequest;
 use iggy_binary_protocol::requests::system::get_client::GetClientRequest;
+use iggy_binary_protocol::requests::system::get_snapshot::GetSnapshotRequest;
 use iggy_binary_protocol::requests::users::{LoginRegisterRequest, LoginRegisterWithPatRequest};
 use iggy_binary_protocol::responses::clients::client_response::ConsumerGroupInfoResponse;
 use iggy_binary_protocol::responses::clients::get_client::ClientDetailsResponse;
 use iggy_binary_protocol::responses::clients::get_clients::GetClientsResponse;
 use iggy_binary_protocol::responses::consumer_groups::SyncConsumerGroupResponse;
+use iggy_binary_protocol::responses::system::get_snapshot::GetSnapshotResponse;
 use iggy_binary_protocol::{
-    ClientVersionInfo, EvictionReason, GenericHeader, KIND_CONSUMER_GROUP, Operation,
-    ProtocolVersion, RequestHeader, WireDecode, WireEncode, is_protocol_compatible,
+    AckLevel, ClientVersionInfo, Command2, EvictionReason, GenericHeader, HEADER_SIZE,
+    KIND_CONSUMER_GROUP, Operation, ProtocolVersion, RequestHeader, WireDecode, WireEncode,
+    WireIdentifier, is_protocol_compatible,
 };
-use iggy_common::{IggyError, PollingStrategy};
+use iggy_common::{IggyError, PollingStrategy, SnapshotCompression, SystemSnapshotType};
 use message_bus::client_listener::RequestHandler;
+use message_bus::framing::MAX_MESSAGE_SIZE;
 use message_bus::replica::listener::MessageHandler;
-use message_bus::{IggyMessageBus, MessageBus};
+use message_bus::{AUTO_COMMIT_CLIENT_ID, IggyMessageBus, MessageBus};
 use metadata::impls::metadata::{
     MetadataSubmitError, StreamsFrontend, build_truncate_partition_client_message,
 };
-use partitions::{PollPlan, PollingArgs, PollingConsumer};
+use metadata::permissioner::Permissioner;
+use partitions::{AutoCommitApplied, PollPlan, PollingArgs, PollingConsumer};
 use secrecy::ExposeSecret;
 use server_common::Message;
 use server_common::sharding::IggyNamespace;
@@ -86,6 +103,7 @@ use shard::{
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
+use std::sync::Arc;
 use tracing::warn;
 
 pub(crate) type ClientRequestQueues = Rc<RefCell<HashMap<u128, VecDeque<Message<GenericHeader>>>>>;
@@ -94,6 +112,7 @@ pub(crate) type ActiveClientRequests = Rc<RefCell<HashSet<u128>>>;
 pub(crate) fn make_client_request_handler(
     shard: &Rc<ServerNgShard>,
     sessions: &Rc<RefCell<SessionManager>>,
+    system_config: Arc<SystemConfig>,
 ) -> RequestHandler {
     let shard = Rc::clone(shard);
     let sessions = Rc::clone(sessions);
@@ -115,6 +134,7 @@ pub(crate) fn make_client_request_handler(
         enqueue_client_request(
             Rc::clone(&shard),
             Rc::clone(&sessions),
+            Arc::clone(&system_config),
             Rc::clone(&queues),
             Rc::clone(&active),
             client_id,
@@ -166,10 +186,13 @@ pub(crate) fn make_partition_read_handler(
                         let _ = reply.try_send(PartitionReadReply::NotFound);
                     }
                     Some(plan) if plan.needs_off_pump_io() => {
-                        spawn_poll_io(namespace, plan, reply);
+                        spawn_poll_io(Rc::clone(&shard), namespace, plan, reply);
                     }
                     Some(plan) => {
-                        let (fragments, current_offset) = plan.execute_resident();
+                        let (fragments, current_offset, auto_commit) = plan.execute_resident();
+                        if let Some(applied) = auto_commit {
+                            submit_auto_commit(&shard, namespace, &applied);
+                        }
                         let _ = reply.try_send(PartitionReadReply::Poll {
                             fragments,
                             current_offset,
@@ -217,18 +240,20 @@ pub(crate) fn make_partition_read_handler(
     })
 }
 
-/// Spawn the off-pump leg of a partition poll: disk read + auto-commit
-/// persist/apply on the OWNED plan (disk descriptors, resident-tail `Frozen`
-/// clones, `Arc` offset map), then send the reply. Holds no partition
-/// reference, so it is sound concurrently with the pump's `&mut` writes.
+/// Spawn the off-pump leg of a partition poll: disk read + auto-commit apply on
+/// the OWNED plan (disk descriptors, resident-tail `Frozen` clones, `Arc` offset
+/// map), then replicate the auto-committed offset and send the reply. Holds no
+/// partition reference across the IO, so it is sound concurrently with the
+/// pump's `&mut` writes; the auto-commit submit re-borrows synchronously after.
 fn spawn_poll_io(
+    shard: Rc<ServerNgShard>,
     namespace: IggyNamespace,
     plan: PollPlan,
     reply: shard::Sender<PartitionReadReply>,
 ) {
     compio::runtime::spawn(async move {
         let poll_started = std::time::Instant::now();
-        let (fragments, current_offset) = plan.execute().await;
+        let (fragments, current_offset, auto_commit) = plan.execute().await;
         let elapsed = poll_started.elapsed();
         if elapsed > std::time::Duration::from_secs(1) {
             warn!(
@@ -237,12 +262,131 @@ fn spawn_poll_io(
                 "slow partition poll; gather side may have timed out"
             );
         }
+        // Fire-and-forget: the poll reply is not gated on the offset commit.
+        if let Some(applied) = auto_commit {
+            submit_auto_commit(&shard, namespace, &applied);
+        }
         let _ = reply.try_send(PartitionReadReply::Poll {
             fragments,
             current_offset,
         });
     })
     .detach();
+}
+
+/// Replicate a poll's auto-committed offset through the partition consensus so
+/// it survives failover, mirroring the explicit `StoreConsumerOffset` path: the
+/// same op code, submitted onto the owning shard's own pipeline. Best-effort and
+/// fire-and-forget -- the poll reply never waits on it, and a full inbox drops
+/// the op at WARN rather than backpressuring the reply.
+///
+/// The partition plane admits writes on the primary only (it asserts so), and a
+/// poll is served on whichever node owns the namespace locally, which may be a
+/// backup. So gate on primary status here and drop at WARN otherwise; auto-commit
+/// is server-managed best-effort (at-least-once delivery), so a follower-served
+/// poll simply does not advance the durable offset.
+///
+/// Coalescing: an offset the partition's committed high-water already covers is
+/// dropped without a consensus op (the steady state for a re-poll of committed
+/// data, hence no log). The gate reads committed state only, so an offset that
+/// merely sits in flight keeps resubmitting until its covering op commits -- a
+/// dropped op self-heals on the next poll instead of being suppressed forever.
+fn submit_auto_commit(
+    shard: &Rc<ServerNgShard>,
+    namespace: IggyNamespace,
+    applied: &AutoCommitApplied,
+) {
+    enum AutoCommitGate {
+        Submit,
+        Covered,
+        NotPrimary,
+    }
+    let gate = shard
+        .plane
+        .partitions()
+        .with_partition(&namespace, |partition| {
+            let consensus = partition.consensus();
+            if !(consensus.is_primary() && consensus.is_normal() && !consensus.is_syncing()) {
+                AutoCommitGate::NotPrimary
+            } else if partition.is_auto_commit_offset_covered(
+                applied.kind,
+                applied.consumer_id,
+                applied.offset,
+            ) {
+                AutoCommitGate::Covered
+            } else {
+                AutoCommitGate::Submit
+            }
+        });
+    match gate {
+        Some(AutoCommitGate::Submit) => {}
+        Some(AutoCommitGate::Covered) => return,
+        Some(AutoCommitGate::NotPrimary) | None => {
+            warn!(
+                namespace_raw = namespace.inner(),
+                "auto-commit offset not replicated: partition not primary on this node (best-effort)"
+            );
+            return;
+        }
+    }
+    let message = match build_auto_commit_request(namespace, applied) {
+        Ok(message) => message,
+        Err(error) => {
+            warn!(
+                namespace_raw = namespace.inner(),
+                error = %error,
+                "failed to build auto-commit store-offset request"
+            );
+            return;
+        }
+    };
+    // Routes by namespace to this same (owning, primary) shard's inbox; the pump
+    // admits it next turn exactly like a client store. `dispatch` never blocks.
+    shard.dispatch(message.into_generic());
+}
+
+/// Build the synthetic `StoreConsumerOffset2` request for an auto-commit, keyed
+/// to the resolved numeric consumer/group id and stamped with the reserved
+/// [`AUTO_COMMIT_CLIENT_ID`] so the commit path skips the (unwaited) reply. The
+/// wire stream/topic ids are cosmetic here -- admission and apply key off the
+/// header namespace and the consumer id -- but are set from the namespace for a
+/// well-formed body. `ack` is `Quorum` so the offset actually replicates.
+fn build_auto_commit_request(
+    namespace: IggyNamespace,
+    applied: &AutoCommitApplied,
+) -> Result<Message<RequestHeader>, IggyError> {
+    let request = StoreConsumerOffset2Request {
+        consumer: WireConsumer {
+            kind: applied.kind.as_code(),
+            id: WireIdentifier::Numeric(applied.consumer_id),
+        },
+        stream_id: WireIdentifier::Numeric(usize_to_u32(namespace.stream_id())?),
+        topic_id: WireIdentifier::Numeric(usize_to_u32(namespace.topic_id())?),
+        partition_id: Some(usize_to_u32(namespace.partition_id())?),
+        offset: applied.offset,
+        ack: AckLevel::Quorum,
+    };
+    let body = request.to_bytes();
+    let header_size = std::mem::size_of::<RequestHeader>();
+    let total_size = header_size + body.len();
+    let size = u32::try_from(total_size).map_err(|_| IggyError::InvalidConfiguration)?;
+    let mut message = Message::<RequestHeader>::new(total_size);
+    message.as_mut_slice()[header_size..].copy_from_slice(&body);
+    Ok(message.transmute_header(|_, header: &mut RequestHeader| {
+        *header = RequestHeader {
+            command: Command2::Request,
+            operation: Operation::StoreConsumerOffset2,
+            size,
+            client: AUTO_COMMIT_CLIENT_ID,
+            // The partition plane is sessionless (no `ClientTable` dedup); a
+            // nonzero session + request just satisfy the wire header
+            // validation.
+            session: 1,
+            request: 1,
+            namespace: namespace.inner(),
+            ..Default::default()
+        };
+    }))
 }
 
 pub(crate) fn make_deferred_replica_message_handler(
@@ -260,6 +404,7 @@ pub(crate) fn make_deferred_client_request_handler(
     bus: &Rc<IggyMessageBus>,
     shard_handle: &ServerNgShardHandle,
     sessions: &Rc<RefCell<SessionManager>>,
+    system_config: Arc<SystemConfig>,
 ) -> RequestHandler {
     let shard_handle = Rc::clone(shard_handle);
     let sessions = Rc::clone(sessions);
@@ -279,6 +424,7 @@ pub(crate) fn make_deferred_client_request_handler(
     Rc::new(move |client_id, message| {
         let shard_handle = Rc::clone(&shard_handle);
         let sessions = Rc::clone(&sessions);
+        let system_config = Arc::clone(&system_config);
         let queues = Rc::clone(&queues);
         let active = Rc::clone(&active);
         queues
@@ -294,7 +440,7 @@ pub(crate) fn make_deferred_client_request_handler(
                 active.borrow_mut().remove(&client_id);
                 return;
             };
-            drain_client_requests(shard, sessions, queues, active, client_id).await;
+            drain_client_requests(shard, sessions, system_config, queues, active, client_id).await;
         })
         .detach();
     })
@@ -319,12 +465,13 @@ pub(crate) fn make_metadata_submit_handler(
             match submit {
                 shard::MetadataSubmit::Register {
                     vsr_client_id,
+                    user_id,
                     reply,
                 } => {
                     let session = shard
                         .plane
                         .metadata()
-                        .submit_register_in_process(vsr_client_id)
+                        .submit_register_in_process(vsr_client_id, user_id)
                         .await
                         .ok();
                     let _ = reply.try_send(session);
@@ -389,6 +536,7 @@ pub(crate) fn make_metadata_submit_handler(
 fn enqueue_client_request(
     shard: Rc<ServerNgShard>,
     sessions: Rc<RefCell<SessionManager>>,
+    system_config: Arc<SystemConfig>,
     queues: ClientRequestQueues,
     active: ActiveClientRequests,
     client_id: u128,
@@ -404,7 +552,7 @@ fn enqueue_client_request(
     }
 
     compio::runtime::spawn(async move {
-        drain_client_requests(shard, sessions, queues, active, client_id).await;
+        drain_client_requests(shard, sessions, system_config, queues, active, client_id).await;
     })
     .detach();
 }
@@ -413,6 +561,7 @@ fn enqueue_client_request(
 async fn drain_client_requests(
     shard: Rc<ServerNgShard>,
     sessions: Rc<RefCell<SessionManager>>,
+    system_config: Arc<SystemConfig>,
     queues: ClientRequestQueues,
     active: ActiveClientRequests,
     client_id: u128,
@@ -421,7 +570,7 @@ async fn drain_client_requests(
         let Some(message) = pop_next_client_request(&queues, &active, client_id) else {
             return;
         };
-        handle_client_request(&shard, &sessions, client_id, message).await;
+        handle_client_request(&shard, &sessions, &system_config, client_id, message).await;
     }
 }
 
@@ -449,6 +598,7 @@ fn pop_next_client_request(
 async fn handle_client_request(
     shard: &Rc<ServerNgShard>,
     sessions: &Rc<RefCell<SessionManager>>,
+    system_config: &Arc<SystemConfig>,
     transport_client_id: u128,
     message: Message<iggy_binary_protocol::GenericHeader>,
 ) {
@@ -478,9 +628,35 @@ async fn handle_client_request(
         // legitimately pre-auth (liveness probe + connection bootstrap
         // metadata). Every other non-replicated code (`GET_STREAM*`,
         // `GET_TOPIC*`, `GET_STATS`, `POLL_MESSAGES`) reads live state and
-        // MUST go through Register first, since server-ng has no
-        // per-resource authz layer.
+        // MUST go through Register first, which binds the acting user the
+        // per-op authz gates resolve.
         let nr_code = u32::from_le_bytes(request.header().reserved[..4].try_into().unwrap());
+        // Legacy (pre-register) login codes. server-ng authenticates only via
+        // the Register handshake (LOGIN_REGISTER / LOGIN_REGISTER_WITH_PAT,
+        // Operation::Register); the vsr SDK funnels both logins there and never
+        // emits these. Reject them uniformly with a typed MalformedLogin (the
+        // SDK maps it to InvalidFormat) before the session gate, so a legacy or
+        // foreign client fails fast instead of getting the misleading
+        // NoSession eviction the pre-auth guard would send unbound, or the
+        // silent empty-ok Reply the bound non-replicated path would send.
+        if matches!(
+            nr_code,
+            LOGIN_USER_CODE | LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE
+        ) {
+            warn!(
+                transport_client_id,
+                code = nr_code,
+                "rejecting legacy login code; server-ng requires the register handshake"
+            );
+            send_login_eviction(
+                shard,
+                transport_client_id,
+                header.client,
+                EvictionReason::MalformedLogin,
+            )
+            .await;
+            return;
+        }
         let allowed_pre_auth = matches!(nr_code, PING_CODE | GET_CLUSTER_METADATA_CODE);
         if !allowed_pre_auth && sessions.borrow().get_session(transport_client_id).is_none() {
             warn!(
@@ -491,7 +667,8 @@ async fn handle_client_request(
             send_unauthenticated_eviction(shard, transport_client_id).await;
             return;
         }
-        handle_non_replicated_request(shard, sessions, transport_client_id, request).await;
+        handle_non_replicated_request(shard, sessions, system_config, transport_client_id, request)
+            .await;
         return;
     }
 
@@ -549,90 +726,22 @@ async fn handle_client_request(
         return;
     }
 
-    // Partition data-plane op (SendMessages / consumer-offset writes): the
-    // op belongs to the partition's own consensus group, not the metadata
-    // group. Route it through the shard mesh by namespace; the owning
-    // shard's partitions plane runs at-least-once consensus and replies
-    // directly via `send_to_client`. `header.client` therefore stays the
-    // TRANSPORT id (home-shard routing bits), not the VSR session id --
-    // partition ops are sessionless ("session lifecycle is metadata-only").
     if header.operation.is_partition() {
-        // The consumer-group offset fence keys on the bound VSR client id (the
-        // member id), not the transport id stamped into the partition-op
-        // header. `bound` is Some here (unbound transports returned above).
-        let vsr_client_id = bound.map_or(0, |(client_id, _)| client_id);
-        let namespace = match resolve_partition_request_namespace(
+        // `bound` is Some here (unbound transports returned above).
+        let (vsr_client_id, bound_session) = bound.unwrap_or((0, 0));
+        // `get_session` discards the acting user id the partition gate needs;
+        // resolve it from the same bound connection. A bound transport always
+        // has one, but the gate fails closed on `None` rather than trust that.
+        let acting_user_id = sessions.borrow().get_user_id(transport_client_id);
+        dispatch_partition_request(
             shard,
-            header.operation,
-            request_body(&request),
+            request,
             vsr_client_id,
-        ) {
-            Ok(namespace) => namespace,
-            Err(error) => {
-                // A partition op against a stream/topic that no longer
-                // resolves (e.g. a consumer's trailing auto-commit racing a
-                // `delete_stream`). A silent drop wedges the SDK connection
-                // forever; reply empty so the client fails fast instead.
-                warn!(
-                    transport_client_id,
-                    error = %error,
-                    operation = ?header.operation,
-                    "partition request with unresolved namespace; replying empty"
-                );
-                send_empty_partition_reply(shard, transport_client_id, &header).await;
-                return;
-            }
-        };
-        // Convergence wait: a CreateTopic commit returns to the client
-        // before the per-shard reconcilers seed routing rows and
-        // materialise the partition (next wake/periodic tick). The SDK
-        // does not replay sends, so an immediately-following partition op
-        // would be dropped as unroutable. Absorb that window here with a
-        // bounded wait; steady-state sends (row present, partition probed
-        // once) skip it entirely.
-        if !wait_for_partition_routable(shard, IggyNamespace::from_raw(namespace)).await {
-            warn!(
-                transport_client_id,
-                namespace,
-                operation = ?header.operation,
-                "partition request not routable within budget; replying empty"
-            );
-            send_empty_partition_reply(shard, transport_client_id, &header).await;
-            return;
-        }
-        // A group consumer-offset op carries the group NAME on the wire; the
-        // partition plane keys the offset by the group's monotonic id (the same
-        // key the poll path auto-commits under and the read path resolves), so
-        // rewrite the consumer id before replication -- the apply layer has no
-        // metadata access to resolve it.
-        let request = match maybe_rewrite_consumer_offset_request(shard, request) {
-            Ok(rewritten) => rewritten,
-            Err(error) => {
-                warn!(
-                    transport_client_id,
-                    error = %error,
-                    operation = ?header.operation,
-                    "failed to rewrite consumer-offset request; replying empty"
-                );
-                send_empty_partition_reply(shard, transport_client_id, &header).await;
-                return;
-            }
-        };
-        let request = request.transmute_header(|header, new_header: &mut RequestHeader| {
-            *new_header = header;
-            new_header.namespace = namespace;
-            new_header.client = transport_client_id;
-            // Header validation requires `session > 0 && request > 0` for
-            // non-register ops. The partition plane itself is sessionless
-            // (at-least-once, no `ClientTable` dedup), so the bound VSR
-            // session merely satisfies validation, and a zero request id
-            // (the SDK does not number data-plane ops) is normalized.
-            if let Some((_, bound_session)) = bound {
-                new_header.session = bound_session;
-            }
-            new_header.request = new_header.request.max(1);
-        });
-        shard.dispatch(request.into_generic());
+            bound_session,
+            transport_client_id,
+            acting_user_id,
+        )
+        .await;
         return;
     }
 
@@ -658,17 +767,36 @@ async fn handle_client_request(
                 return;
             }
         };
-    // Hash raw passwords on the primary before replication (CreateUser /
-    // ChangePassword); see `crate::users`. Replicas store the hash directly.
-    let request = match maybe_rewrite_user_password_request(request) {
+    // Hash raw passwords and, for ChangePassword, verify the current password
+    // on the primary before replication; see `crate::users`. Replicas store the
+    // hash directly. A wrong current password is not denied here: it rides
+    // consensus and applies as a committed InvalidCredentials no-op, so the only
+    // Err returned is a malformed body.
+    let request = match maybe_rewrite_user_password_request(shard, request) {
         Ok(rewritten) => rewritten,
         Err(error) => {
+            // Malformed body: deny fast with InvalidCommand. A silent drop
+            // would wedge every later request on the connection until the
+            // socket read timeout.
             warn!(
                 transport_client_id,
                 error = %error,
                 operation = ?header.operation,
-                "dropping user request with invalid password payload"
+                "denying user password request"
             );
+            let commit = current_metadata_commit(shard);
+            let reply = build_deny_reply(&header, transport_client_id, 0, commit, error.as_code());
+            if let Err(send_error) = shard
+                .bus
+                .send_to_client(transport_client_id, reply.into_generic().into_frozen())
+                .await
+            {
+                warn!(
+                    transport_client_id,
+                    error = %send_error,
+                    "failed to send password-deny reply"
+                );
+            }
             return;
         }
     };
@@ -775,15 +903,148 @@ async fn handle_get_me(
     .await;
 }
 
+/// Route a partition data-plane op (`SendMessages` / consumer-offset writes)
+/// through the shard mesh by namespace: the op belongs to the partition's
+/// own consensus group, not the metadata group. The owning shard's
+/// partitions plane runs at-least-once consensus and replies directly via
+/// `send_to_client`. `header.client` therefore stays the TRANSPORT id
+/// (home-shard routing bits), not the VSR session id -- partition ops are
+/// sessionless ("session lifecycle is metadata-only").
+///
+/// Callers must have authenticated the transport already: `vsr_client_id` /
+/// `bound_session` come from its bound VSR session. Every failure before
+/// dispatch replies empty so the client fails fast instead of wedging on a
+/// silent drop.
+///
+/// `vsr_client_id` keys the consumer-group offset fence (the member id),
+/// not the transport id stamped into the partition-op header.
 #[allow(clippy::future_not_send)]
+pub(crate) async fn dispatch_partition_request(
+    shard: &Rc<ServerNgShard>,
+    request: Message<RequestHeader>,
+    vsr_client_id: u128,
+    bound_session: u64,
+    transport_client_id: u128,
+    acting_user_id: Option<u32>,
+) {
+    let header = *request.header();
+    let namespace = match resolve_partition_request_namespace(
+        shard,
+        header.operation,
+        request_body(&request),
+        vsr_client_id,
+    ) {
+        Ok(namespace) => namespace,
+        Err(error) => {
+            // A partition op against a stream/topic that no longer
+            // resolves (e.g. a consumer's trailing auto-commit racing a
+            // `delete_stream`). A silent drop wedges the SDK connection
+            // forever; reply empty so the client fails fast instead.
+            warn!(
+                transport_client_id,
+                error = %error,
+                operation = ?header.operation,
+                "partition request with unresolved namespace; replying empty"
+            );
+            send_empty_partition_reply(shard, transport_client_id, &header).await;
+            return;
+        }
+    };
+    // Dispatch-time RBAC. The partition plane is not replicated through the
+    // metadata STM, so the in-apply gate cannot cover it; authorize here, on
+    // the connection's own shard, before burning the routable wait or touching
+    // the plane. The namespace resolved above, so its stream/topic are the
+    // committed slab ids the permissioner keys on directly. A denial replies
+    // the op's frame with an empty body and a nonzero `status` the SDK peeks.
+    //
+    // Consistency: this reads THIS shard's local committed permissioner. On a
+    // peer shard that is a replicated read-mirror, so a permission revocation
+    // takes effect on the partition plane only once this shard applies the
+    // revoking commit -- an apply-lag window bounded by replication lag.
+    // Control-plane ops are exact (gated in-apply, in the same committed order
+    // on every replica); this local-read relaxation on the data plane is the
+    // accepted trade for keeping partition ops off the metadata consensus.
+    let scope = IggyNamespace::from_raw(namespace);
+    if let Some(status) = authorize_partition_op(
+        shard,
+        header.operation,
+        acting_user_id,
+        scope.stream_id(),
+        scope.topic_id(),
+    ) {
+        warn!(
+            transport_client_id,
+            status,
+            operation = ?header.operation,
+            "partition request denied by authorization; replying with status"
+        );
+        send_partition_deny_reply(shard, transport_client_id, &header, status).await;
+        return;
+    }
+    // Convergence wait: a CreateTopic commit returns to the client
+    // before the per-shard reconcilers seed routing rows and
+    // materialise the partition (next wake/periodic tick). The SDK
+    // does not replay sends, so an immediately-following partition op
+    // would be dropped as unroutable. Absorb that window here with a
+    // bounded wait; steady-state sends (row present, partition probed
+    // once) skip it entirely.
+    if !wait_for_partition_routable(shard, IggyNamespace::from_raw(namespace)).await {
+        warn!(
+            transport_client_id,
+            namespace,
+            operation = ?header.operation,
+            "partition request not routable within budget; replying empty"
+        );
+        send_empty_partition_reply(shard, transport_client_id, &header).await;
+        return;
+    }
+    // A group consumer-offset op carries the group NAME on the wire; the
+    // partition plane keys the offset by the group's monotonic id (the same
+    // key the poll path auto-commits under and the read path resolves), so
+    // rewrite the consumer id before replication -- the apply layer has no
+    // metadata access to resolve it.
+    let request = match maybe_rewrite_consumer_offset_request(shard, request) {
+        Ok(rewritten) => rewritten,
+        Err(error) => {
+            warn!(
+                transport_client_id,
+                error = %error,
+                operation = ?header.operation,
+                "failed to rewrite consumer-offset request; replying empty"
+            );
+            send_empty_partition_reply(shard, transport_client_id, &header).await;
+            return;
+        }
+    };
+    let request = request.transmute_header(|header, new_header: &mut RequestHeader| {
+        *new_header = header;
+        new_header.namespace = namespace;
+        new_header.client = transport_client_id;
+        // Header validation requires `session > 0 && request > 0` for
+        // non-register ops. The partition plane itself is sessionless
+        // (at-least-once, no `ClientTable` dedup), so the bound VSR
+        // session merely satisfies validation, and a zero request id
+        // (the SDK does not number data-plane ops) is normalized.
+        new_header.session = bound_session;
+        new_header.request = new_header.request.max(1);
+    });
+    shard.dispatch(request.into_generic());
+}
+
+#[allow(clippy::future_not_send, clippy::too_many_lines)]
 async fn handle_non_replicated_request(
     shard: &Rc<ServerNgShard>,
     sessions: &Rc<RefCell<SessionManager>>,
+    system_config: &Arc<SystemConfig>,
     transport_client_id: u128,
     request: Message<RequestHeader>,
 ) {
     const CODE_RANGE: std::ops::Range<usize> = 0..4;
     let code = u32::from_le_bytes(request.header().reserved[CODE_RANGE].try_into().unwrap());
+    // Acting user for the read gates below, resolved once. `None` only on the
+    // pre-auth path (PING / GET_CLUSTER_METADATA), which serves ungated codes;
+    // the gated arms fail closed on it.
+    let user_id = sessions.borrow().get_user_id(transport_client_id);
     match code {
         PING_CODE => {
             // A ping is the client's liveness proof; reset its staleness clock
@@ -815,6 +1076,11 @@ async fn handle_non_replicated_request(
             handle_get_personal_access_tokens(shard, sessions, transport_client_id, &request).await;
         }
         GET_CLIENTS_CODE => {
+            if let Err(error) = authorize_uid(shard, user_id, Permissioner::get_clients) {
+                send_non_replicated_deny(shard, &request, transport_client_id, error.as_code())
+                    .await;
+                return;
+            }
             // Shared-nothing: each shard knows only its own connections, so
             // gather across all shards (scatter-gather over the mesh).
             let infos = shard.list_all_clients().await;
@@ -834,6 +1100,11 @@ async fn handle_non_replicated_request(
             .await;
         }
         GET_CLIENT_CODE => {
+            if let Err(error) = authorize_uid(shard, user_id, Permissioner::get_client) {
+                send_non_replicated_deny(shard, &request, transport_client_id, error.as_code())
+                    .await;
+                return;
+            }
             // No reverse map from the wire u32 id to a u128 transport id /
             // home shard (the u32 is just the seq tail), so gather all and
             // filter -- same fan-out as `get_clients`.
@@ -871,16 +1142,32 @@ async fn handle_non_replicated_request(
             send_non_replicated_bytes(shard, &request, transport_client_id, bytes, "get_client")
                 .await;
         }
+        GET_SNAPSHOT_FILE_CODE => {
+            handle_get_snapshot(shard, system_config, transport_client_id, &request, user_id).await;
+        }
         POLL_MESSAGES_CODE => {
-            handle_poll_messages(shard, transport_client_id, &request).await;
+            handle_poll_messages(shard, transport_client_id, &request, user_id).await;
         }
         GET_CONSUMER_OFFSET_CODE => {
-            handle_get_consumer_offset(shard, transport_client_id, &request).await;
+            handle_get_consumer_offset(shard, transport_client_id, &request, user_id).await;
         }
         SYNC_CONSUMER_GROUP_CODE => {
+            // Self-scoped: serves the caller's own assignment keyed by the
+            // header client id, so it carries no permissioner rule.
             handle_sync_consumer_group(shard, transport_client_id, &request).await;
         }
-        _ => handle_default_non_replicated(shard, transport_client_id, code, &request).await,
+        _ => {
+            let roster = sessions.borrow().cluster_roster();
+            handle_default_non_replicated(
+                shard,
+                transport_client_id,
+                code,
+                &request,
+                user_id,
+                &roster,
+            )
+            .await;
+        }
     }
 }
 
@@ -890,8 +1177,17 @@ async fn handle_default_non_replicated(
     transport_client_id: u128,
     code: u32,
     request: &Message<RequestHeader>,
+    user_id: Option<u32>,
+    roster: &ClusterRoster,
 ) {
-    match build_non_replicated_response(shard, code, request_body(request)) {
+    // Gate by command code before the shared builder runs. The builder stays
+    // authz-free (it is byte-shared with the HTTP read path, which gates
+    // separately); a denial replies status!=0 with an empty body.
+    if let Err(error) = authorize_default_read(shard, code, request_body(request), user_id) {
+        send_non_replicated_deny(shard, request, transport_client_id, error.as_code()).await;
+        return;
+    }
+    match build_non_replicated_response(shard, code, request_body(request), user_id, roster) {
         Ok(response) => {
             let commit = current_metadata_commit(shard);
             let reply = response.into_reply(
@@ -914,14 +1210,96 @@ async fn handle_default_non_replicated(
             }
         }
         Err(error) => {
+            // Surface the builder's typed error (unsupported op, undecodable
+            // body, or a not-found parity read) on the same deny channel the
+            // authz gate uses; a silent drop would wedge the client until its
+            // read timeout.
             warn!(
                 transport_client_id,
                 code,
                 error = %error,
-                "dropping unsupported non-replicated VSR request"
+                "denying non-replicated VSR request"
             );
+            send_non_replicated_deny(shard, request, transport_client_id, error.as_code()).await;
         }
     }
+}
+
+/// Serve `GET_SNAPSHOT_FILE`: gate on the snapshot rule (`read_servers ||
+/// manage_servers`, the legacy gate - the archive dumps host diagnostics, so
+/// plain authentication must not suffice), then await the off-thread
+/// collection (see `snapshot::collect`) and reply with the raw ZIP bytes.
+#[allow(clippy::future_not_send)]
+async fn handle_get_snapshot(
+    shard: &Rc<ServerNgShard>,
+    system_config: &Arc<SystemConfig>,
+    transport_client_id: u128,
+    request: &Message<RequestHeader>,
+    user_id: Option<u32>,
+) {
+    if let Err(error) = authorize_uid(shard, user_id, Permissioner::get_snapshot) {
+        send_non_replicated_deny(shard, request, transport_client_id, error.as_code()).await;
+        return;
+    }
+    let result = match decode_get_snapshot(request_body(request)) {
+        Ok((compression, snapshot_types)) => {
+            snapshot::collect(Arc::clone(system_config), compression, snapshot_types).await
+        }
+        Err(error) => Err(error),
+    };
+    match result {
+        Ok(archive) => {
+            // The reply frames as `[256-byte header][archive]`. The client's
+            // `message_bus::read_message` rejects any frame past `MAX_MESSAGE_SIZE`
+            // (64 MiB) by tearing the connection down untyped, and a frame past
+            // `u32::MAX` would panic `build_reply_with_body`. The archive is the
+            // only unbounded non-replicated body, so refuse an oversized one with a
+            // typed error the SDK decodes. The HTTP path streams via `Body` (not
+            // this framing), so it stays uncapped.
+            let frame_size = HEADER_SIZE + archive.len();
+            if frame_size > MAX_MESSAGE_SIZE {
+                warn!(
+                    transport_client_id,
+                    frame_size,
+                    max = MAX_MESSAGE_SIZE,
+                    "snapshot archive exceeds the client frame limit; refusing to send"
+                );
+                send_non_replicated_deny(
+                    shard,
+                    request,
+                    transport_client_id,
+                    IggyError::SnapshotFileCompletionFailed.as_code(),
+                )
+                .await;
+                return;
+            }
+            send_non_replicated_bytes(
+                shard,
+                request,
+                transport_client_id,
+                GetSnapshotResponse { data: archive }.to_bytes(),
+                "get_snapshot",
+            )
+            .await;
+        }
+        Err(error) => {
+            warn!(transport_client_id, error = %error, "denying snapshot request");
+            send_non_replicated_deny(shard, request, transport_client_id, error.as_code()).await;
+        }
+    }
+}
+
+fn decode_get_snapshot(
+    body: &[u8],
+) -> Result<(SnapshotCompression, Vec<SystemSnapshotType>), IggyError> {
+    let request = GetSnapshotRequest::decode_from(body).map_err(|_| IggyError::InvalidCommand)?;
+    let compression = SnapshotCompression::from_code(request.compression)?;
+    let snapshot_types = request
+        .snapshot_types
+        .iter()
+        .map(|&code| SystemSnapshotType::from_code(code))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((compression, snapshot_types))
 }
 
 /// Send a non-replicated reply body to a client, stamping the current
@@ -1091,8 +1469,37 @@ async fn handle_poll_messages(
     shard: &Rc<ServerNgShard>,
     transport_client_id: u128,
     request: &Message<RequestHeader>,
+    user_id: Option<u32>,
 ) {
-    let body = match decode_poll_request(shard, request) {
+    let Ok(wire) = PollMessagesRequest::decode_from(request_body(request)) else {
+        // Undecodable poll: keep the fail-fast empty-poll shape.
+        send_non_replicated_bytes(
+            shard,
+            request,
+            transport_client_id,
+            empty_polled_messages_body(0),
+            "poll_messages",
+        )
+        .await;
+        return;
+    };
+    // Gate on (stream, topic) before touching the partition plane. A resolution
+    // miss falls through to the resolve path below (empty-poll / not-found); a
+    // denial replies status!=0 with an empty body, distinct from the empty-poll
+    // "0 messages" shape.
+    if let Some(status) = authorize_partition_read(
+        shard,
+        &wire.stream_id,
+        &wire.topic_id,
+        user_id,
+        |permissioner, uid, stream_id, topic_id| {
+            permissioner.poll_messages(uid, stream_id, topic_id)
+        },
+    ) {
+        send_non_replicated_deny(shard, request, transport_client_id, status).await;
+        return;
+    }
+    let body = match resolve_poll_request(shard, &wire, request.header().client) {
         Ok((namespace, partition_id, consumer, args)) => {
             match shard
                 .partition_read(namespace, PartitionRead::Poll { consumer, args })
@@ -1150,8 +1557,33 @@ async fn handle_get_consumer_offset(
     shard: &Rc<ServerNgShard>,
     transport_client_id: u128,
     request: &Message<RequestHeader>,
+    user_id: Option<u32>,
 ) {
-    let body = match decode_consumer_offset_request(shard, request) {
+    let Ok(wire) = GetConsumerOffsetRequest::decode_from(request_body(request)) else {
+        // Undecodable: an empty body decodes as None (no offset) on the SDK.
+        send_non_replicated_bytes(
+            shard,
+            request,
+            transport_client_id,
+            Bytes::new(),
+            "get_consumer_offset",
+        )
+        .await;
+        return;
+    };
+    if let Some(status) = authorize_partition_read(
+        shard,
+        &wire.stream_id,
+        &wire.topic_id,
+        user_id,
+        |permissioner, uid, stream_id, topic_id| {
+            permissioner.get_consumer_offset(uid, stream_id, topic_id)
+        },
+    ) {
+        send_non_replicated_deny(shard, request, transport_client_id, status).await;
+        return;
+    }
+    let body = match resolve_consumer_offset_request(shard, &wire) {
         Ok((namespace, partition_id, consumer)) => {
             match shard
                 .partition_read(namespace, PartitionRead::ConsumerOffset { consumer })
@@ -1316,15 +1748,18 @@ fn empty_polled_messages_body(partition_id: u32) -> Bytes {
     Bytes::from(body)
 }
 
-type DecodedPollRequest = (IggyNamespace, u32, PollingConsumer, PollingArgs);
+pub(crate) type DecodedPollRequest = (IggyNamespace, u32, PollingConsumer, PollingArgs);
 
+/// Resolve a decoded poll request into its owning-shard read: namespace,
+/// partition, polling consumer, and args. Shared by the TCP dispatch (client
+/// id = the connection's bound VSR client) and the HTTP route (client id 0,
+/// which fences group polls closed).
 #[allow(clippy::cast_possible_truncation)]
-fn decode_poll_request(
+pub(crate) fn resolve_poll_request(
     shard: &Rc<ServerNgShard>,
-    request: &Message<RequestHeader>,
+    wire: &PollMessagesRequest,
+    client_id: u128,
 ) -> Result<DecodedPollRequest, IggyError> {
-    let wire = PollMessagesRequest::decode_from(request_body(request))
-        .map_err(|_| IggyError::InvalidCommand)?;
     let strategy = polling_strategy_from_wire(&wire.strategy)?;
     let args = PollingArgs::new(strategy, wire.count, wire.auto_commit);
 
@@ -1336,7 +1771,6 @@ fn decode_poll_request(
     // both use, so `next()` reads back the offset it just committed.
     if wire.consumer.kind == KIND_CONSUMER_GROUP {
         let partition_id = wire.partition_id.ok_or(IggyError::InvalidIdentifier)?;
-        let client_id = request.header().client;
         let group_id = shard
             .plane
             .metadata()
@@ -1377,12 +1811,14 @@ fn decode_poll_request(
     Ok((namespace, partition_id, consumer, args))
 }
 
-fn decode_consumer_offset_request(
+/// Resolve a decoded consumer-offset read into its owning-shard read:
+/// namespace, partition, and polling consumer. Shared by the TCP dispatch and
+/// the HTTP route; needs no client id because offset reads are not fenced
+/// (any client may read a group's offset, member or not).
+pub(crate) fn resolve_consumer_offset_request(
     shard: &Rc<ServerNgShard>,
-    request: &Message<RequestHeader>,
+    wire: &GetConsumerOffsetRequest,
 ) -> Result<(IggyNamespace, u32, PollingConsumer), IggyError> {
-    let wire = GetConsumerOffsetRequest::decode_from(request_body(request))
-        .map_err(|_| IggyError::InvalidCommand)?;
     // Omitted partition reads partition 0, matching the legacy resolver for
     // both consumer kinds (`unwrap_or(0)`).
     let partition_id = wire.partition_id.unwrap_or(0);
@@ -1461,17 +1897,19 @@ fn polling_strategy_from_wire(
 pub(crate) async fn submit_register_on_owner(
     shard: &Rc<ServerNgShard>,
     vsr_client_id: u128,
+    user_id: u32,
 ) -> Result<u64, MetadataSubmitError> {
     if shard.id == 0 {
         return shard
             .plane
             .metadata()
-            .submit_register_in_process(vsr_client_id)
+            .submit_register_in_process(vsr_client_id, user_id)
             .await;
     }
     let (reply, rx) = shard::channel::<Option<u64>>(1);
     shard.forward_metadata_submit(shard::MetadataSubmit::Register {
         vsr_client_id,
+        user_id,
         reply,
     });
     match rx.recv().await {
@@ -1482,7 +1920,7 @@ pub(crate) async fn submit_register_on_owner(
 
 /// Logout counterpart of [`submit_register_on_owner`].
 #[allow(clippy::future_not_send)]
-async fn submit_logout_on_owner(
+pub(crate) async fn submit_logout_on_owner(
     shard: &Rc<ServerNgShard>,
     vsr_client_id: u128,
     session: u64,
@@ -1542,51 +1980,9 @@ async fn handle_delete_segments_request(
     // `request == committed + 1` preflight -> RequestGap -> silent drop -> the
     // SDK blocks until timeout. A no-op delete still commits `up_to_offset = 0`
     // (monotonic apply) for the same reason.
-    #[allow(clippy::cast_possible_truncation)]
-    let truncate = match DeleteSegmentsRequest::decode_from(body) {
-        Ok(parsed) => match resolve_partition_request_namespace(
-            shard,
-            Operation::DeleteSegments,
-            body,
-            transport_client_id,
-        ) {
-            Ok(namespace_raw) => {
-                let namespace = IggyNamespace::from_raw(namespace_raw);
-                let up_to_offset = match shard
-                    .partition_read(
-                        namespace,
-                        PartitionRead::ResolveSegmentDeleteOffset {
-                            count: parsed.segments_count,
-                        },
-                    )
-                    .await
-                {
-                    Some(PartitionReadReply::SegmentDeleteOffset {
-                        up_to_offset: Some(offset),
-                    }) => offset,
-                    _ => 0,
-                };
-                Some(build_truncate_partition_client_message(
-                    &header,
-                    vsr_client_id,
-                    session,
-                    namespace.stream_id() as u32,
-                    namespace.topic_id() as u32,
-                    namespace.partition_id() as u32,
-                    up_to_offset,
-                ))
-            }
-            Err(error) => {
-                warn!(
-                    transport_client_id,
-                    error = %error,
-                    "delete_segments: unresolved namespace"
-                );
-                None
-            }
-        },
-        Err(_) => None,
-    };
+    let truncate = resolve_delete_segments_truncate(shard, &header, vsr_client_id, session, body)
+        .await
+        .ok();
 
     if let Some(truncate) = truncate
         && submit_client_request_on_owner(shard, truncate)
@@ -1617,6 +2013,58 @@ async fn handle_delete_segments_request(
             "delete_segments: failed to send reply"
         );
     }
+}
+
+/// Resolve a client `DeleteSegments` to the `TruncatePartition` that commits the
+/// trim. Shared by the TCP dispatch and the HTTP listener so both resolve the
+/// requested segment count to a concrete watermark identically.
+///
+/// `template` supplies the wire `cluster` / `view` / `release` and the client's
+/// `request` number; `client_id` / `session` are the bound VSR identity the
+/// truncate commits under. A resolvable namespace with nothing sealed to delete
+/// still yields a `TruncatePartition(up_to_offset = 0)` so the metadata request
+/// sequence stays contiguous. `Err` on a malformed body or an unresolved
+/// namespace: the TCP caller drops it to a silent replay, the HTTP caller renders
+/// the error.
+#[allow(clippy::future_not_send)]
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) async fn resolve_delete_segments_truncate(
+    shard: &Rc<ServerNgShard>,
+    template: &RequestHeader,
+    client_id: u128,
+    session: u64,
+    body: &[u8],
+) -> Result<Message<RequestHeader>, IggyError> {
+    let parsed = DeleteSegmentsRequest::decode_from(body).map_err(|_| IggyError::InvalidCommand)?;
+    let namespace_raw =
+        resolve_partition_request_namespace(shard, Operation::DeleteSegments, body, client_id)
+            .inspect_err(|error| {
+                warn!(client_id, error = %error, "delete_segments: unresolved namespace");
+            })?;
+    let namespace = IggyNamespace::from_raw(namespace_raw);
+    let up_to_offset = match shard
+        .partition_read(
+            namespace,
+            PartitionRead::ResolveSegmentDeleteOffset {
+                count: parsed.segments_count,
+            },
+        )
+        .await
+    {
+        Some(PartitionReadReply::SegmentDeleteOffset {
+            up_to_offset: Some(offset),
+        }) => offset,
+        _ => 0,
+    };
+    Ok(build_truncate_partition_client_message(
+        template,
+        client_id,
+        session,
+        namespace.stream_id() as u32,
+        namespace.topic_id() as u32,
+        namespace.partition_id() as u32,
+        up_to_offset,
+    ))
 }
 
 /// Disconnect cleanup: the local `SessionManager` connection is already
@@ -1663,7 +2111,7 @@ fn submit_disconnect_logout(shard: Rc<ServerNgShard>, vsr_client_id: u128, sessi
 /// `client` id (it's the VSR id, not the transport/home-shard-encoding id).
 /// `None` = transient submit failure (SDK read-timeout replays).
 #[allow(clippy::future_not_send)]
-async fn submit_client_request_on_owner(
+pub(crate) async fn submit_client_request_on_owner(
     shard: &Rc<ServerNgShard>,
     request: Message<RequestHeader>,
 ) -> Option<Message<GenericHeader>> {

--- a/core/server-ng/src/dispatch/authz.rs
+++ b/core/server-ng/src/dispatch/authz.rs
@@ -1,0 +1,360 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Dispatch-time authorization.
+//!
+//! The metadata STM enforces RBAC in-apply for replicated control ops. What
+//! that gate cannot see -- partition-plane ops and non-replicated reads, both
+//! decided on the connection's own shard without a replicated apply -- is gated
+//! here against the live permissioner via `Users::authorize`. A denial rides
+//! `ReplyHeader.status` (empty body), the request-level error channel the SDK
+//! peeks before body decode. Root holds every grant in the permissioner, so the
+//! rules pass for it without any user-id short-circuit.
+
+use std::rc::Rc;
+
+use consensus::MetadataHandle;
+use iggy_binary_protocol::codes::{
+    GET_CONSUMER_GROUP_CODE, GET_CONSUMER_GROUPS_CODE, GET_PERSONAL_ACCESS_TOKENS_CODE,
+    GET_STATS_CODE, GET_STREAM_CODE, GET_STREAMS_CODE, GET_TOPIC_CODE, GET_TOPICS_CODE,
+    GET_USER_CODE, GET_USERS_CODE,
+};
+use iggy_binary_protocol::requests::consumer_groups::{
+    GetConsumerGroupRequest, GetConsumerGroupsRequest,
+};
+use iggy_binary_protocol::requests::streams::GetStreamRequest;
+use iggy_binary_protocol::requests::topics::{GetTopicRequest, GetTopicsRequest};
+use iggy_binary_protocol::{Operation, RequestHeader, WireDecode, WireIdentifier};
+use iggy_common::IggyError;
+use message_bus::MessageBus;
+use metadata::impls::metadata::StreamsFrontend;
+use metadata::permissioner::Permissioner;
+use server_common::Message;
+use tracing::warn;
+
+use crate::bootstrap::ServerNgShard;
+use crate::responses::{
+    build_deny_reply, current_metadata_commit, resolve_stream_id, resolve_topic_id,
+};
+
+/// Authorize a partition-plane op on its resolved (stream, topic) for the
+/// acting user, returning the deny status code or `None` to proceed. The
+/// namespace already resolved, so the entity exists; a `None` user id (which
+/// the bound-session gate should preclude) fails closed with `Unauthenticated`
+/// rather than allow an unattributed write.
+pub(super) fn authorize_partition_op(
+    shard: &Rc<ServerNgShard>,
+    operation: Operation,
+    user_id: Option<u32>,
+    stream_id: usize,
+    topic_id: usize,
+) -> Option<u32> {
+    let Some(user_id) = user_id else {
+        return Some(IggyError::Unauthenticated.as_code());
+    };
+    let decision =
+        shard
+            .plane
+            .metadata()
+            .mux_stm
+            .users()
+            .authorize(|permissioner| match operation {
+                Operation::SendMessages => {
+                    permissioner.append_messages(user_id, stream_id, topic_id)
+                }
+                Operation::StoreConsumerOffset | Operation::StoreConsumerOffset2 => {
+                    permissioner.store_consumer_offset(user_id, stream_id, topic_id)
+                }
+                Operation::DeleteConsumerOffset | Operation::DeleteConsumerOffset2 => {
+                    permissioner.delete_consumer_offset(user_id, stream_id, topic_id)
+                }
+                // The caller only routes the five partition ops above here. The
+                // rest are listed exhaustively (no `_`) so a newly added op
+                // forces a gate decision at compile time instead of silently
+                // slipping through ungated.
+                Operation::Reserved
+                | Operation::Register
+                | Operation::NonReplicated
+                | Operation::Logout
+                | Operation::CreateTopicWithAssignments
+                | Operation::CreatePartitionsWithAssignments
+                | Operation::RemoveConsumerGroupMember
+                | Operation::CompleteConsumerGroupRevocation
+                | Operation::TruncatePartition
+                | Operation::CreateStream
+                | Operation::UpdateStream
+                | Operation::DeleteStream
+                | Operation::PurgeStream
+                | Operation::CreateTopic
+                | Operation::UpdateTopic
+                | Operation::DeleteTopic
+                | Operation::PurgeTopic
+                | Operation::CreatePartitions
+                | Operation::DeletePartitions
+                | Operation::DeleteSegments
+                | Operation::CreateConsumerGroup
+                | Operation::DeleteConsumerGroup
+                | Operation::CreateUser
+                | Operation::UpdateUser
+                | Operation::DeleteUser
+                | Operation::ChangePassword
+                | Operation::UpdatePermissions
+                | Operation::CreatePersonalAccessToken
+                | Operation::DeletePersonalAccessToken
+                | Operation::JoinConsumerGroup
+                | Operation::LeaveConsumerGroup => Ok(()),
+            });
+    decision.err().map(|error| error.as_code())
+}
+
+/// Reply to a denied partition op with the op's frame: empty body + nonzero
+/// `status`. Distinct from `send_empty_partition_reply` (status 0, the
+/// fail-fast "not routable" ack); here the SDK peeks the status and surfaces
+/// the typed authorization error. Same lockstep reasoning: a silent drop would
+/// wedge every later request on the connection.
+#[allow(clippy::future_not_send)]
+pub(super) async fn send_partition_deny_reply(
+    shard: &Rc<ServerNgShard>,
+    transport_client_id: u128,
+    request_header: &RequestHeader,
+    status: u32,
+) {
+    let commit = current_metadata_commit(shard);
+    let reply = build_deny_reply(request_header, transport_client_id, 0, commit, status);
+    if let Err(error) = shard
+        .bus
+        .send_to_client(transport_client_id, reply.into_generic().into_frozen())
+        .await
+    {
+        warn!(
+            transport_client_id,
+            status,
+            error = %error,
+            operation = ?request_header.operation,
+            "failed to surface partition authz denial"
+        );
+    }
+}
+
+/// Run an unscoped non-replicated-read rule for the acting user. A `None` user
+/// id (only the pre-auth path, which serves ungated codes) fails closed.
+pub(super) fn authorize_uid(
+    shard: &Rc<ServerNgShard>,
+    user_id: Option<u32>,
+    rule: impl FnOnce(&Permissioner, u32) -> Result<(), IggyError>,
+) -> Result<(), IggyError> {
+    let user_id = user_id.ok_or(IggyError::Unauthenticated)?;
+    shard
+        .plane
+        .metadata()
+        .mux_stm
+        .users()
+        .authorize(|permissioner| rule(permissioner, user_id))
+}
+
+/// Authorize a partition-plane non-replicated read (poll / consumer-offset) on
+/// (stream, topic). `None` proceeds (allowed, or a resolution miss the caller's
+/// own not-found path handles); `Some(status)` denies. A `None` user id fails
+/// closed.
+pub(super) fn authorize_partition_read(
+    shard: &Rc<ServerNgShard>,
+    stream_id: &WireIdentifier,
+    topic_id: &WireIdentifier,
+    user_id: Option<u32>,
+    rule: impl FnOnce(&Permissioner, u32, usize, usize) -> Result<(), IggyError>,
+) -> Option<u32> {
+    let Some(user_id) = user_id else {
+        return Some(IggyError::Unauthenticated.as_code());
+    };
+    let (stream_id, topic_id) = resolve_topic_scope(shard, stream_id, topic_id)?;
+    shard
+        .plane
+        .metadata()
+        .mux_stm
+        .users()
+        .authorize(|permissioner| rule(permissioner, user_id, stream_id, topic_id))
+        .err()
+        .map(|error| error.as_code())
+}
+
+/// Authorize a non-replicated read routed through `build_non_replicated_response`
+/// (`handle_default_non_replicated`). `Ok(())` allows -- including a resolution
+/// miss, which falls through to the builder's own not-found reply so the legacy
+/// notfound-before-permission ordering holds. `Err` denies with that code.
+/// Unscoped rules gate directly; identifier-scoped rules resolve (stream[,
+/// topic]) against committed state first. The PAT list is self-scoped, so
+/// authentication is its whole rule. `GET_CLUSTER_METADATA` is deliberately
+/// pre-auth (bootstrap / leader discovery; the dispatch allowlist admits it
+/// unauthenticated) and, like every other code the builder serves, is ungated
+/// here.
+pub(super) fn authorize_default_read(
+    shard: &Rc<ServerNgShard>,
+    code: u32,
+    body: &[u8],
+    user_id: Option<u32>,
+) -> Result<(), IggyError> {
+    // A `u32` match cannot be exhaustive: every gated code is named explicitly,
+    // and the final arm is the ungated set the builder serves without a rule.
+    match code {
+        GET_STATS_CODE => authorize_uid(shard, user_id, Permissioner::get_stats),
+        GET_USERS_CODE => authorize_uid(shard, user_id, Permissioner::get_users),
+        GET_USER_CODE => authorize_uid(shard, user_id, Permissioner::get_user),
+        // Self-scoped: lists only the caller's own tokens, so there is no
+        // permissioner rule to run (legacy runs none either).
+        GET_PERSONAL_ACCESS_TOKENS_CODE => user_id.map(|_| ()).ok_or(IggyError::Unauthenticated),
+        GET_STREAMS_CODE => authorize_uid(shard, user_id, Permissioner::get_streams),
+        GET_STREAM_CODE => gate_stream_scoped::<GetStreamRequest>(
+            shard,
+            user_id,
+            body,
+            |request| &request.stream_id,
+            Permissioner::get_stream,
+        ),
+        GET_TOPICS_CODE => gate_stream_scoped::<GetTopicsRequest>(
+            shard,
+            user_id,
+            body,
+            |request| &request.stream_id,
+            Permissioner::get_topics,
+        ),
+        GET_TOPIC_CODE => gate_topic_scoped::<GetTopicRequest>(
+            shard,
+            user_id,
+            body,
+            |request| (&request.stream_id, &request.topic_id),
+            Permissioner::get_topic,
+        ),
+        GET_CONSUMER_GROUP_CODE => gate_topic_scoped::<GetConsumerGroupRequest>(
+            shard,
+            user_id,
+            body,
+            |request| (&request.stream_id, &request.topic_id),
+            Permissioner::get_consumer_group,
+        ),
+        GET_CONSUMER_GROUPS_CODE => gate_topic_scoped::<GetConsumerGroupsRequest>(
+            shard,
+            user_id,
+            body,
+            |request| (&request.stream_id, &request.topic_id),
+            Permissioner::get_consumer_groups,
+        ),
+        _ => Ok(()),
+    }
+}
+
+/// Reply to a denied non-replicated read with the request's reply frame: empty
+/// body + nonzero `status`. The SDK peeks the status before body decode and
+/// surfaces the typed error, so a poll denial never reaches the empty-poll
+/// "0 messages" body path.
+#[allow(clippy::future_not_send)]
+pub(super) async fn send_non_replicated_deny(
+    shard: &Rc<ServerNgShard>,
+    request: &Message<RequestHeader>,
+    transport_client_id: u128,
+    status: u32,
+) {
+    let commit = current_metadata_commit(shard);
+    let reply = build_deny_reply(
+        request.header(),
+        request.header().client,
+        request.header().session,
+        commit,
+        status,
+    );
+    if let Err(error) = shard
+        .bus
+        .send_to_client(transport_client_id, reply.into_generic().into_frozen())
+        .await
+    {
+        warn!(
+            transport_client_id,
+            status,
+            error = %error,
+            "failed to surface non-replicated authz denial"
+        );
+    }
+}
+
+/// Gate a stream-scoped read: decode the request, project its wire stream id,
+/// resolve it to the committed slab id, then run `rule`. A malformed body or a
+/// resolution miss returns `Ok(())` so the builder's own error / not-found
+/// reply is what the client sees (decode-and-notfound-before-permission).
+fn gate_stream_scoped<T: WireDecode>(
+    shard: &Rc<ServerNgShard>,
+    user_id: Option<u32>,
+    body: &[u8],
+    stream_id: impl FnOnce(&T) -> &WireIdentifier,
+    rule: impl FnOnce(&Permissioner, u32, usize) -> Result<(), IggyError>,
+) -> Result<(), IggyError> {
+    let Ok(request) = T::decode_from(body) else {
+        return Ok(());
+    };
+    let Some(stream_id) = resolve_stream_scope(shard, stream_id(&request)) else {
+        return Ok(());
+    };
+    authorize_uid(shard, user_id, |permissioner, uid| {
+        rule(permissioner, uid, stream_id)
+    })
+}
+
+/// Gate a topic-scoped read: decode the request, project its wire (stream,
+/// topic) pair, resolve both to committed slab ids, then run `rule`. A malformed
+/// body or a resolution miss on either returns `Ok(())` so the builder's own
+/// error / not-found reply holds (decode-and-notfound-before-permission).
+fn gate_topic_scoped<T: WireDecode>(
+    shard: &Rc<ServerNgShard>,
+    user_id: Option<u32>,
+    body: &[u8],
+    ids: impl FnOnce(&T) -> (&WireIdentifier, &WireIdentifier),
+    rule: impl FnOnce(&Permissioner, u32, usize, usize) -> Result<(), IggyError>,
+) -> Result<(), IggyError> {
+    let Ok(request) = T::decode_from(body) else {
+        return Ok(());
+    };
+    let (stream_id, topic_id) = ids(&request);
+    let Some((stream_id, topic_id)) = resolve_topic_scope(shard, stream_id, topic_id) else {
+        return Ok(());
+    };
+    authorize_uid(shard, user_id, |permissioner, uid| {
+        rule(permissioner, uid, stream_id, topic_id)
+    })
+}
+
+/// Resolve a wire stream identifier to its committed slab id, or `None` on a
+/// miss (the gate then falls through to the builder's not-found reply).
+fn resolve_stream_scope(shard: &Rc<ServerNgShard>, stream_id: &WireIdentifier) -> Option<usize> {
+    shard
+        .plane
+        .metadata()
+        .mux_stm
+        .streams()
+        .read(|inner| resolve_stream_id(inner, stream_id))
+}
+
+/// Resolve a wire (stream, topic) pair to committed slab ids, or `None` if
+/// either misses.
+fn resolve_topic_scope(
+    shard: &Rc<ServerNgShard>,
+    stream_id: &WireIdentifier,
+    topic_id: &WireIdentifier,
+) -> Option<(usize, usize)> {
+    shard.plane.metadata().mux_stm.streams().read(|inner| {
+        let stream_id = resolve_stream_id(inner, stream_id)?;
+        let topic_id = resolve_topic_id(inner, stream_id, topic_id)?;
+        Some((stream_id, topic_id))
+    })
+}

--- a/core/server-ng/src/http.rs
+++ b/core/server-ng/src/http.rs
@@ -1,0 +1,239 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shard-0 HTTP/REST listener. This root binds the listener and assembles the
+//! router; the rest is split across submodules: the `state` bridge and axum
+//! `State`, the bearer `extractor` and `jwt` issuer, the route `handlers`, the
+//! `reads` gates, the `submit` write paths, `wire` request mapping,
+//! partition-write `admission`, committed-reply `reply` decoding, the rejection
+//! `error` types, and per-credential `session` state.
+
+mod admission;
+mod error;
+mod extractor;
+mod handlers;
+mod jwt;
+mod reads;
+mod reply;
+mod session;
+mod state;
+mod submit;
+mod wire;
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::{DefaultBodyLimit, Request};
+use axum::middleware::{Next, from_fn};
+use axum::routing::{delete, get, post, put};
+use configs::cluster::{ClusterConfig, TransportPorts};
+use configs::http::HttpConfig;
+use configs::system::SystemConfig;
+use message_bus::client_listener;
+use send_wrapper::SendWrapper;
+use tracing::{error, info};
+
+use crate::bootstrap::ServerNgShard;
+use crate::cluster_meta::ClusterRoster;
+use crate::http::handlers::{
+    change_password, create_cg, create_partitions, create_pat, create_stream, create_topic,
+    create_user, delete_cg, delete_consumer_offset, delete_partitions, delete_pat, delete_segments,
+    delete_stream, delete_topic, delete_user, get_cg, get_cgs, get_client, get_clients,
+    get_cluster_metadata, get_consumer_offset, get_pats, get_snapshot, get_stats, get_stream,
+    get_streams, get_topic, get_topics, get_user, get_users, login_user,
+    login_with_personal_access_token, logout_user, ping, poll_messages, purge_stream, purge_topic,
+    refresh_token, send_messages, store_consumer_offset, update_permissions, update_stream,
+    update_topic, update_user,
+};
+use crate::http::jwt::JwtManager;
+use crate::http::session::RegistrationBarrier;
+use crate::http::state::{HttpInner, HttpState, insert_view_header};
+use crate::server_error::ServerNgError;
+
+/// Bind the shard-0 HTTP listener and spawn the `cyper-axum` serve loop as a
+/// background task on shard 0's compio runtime.
+///
+/// The caller gates this to shard 0 and to `http.enabled`; the listener stops
+/// when the bus shutdown token fires.
+///
+/// # Errors
+///
+/// Returns [`ServerNgError`] if the JWT manager cannot be built from
+/// `http_config.jwt` or the listener cannot bind to `addr`.
+pub async fn start(
+    shard: &Rc<ServerNgShard>,
+    addr: SocketAddr,
+    http_config: &HttpConfig,
+    cluster: &ClusterConfig,
+    system_config: Arc<SystemConfig>,
+    self_ports: TransportPorts,
+) -> Result<(), ServerNgError> {
+    let jwt = JwtManager::build(&http_config.jwt)?;
+    let (listener, bound_addr) = client_listener::tcp::bind(addr).await?;
+    info!(address = %bound_addr, "server-ng HTTP listener started");
+
+    let state: HttpState = SendWrapper::new(Rc::new(HttpInner {
+        shard: Rc::clone(shard),
+        jwt,
+        system_config,
+        sessions: RefCell::new(HashMap::new()),
+        registrations: RegistrationBarrier::default(),
+        roster: ClusterRoster {
+            enabled: cluster.enabled,
+            name: cluster.name.clone(),
+            nodes: cluster.nodes.clone(),
+            self_ip: bound_addr.ip().to_string(),
+            // The self node reports the live bound HTTP port; the other client
+            // ports arrive resolved from the caller.
+            self_ports: TransportPorts {
+                http: Some(bound_addr.port()),
+                ..self_ports
+            },
+        },
+        in_flight_writes: Cell::new(0),
+    }));
+    // Saturating: a configured limit past the pointer width (32-bit target,
+    // >4 GiB value) clamps to the largest enforceable cap instead of wrapping.
+    let max_request_size =
+        usize::try_from(http_config.max_request_size.as_bytes_u64()).unwrap_or(usize::MAX);
+    let router = router(state, max_request_size);
+
+    let shutdown = shard.bus.token();
+    let handle = compio::runtime::spawn(async move {
+        if let Err(error) = cyper_axum::serve(listener, router)
+            .with_graceful_shutdown(async move { shutdown.wait().await })
+            .await
+        {
+            error!(%error, "server-ng HTTP listener terminated with error");
+        }
+    });
+    shard.bus.track_background(handle);
+
+    Ok(())
+}
+
+/// Health-probe path. Public and pre-auth, and the one success route reached
+/// without proving a credential, so the `X-Iggy-View` layer withholds the
+/// cluster-internal view number here (see the response layer below).
+const PING_PATH: &str = "/ping";
+
+/// Assemble the shard-0 router: unauthenticated health + login routes plus the
+/// authenticated REST surface.
+///
+/// `max_request_size` becomes the router-wide `DefaultBodyLimit` (413 past
+/// it), exactly like the legacy server: it bounds the per-request term of the
+/// admission math - what one body may cost in bytes and decode CPU - while
+/// the in-flight caps bound the multiplier.
+fn router(state: HttpState, max_request_size: usize) -> Router {
+    // Cloned for the response layer so `X-Iggy-View` reads the live view per
+    // response; the original `state` is moved into `with_state` below.
+    let view_source = state.clone();
+    Router::new()
+        .route(PING_PATH, get(ping))
+        .route("/users/login", post(login_user))
+        .route("/users/refresh-token", post(refresh_token))
+        .route(
+            "/personal-access-tokens/login",
+            post(login_with_personal_access_token),
+        )
+        .route("/users", get(get_users).post(create_user))
+        .route(
+            "/users/{user_id}",
+            get(get_user).put(update_user).delete(delete_user),
+        )
+        .route("/users/{user_id}/password", put(change_password))
+        .route("/users/{user_id}/permissions", put(update_permissions))
+        // Static `logout` outranks the `{user_id}` capture in axum's matcher, so
+        // `DELETE /users/logout` never misroutes to `delete_user`.
+        .route("/users/logout", delete(logout_user))
+        .route("/streams", get(get_streams).post(create_stream))
+        .route(
+            "/streams/{stream_id}",
+            get(get_stream).put(update_stream).delete(delete_stream),
+        )
+        .route("/streams/{stream_id}/purge", delete(purge_stream))
+        .route(
+            "/streams/{stream_id}/topics",
+            get(get_topics).post(create_topic),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}",
+            get(get_topic).put(update_topic).delete(delete_topic),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}/purge",
+            delete(purge_topic),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}/partitions",
+            post(create_partitions).delete(delete_partitions),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}/partitions/{partition_id}",
+            delete(delete_segments),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}/messages",
+            get(poll_messages).post(send_messages),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}/consumer-offsets",
+            get(get_consumer_offset).put(store_consumer_offset),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}/consumer-offsets/{consumer_id}",
+            delete(delete_consumer_offset),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}/consumer-groups",
+            get(get_cgs).post(create_cg),
+        )
+        .route(
+            "/streams/{stream_id}/topics/{topic_id}/consumer-groups/{group_id}",
+            get(get_cg).delete(delete_cg),
+        )
+        .route("/personal-access-tokens", get(get_pats).post(create_pat))
+        .route("/personal-access-tokens/{name}", delete(delete_pat))
+        .route("/stats", get(get_stats))
+        .route("/snapshot", post(get_snapshot))
+        .route("/cluster/metadata", get(get_cluster_metadata))
+        .route("/clients", get(get_clients))
+        .route("/clients/{client_id}", get(get_client))
+        .with_state(state)
+        .layer(DefaultBodyLimit::max(max_request_size))
+        .layer(from_fn(move |request: Request, next: Next| {
+            let view_source = view_source.clone();
+            // `/ping` is the sole success route reached without proving a
+            // credential, so it must not leak the cluster-internal view number
+            // (the anon-leak gate). Every other route authenticates before its
+            // handler, so a success/redirect there is an authed flow that may
+            // carry the header; the login routes prove credentials on success.
+            let suppress_view = request.uri().path() == PING_PATH;
+            async move {
+                let response = next.run(request).await;
+                if suppress_view {
+                    response
+                } else {
+                    insert_view_header(&view_source, response)
+                }
+            }
+        }))
+}

--- a/core/server-ng/src/http/admission.rs
+++ b/core/server-ng/src/http/admission.rs
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! In-flight admission for awaited partition writes: the per-session /
+//! shard-global budget guard. Coupled to the router body cap because the shard
+//! inbox is one shared bounded channel, so admission is correctness-adjacent.
+
+use std::cell::Cell;
+
+use crate::http::error::PartitionWriteError;
+
+/// Per-session cap on concurrently awaited partition writes (produce /
+/// consumer-offset). Bounds how much of [`MAX_IN_FLIGHT_WRITES_GLOBAL`] one
+/// credential can occupy, so a session that outruns its own commits saturates
+/// itself (429, its own backpressure signal) before it can starve every other
+/// session out of the shared budget.
+const MAX_IN_FLIGHT_WRITES_PER_SESSION: u32 = 32;
+
+/// Shard-0-global budget for concurrently awaited partition writes, across all
+/// sessions. Every admitted write parks a handler for up to
+/// [`PARTITION_WRITE_REPLY_TIMEOUT`] while pinning its buffered body, and its
+/// decode/encode/HS256 CPU runs on the same single-threaded core that pumps
+/// consensus. The budget therefore bounds both starvation terms: budget x
+/// `max_request_size` bounds the worst-case buffered bytes, and budget x
+/// per-request CPU bounds how far admitted HTTP work can delay the consensus
+/// pump. `?ack=none` produces are admitted through the same caps: they install
+/// no reply slot and never await a commit, but they still park inside dispatch
+/// for the routable-wait budget while pinning their buffered body, so leaving
+/// them uncapped would bypass both terms. A session that saturates its own cap
+/// reads its own 429 before it can spill onto the shared budget.
+const MAX_IN_FLIGHT_WRITES_GLOBAL: u32 = 128;
+
+/// In-flight admission token for one awaited partition write. One guard owns
+/// both releases (session + global) so success, every error return, the reply
+/// timeout, and handler cancellation (the client hanging up mid-await drops
+/// this future) all decrement through the same `Drop`.
+pub(in crate::http) struct InFlightWriteGuard<'a> {
+    session_in_flight: &'a Cell<u32>,
+    global_in_flight: &'a Cell<u32>,
+}
+
+impl Drop for InFlightWriteGuard<'_> {
+    fn drop(&mut self) {
+        self.session_in_flight.set(self.session_in_flight.get() - 1);
+        self.global_in_flight.set(self.global_in_flight.get() - 1);
+    }
+}
+
+/// Admit one awaited partition write against the per-session cap and the
+/// shard-0 global budget, incrementing both counters only when both pass. The
+/// session cap is checked first so a session that saturates itself reads as
+/// its own 429 rather than as server-wide pressure.
+pub(in crate::http) fn admit_partition_write<'a>(
+    session_in_flight: &'a Cell<u32>,
+    global_in_flight: &'a Cell<u32>,
+) -> Result<InFlightWriteGuard<'a>, PartitionWriteError> {
+    if session_in_flight.get() >= MAX_IN_FLIGHT_WRITES_PER_SESSION {
+        return Err(PartitionWriteError::TooManyInFlight);
+    }
+    if global_in_flight.get() >= MAX_IN_FLIGHT_WRITES_GLOBAL {
+        return Err(PartitionWriteError::ServerBusy);
+    }
+    session_in_flight.set(session_in_flight.get() + 1);
+    global_in_flight.set(global_in_flight.get() + 1);
+    Ok(InFlightWriteGuard {
+        session_in_flight,
+        global_in_flight,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_flight_write_guard_decrements_both_counters_on_drop() {
+        let session = Cell::new(0);
+        let global = Cell::new(0);
+        let guard = admit_partition_write(&session, &global).expect("below both caps");
+        assert_eq!(session.get(), 1);
+        assert_eq!(global.get(), 1);
+        drop(guard);
+        assert_eq!(session.get(), 0);
+        assert_eq!(global.get(), 0);
+    }
+
+    #[test]
+    fn admission_at_session_cap_rejects_with_too_many_in_flight() {
+        let session = Cell::new(MAX_IN_FLIGHT_WRITES_PER_SESSION);
+        let global = Cell::new(0);
+        assert!(matches!(
+            admit_partition_write(&session, &global),
+            Err(PartitionWriteError::TooManyInFlight)
+        ));
+        // A refusal must not leak a partial increment on either counter.
+        assert_eq!(session.get(), MAX_IN_FLIGHT_WRITES_PER_SESSION);
+        assert_eq!(global.get(), 0);
+    }
+
+    #[test]
+    fn admission_at_global_budget_rejects_with_server_busy() {
+        let session = Cell::new(0);
+        let global = Cell::new(MAX_IN_FLIGHT_WRITES_GLOBAL);
+        assert!(matches!(
+            admit_partition_write(&session, &global),
+            Err(PartitionWriteError::ServerBusy)
+        ));
+        assert_eq!(session.get(), 0);
+        assert_eq!(global.get(), MAX_IN_FLIGHT_WRITES_GLOBAL);
+    }
+
+    #[test]
+    fn interleaved_admission_reopens_exactly_released_session_slots() {
+        let session = Cell::new(0);
+        let global = Cell::new(0);
+        let mut guards = Vec::new();
+        for _ in 0..MAX_IN_FLIGHT_WRITES_PER_SESSION {
+            guards.push(admit_partition_write(&session, &global).expect("below both caps"));
+        }
+        assert!(matches!(
+            admit_partition_write(&session, &global),
+            Err(PartitionWriteError::TooManyInFlight)
+        ));
+        let released = 3;
+        guards.truncate((MAX_IN_FLIGHT_WRITES_PER_SESSION - released) as usize);
+        assert_eq!(session.get(), MAX_IN_FLIGHT_WRITES_PER_SESSION - released);
+        for _ in 0..released {
+            guards.push(admit_partition_write(&session, &global).expect("released slots"));
+        }
+        assert!(matches!(
+            admit_partition_write(&session, &global),
+            Err(PartitionWriteError::TooManyInFlight)
+        ));
+        drop(guards);
+        assert_eq!(session.get(), 0);
+        assert_eq!(global.get(), 0);
+    }
+
+    #[test]
+    fn global_budget_spans_sessions_and_reopens_after_release() {
+        let global = Cell::new(0);
+        let session_count =
+            MAX_IN_FLIGHT_WRITES_GLOBAL.div_ceil(MAX_IN_FLIGHT_WRITES_PER_SESSION) as usize;
+        let sessions: Vec<Cell<u32>> = (0..session_count).map(|_| Cell::new(0)).collect();
+        let mut guards = Vec::new();
+        'fill: for session in &sessions {
+            for _ in 0..MAX_IN_FLIGHT_WRITES_PER_SESSION {
+                match admit_partition_write(session, &global) {
+                    Ok(guard) => guards.push(guard),
+                    Err(PartitionWriteError::ServerBusy) => break 'fill,
+                    Err(other) => {
+                        panic!("only the global budget may refuse this fill, got {other:?}")
+                    }
+                }
+            }
+        }
+        assert_eq!(global.get(), MAX_IN_FLIGHT_WRITES_GLOBAL);
+        // A fresh session is refused on the shared budget, not its own cap.
+        let fresh = Cell::new(0);
+        assert!(matches!(
+            admit_partition_write(&fresh, &global),
+            Err(PartitionWriteError::ServerBusy)
+        ));
+        drop(guards.pop());
+        let readmitted = admit_partition_write(&fresh, &global).expect("budget slot released");
+        assert_eq!(fresh.get(), 1);
+        assert_eq!(global.get(), MAX_IN_FLIGHT_WRITES_GLOBAL);
+        drop(readmitted);
+    }
+}

--- a/core/server-ng/src/http/error.rs
+++ b/core/server-ng/src/http/error.rs
@@ -1,0 +1,558 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! HTTP rejection types and hand-built error responses: the auth / write /
+//! read / partition-write error enums, their `IntoResponse` renderings, the
+//! `?consistency=` and `?ack=` query DTOs, and the primary-redirect helpers.
+
+use std::net::{IpAddr, SocketAddr};
+
+use axum::Json;
+use axum::http::header::{LOCATION, RETRY_AFTER};
+use axum::http::{HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use iggy_binary_protocol::Operation;
+use iggy_common::IggyError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::error;
+
+use crate::cluster_meta::ClusterRoster;
+
+#[derive(Debug, Error)]
+pub(in crate::http) enum CustomError {
+    #[error(transparent)]
+    Error(#[from] IggyError),
+    #[error("Resource not found")]
+    ResourceNotFound,
+}
+
+#[derive(Debug, Serialize)]
+pub(in crate::http) struct ErrorResponse {
+    /// Two conventions by construction: the `IggyError` numeric code
+    /// (`IggyError::as_code`) when the error wraps one (via [`Self::from_error`]),
+    /// or the HTTP status code for the hand-built HTTP-layer errors (429/503/504
+    /// and the 404 not-found fallback) that carry no underlying `IggyError`.
+    pub id: u32,
+    pub code: String,
+    pub reason: String,
+    pub field: Option<String>,
+}
+
+impl IntoResponse for CustomError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Error(error) => {
+                error!("There was an error: {error}");
+                let status_code = match error {
+                    IggyError::StreamIdNotFound(_)
+                    | IggyError::TopicIdNotFound(_, _)
+                    | IggyError::PartitionNotFound(_, _, _)
+                    | IggyError::SegmentNotFound
+                    | IggyError::ClientNotFound(_)
+                    | IggyError::ConsumerGroupIdNotFound(_, _)
+                    | IggyError::ConsumerGroupNameNotFound(_, _)
+                    | IggyError::ConsumerGroupMemberNotFound(_, _, _)
+                    | IggyError::ConsumerOffsetNotFound(_)
+                    | IggyError::ResourceNotFound(_) => StatusCode::NOT_FOUND,
+                    IggyError::Unauthenticated
+                    | IggyError::AccessTokenMissing
+                    | IggyError::InvalidAccessToken
+                    | IggyError::InvalidPersonalAccessToken => StatusCode::UNAUTHORIZED,
+                    IggyError::Unauthorized => StatusCode::FORBIDDEN,
+                    // The pre-consensus retry frame: reaching this render
+                    // means the write path's replay budget is exhausted and
+                    // the op never committed - a transient server condition,
+                    // retryable like the other cannot-commit-right-now 503s
+                    // (see `service_unavailable`), never a caller error.
+                    IggyError::TransientNotCommitted => StatusCode::SERVICE_UNAVAILABLE,
+                    _ => StatusCode::BAD_REQUEST,
+                };
+                (status_code, Json(ErrorResponse::from_error(&error)))
+            }
+            Self::ResourceNotFound => (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    id: 404,
+                    code: "not_found".to_string(),
+                    reason: "Resource not found".to_string(),
+                    field: None,
+                }),
+            ),
+        }
+        .into_response()
+    }
+}
+
+impl ErrorResponse {
+    pub fn from_error(error: &IggyError) -> Self {
+        Self {
+            id: error.as_code(),
+            code: error.as_string().to_string(),
+            reason: error.to_string(),
+            field: match error {
+                IggyError::StreamIdNotFound(_) | IggyError::InvalidStreamId => {
+                    Some("stream_id".to_string())
+                }
+                IggyError::TopicIdNotFound(_, _) | IggyError::InvalidTopicId => {
+                    Some("topic_id".to_string())
+                }
+                IggyError::PartitionNotFound(_, _, _) => Some("partition_id".to_string()),
+                IggyError::SegmentNotFound => Some("segment_id".to_string()),
+                IggyError::ClientNotFound(_) => Some("client_id".to_string()),
+                IggyError::InvalidStreamName
+                | IggyError::StreamNameAlreadyExists(_)
+                | IggyError::InvalidTopicName
+                | IggyError::TopicNameAlreadyExists(_, _)
+                | IggyError::ConsumerGroupNameAlreadyExists(_, _)
+                | IggyError::PersonalAccessTokenAlreadyExists(_, _) => Some("name".to_string()),
+                IggyError::InvalidOffset(_) => Some("offset".to_string()),
+                IggyError::InvalidConsumerGroupId => Some("consumer_group_id".to_string()),
+                IggyError::UserAlreadyExists => Some("username".to_string()),
+                _ => None,
+            },
+        }
+    }
+}
+
+/// Rejection for protected routes.
+///
+/// Two failure classes get two statuses: a missing, invalid, or expired
+/// credential is the caller's fault (401, rendered as the JSON `ErrorResponse`
+/// body every other route error uses), while a VSR session that cannot be
+/// established right now is a transient server condition (503) and must never
+/// masquerade as an auth failure.
+pub enum AuthError {
+    Unauthenticated(IggyError),
+    SessionUnavailable,
+}
+
+impl From<IggyError> for AuthError {
+    fn from(error: IggyError) -> Self {
+        Self::Unauthenticated(error)
+    }
+}
+
+impl IntoResponse for AuthError {
+    fn into_response(self) -> Response {
+        match self {
+            // Render 401 through the shared `IggyError -> CustomError` map so it
+            // carries the same JSON `ErrorResponse` body as every other ng error.
+            // The legacy server's protected-route 401 comes from a bare-status
+            // JWT middleware (empty body), so this is deliberately richer, not
+            // byte-identical to legacy.
+            Self::Unauthenticated(error) => CustomError::from(error).into_response(),
+            // A fresh session could not be established: the Register did not
+            // commit (no caught-up primary, pipeline full, or a view-change
+            // cancel), or the session table is at `MAX_HTTP_SESSIONS` and
+            // refused the fresh registration. Transient server condition -> 503,
+            // retryable.
+            Self::SessionUnavailable => service_unavailable(),
+        }
+    }
+}
+
+/// Rejection for an authenticated control-plane write (`POST /streams` and the
+/// writes that follow it).
+///
+/// Same two-class split as [`AuthError`], for the same reasons: a caller-side
+/// validation failure or a committed business rejection (e.g. a duplicate
+/// stream name) renders through the legacy `IggyError -> CustomError` map so
+/// SDK error bodies stay byte-identical, while a write that cannot commit right
+/// now is a transient server condition (503) and must never surface as a
+/// business error or, worse, a 200 with a stale body.
+pub(in crate::http) enum WriteError {
+    Rejected(IggyError),
+    /// The VSR session was evicted (its client slot was reclaimed cluster-side,
+    /// e.g. LRU-evicted from the full client table). Renders identically to a
+    /// terminal `Rejected` (401 -> re-authenticate), but is a distinct variant
+    /// so the submit path can drop the dead session entry and let the caller's
+    /// next request re-register cleanly instead of 401-looping on it.
+    Evicted(IggyError),
+    Unavailable,
+}
+
+impl IntoResponse for WriteError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Rejected(error) | Self::Evicted(error) => {
+                CustomError::from(error).into_response()
+            }
+            Self::Unavailable => service_unavailable(),
+        }
+    }
+}
+
+/// Rejection for a data-plane partition write (`POST .../messages` produce and
+/// the `PUT`/`DELETE .../consumer-offsets` writes).
+///
+/// Split differently from [`WriteError`] because the partition plane replies
+/// carry no committed error code: a pre-dispatch gate failure is an empty
+/// reply distinguishable only by header (see [`classify_partition_reply`]),
+/// and an unanswered write is a distinct outcome the caller must treat as
+/// unknown rather than failed.
+#[derive(Debug)]
+pub(in crate::http) enum PartitionWriteError {
+    /// Caller-side rejection (bad identifier, oversized batch, an authorization
+    /// denial), a typed pre-commit deny from the partition plane
+    /// (`ReplyHeader.status`), or a malformed reply frame, rendered through the
+    /// legacy `IggyError -> status` map for SDK-identical bodies.
+    Rejected(IggyError),
+    /// The dispatch gates could not route the write: the stream, topic, or
+    /// partition does not resolve (or never materialised within the routable
+    /// budget). Rendered as the legacy 404 body.
+    NotFound,
+    /// The in-process reply slot could not be installed. Transient server
+    /// condition -> the shared 503, retryable.
+    Unavailable,
+    /// This session is already at [`MAX_IN_FLIGHT_WRITES_PER_SESSION`]
+    /// awaited writes. 429: the caller's own concurrency is the problem, so
+    /// it must drain its outstanding writes before submitting more.
+    TooManyInFlight,
+    /// Shard 0 is already at [`MAX_IN_FLIGHT_WRITES_GLOBAL`] awaited writes
+    /// across all sessions. 503 with its own code (distinct from the shared
+    /// consensus-unavailable body) so an operator can tell admission shedding
+    /// from a consensus outage.
+    ServerBusy,
+    /// No committed reply within [`PARTITION_WRITE_REPLY_TIMEOUT`], or the
+    /// session's reply target was torn down mid-wait. 504: the commit may
+    /// still land (at-least-once), so this is a hard "outcome unknown", not a
+    /// failure the server may transparently retry. Carries the write's
+    /// operation so the 504 body names which write kind timed out.
+    Timeout(Operation),
+}
+
+impl IntoResponse for PartitionWriteError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Rejected(error) => CustomError::from(error).into_response(),
+            Self::NotFound => CustomError::ResourceNotFound.into_response(),
+            Self::Unavailable => service_unavailable(),
+            Self::TooManyInFlight => too_many_in_flight_response(),
+            Self::ServerBusy => server_busy_response(),
+            Self::Timeout(operation) => partition_write_timeout_response(operation),
+        }
+    }
+}
+
+/// 504 body for a partition write whose commit outcome is unknown, coded per
+/// write kind so a caller can tell a produce timeout from an offset-write
+/// timeout. Shaped like every other HTTP error (`ErrorResponse`) so clients
+/// parse one error schema.
+fn partition_write_timeout_response(operation: Operation) -> Response {
+    let (code, reason) = match operation {
+        Operation::SendMessages => (
+            "produce_timeout",
+            "produce was not acknowledged in time; the write may still commit",
+        ),
+        _ => (
+            "offset_write_timeout",
+            "consumer-offset write was not acknowledged in time; the write may still commit",
+        ),
+    };
+    gateway_timeout_response(code, reason)
+}
+
+/// Advisory `Retry-After` seconds for the shed / transient 429 and 503
+/// responses. One second: admission shedding, a briefly unavailable consensus
+/// group, and a linearizable-read-on-follower all typically clear well within
+/// it, and a small hint keeps a backing-off client responsive.
+const RETRY_AFTER_SECONDS: u64 = 1;
+
+/// Attach the advisory [`RETRY_AFTER_SECONDS`] hint to a retryable 429/503.
+fn with_retry_after(mut response: Response) -> Response {
+    response
+        .headers_mut()
+        .insert(RETRY_AFTER, HeaderValue::from(RETRY_AFTER_SECONDS));
+    response
+}
+
+/// Render an `ErrorResponse` body for `status`, tagged with `code` / `reason`
+/// and no field, so every hand-built HTTP error the routes return parses as the
+/// one error schema clients already handle.
+fn error_response(status: StatusCode, code: &str, reason: &str) -> Response {
+    (
+        status,
+        Json(ErrorResponse {
+            id: status.as_u16().into(),
+            code: code.to_owned(),
+            reason: reason.to_owned(),
+            field: None,
+        }),
+    )
+        .into_response()
+}
+
+/// Shared 504 rendering for an in-band request the partition plane did not
+/// answer in time, shaped like every other HTTP error (`ErrorResponse`) so
+/// clients parse one error schema. Consumed by the partition-write reply wait
+/// and the partition reads ([`ReadError::Timeout`]).
+fn gateway_timeout_response(code: &str, reason: &str) -> Response {
+    error_response(StatusCode::GATEWAY_TIMEOUT, code, reason)
+}
+
+/// The shared 503 body for a request that could not commit right now: no
+/// caught-up primary, a full pipeline, or a view-change cancel. Retryable, and
+/// rendered with the `CannotEstablishConnection` code the SDKs treat as a
+/// connection-level retry rather than a terminal error.
+fn service_unavailable() -> Response {
+    with_retry_after(
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::from_error(
+                &IggyError::CannotEstablishConnection,
+            )),
+        )
+            .into_response(),
+    )
+}
+
+/// 429 for a session at [`MAX_IN_FLIGHT_WRITES_PER_SESSION`] awaited partition
+/// writes. Shaped like every other HTTP error (`ErrorResponse`) so clients
+/// parse one error schema; the remedy is the caller's own: let outstanding
+/// writes finish, then retry.
+fn too_many_in_flight_response() -> Response {
+    with_retry_after(error_response(
+        StatusCode::TOO_MANY_REQUESTS,
+        "too_many_in_flight_writes",
+        "session reached its in-flight write cap; await outstanding writes and retry",
+    ))
+}
+
+/// 503 for shard 0 at [`MAX_IN_FLIGHT_WRITES_GLOBAL`] awaited partition writes
+/// across all sessions. A distinct `server_busy` code (unlike the shared
+/// consensus-unavailable 503) so admission shedding is tellable from a
+/// consensus outage; retry with backoff.
+fn server_busy_response() -> Response {
+    with_retry_after(error_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "server_busy",
+        "shard is at its in-flight write budget; retry with backoff",
+    ))
+}
+
+/// Read consistency selected by the `?consistency=` query param.
+///
+/// `serializable` (the default) serves from this node's local metadata STM:
+/// correct and consensus-free, but may trail the primary by the replication
+/// delay. `linearizable` demands the freshest committed state and is honored
+/// only on the primary; a follower redirects (307) to the primary when its HTTP
+/// address resolves from the roster, else fails closed to 503 (see
+/// [`read_local`]).
+#[derive(Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(in crate::http) enum Consistency {
+    #[default]
+    Serializable,
+    Linearizable,
+}
+
+/// `?consistency=` query wrapper. An absent param defaults to
+/// [`Consistency::Serializable`]; an unrecognized value is a 400 (axum `Query`).
+#[derive(Default, Deserialize)]
+pub(in crate::http) struct ConsistencyQuery {
+    #[serde(default)]
+    pub(in crate::http) consistency: Consistency,
+}
+
+/// Produce acknowledgement selected by the `?ack=` query param.
+///
+/// `replicated` (the default) answers 201 only after the partition group's
+/// quorum commit. `none` is fire-and-forget: the request is validated,
+/// dispatched, and answered 202 immediately; the commit still happens, but its
+/// reply is shed at the bus (no reply slot is installed).
+#[derive(Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(in crate::http) enum ProduceAck {
+    #[default]
+    Replicated,
+    None,
+}
+
+/// `?ack=` query wrapper. An absent param defaults to
+/// [`ProduceAck::Replicated`]; an unrecognized value is a 400 (axum `Query`).
+#[derive(Default, Deserialize)]
+pub(in crate::http) struct ProduceQuery {
+    #[serde(default)]
+    pub(in crate::http) ack: ProduceAck,
+}
+
+/// Rejection for an authenticated read route (`GET /streams`,
+/// `GET /streams/{id}`, and the reads that follow).
+pub(in crate::http) enum ReadError {
+    /// Caller-side or STM rejection (bad identifier, unsupported op, or an
+    /// authorization denial) graded through the legacy `IggyError -> status`
+    /// map so SDK error bodies stay byte-identical.
+    Rejected(IggyError),
+    /// Requested entity is absent -> 404 with the legacy not-found body.
+    NotFound,
+    /// A linearizable read reached a follower and the primary's HTTP address was
+    /// not resolvable from the roster. Fail-closed 503, retryable against the
+    /// leader (see [`not_primary_response`]).
+    NotPrimary,
+    /// A linearizable read reached a follower and the current VSR primary's HTTP
+    /// address resolved: 307 to that address carrying the original path and
+    /// query, so the caller re-issues the read against the leader (see
+    /// [`primary_redirect_response`]).
+    RedirectToPrimary(String),
+    /// A partition read (poll / consumer-offset) got no reply from the owning
+    /// shard within the mesh budget. 504 like a produce timeout: the outcome is
+    /// unknown (the abandoned read may still be running), so the caller retries.
+    Timeout,
+}
+
+impl IntoResponse for ReadError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Rejected(error) => CustomError::from(error).into_response(),
+            // Reuse the legacy 404 body so a missing stream renders exactly as
+            // the legacy server's `CustomError::ResourceNotFound` does.
+            Self::NotFound => CustomError::ResourceNotFound.into_response(),
+            Self::NotPrimary => not_primary_response(),
+            Self::RedirectToPrimary(location) => primary_redirect_response(&location),
+            Self::Timeout => gateway_timeout_response(
+                "partition_read_timeout",
+                "the partition owner did not answer the read in time; retry",
+            ),
+        }
+    }
+}
+
+/// The 503 fail-closed body for a linearizable read that reached a follower
+/// whose primary HTTP address could not be resolved (absent consensus, a roster
+/// with no node at the primary index, or a port-less node). The resolvable case
+/// is a 307 via [`primary_redirect_response`] instead. Rendered as an
+/// `ErrorResponse` so the body shape matches every other HTTP error; the caller
+/// retries against the leader.
+fn not_primary_response() -> Response {
+    with_retry_after(error_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "not_primary",
+        "linearizable read requires the primary; retry against the leader",
+    ))
+}
+
+/// 307 Temporary Redirect to the current VSR primary for a linearizable read
+/// that reached a follower. `Location` is the primary's HTTP base plus the
+/// original path and query, so the caller re-issues the identical read against
+/// the leader. Dormant on a single node (always primary) and followed by no SDK
+/// yet. A `Location` that is not a valid header value falls back to the 503.
+fn primary_redirect_response(location: &str) -> Response {
+    HeaderValue::from_str(location).map_or_else(
+        |_| not_primary_response(),
+        |value| {
+            let mut response = StatusCode::TEMPORARY_REDIRECT.into_response();
+            response.headers_mut().insert(LOCATION, value);
+            response
+        },
+    )
+}
+
+/// Build the `Location` for a 307 redirect of a linearizable read to the VSR
+/// primary: `http://<host>:<http-port><path_and_query>`. `None` when the roster
+/// has no node at `primary_index`, that node exposes no HTTP port, or its `ip`
+/// is not a valid address, so the caller fails closed to a 503 rather than
+/// pointing at an unreachable target. Formats through [`SocketAddr`] so an IPv6
+/// host is bracketed (`http://[::1]:8080/...`) rather than left ambiguous. Pure
+/// (no consensus or axum dependency) so the redirect target is unit-tested in
+/// isolation.
+pub(in crate::http) fn primary_redirect_location(
+    roster: &ClusterRoster,
+    primary_index: u8,
+    path_and_query: &str,
+) -> Option<String> {
+    let node = roster
+        .nodes
+        .iter()
+        .find(|node| node.replica_id == primary_index)?;
+    let http_port = node.ports.http?;
+    let ip = node.ip.parse::<IpAddr>().ok()?;
+    let socket = SocketAddr::new(ip, http_port);
+    Some(format!("http://{socket}{path_and_query}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use configs::cluster::{ClusterNodeConfig, TransportPorts};
+
+    const READ_PATH: &str = "/streams?consistency=linearizable";
+    fn node(replica_id: u8, ip: &str, http: Option<u16>) -> ClusterNodeConfig {
+        ClusterNodeConfig {
+            name: format!("node-{replica_id}"),
+            ip: ip.to_owned(),
+            replica_id,
+            ports: TransportPorts {
+                tcp: None,
+                quic: None,
+                http,
+                websocket: None,
+                tcp_replica: None,
+            },
+        }
+    }
+
+    fn roster(nodes: Vec<ClusterNodeConfig>) -> ClusterRoster {
+        ClusterRoster {
+            enabled: true,
+            name: "test-cluster".to_owned(),
+            nodes,
+            self_ip: "127.0.0.1".to_owned(),
+            self_ports: TransportPorts::default(),
+        }
+    }
+
+    #[test]
+    fn primary_redirect_location_targets_primary_http_addr_with_path_passthrough() {
+        let roster = roster(vec![
+            node(0, "10.0.0.1", Some(8080)),
+            node(1, "10.0.0.2", Some(8090)),
+        ]);
+        assert_eq!(
+            primary_redirect_location(&roster, 1, READ_PATH),
+            Some("http://10.0.0.2:8090/streams?consistency=linearizable".to_owned())
+        );
+    }
+
+    #[test]
+    fn primary_redirect_location_is_none_when_no_node_matches_primary_index() {
+        let roster = roster(vec![node(0, "10.0.0.1", Some(8080))]);
+        assert_eq!(primary_redirect_location(&roster, 2, READ_PATH), None);
+    }
+
+    #[test]
+    fn primary_redirect_location_is_none_when_primary_has_no_http_port() {
+        let roster = roster(vec![node(0, "10.0.0.1", None)]);
+        assert_eq!(primary_redirect_location(&roster, 0, READ_PATH), None);
+    }
+
+    #[test]
+    fn primary_redirect_location_is_none_for_empty_roster() {
+        let roster = roster(Vec::new());
+        assert_eq!(primary_redirect_location(&roster, 0, READ_PATH), None);
+    }
+
+    #[test]
+    fn primary_redirect_location_brackets_ipv6_host() {
+        let roster = roster(vec![node(0, "::1", Some(8080))]);
+        assert_eq!(
+            primary_redirect_location(&roster, 0, READ_PATH),
+            Some("http://[::1]:8080/streams?consistency=linearizable".to_owned())
+        );
+    }
+}

--- a/core/server-ng/src/http/extractor.rs
+++ b/core/server-ng/src/http/extractor.rs
@@ -1,0 +1,160 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Bearer-credential extractor for protected shard-0 HTTP routes.
+
+use std::rc::Rc;
+
+use axum::extract::FromRequestParts;
+use axum::http::header::AUTHORIZATION;
+use axum::http::request::Parts;
+use iggy_common::{IggyError, PersonalAccessToken};
+use send_wrapper::SendWrapper;
+
+use super::HttpState;
+use super::error::AuthError;
+use super::session::HttpSession;
+use crate::auth::verify_pat_credentials_with_expiry;
+
+/// Bearer scheme prefix in the `Authorization` header.
+const BEARER: &str = "Bearer ";
+
+/// Key-space prefixes: a JWT `jti` and a PAT hash live in disjoint namespaces
+/// so the two credential kinds can never collide on the same table key.
+const JWT_KEY_PREFIX: &str = "jwt:";
+const PAT_KEY_PREFIX: &str = "pat:";
+
+/// Resolved caller identity for a protected write route: the shared VSR
+/// session established once per presenting credential (it carries the
+/// authenticated user id).
+pub struct Authenticated {
+    /// Per-credential VSR session. The write path reads its client id and
+    /// session number and serializes writes through its gate.
+    ///
+    /// Wrapped because axum requires every handler argument to be `Send` and
+    /// `Rc` is not; this mirrors the `HttpState` bridge. Sound for the same
+    /// reason: the extractor mints it on shard 0's compio thread and every
+    /// handler runs on that same thread, so the wrapper is never crossed.
+    pub session: SendWrapper<Rc<HttpSession>>,
+}
+
+impl FromRequestParts<HttpState> for Authenticated {
+    type Rejection = AuthError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &HttpState,
+    ) -> Result<Self, Self::Rejection> {
+        let bearer = bearer_token(parts)?;
+
+        let (key, user_id, expiry) = resolve_credential(state, bearer)?;
+
+        // `resolve_session` is `Rc`-based and `!Send`, yet axum requires this
+        // extractor future to be `Send`. `SendWrapper` bridges the gap: sound
+        // because compio pins the future to shard 0's thread - the only thread
+        // that ever touches the session table (mirrors legacy `HttpSafeShard`).
+        let session = SendWrapper::new(state.resolve_session(key, user_id, expiry)).await?;
+        Ok(Self {
+            session: SendWrapper::new(session),
+        })
+    }
+}
+
+/// Read-only caller identity for a protected read route: the authenticated
+/// user id and nothing else.
+///
+/// Unlike [`Authenticated`], it verifies the bearer WITHOUT minting or
+/// Registering a VSR session. Reads are served from the local metadata STM and
+/// never enter consensus, so a session (and the `Register` commit round-trip it
+/// costs) would be dead weight. Same 401 rejection surface as [`Authenticated`]
+/// (missing/invalid/expired credential), and the verify runs through the same
+/// [`resolve_credential`] chokepoint, so a JWT and a PAT are honored identically.
+pub struct Identity {
+    pub user_id: u32,
+    /// Original request path + query (e.g. `/streams?consistency=linearizable`),
+    /// captured so a linearizable read that reaches a follower can build the
+    /// `Location` for its 307 redirect to the primary. Empty only when the URI
+    /// carries neither, which a routed read never is.
+    pub path_and_query: String,
+}
+
+impl FromRequestParts<HttpState> for Identity {
+    type Rejection = AuthError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &HttpState,
+    ) -> Result<Self, Self::Rejection> {
+        let bearer = bearer_token(parts)?;
+
+        // Verify only. The session key and expiry `resolve_credential` also
+        // returns feed the write path's session table; a read discards them.
+        // No `.await` and no session borrow here, so the extractor future needs
+        // no `SendWrapper` bridge (contrast [`Authenticated`], which awaits the
+        // `!Send` `resolve_session`).
+        let (_key, user_id, _expiry) = resolve_credential(state, bearer)?;
+        let path_and_query = parts
+            .uri
+            .path_and_query()
+            .map(|value| value.as_str().to_owned())
+            .unwrap_or_default();
+        Ok(Self {
+            user_id,
+            path_and_query,
+        })
+    }
+}
+
+/// Extract the raw bearer token from `Authorization: Bearer <token>`, or reject
+/// as `AccessTokenMissing` (the 401 both extractors share). The `?` at each call
+/// site converts the `IggyError` into the extractor's `AuthError`.
+fn bearer_token(parts: &Parts) -> Result<&str, IggyError> {
+    parts
+        .headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix(BEARER))
+        .ok_or(IggyError::AccessTokenMissing)
+}
+
+/// Map a bearer credential to its `(session key, user id, expiry secs)`.
+///
+/// A JWT is the primary credential, keyed by its `jti`. A raw PAT presented as
+/// the bearer is the documented fallback, keyed by the same 256-bit BLAKE3
+/// digest (`PersonalAccessToken::hash_token`) Iggy already indexes PATs by, so
+/// the key is stable and collision-free while the raw secret never enters the
+/// table. Both checks are local and synchronous, so no borrow is held across an
+/// await here.
+fn resolve_credential(state: &HttpState, bearer: &str) -> Result<(String, u32, u64), AuthError> {
+    if let Ok(claims) = state.jwt.decode(bearer)
+        && let Ok(user_id) = claims.sub.parse::<u32>()
+    {
+        return Ok((
+            format!("{JWT_KEY_PREFIX}{}", claims.jti),
+            user_id,
+            claims.exp,
+        ));
+    }
+
+    let (user_id, expiry) = verify_pat_credentials_with_expiry(&state.shard, bearer)
+        .map_err(|_| IggyError::Unauthenticated)?;
+    let key = format!(
+        "{PAT_KEY_PREFIX}{}",
+        PersonalAccessToken::hash_token(bearer)
+    );
+    Ok((key, user_id, expiry))
+}

--- a/core/server-ng/src/http/handlers.rs
+++ b/core/server-ng/src/http/handlers.rs
@@ -1,0 +1,1548 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! The shard-0 REST route handlers: health, login/logout, the metadata reads,
+//! the control-plane writes, and the data-plane produce / poll / consumer-offset
+//! routes the router binds.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::body::Body;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use chrono::Local;
+use consensus::MetadataHandle;
+use iggy_binary_protocol::codes::{
+    GET_CONSUMER_GROUP_CODE, GET_CONSUMER_GROUPS_CODE, GET_PERSONAL_ACCESS_TOKENS_CODE,
+    GET_STATS_CODE, GET_STREAM_CODE, GET_STREAMS_CODE, GET_TOPIC_CODE, GET_TOPICS_CODE,
+    GET_USER_CODE, GET_USERS_CODE,
+};
+use iggy_binary_protocol::requests::consumer_groups::{
+    CreateConsumerGroupRequest, DeleteConsumerGroupRequest, GetConsumerGroupRequest,
+    GetConsumerGroupsRequest,
+};
+use iggy_binary_protocol::requests::partitions::{
+    CreatePartitionsRequest, DeletePartitionsRequest,
+};
+use iggy_binary_protocol::requests::personal_access_tokens::{
+    CreatePersonalAccessTokenRequest, DeletePersonalAccessTokenRequest,
+    GetPersonalAccessTokensRequest,
+};
+use iggy_binary_protocol::requests::segments::DeleteSegmentsRequest;
+use iggy_binary_protocol::requests::streams::{
+    CreateStreamRequest, DeleteStreamRequest, GetStreamRequest, GetStreamsRequest,
+    PurgeStreamRequest, UpdateStreamRequest,
+};
+use iggy_binary_protocol::requests::system::GetStatsRequest;
+use iggy_binary_protocol::requests::topics::{
+    CreateTopicRequest, DeleteTopicRequest, GetTopicRequest, GetTopicsRequest, PurgeTopicRequest,
+    UpdateTopicRequest,
+};
+use iggy_binary_protocol::requests::users::{
+    ChangePasswordRequest, CreateUserRequest, DeleteUserRequest, GetUserRequest, GetUsersRequest,
+    UpdatePermissionsRequest, UpdateUserRequest,
+};
+use iggy_binary_protocol::responses::clients::client_response::ConsumerGroupInfoResponse;
+use iggy_binary_protocol::responses::clients::get_client::ClientDetailsResponse;
+use iggy_binary_protocol::responses::clients::get_clients::GetClientsResponse;
+use iggy_binary_protocol::responses::consumer_groups::get_consumer_group::ConsumerGroupDetailsResponse;
+use iggy_binary_protocol::responses::consumer_groups::get_consumer_groups::GetConsumerGroupsResponse;
+use iggy_binary_protocol::responses::personal_access_tokens::GetPersonalAccessTokensResponse;
+use iggy_binary_protocol::responses::streams::get_stream::GetStreamResponse;
+use iggy_binary_protocol::responses::streams::get_streams::GetStreamsResponse;
+use iggy_binary_protocol::responses::system::get_stats::StatsResponse;
+use iggy_binary_protocol::responses::topics::get_topic::GetTopicResponse;
+use iggy_binary_protocol::responses::topics::get_topics::GetTopicsResponse;
+use iggy_binary_protocol::responses::users::get_user::UserDetailsResponse;
+use iggy_binary_protocol::responses::users::get_users::GetUsersResponse;
+use iggy_binary_protocol::{Operation, WireDecode, WireEncode, WireIdentifier, WireName};
+use iggy_common::change_password::ChangePassword;
+use iggy_common::create_consumer_group::CreateConsumerGroup;
+use iggy_common::create_partitions::CreatePartitions;
+use iggy_common::create_personal_access_token::CreatePersonalAccessToken;
+use iggy_common::create_stream::CreateStream;
+use iggy_common::create_topic::CreateTopic;
+use iggy_common::create_user::CreateUser;
+use iggy_common::delete_consumer_offset::DeleteConsumerOffset;
+use iggy_common::delete_partitions::DeletePartitions;
+use iggy_common::delete_segments::DeleteSegments;
+use iggy_common::get_consumer_offset::GetConsumerOffset;
+use iggy_common::get_snapshot::GetSnapshot;
+use iggy_common::login_user::LoginUser;
+use iggy_common::login_with_personal_access_token::LoginWithPersonalAccessToken;
+use iggy_common::store_consumer_offset::StoreConsumerOffset;
+use iggy_common::update_permissions::UpdatePermissions;
+use iggy_common::update_stream::UpdateStream;
+use iggy_common::update_topic::UpdateTopic;
+use iggy_common::update_user::UpdateUser;
+use iggy_common::wire_conversions::{
+    clients_from_wire, consumer_groups_from_wire, identifier_to_wire, permissions_to_wire,
+    personal_access_tokens_from_wire, streams_from_wire, topics_from_wire, users_from_wire,
+};
+use iggy_common::{
+    ClientInfo, ClientInfoDetails, ClusterMetadata, Consumer, ConsumerGroup, ConsumerGroupDetails,
+    ConsumerOffsetInfo, Identifier, IdentityInfo, IggyError, PersonalAccessTokenInfo, PollMessages,
+    PolledMessages, RawPersonalAccessToken, SendMessages, Stats, Stream, StreamDetails, TokenInfo,
+    Topic, TopicDetails, UserInfo, UserInfoDetails, Validatable,
+};
+use metadata::impls::metadata::StreamsFrontend;
+use metadata::permissioner::Permissioner;
+use secrecy::ExposeSecret;
+use send_wrapper::SendWrapper;
+use serde::Deserialize;
+use shard::{PartitionRead, PartitionReadReply};
+
+use crate::auth::{verify_login_credentials, verify_pat_credentials};
+use crate::dispatch::{resolve_consumer_offset_request, resolve_poll_request};
+use crate::http::error::{
+    ConsistencyQuery, CustomError, PartitionWriteError, ProduceAck, ProduceQuery, ReadError,
+    WriteError,
+};
+use crate::http::extractor::{Authenticated, Identity};
+use crate::http::reads::{
+    authorize_data_plane, authorize_read, read_local, resolve_gate_stream, resolve_gate_topic,
+    resolve_gate_topic_ids,
+};
+use crate::http::reply::{
+    committed_payload, decode_consumer_group_details, decode_raw_pat_token, decode_stream_details,
+    decode_topic_details, decode_user_details, login_error_to_iggy,
+};
+use crate::http::state::{HttpInner, HttpState};
+use crate::http::submit::{
+    logout_session, partition_write_replicated, produce_unacked, submit_committed, submit_write,
+};
+use crate::http::wire::{
+    consumer_offset_wire_request, delete_offset_wire_request, encode_send_messages,
+    poll_wire_request, resync_required_polled_messages, store_offset_wire_request,
+};
+use crate::responses::{
+    build_polled_messages_body, build_raw_pat_reply, connected_client_to_response,
+};
+use crate::snapshot;
+
+/// `GET /ping` response body, matching the legacy HTTP server's health probe.
+const PONG: &str = "pong";
+
+/// VSR client id stamped on HTTP data-plane reads (poll / consumer-offset).
+/// HTTP reads never Register a VSR client, and shard-0 client ids are minted
+/// from 1, so 0 can never name a live consumer-group member: a group-kind
+/// poll fences closed with `ConsumerGroupPartitionNotOwned` and answers the
+/// re-sync sentinel empty poll - the same failure a stale TCP member sees.
+/// Legacy HTTP polls with client id 0 for the same reason (no persistent
+/// sessions, so no group membership).
+const HTTP_READ_CLIENT_ID: u128 = 0;
+
+/// Response header attesting what durability a produce response proves:
+/// [`DURABILITY_REPLICATED_MEMORY`] after an awaited quorum commit,
+/// [`DURABILITY_NONE`] for a `?ack=none` fire-and-forget.
+const DURABILITY_HEADER: HeaderName = HeaderName::from_static("x-iggy-durability");
+
+const DURABILITY_REPLICATED_MEMORY: &str = "replicated-memory";
+
+const DURABILITY_NONE: &str = "none";
+
+/// `{user_id}` segment alias resolving to the caller in `GET /users/{user_id}`.
+/// Handled inside the handler rather than as a static `/users/me` route so it
+/// cannot shadow `{user_id}` matching (a user literally named "me" stays
+/// reachable by numeric id).
+const CURRENT_USER_ALIAS: &str = "me";
+
+/// Extracting the state here proves at compile time that the `!Send` state
+/// bridges into axum's `Send + Sync` router state on shard 0's compio thread.
+/// Ping needs no state, so it is discarded.
+pub(in crate::http) async fn ping(State(_state): State<HttpState>) -> &'static str {
+    PONG
+}
+
+pub(in crate::http) async fn login_user(
+    State(state): State<HttpState>,
+    Json(command): Json<LoginUser>,
+) -> Result<Json<IdentityInfo>, CustomError> {
+    let user_id = verify_login_credentials(
+        &state.shard,
+        &command.username,
+        command.password.expose_secret(),
+    )
+    .map_err(|error| login_error_to_iggy(&error))?;
+    issue_identity(&state, user_id)
+}
+
+pub(in crate::http) async fn login_with_personal_access_token(
+    State(state): State<HttpState>,
+    Json(command): Json<LoginWithPersonalAccessToken>,
+) -> Result<Json<IdentityInfo>, CustomError> {
+    let user_id = verify_pat_credentials(&state.shard, command.token.expose_secret())
+        .map_err(|error| login_error_to_iggy(&error))?;
+    issue_identity(&state, user_id)
+}
+
+/// `POST /users/refresh-token` body. The route is unauthenticated, so the
+/// caller's current access token travels in the body, not a bearer header.
+#[derive(Debug, Deserialize)]
+pub(in crate::http) struct RefreshToken {
+    token: String,
+}
+
+/// `POST /users/refresh-token`: re-issue an access token from a still-valid one,
+/// answering the same `IdentityInfo` shape as login.
+///
+/// Stateless by design: server-ng has no replicated revocation list (the P3
+/// roadmap item), so refreshing cannot invalidate the presented token - it stays
+/// valid until its own `exp`, the same posture as logout ending a session
+/// without revoking its bearer. Per-node revocation would be false security in a
+/// cluster, so legacy's one-shot revoke-old-jti behavior is deliberately dropped
+/// rather than ported.
+pub(in crate::http) async fn refresh_token(
+    State(state): State<HttpState>,
+    Json(command): Json<RefreshToken>,
+) -> Result<Json<IdentityInfo>, CustomError> {
+    if command.token.is_empty() {
+        return Err(IggyError::Unauthenticated.into());
+    }
+    let claims = state.jwt.decode(&command.token)?;
+    let user_id = claims
+        .sub
+        .parse::<u32>()
+        .map_err(|_| IggyError::Unauthenticated)?;
+    issue_identity(&state, user_id)
+}
+
+/// `DELETE /users/logout`: end the caller's session and answer 204 - the status
+/// the SDK's `logout_user()` awaits before dropping its stored bearer. The
+/// teardown itself is [`logout_session`]; it is best-effort, so once the caller
+/// authenticates this always answers 204.
+pub(in crate::http) async fn logout_user(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+) -> StatusCode {
+    // `logout_session` is `!Send`; bridge it like every other write path on this
+    // shard-0 listener (see [`delete_user`]).
+    SendWrapper::new(logout_session(&state, &identity.session)).await;
+    StatusCode::NO_CONTENT
+}
+
+/// `GET /streams`: list every stream as the same `Vec<Stream>` JSON the legacy
+/// server returns. A consensus-free local STM read via [`read_local`].
+pub(in crate::http) async fn get_streams(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<Vec<Stream>>, ReadError> {
+    let body = GetStreamsRequest.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_STREAMS_CODE,
+        &body,
+        Permissioner::get_streams,
+    )?;
+    let response = GetStreamsResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(streams_from_wire(response)))
+}
+
+/// `GET /streams/{stream_id}`: fetch one stream by numeric id or name as the
+/// same `StreamDetails` JSON the legacy server returns; 404 when absent. A
+/// consensus-free local STM read via [`read_local`].
+pub(in crate::http) async fn get_stream(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path(stream_id): Path<String>,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<StreamDetails>, ReadError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(ReadError::Rejected)?;
+    let wire_stream_id = identifier_to_wire(&stream_id).map_err(ReadError::Rejected)?;
+    // Resolve for the gate; a miss leaves it a pass-through so the read renders
+    // the existing 404 rather than a 403.
+    let scope = resolve_gate_stream(&state, &wire_stream_id);
+    let request = GetStreamRequest {
+        stream_id: wire_stream_id,
+    };
+    let body = request.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_STREAM_CODE,
+        &body,
+        |permissioner, uid| {
+            scope.map_or(Ok(()), |stream_id| permissioner.get_stream(uid, stream_id))
+        },
+    )?;
+    let response = GetStreamResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(
+        StreamDetails::try_from(response).map_err(ReadError::Rejected)?,
+    ))
+}
+
+/// `GET /streams/{stream_id}/topics`: list a stream's topics as the same
+/// `Vec<Topic>` JSON the legacy server returns. A consensus-free local STM read
+/// via [`read_local`].
+pub(in crate::http) async fn get_topics(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path(stream_id): Path<String>,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<Vec<Topic>>, ReadError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(ReadError::Rejected)?;
+    let wire_stream_id = identifier_to_wire(&stream_id).map_err(ReadError::Rejected)?;
+    let scope = resolve_gate_stream(&state, &wire_stream_id);
+    let request = GetTopicsRequest {
+        stream_id: wire_stream_id,
+    };
+    let body = request.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_TOPICS_CODE,
+        &body,
+        |permissioner, uid| {
+            scope.map_or(Ok(()), |stream_id| permissioner.get_topics(uid, stream_id))
+        },
+    )?;
+    let response = GetTopicsResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(
+        topics_from_wire(response).map_err(ReadError::Rejected)?,
+    ))
+}
+
+/// `GET /streams/{stream_id}/topics/{topic_id}`: fetch one topic by numeric id
+/// or name as the same `TopicDetails` JSON the legacy server returns; 404 when
+/// absent. A consensus-free local STM read via [`read_local`].
+pub(in crate::http) async fn get_topic(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<TopicDetails>, ReadError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(ReadError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(ReadError::Rejected)?;
+    let wire_stream_id = identifier_to_wire(&stream_id).map_err(ReadError::Rejected)?;
+    let wire_topic_id = identifier_to_wire(&topic_id).map_err(ReadError::Rejected)?;
+    let scope = resolve_gate_topic(&state, &wire_stream_id, &wire_topic_id);
+    let request = GetTopicRequest {
+        stream_id: wire_stream_id,
+        topic_id: wire_topic_id,
+    };
+    let body = request.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_TOPIC_CODE,
+        &body,
+        |permissioner, uid| {
+            scope.map_or(Ok(()), |(stream_id, topic_id)| {
+                permissioner.get_topic(uid, stream_id, topic_id)
+            })
+        },
+    )?;
+    let response = GetTopicResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(
+        TopicDetails::try_from(response).map_err(ReadError::Rejected)?,
+    ))
+}
+
+/// `GET /users`: list every user as the same `Vec<UserInfo>` JSON the legacy
+/// server returns. A consensus-free local STM read via [`read_local`].
+pub(in crate::http) async fn get_users(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<Vec<UserInfo>>, ReadError> {
+    let body = GetUsersRequest.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_USERS_CODE,
+        &body,
+        Permissioner::get_users,
+    )?;
+    let response = GetUsersResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(
+        users_from_wire(response).map_err(ReadError::Rejected)?,
+    ))
+}
+
+/// `GET /users/{user_id}`: fetch one user by numeric id or name as the same
+/// `UserInfoDetails` JSON the legacy server returns; 404 when absent. A
+/// consensus-free local STM read via [`read_local`]. [`CURRENT_USER_ALIAS`]
+/// resolves to the caller and skips the `read_users` gate, mirroring the
+/// legacy self-read bypass.
+pub(in crate::http) async fn get_user(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path(user_id): Path<String>,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<UserInfoDetails>, ReadError> {
+    let is_self = user_id == CURRENT_USER_ALIAS;
+    let wire_user_id = if is_self {
+        WireIdentifier::numeric(identity.user_id)
+    } else {
+        let user_id = Identifier::from_str_value(&user_id).map_err(ReadError::Rejected)?;
+        identifier_to_wire(&user_id).map_err(ReadError::Rejected)?
+    };
+    let request = GetUserRequest {
+        user_id: wire_user_id,
+    };
+    let body = request.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_USER_CODE,
+        &body,
+        |permissioner, uid| {
+            if is_self {
+                Ok(())
+            } else {
+                permissioner.get_user(uid)
+            }
+        },
+    )?;
+    let response = UserDetailsResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(
+        UserInfoDetails::try_from(response).map_err(ReadError::Rejected)?,
+    ))
+}
+
+/// `GET /streams/{stream_id}/topics/{topic_id}/consumer-groups`: list a topic's
+/// consumer groups as the same `Vec<ConsumerGroup>` JSON the legacy server
+/// returns. A consensus-free local STM read via [`read_local`].
+pub(in crate::http) async fn get_cgs(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<Vec<ConsumerGroup>>, ReadError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(ReadError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(ReadError::Rejected)?;
+    let wire_stream_id = identifier_to_wire(&stream_id).map_err(ReadError::Rejected)?;
+    let wire_topic_id = identifier_to_wire(&topic_id).map_err(ReadError::Rejected)?;
+    let scope = resolve_gate_topic(&state, &wire_stream_id, &wire_topic_id);
+    let request = GetConsumerGroupsRequest {
+        stream_id: wire_stream_id,
+        topic_id: wire_topic_id,
+    };
+    let body = request.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_CONSUMER_GROUPS_CODE,
+        &body,
+        |permissioner, uid| {
+            scope.map_or(Ok(()), |(stream_id, topic_id)| {
+                permissioner.get_consumer_groups(uid, stream_id, topic_id)
+            })
+        },
+    )?;
+    let response = GetConsumerGroupsResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(consumer_groups_from_wire(response)))
+}
+
+/// `GET /streams/{stream_id}/topics/{topic_id}/consumer-groups/{group_id}`:
+/// fetch one consumer group by numeric id or name as the same
+/// `ConsumerGroupDetails` JSON the legacy server returns; 404 when absent. The
+/// wire-to-domain conversion is infallible.
+pub(in crate::http) async fn get_cg(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path((stream_id, topic_id, group_id)): Path<(String, String, String)>,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<ConsumerGroupDetails>, ReadError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(ReadError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(ReadError::Rejected)?;
+    let group_id = Identifier::from_str_value(&group_id).map_err(ReadError::Rejected)?;
+    let wire_stream_id = identifier_to_wire(&stream_id).map_err(ReadError::Rejected)?;
+    let wire_topic_id = identifier_to_wire(&topic_id).map_err(ReadError::Rejected)?;
+    let scope = resolve_gate_topic(&state, &wire_stream_id, &wire_topic_id);
+    let request = GetConsumerGroupRequest {
+        stream_id: wire_stream_id,
+        topic_id: wire_topic_id,
+        group_id: identifier_to_wire(&group_id).map_err(ReadError::Rejected)?,
+    };
+    let body = request.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_CONSUMER_GROUP_CODE,
+        &body,
+        |permissioner, uid| {
+            scope.map_or(Ok(()), |(stream_id, topic_id)| {
+                permissioner.get_consumer_group(uid, stream_id, topic_id)
+            })
+        },
+    )?;
+    let response = ConsumerGroupDetailsResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(ConsumerGroupDetails::from(response)))
+}
+
+/// `GET /stats`: server + storage counters as the same `Stats` JSON the legacy
+/// server returns. `GET_STATS` is served by `build_non_replicated_response` like
+/// the entity reads, so it flows through [`read_local`] unchanged rather than a
+/// dedicated builder. No entity can be missing, so no 404 branch.
+pub(in crate::http) async fn get_stats(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<Stats>, ReadError> {
+    let body = GetStatsRequest.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_STATS_CODE,
+        &body,
+        Permissioner::get_stats,
+    )?;
+    let response = StatsResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(Stats::from(response)))
+}
+
+/// `POST /snapshot`: collect a diagnostic archive and return it as a ZIP
+/// download with the same headers the legacy server sets.
+///
+/// Gated on the snapshot rule (`read_servers || manage_servers`) via the
+/// shared [`authorize_read`] gate. Collection shells out to system tools on a
+/// dedicated OS thread (see `snapshot::collect`); this handler only awaits the
+/// result handoff, which is `Send`, so no `SendWrapper` bridge is needed.
+pub(in crate::http) async fn get_snapshot(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Query(query): Query<ConsistencyQuery>,
+    Json(command): Json<GetSnapshot>,
+) -> Result<(HeaderMap, Body), ReadError> {
+    authorize_read(&state, &identity, query.consistency, |permissioner, uid| {
+        permissioner.get_snapshot(uid)
+    })?;
+    let archive = snapshot::collect(
+        Arc::clone(&state.system_config),
+        command.compression,
+        command.snapshot_types,
+    )
+    .await
+    .map_err(ReadError::Rejected)?;
+
+    let filename = format!("iggy_snapshot_{}.zip", Local::now().format("%Y%m%d_%H%M%S"));
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/zip"),
+    );
+    // The formatted value is fixed ASCII (digits + underscores), but keep the
+    // fallback total: a bare attachment still downloads correctly.
+    let disposition = HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
+        .unwrap_or_else(|_| HeaderValue::from_static("attachment"));
+    headers.insert(header::CONTENT_DISPOSITION, disposition);
+    Ok((headers, Body::from(archive)))
+}
+
+/// `GET /cluster/metadata`: report the live cluster topology as the same
+/// `ClusterMetadata` JSON the legacy server returns.
+///
+/// Auth-only: any valid token serves. Unlike the entity reads it bypasses both
+/// the per-op authorization gate and the consistency gate, and serves from the
+/// roster captured at listener start plus the sync consensus getters, so it
+/// never touches the metadata STM, consensus, or a VSR session and stays fully
+/// synchronous.
+pub(in crate::http) async fn get_cluster_metadata(
+    State(state): State<HttpState>,
+    _identity: Identity,
+) -> Json<ClusterMetadata> {
+    Json(state.build_cluster_metadata())
+}
+
+/// `GET /clients`: list every connected client across all shards as the same
+/// `Vec<ClientInfo>` JSON the legacy server returns.
+///
+/// Unlike the entity reads, connections live in each shard's session manager,
+/// not the metadata STM, so this scatter-gathers over the shard mesh
+/// (`list_all_clients`) instead of going through [`read_local`]. It still runs
+/// the identical per-op + consistency gate via [`authorize_read`], so its
+/// authorization matches every metadata read. The gather future is `!Send`,
+/// bridged onto shard 0's thread by `SendWrapper` exactly as the write path
+/// bridges its submit.
+pub(in crate::http) async fn get_clients(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<Vec<ClientInfo>>, ReadError> {
+    authorize_read(&state, &identity, query.consistency, |permissioner, uid| {
+        permissioner.get_clients(uid)
+    })?;
+    let infos = SendWrapper::new(state.shard.list_all_clients()).await;
+    let response = GetClientsResponse {
+        clients: infos
+            .iter()
+            .map(|info| connected_client_to_response(&state.shard, info))
+            .collect(),
+    };
+    Ok(Json(clients_from_wire(response)))
+}
+
+/// `GET /clients/{client_id}`: fetch one connected client as the same
+/// `ClientInfoDetails` JSON the legacy server returns; 404 when absent.
+///
+/// The path id is the `u32` wire client id (the seq tail of the u128 transport
+/// id), matching the legacy route's `Path<u32>`. There is no reverse map from
+/// that id to a home shard, so this gathers every shard's clients and filters -
+/// the same fan-out-and-filter as [`get_clients`] and the TCP `get_client`
+/// dispatch. The wire-to-domain conversion is infallible.
+pub(in crate::http) async fn get_client(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path(client_id): Path<u32>,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<ClientInfoDetails>, ReadError> {
+    authorize_read(&state, &identity, query.consistency, |permissioner, uid| {
+        permissioner.get_client(uid)
+    })?;
+    let infos = SendWrapper::new(state.shard.list_all_clients()).await;
+    // The wire client id is the u32 seq tail of the u128 transport id.
+    #[allow(clippy::cast_possible_truncation)]
+    let info = infos
+        .iter()
+        .find(|info| info.client_id as u32 == client_id)
+        .ok_or(ReadError::NotFound)?;
+    let consumer_groups = info.vsr_client_id.map_or_else(Vec::new, |vsr_client_id| {
+        state
+            .shard
+            .plane
+            .metadata()
+            .mux_stm
+            .streams()
+            .consumer_group_memberships(vsr_client_id)
+            .into_iter()
+            .map(
+                |(stream_id, topic_id, group_id)| ConsumerGroupInfoResponse {
+                    stream_id,
+                    topic_id,
+                    group_id,
+                },
+            )
+            .collect()
+    });
+    let response = ClientDetailsResponse {
+        client: connected_client_to_response(&state.shard, info),
+        consumer_groups,
+    };
+    Ok(Json(ClientInfoDetails::from(response)))
+}
+
+/// `POST /streams`: create a stream and render the committed reply as the same
+/// `StreamDetails` JSON the legacy server returns.
+///
+/// The accepted body is name-only (`{"name": ...}`), matching the legacy
+/// request; server-ng's wire `CreateStreamRequest` is likewise name-only and
+/// auto-assigns the id, so there is no client-supplied stream id to honor.
+pub(in crate::http) async fn create_stream(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Json(command): Json<CreateStream>,
+) -> Result<Json<StreamDetails>, WriteError> {
+    let request = CreateStreamRequest {
+        name: WireName::new(command.name)
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidStreamName))?,
+    };
+    let body = request.to_bytes();
+    let payload = SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::CreateStream,
+        &body,
+    ))
+    .await?;
+    Ok(Json(decode_stream_details(&payload)?))
+}
+
+/// `PUT /streams/{stream_id}`: rename a stream. A committed write returns 204
+/// with no body, matching the legacy server.
+pub(in crate::http) async fn update_stream(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(stream_id): Path<String>,
+    Json(command): Json<UpdateStream>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let request = UpdateStreamRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        name: WireName::new(command.name)
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidStreamName))?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::UpdateStream,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /streams/{stream_id}`: delete a stream. Returns 204 on commit.
+pub(in crate::http) async fn delete_stream(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(stream_id): Path<String>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let request = DeleteStreamRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::DeleteStream,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /streams/{stream_id}/purge`: drop a stream's messages. Returns 204.
+pub(in crate::http) async fn purge_stream(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(stream_id): Path<String>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let request = PurgeStreamRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::PurgeStream,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /streams/{stream_id}/topics`: create a topic under a stream and render
+/// the committed reply as the same `TopicDetails` JSON the legacy server returns.
+///
+/// The stream comes from the path; the JSON body carries the remaining fields.
+/// The submitted op is a plain `CreateTopic`; the metadata owner allocates the
+/// consensus group ids and rewrites it to `CreateTopicWithAssignments` before
+/// replication, so this handler stays a pure submit-and-decode.
+pub(in crate::http) async fn create_topic(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(stream_id): Path<String>,
+    Json(command): Json<CreateTopic>,
+) -> Result<Json<TopicDetails>, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    // Rejects empty/oversized name, partitions_count > MAX, replication_factor == Some(0).
+    command.validate().map_err(WriteError::Rejected)?;
+    let request = CreateTopicRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        partitions_count: command.partitions_count,
+        compression_algorithm: command.compression_algorithm.as_code(),
+        message_expiry: command.message_expiry.into(),
+        max_topic_size: command.max_topic_size.into(),
+        replication_factor: command.replication_factor.unwrap_or(0),
+        name: WireName::new(command.name)
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidTopicName))?,
+    };
+    let body = request.to_bytes();
+    let payload = SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::CreateTopic,
+        &body,
+    ))
+    .await?;
+    Ok(Json(decode_topic_details(&payload)?))
+}
+
+/// `PUT /streams/{stream_id}/topics/{topic_id}`: update a topic. Returns 204.
+pub(in crate::http) async fn update_topic(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Json(command): Json<UpdateTopic>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(WriteError::Rejected)?;
+    // Also rejects replication_factor == Some(0), which `WireName` cannot see.
+    command.validate().map_err(WriteError::Rejected)?;
+    let request = UpdateTopicRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        topic_id: identifier_to_wire(&topic_id).map_err(WriteError::Rejected)?,
+        compression_algorithm: command.compression_algorithm.as_code(),
+        message_expiry: command.message_expiry.into(),
+        max_topic_size: command.max_topic_size.into(),
+        replication_factor: command.replication_factor.unwrap_or(0),
+        name: WireName::new(command.name)
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidTopicName))?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::UpdateTopic,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /streams/{stream_id}/topics/{topic_id}`: delete a topic. Returns 204.
+pub(in crate::http) async fn delete_topic(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(WriteError::Rejected)?;
+    let request = DeleteTopicRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        topic_id: identifier_to_wire(&topic_id).map_err(WriteError::Rejected)?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::DeleteTopic,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /streams/{stream_id}/topics/{topic_id}/purge`: drop a topic's
+/// messages. Returns 204.
+pub(in crate::http) async fn purge_topic(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(WriteError::Rejected)?;
+    let request = PurgeTopicRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        topic_id: identifier_to_wire(&topic_id).map_err(WriteError::Rejected)?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::PurgeTopic,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /streams/{stream_id}/topics/{topic_id}/partitions`: add partitions to a
+/// topic. Returns 200 (this listener answers create routes 200, the
+/// legacy-majority parity). `partitions_count` comes from the JSON body; stream
+/// and topic from the path. RBAC is enforced in-apply on the metadata STM, like
+/// the sibling topic writes.
+pub(in crate::http) async fn create_partitions(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Json(command): Json<CreatePartitions>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(WriteError::Rejected)?;
+    command.validate().map_err(WriteError::Rejected)?;
+    let request = CreatePartitionsRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        topic_id: identifier_to_wire(&topic_id).map_err(WriteError::Rejected)?,
+        partitions_count: command.partitions_count,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::CreatePartitions,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::OK)
+}
+
+/// `DELETE /streams/{stream_id}/topics/{topic_id}/partitions`: remove partitions
+/// from a topic. Returns 204. `partitions_count` comes from the query; stream and
+/// topic from the path. RBAC in-apply on the metadata STM.
+pub(in crate::http) async fn delete_partitions(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Query(query): Query<DeletePartitions>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(WriteError::Rejected)?;
+    query.validate().map_err(WriteError::Rejected)?;
+    let request = DeletePartitionsRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        topic_id: identifier_to_wire(&topic_id).map_err(WriteError::Rejected)?,
+        partitions_count: query.partitions_count,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::DeletePartitions,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /streams/{stream_id}/topics/{topic_id}/partitions/{partition_id}`:
+/// delete the oldest `segments_count` sealed segments from a partition. Returns
+/// 204. `segments_count` comes from the query; stream, topic, and partition from
+/// the path.
+///
+/// `DeleteSegments` is not itself a consensus op: [`submit_write`] carries it
+/// through [`submit_gated`], which resolves it to the `TruncatePartition` that
+/// commits the trim. RBAC (`delete_segments`) is enforced in-apply on that
+/// truncate, like the sibling topic writes.
+pub(in crate::http) async fn delete_segments(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id, partition_id)): Path<(String, String, u32)>,
+    Query(query): Query<DeleteSegments>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(WriteError::Rejected)?;
+    let request = DeleteSegmentsRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        topic_id: identifier_to_wire(&topic_id).map_err(WriteError::Rejected)?,
+        partition_id,
+        segments_count: query.segments_count,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::DeleteSegments,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /streams/{stream_id}/topics/{topic_id}/messages`: poll a batch of
+/// messages as the same `PolledMessages` JSON the legacy server returns. The
+/// query is the same flattened `PollMessages` shape the legacy server accepts
+/// (`consumer_id`, `partition_id`, strategy `kind`+`value`, `count`,
+/// `auto_commit`); stream and topic come from the path.
+///
+/// A non-replicated read served in band: the same resolution the TCP dispatch
+/// runs ([`resolve_poll_request`]), then a mesh read on the owning shard and a
+/// re-encode of the stored batches into the legacy wire body, decoded here by
+/// the SDK's own [`PolledMessages::from_bytes`] so the JSON is field-identical
+/// to a TCP poll. `auto_commit` rides [`resolve_poll_request`]'s args and is
+/// honored by the owning shard's poll plan; no extra HTTP work.
+pub(in crate::http) async fn poll_messages(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Query(query): Query<PollMessages>,
+    Query(consistency): Query<ConsistencyQuery>,
+) -> Result<Json<PolledMessages>, ReadError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(ReadError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(ReadError::Rejected)?;
+    let scope = resolve_gate_topic_ids(&state, &stream_id, &topic_id);
+    authorize_read(
+        &state,
+        &identity,
+        consistency.consistency,
+        |permissioner, uid| {
+            scope.map_or(Ok(()), |(stream_id, topic_id)| {
+                permissioner.poll_messages(uid, stream_id, topic_id)
+            })
+        },
+    )?;
+    let wire = poll_wire_request(&stream_id, &topic_id, &query).map_err(ReadError::Rejected)?;
+    let (namespace, partition_id, consumer, args) =
+        match resolve_poll_request(&state.shard, &wire, HTTP_READ_CLIENT_ID) {
+            Ok(decoded) => decoded,
+            // TCP parity: a fenced group poll answers 200 with the re-sync
+            // sentinel partition, not an error (see [`HTTP_READ_CLIENT_ID`]).
+            Err(IggyError::ConsumerGroupPartitionNotOwned(..)) => {
+                return Ok(Json(resync_required_polled_messages()));
+            }
+            // The remaining resolver failures are STM lookups that came up
+            // empty (unknown stream, topic, partition, or consumer group), so
+            // they render as the legacy 404 body.
+            Err(_) => return Err(ReadError::NotFound),
+        };
+    let reply = SendWrapper::new(
+        state
+            .shard
+            .partition_read(namespace, PartitionRead::Poll { consumer, args }),
+    )
+    .await;
+    match reply {
+        Some(PartitionReadReply::Poll {
+            fragments,
+            current_offset,
+        }) => {
+            let body = build_polled_messages_body(partition_id, current_offset, fragments)
+                .map_err(ReadError::Rejected)?;
+            Ok(Json(
+                PolledMessages::from_bytes(body).map_err(ReadError::Rejected)?,
+            ))
+        }
+        Some(PartitionReadReply::NotFound) => Err(ReadError::NotFound),
+        Some(_) => Err(ReadError::Rejected(IggyError::InvalidCommand)),
+        None => Err(ReadError::Timeout),
+    }
+}
+
+/// `GET /streams/{stream_id}/topics/{topic_id}/consumer-offsets`: fetch a
+/// consumer's stored offset as the same `ConsumerOffsetInfo` JSON the legacy
+/// server returns. The query is the same flattened `GetConsumerOffset` shape
+/// the legacy server accepts (`consumer_id`, optional `partition_id`).
+///
+/// A non-replicated read served in band, mirroring [`poll_messages`]. A
+/// missing offset (never stored, or the partition unknown to its owner) is
+/// the legacy 404: the TCP path replies an empty body the SDK decodes as
+/// `None`, and the legacy HTTP server renders that `None` as
+/// `CustomError::ResourceNotFound`.
+pub(in crate::http) async fn get_consumer_offset(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Query(query): Query<GetConsumerOffset>,
+    Query(consistency): Query<ConsistencyQuery>,
+) -> Result<Json<ConsumerOffsetInfo>, ReadError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(ReadError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(ReadError::Rejected)?;
+    let scope = resolve_gate_topic_ids(&state, &stream_id, &topic_id);
+    authorize_read(
+        &state,
+        &identity,
+        consistency.consistency,
+        |permissioner, uid| {
+            scope.map_or(Ok(()), |(stream_id, topic_id)| {
+                permissioner.get_consumer_offset(uid, stream_id, topic_id)
+            })
+        },
+    )?;
+    let wire =
+        consumer_offset_wire_request(&stream_id, &topic_id, &query).map_err(ReadError::Rejected)?;
+    let (namespace, partition_id, consumer) =
+        resolve_consumer_offset_request(&state.shard, &wire).map_err(|_| ReadError::NotFound)?;
+    let reply = SendWrapper::new(
+        state
+            .shard
+            .partition_read(namespace, PartitionRead::ConsumerOffset { consumer }),
+    )
+    .await;
+    match reply {
+        Some(PartitionReadReply::ConsumerOffset {
+            stored: Some(stored_offset),
+            current_offset,
+        }) => Ok(Json(ConsumerOffsetInfo {
+            partition_id,
+            current_offset,
+            stored_offset,
+        })),
+        Some(
+            PartitionReadReply::ConsumerOffset { stored: None, .. } | PartitionReadReply::NotFound,
+        ) => Err(ReadError::NotFound),
+        Some(_) => Err(ReadError::Rejected(IggyError::InvalidCommand)),
+        None => Err(ReadError::Timeout),
+    }
+}
+
+/// `POST /streams/{stream_id}/topics/{topic_id}/messages`: produce a batch of
+/// messages to a topic. The JSON body is the same `SendMessages` shape the
+/// legacy server accepts (partitioning + base64 messages); stream and topic
+/// come from the path.
+///
+/// Data plane, not control plane: the batch rides the partition group's own
+/// consensus (at-least-once, no dedup, no session gate - concurrent produces
+/// on one credential are legal), and the committed reply comes back through
+/// the session's in-process reply slot rather than a submit return value.
+/// The default answers 201 + `X-Iggy-Durability: replicated-memory` only
+/// after the quorum commit; `?ack=none` answers 202 + `X-Iggy-Durability:
+/// none` immediately after dispatch.
+pub(in crate::http) async fn send_messages(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Query(query): Query<ProduceQuery>,
+    Json(command): Json<SendMessages>,
+) -> Result<Response, PartitionWriteError> {
+    let stream_id =
+        Identifier::from_str_value(&stream_id).map_err(PartitionWriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(PartitionWriteError::Rejected)?;
+    // RBAC: authorize the produce on (stream, topic) before any consensus work.
+    // Handler-side so an HTTP denial never enters the partition plane.
+    authorize_data_plane(
+        &state,
+        identity.session.user_id,
+        &stream_id,
+        &topic_id,
+        Permissioner::append_messages,
+    )
+    .map_err(PartitionWriteError::Rejected)?;
+    // Rejects an oversized partitioning key and an empty or oversized batch.
+    command.validate().map_err(PartitionWriteError::Rejected)?;
+    let body = encode_send_messages(&stream_id, &topic_id, &command)
+        .map_err(PartitionWriteError::Rejected)?;
+    match query.ack {
+        ProduceAck::Replicated => {
+            SendWrapper::new(partition_write_replicated(
+                &state,
+                &identity.session,
+                Operation::SendMessages,
+                &body,
+            ))
+            .await?;
+            Ok((
+                StatusCode::CREATED,
+                [(
+                    DURABILITY_HEADER,
+                    HeaderValue::from_static(DURABILITY_REPLICATED_MEMORY),
+                )],
+            )
+                .into_response())
+        }
+        ProduceAck::None => {
+            SendWrapper::new(produce_unacked(&state, &identity.session, &body)).await?;
+            Ok((
+                StatusCode::ACCEPTED,
+                [(DURABILITY_HEADER, HeaderValue::from_static(DURABILITY_NONE))],
+            )
+                .into_response())
+        }
+    }
+}
+
+/// `PUT /streams/{stream_id}/topics/{topic_id}/consumer-offsets`: store a
+/// consumer's offset. The JSON body is the same `StoreConsumerOffset` shape the
+/// legacy server accepts (flattened `consumer_id`, optional `partition_id`,
+/// `offset`); stream and topic come from the path. Returns 204 on commit,
+/// matching the legacy server.
+///
+/// Data plane like a produce: the offset write is a replicated op on the
+/// partition group's own consensus, awaited through the session's in-process
+/// reply slot ([`partition_write_replicated`]). The v2 wire op is pinned to
+/// `ack = Quorum` - `?ack=none` is a produce-only surface. The consumer
+/// identifier passes through on the wire; the dispatch resolvers hash named
+/// consumers and rewrite group ids server-side, identically to TCP.
+pub(in crate::http) async fn store_consumer_offset(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Json(command): Json<StoreConsumerOffset>,
+) -> Result<StatusCode, PartitionWriteError> {
+    let stream_id =
+        Identifier::from_str_value(&stream_id).map_err(PartitionWriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(PartitionWriteError::Rejected)?;
+    // RBAC: authorize the offset write on (stream, topic) handler-side.
+    authorize_data_plane(
+        &state,
+        identity.session.user_id,
+        &stream_id,
+        &topic_id,
+        Permissioner::store_consumer_offset,
+    )
+    .map_err(PartitionWriteError::Rejected)?;
+    let request = store_offset_wire_request(&stream_id, &topic_id, &command)
+        .map_err(PartitionWriteError::Rejected)?;
+    let body = request.to_bytes();
+    SendWrapper::new(partition_write_replicated(
+        &state,
+        &identity.session,
+        Operation::StoreConsumerOffset2,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /streams/{stream_id}/topics/{topic_id}/consumer-offsets/{consumer_id}`:
+/// delete a consumer's stored offset. The consumer comes from the path and the
+/// optional `partition_id` from the query, the same `DeleteConsumerOffset`
+/// shape the legacy server accepts. Returns 204 on commit, matching the legacy
+/// server; a delete of a never-stored offset is denied by the partition
+/// primary (`ReplyHeader.status`) and renders the legacy typed 404. Same
+/// replicated partition write as [`store_consumer_offset`].
+pub(in crate::http) async fn delete_consumer_offset(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id, consumer_id)): Path<(String, String, String)>,
+    Query(query): Query<DeleteConsumerOffset>,
+) -> Result<StatusCode, PartitionWriteError> {
+    let stream_id =
+        Identifier::from_str_value(&stream_id).map_err(PartitionWriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(PartitionWriteError::Rejected)?;
+    // RBAC: authorize the offset delete on (stream, topic) handler-side.
+    authorize_data_plane(
+        &state,
+        identity.session.user_id,
+        &stream_id,
+        &topic_id,
+        Permissioner::delete_consumer_offset,
+    )
+    .map_err(PartitionWriteError::Rejected)?;
+    // `Consumer::new` fixes the kind to `Consumer`, exactly as the legacy
+    // handler does; HTTP cannot express a group-kind offset op.
+    let consumer = Consumer::new(
+        Identifier::from_str_value(&consumer_id).map_err(PartitionWriteError::Rejected)?,
+    );
+    let request = delete_offset_wire_request(&stream_id, &topic_id, &consumer, query.partition_id)
+        .map_err(PartitionWriteError::Rejected)?;
+    let body = request.to_bytes();
+    SendWrapper::new(partition_write_replicated(
+        &state,
+        &identity.session,
+        Operation::DeleteConsumerOffset2,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /streams/{stream_id}/topics/{topic_id}/consumer-groups`: create a
+/// consumer group under a topic and render the committed reply as the same
+/// `ConsumerGroupDetails` JSON the legacy server returns.
+///
+/// The stream and topic come from the path; the JSON body is name-only
+/// (`{"name": ...}`), matching the legacy request. The submitted op is a plain
+/// `CreateConsumerGroup`; the metadata owner assigns the group id, so this
+/// handler never allocates one itself. Answers 200, uniform with every other ng
+/// create route; the legacy server answers 201 here (yet 200 for stream / topic
+/// / user creates), so this trades legacy status parity for internal consistency.
+pub(in crate::http) async fn create_cg(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id)): Path<(String, String)>,
+    Json(command): Json<CreateConsumerGroup>,
+) -> Result<Json<ConsumerGroupDetails>, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(WriteError::Rejected)?;
+    let request = CreateConsumerGroupRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        topic_id: identifier_to_wire(&topic_id).map_err(WriteError::Rejected)?,
+        name: WireName::new(command.name)
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidConsumerGroupName))?,
+    };
+    let body = request.to_bytes();
+    let payload = SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::CreateConsumerGroup,
+        &body,
+    ))
+    .await?;
+    Ok(Json(decode_consumer_group_details(&payload)?))
+}
+
+/// `DELETE /streams/{stream_id}/topics/{topic_id}/consumer-groups/{group_id}`:
+/// delete a consumer group. Returns 204 on commit.
+pub(in crate::http) async fn delete_cg(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path((stream_id, topic_id, group_id)): Path<(String, String, String)>,
+) -> Result<StatusCode, WriteError> {
+    let stream_id = Identifier::from_str_value(&stream_id).map_err(WriteError::Rejected)?;
+    let topic_id = Identifier::from_str_value(&topic_id).map_err(WriteError::Rejected)?;
+    let group_id = Identifier::from_str_value(&group_id).map_err(WriteError::Rejected)?;
+    let request = DeleteConsumerGroupRequest {
+        stream_id: identifier_to_wire(&stream_id).map_err(WriteError::Rejected)?,
+        topic_id: identifier_to_wire(&topic_id).map_err(WriteError::Rejected)?,
+        group_id: identifier_to_wire(&group_id).map_err(WriteError::Rejected)?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::DeleteConsumerGroup,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /users`: create a user and render the committed reply as the same
+/// `UserInfoDetails` JSON the legacy server returns.
+///
+/// The plaintext password rides the JSON body; [`submit_write`] hashes it on
+/// shard 0 before the request enters consensus (see
+/// [`maybe_rewrite_user_password_request`]), so no plaintext is ever replicated.
+pub(in crate::http) async fn create_user(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Json(command): Json<CreateUser>,
+) -> Result<Json<UserInfoDetails>, WriteError> {
+    // Rejects empty/oversized username or password before any consensus work.
+    command.validate().map_err(WriteError::Rejected)?;
+    let request = CreateUserRequest {
+        username: WireName::new(&command.username)
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidUsername))?,
+        password: command.password.expose_secret().to_string(),
+        status: command.status.as_code(),
+        permissions: command.permissions.as_ref().map(permissions_to_wire),
+    };
+    let body = request.to_bytes();
+    let payload = SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::CreateUser,
+        &body,
+    ))
+    .await?;
+    Ok(Json(decode_user_details(&payload)?))
+}
+
+/// `PUT /users/{user_id}`: update a user's username and/or status. Returns 204.
+pub(in crate::http) async fn update_user(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(user_id): Path<String>,
+    Json(command): Json<UpdateUser>,
+) -> Result<StatusCode, WriteError> {
+    let user_id = Identifier::from_str_value(&user_id).map_err(WriteError::Rejected)?;
+    // Rejects an oversized replacement username; a no-op when username is absent.
+    command.validate().map_err(WriteError::Rejected)?;
+    let request = UpdateUserRequest {
+        user_id: identifier_to_wire(&user_id).map_err(WriteError::Rejected)?,
+        username: command
+            .username
+            .as_deref()
+            .map(WireName::new)
+            .transpose()
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidUsername))?,
+        status: command.status.map(|status| status.as_code()),
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::UpdateUser,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /users/{user_id}`: delete a user. Returns 204.
+pub(in crate::http) async fn delete_user(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(user_id): Path<String>,
+) -> Result<StatusCode, WriteError> {
+    let user_id = Identifier::from_str_value(&user_id).map_err(WriteError::Rejected)?;
+    let request = DeleteUserRequest {
+        user_id: identifier_to_wire(&user_id).map_err(WriteError::Rejected)?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::DeleteUser,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `PUT /users/{user_id}/password`: change a user's password. Returns 204.
+///
+/// Both passwords ride the JSON body in plaintext. On shard 0, before the op
+/// enters consensus, [`maybe_rewrite_user_password_request`] hashes the new
+/// password and strips the current one (so neither plaintext is ever
+/// replicated), and verifies `current_password` against the target's stored
+/// hash. A wrong current password is not denied pre-consensus: the op still
+/// commits, carrying an empty new-password hash the replicated apply turns into
+/// an `InvalidCredentials` no-op (surfaced here as 400), so the caller's request
+/// sequence stays contiguous.
+pub(in crate::http) async fn change_password(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(user_id): Path<String>,
+    Json(command): Json<ChangePassword>,
+) -> Result<StatusCode, WriteError> {
+    let user_id = Identifier::from_str_value(&user_id).map_err(WriteError::Rejected)?;
+    // Rejects empty/oversized current or new password before any consensus work.
+    command.validate().map_err(WriteError::Rejected)?;
+    let request = ChangePasswordRequest {
+        user_id: identifier_to_wire(&user_id).map_err(WriteError::Rejected)?,
+        current_password: command.current_password.expose_secret().to_string(),
+        new_password: command.new_password.expose_secret().to_string(),
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::ChangePassword,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `PUT /users/{user_id}/permissions`: replace a user's permissions. Returns 204.
+pub(in crate::http) async fn update_permissions(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(user_id): Path<String>,
+    Json(command): Json<UpdatePermissions>,
+) -> Result<StatusCode, WriteError> {
+    let user_id = Identifier::from_str_value(&user_id).map_err(WriteError::Rejected)?;
+    command.validate().map_err(WriteError::Rejected)?;
+    let request = UpdatePermissionsRequest {
+        user_id: identifier_to_wire(&user_id).map_err(WriteError::Rejected)?,
+        permissions: command.permissions.as_ref().map(permissions_to_wire),
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::UpdatePermissions,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /personal-access-tokens`: list the caller's own tokens (name +
+/// expiry, never the secrets) as the same `Vec<PersonalAccessTokenInfo>` JSON
+/// the legacy server returns. Self-scoped, so authentication is the whole
+/// rule - no permissioner check, matching legacy parity. A consensus-free
+/// local STM read via [`read_local`].
+pub(in crate::http) async fn get_pats(
+    State(state): State<HttpState>,
+    identity: Identity,
+    Query(query): Query<ConsistencyQuery>,
+) -> Result<Json<Vec<PersonalAccessTokenInfo>>, ReadError> {
+    let body = GetPersonalAccessTokensRequest.to_bytes();
+    let bytes = read_local(
+        &state,
+        &identity,
+        query.consistency,
+        GET_PERSONAL_ACCESS_TOKENS_CODE,
+        &body,
+        |_, _| Ok(()),
+    )?;
+    let response = GetPersonalAccessTokensResponse::decode_from(&bytes)
+        .map_err(|_| ReadError::Rejected(IggyError::InvalidCommand))?;
+    Ok(Json(personal_access_tokens_from_wire(response)))
+}
+
+/// `POST /personal-access-tokens`: mint a personal access token for the caller
+/// and return its one-time raw secret as the same `{"token": ...}` JSON the
+/// legacy server returns, with HTTP 200.
+///
+/// The raw token is non-deterministic and secret, so it must never enter
+/// consensus: [`rewrite_pat_request_for_user`] (invoked inside
+/// [`submit_committed`]) mints it on shard 0 and replicates only its hash, so a
+/// successful committed reply body is empty. [`build_raw_pat_reply`] then splices
+/// the raw secret back into that reply locally, using the confirmed commit
+/// position. The token is surfaced only after the write commits; a malformed
+/// splice fails closed rather than emitting a blank token.
+///
+/// A committed create can still carry a business rejection (duplicate name,
+/// invalid expiry), so the result code is honored via [`committed_payload`] -
+/// exactly as the mechanical routes do - BEFORE the secret is spliced. Only a
+/// genuine success gets a token; a rejection renders the legacy error instead of
+/// a bogus 200 + token.
+pub(in crate::http) async fn create_pat(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Json(command): Json<CreatePersonalAccessToken>,
+) -> Result<Json<RawPersonalAccessToken>, WriteError> {
+    // Rejects an empty/oversized token name before any consensus work.
+    command.validate().map_err(WriteError::Rejected)?;
+    let request = CreatePersonalAccessTokenRequest {
+        name: WireName::new(&command.name)
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidPersonalAccessTokenName))?,
+        expiry: command.expiry.into(),
+    };
+    let body = request.to_bytes();
+    let (request_header, committed, raw_token) = SendWrapper::new(submit_committed(
+        &state,
+        &identity.session,
+        Operation::CreatePersonalAccessToken,
+        &body,
+    ))
+    .await?;
+    // Reject a committed business error before splicing the secret; the success
+    // payload is empty, so the returned slice is discarded.
+    committed_payload(&committed)?;
+    let reply =
+        build_raw_pat_reply(&request_header, committed, raw_token).map_err(WriteError::Rejected)?;
+    Ok(Json(RawPersonalAccessToken {
+        token: decode_raw_pat_token(&reply)?,
+    }))
+}
+
+/// `DELETE /personal-access-tokens/{name}`: delete one of the caller's tokens by
+/// name. Returns 204 on commit. Self-scoped: any authenticated user may delete
+/// their own tokens (the in-apply gate skips PAT ops), matching legacy parity.
+pub(in crate::http) async fn delete_pat(
+    State(state): State<HttpState>,
+    identity: Authenticated,
+    Path(name): Path<String>,
+) -> Result<StatusCode, WriteError> {
+    let request = DeletePersonalAccessTokenRequest {
+        name: WireName::new(&name)
+            .map_err(|_| WriteError::Rejected(IggyError::InvalidPersonalAccessTokenName))?,
+    };
+    let body = request.to_bytes();
+    SendWrapper::new(submit_write(
+        &state,
+        &identity.session,
+        Operation::DeletePersonalAccessToken,
+        &body,
+    ))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Issue a fresh access token for `user_id` and wrap it in the exact
+/// `IdentityInfo` shape the SDKs pin: numeric `user_id` plus an `access_token`
+/// carrying the token string and its unix-seconds expiry.
+fn issue_identity(inner: &HttpInner, user_id: u32) -> Result<Json<IdentityInfo>, CustomError> {
+    let generated = inner.jwt.generate(user_id)?;
+    Ok(Json(IdentityInfo {
+        user_id: generated.user_id,
+        access_token: Some(TokenInfo {
+            token: generated.access_token,
+            expiry: generated.access_token_expiry,
+        }),
+    }))
+}

--- a/core/server-ng/src/http/jwt.rs
+++ b/core/server-ng/src/http/jwt.rs
@@ -1,0 +1,307 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Minimal JWT issuer/verifier for the shard-0 HTTP listener.
+//!
+//! Ported from the legacy `server::http::jwt::jwt_manager::JwtManager`, reduced
+//! to the issue + verify half: no revoked-token persistence, no JWKS /
+//! trusted-issuer path. The refresh-token route re-issues by composing `decode`
+//! with `generate` at the handler; without a revocation list that refresh is
+//! stateless, so the token it was minted from stays valid until its own `exp`.
+//! The claim set (`JwtClaims`, including the `jti`) and the `IggyError -> HTTP`
+//! grading are reused verbatim so issued tokens and error bodies stay identical
+//! to the legacy server.
+
+use std::ops::Range;
+
+use configs::http::HttpJwtConfig;
+use iggy_common::{IggyDuration, IggyError, IggyExpiry, IggyTimestamp, UserId};
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use server_common::crypto;
+use tracing::warn;
+use uuid::Uuid;
+
+/// Length window for the random secret minted when no secret is configured.
+/// Matches the legacy server so both behave identically on an empty secret.
+const GENERATED_SECRET_LEN: Range<usize> = 32..64;
+
+/// Expiry stamp used for a non-expiring token: far enough out to never trip
+/// `exp` validation, small enough to fit `u32`. Mirrors the legacy server.
+const NEVER_EXPIRE_SECS: u32 = 1_000_000_000;
+
+/// Fixed-lifetime issuer/verifier for HTTP bearer tokens on shard 0.
+pub struct JwtManager {
+    algorithm: Algorithm,
+    issuer: String,
+    audience: String,
+    access_token_expiry: IggyExpiry,
+    not_before: IggyDuration,
+    encoding_key: EncodingKey,
+    decoding_key: DecodingKey,
+    validation: Validation,
+}
+
+impl JwtManager {
+    /// Build the manager from the `[http.jwt]` config, normalizing an
+    /// unconfigured secret the same way the legacy server does (mint a random
+    /// ephemeral secret, or mirror whichever half is set).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IggyError`] if the configured algorithm is unsupported or a
+    /// secret cannot be turned into an encoding/decoding key.
+    pub fn build(config: &HttpJwtConfig) -> Result<Self, IggyError> {
+        let config = normalize_secrets(config.clone());
+        let algorithm = config.get_algorithm()?;
+        let encoding_key = config.get_encoding_key()?;
+        let decoding_key = config.get_decoding_key()?;
+        let mut validation = Validation::new(algorithm);
+        validation.set_issuer(&config.valid_issuers);
+        validation.set_audience(&config.valid_audiences);
+        validation.leeway = u64::from(config.clock_skew.as_secs());
+        // The issuer always stamps `nbf`, so enforce it: a token presented
+        // before its not-before instant (beyond `leeway`) is rejected.
+        // `jsonwebtoken` leaves `validate_nbf` off by default, so this is
+        // explicit; the claim is always present, so it only ever tightens.
+        validation.validate_nbf = true;
+        Ok(Self {
+            algorithm,
+            issuer: config.issuer,
+            audience: config.audience,
+            access_token_expiry: config.access_token_expiry,
+            not_before: config.not_before,
+            encoding_key,
+            decoding_key,
+            validation,
+        })
+    }
+
+    /// Issue a signed access token for `user_id` carrying a unique `jti` plus
+    /// issued-at / not-before / expiry stamps derived from the config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IggyError::CannotGenerateJwt`] if signing fails.
+    pub fn generate(&self, user_id: UserId) -> Result<GeneratedToken, IggyError> {
+        let header = Header::new(self.algorithm);
+        let iat = IggyTimestamp::now().to_secs();
+        let expiry_secs = match self.access_token_expiry {
+            IggyExpiry::NeverExpire => NEVER_EXPIRE_SECS,
+            IggyExpiry::ServerDefault => 0,
+            IggyExpiry::ExpireDuration(duration) => duration.as_secs(),
+        };
+        let exp = iat + u64::from(expiry_secs);
+        let nbf = iat + u64::from(self.not_before.as_secs());
+        let claims = JwtClaims {
+            jti: Uuid::now_v7().to_string(),
+            sub: user_id.to_string(),
+            aud: Audience::from(self.audience.clone()),
+            iss: self.issuer.clone(),
+            iat,
+            exp,
+            nbf,
+        };
+        let access_token = encode::<JwtClaims>(&header, &claims, &self.encoding_key)
+            .map_err(|_| IggyError::CannotGenerateJwt)?;
+        Ok(GeneratedToken {
+            user_id,
+            access_token,
+            access_token_expiry: exp,
+        })
+    }
+
+    /// Verify a token's signature and registered claims, returning its claim
+    /// set (the `jti` is what a session table keys on).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IggyError::Unauthenticated`] if the token is malformed,
+    /// expired, or fails issuer/audience/signature validation.
+    pub fn decode(&self, token: &str) -> Result<JwtClaims, IggyError> {
+        decode::<JwtClaims>(token, &self.decoding_key, &self.validation)
+            .map(|data| data.claims)
+            .map_err(|_| IggyError::Unauthenticated)
+    }
+}
+
+/// Fill in an unconfigured JWT secret exactly like the legacy HTTP server:
+/// both empty -> one random ephemeral secret; one empty -> mirror the other;
+/// both set but different under an HMAC algorithm -> warn (they must match).
+fn normalize_secrets(mut config: HttpJwtConfig) -> HttpJwtConfig {
+    match (
+        config.encoding_secret.is_empty(),
+        config.decoding_secret.is_empty(),
+    ) {
+        (true, true) => {
+            let secret = crypto::generate_secret(GENERATED_SECRET_LEN);
+            let redacted: String = secret.chars().take(3).collect();
+            warn!(
+                "JWT encoding and decoding secrets are not configured - generated a random secret: {redacted}***. JWT tokens will be invalidated on server restart. Set 'encoding_secret' and 'decoding_secret' in the config to use persistent secrets."
+            );
+            config.encoding_secret.clone_from(&secret);
+            config.decoding_secret = secret;
+        }
+        (true, false) => {
+            warn!(
+                "JWT encoding secret is not configured but decoding secret is set - using decoding secret for both. Set 'encoding_secret' in the config to avoid this warning."
+            );
+            config.encoding_secret = config.decoding_secret.clone();
+        }
+        (false, true) => {
+            warn!(
+                "JWT decoding secret is not configured but encoding secret is set - using encoding secret for both. Set 'decoding_secret' in the config to avoid this warning."
+            );
+            config.decoding_secret = config.encoding_secret.clone();
+        }
+        (false, false) => {
+            if config.encoding_secret != config.decoding_secret
+                && config.algorithm.starts_with("HS")
+            {
+                warn!(
+                    "JWT encoding and decoding secrets are different but algorithm is {} (HMAC) - both secrets must be identical for symmetric algorithms.",
+                    config.algorithm
+                );
+            }
+        }
+    }
+    config
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::http) enum Audience {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl From<String> for Audience {
+    fn from(aud: String) -> Self {
+        Self::Single(aud)
+    }
+}
+
+impl Serialize for Audience {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Single(aud) => serializer.serialize_str(aud),
+            Self::Multiple(auds) => auds.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Audience {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct AudienceVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for AudienceVisitor {
+            type Value = Audience;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string or an array of strings")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Audience::Single(value.to_string()))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Audience::Single(value))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut auds = Vec::new();
+                while let Some(aud) = seq.next_element::<String>()? {
+                    auds.push(aud);
+                }
+                Ok(Audience::Multiple(auds))
+            }
+        }
+
+        deserializer.deserialize_any(AudienceVisitor)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(in crate::http) struct JwtClaims {
+    pub jti: String,
+    pub iss: String,
+    pub aud: Audience,
+    pub sub: String,
+    pub iat: u64,
+    pub exp: u64,
+    pub nbf: u64,
+}
+
+#[derive(Debug)]
+pub(in crate::http) struct GeneratedToken {
+    pub user_id: UserId,
+    pub access_token: String,
+    pub access_token_expiry: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A default config (HS256, matching issuer/audience, empty secrets ->
+    /// one ephemeral secret shared by encode and decode) with the two
+    /// timing knobs overridden.
+    fn config(not_before: &str, clock_skew: &str) -> HttpJwtConfig {
+        HttpJwtConfig {
+            not_before: not_before.parse().expect("valid duration"),
+            clock_skew: clock_skew.parse().expect("valid duration"),
+            ..HttpJwtConfig::default()
+        }
+    }
+
+    #[test]
+    fn token_presented_before_its_nbf_is_rejected() {
+        // not_before well past the leeway window, so the freshly issued token
+        // is not yet valid and decode must reject it.
+        let manager = JwtManager::build(&config("3600 s", "5 s")).expect("builds");
+        let token = manager.generate(7).expect("issues");
+        assert!(
+            manager.decode(&token.access_token).is_err(),
+            "a token presented before its nbf must be rejected"
+        );
+    }
+
+    #[test]
+    fn token_at_its_nbf_is_accepted() {
+        // Default not_before (0s) => nbf == iat, so the token is valid now and
+        // enabling nbf validation does not reject a normally issued token.
+        let manager = JwtManager::build(&config("0 s", "5 s")).expect("builds");
+        let token = manager.generate(7).expect("issues");
+        let claims = manager.decode(&token.access_token).expect("valid now");
+        assert_eq!(claims.sub, "7");
+    }
+}

--- a/core/server-ng/src/http/reads.rs
+++ b/core/server-ng/src/http/reads.rs
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Read-path gates: the shared per-op RBAC + consistency check, the local
+//! metadata-STM read entry, and the wire/domain identifier resolvers the read
+//! and data-plane routes ground their scopes through.
+
+use bytes::Bytes;
+use consensus::MetadataHandle;
+use iggy_binary_protocol::WireIdentifier;
+use iggy_common::wire_conversions::identifier_to_wire;
+use iggy_common::{Identifier, IggyError};
+use metadata::impls::metadata::StreamsFrontend;
+use metadata::permissioner::Permissioner;
+
+use crate::http::error::{Consistency, ReadError};
+use crate::http::extractor::Identity;
+use crate::http::state::HttpInner;
+use crate::responses::{
+    NonReplicatedResponse, build_non_replicated_response, resolve_stream_id, resolve_topic_id,
+};
+
+/// The two cross-cutting gates every authenticated read enforces before it
+/// touches state. Factored out of [`read_local`] so the cross-shard client
+/// reads (`get_clients` / `get_client`) - which serve from the shard session
+/// managers, not the local STM, and so cannot use [`read_local`] - still pass
+/// the identical gate. Keeping it in one place is what guarantees no read route
+/// can silently skip authz or answer a linearizable request on a follower.
+///
+/// Per-op RBAC: run the route's `rule` against the caller's committed
+/// permissions via the live permissioner. A denial (always `Unauthorized`)
+/// renders 403 through the legacy `IggyError -> status` map; root holds every
+/// grant, so its reads pass without a user-id short-circuit. A linearizable
+/// read must come from the primary; on a follower it redirects (307) to the
+/// primary's HTTP address when resolvable, else fails closed to a 503 (see
+/// [`HttpInner::not_primary_read_error`]).
+pub(in crate::http) fn authorize_read(
+    state: &HttpInner,
+    identity: &Identity,
+    consistency: Consistency,
+    rule: impl FnOnce(&Permissioner, u32) -> Result<(), IggyError>,
+) -> Result<(), ReadError> {
+    state
+        .shard
+        .plane
+        .metadata()
+        .mux_stm
+        .users()
+        .authorize(|permissioner| rule(permissioner, identity.user_id))
+        .map_err(ReadError::Rejected)?;
+    if consistency == Consistency::Linearizable && !state.is_metadata_primary() {
+        return Err(state.not_primary_read_error(&identity.path_and_query));
+    }
+    Ok(())
+}
+
+/// Serve one authenticated read from the local metadata STM and hand back the
+/// wire response body. Shared chokepoint for every read route whose data lives
+/// in the metadata STM: it runs the shared [`authorize_read`] gate, then
+/// delegates to [`build_non_replicated_response`], the SAME local-read entry the
+/// TCP dispatch spine uses (`handle_default_non_replicated`), so an HTTP read and
+/// a TCP read of the same entity return byte-identical bodies.
+///
+/// Reads never touch consensus or a VSR session: `build_non_replicated_response`
+/// is a pure STM read. It is synchronous, so this helper is too - no submit
+/// await, no gate, no `SendWrapper`. An absent entity surfaces as
+/// [`NonReplicatedResponse::Empty`], mapped to 404 here because every REST read
+/// whose entity can be missing shares that not-found shape.
+pub(in crate::http) fn read_local(
+    state: &HttpInner,
+    identity: &Identity,
+    consistency: Consistency,
+    code: u32,
+    body: &[u8],
+    rule: impl FnOnce(&Permissioner, u32) -> Result<(), IggyError>,
+) -> Result<Bytes, ReadError> {
+    authorize_read(state, identity, consistency, rule)?;
+    match build_non_replicated_response(
+        &state.shard,
+        code,
+        body,
+        Some(identity.user_id),
+        &state.roster,
+    )
+    .map_err(ReadError::Rejected)?
+    {
+        NonReplicatedResponse::Empty => Err(ReadError::NotFound),
+        NonReplicatedResponse::Bytes(bytes) => Ok(bytes),
+    }
+}
+
+/// Resolve a wire stream identifier to its committed slab id for a read/write
+/// gate, or `None` on a miss (the gate is then a pass-through, so the existing
+/// not-found path renders the 404). Mirrors the TCP dispatch resolvers.
+pub(in crate::http) fn resolve_gate_stream(
+    state: &HttpInner,
+    stream_id: &WireIdentifier,
+) -> Option<usize> {
+    state
+        .shard
+        .plane
+        .metadata()
+        .mux_stm
+        .streams()
+        .read(|inner| resolve_stream_id(inner, stream_id))
+}
+
+/// Resolve a wire (stream, topic) pair to committed slab ids, or `None` if
+/// either misses.
+pub(in crate::http) fn resolve_gate_topic(
+    state: &HttpInner,
+    stream_id: &WireIdentifier,
+    topic_id: &WireIdentifier,
+) -> Option<(usize, usize)> {
+    state
+        .shard
+        .plane
+        .metadata()
+        .mux_stm
+        .streams()
+        .read(|inner| {
+            let stream_id = resolve_stream_id(inner, stream_id)?;
+            let topic_id = resolve_topic_id(inner, stream_id, topic_id)?;
+            Some((stream_id, topic_id))
+        })
+}
+
+/// Resolve an (`Identifier`, `Identifier`) pair to committed (stream, topic)
+/// slab ids for a gate, or `None` on any conversion or resolution miss. For the
+/// poll / consumer-offset read routes, which carry domain identifiers rather
+/// than the pre-converted wire form the entity reads hold.
+pub(in crate::http) fn resolve_gate_topic_ids(
+    state: &HttpInner,
+    stream_id: &Identifier,
+    topic_id: &Identifier,
+) -> Option<(usize, usize)> {
+    let wire_stream = identifier_to_wire(stream_id).ok()?;
+    let wire_topic = identifier_to_wire(topic_id).ok()?;
+    resolve_gate_topic(state, &wire_stream, &wire_topic)
+}
+
+/// Authorize an HTTP data-plane write (produce / consumer-offset) on (stream,
+/// topic). A resolution miss returns `Ok(())` so the write proceeds to the
+/// dispatch gates, which render the existing 404; a resolved entity whose rule
+/// rejects returns the `Unauthorized` error for a 403. Kept handler-side so an
+/// HTTP denial never enters the partition plane (the plane's empty replies
+/// carry no status a slot-waiting handler could read as a 403).
+pub(in crate::http) fn authorize_data_plane(
+    state: &HttpInner,
+    user_id: u32,
+    stream_id: &Identifier,
+    topic_id: &Identifier,
+    rule: impl FnOnce(&Permissioner, u32, usize, usize) -> Result<(), IggyError>,
+) -> Result<(), IggyError> {
+    let (Ok(wire_stream), Ok(wire_topic)) =
+        (identifier_to_wire(stream_id), identifier_to_wire(topic_id))
+    else {
+        return Ok(());
+    };
+    let Some((stream_id, topic_id)) = resolve_gate_topic(state, &wire_stream, &wire_topic) else {
+        return Ok(());
+    };
+    state
+        .shard
+        .plane
+        .metadata()
+        .mux_stm
+        .users()
+        .authorize(|permissioner| rule(permissioner, user_id, stream_id, topic_id))
+}

--- a/core/server-ng/src/http/reply.rs
+++ b/core/server-ng/src/http/reply.rs
@@ -1,0 +1,425 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Committed-reply decoding and classification: result-section grading, typed
+//! payload decoders, partition-reply status classification, and the eviction /
+//! login error mappings the write and auth paths render through.
+
+use iggy_binary_protocol::consensus::{
+    Command2, EvictionHeader, HEADER_SIZE, result_code, result_section_len,
+};
+use iggy_binary_protocol::responses::consumer_groups::get_consumer_group::ConsumerGroupDetailsResponse;
+use iggy_binary_protocol::responses::personal_access_tokens::RawPersonalAccessTokenResponse;
+use iggy_binary_protocol::responses::streams::get_stream::GetStreamResponse;
+use iggy_binary_protocol::responses::topics::get_topic::GetTopicResponse;
+use iggy_binary_protocol::responses::users::get_user::UserDetailsResponse;
+use iggy_binary_protocol::{GenericHeader, ReplyHeader, WireDecode};
+use iggy_common::{
+    ConsumerGroupDetails, IggyError, StreamDetails, TopicDetails, UserInfoDetails,
+    eviction_reason_to_error,
+};
+use message_bus::BusMessage;
+use server_common::Message;
+
+use crate::http::error::{PartitionWriteError, WriteError};
+use crate::login_register::LoginRegisterError;
+
+/// Discriminate a partition write reply. Partition replies carry no result
+/// section (success and denial are both empty-bodied), so the discriminators
+/// live in the header. `status` is read first: a nonzero value is the typed
+/// pre-commit denial (the partition primary's delete-of-missing-offset
+/// rejection, or a dispatch-time authorization denial) and renders through
+/// the legacy `IggyError -> status` map. With status 0, the reply's `op`
+/// splits the rest: a committed reply is built from its prepare header, whose
+/// op (the partition group's commit number) is always >= 1, while the
+/// pre-dispatch gate failures reply through `build_empty_reply` with 0 in
+/// that field. The gate reply cannot name which entity was missing, hence the
+/// generic legacy 404 body.
+pub(in crate::http) fn classify_partition_reply(
+    reply: &BusMessage,
+) -> Result<(), PartitionWriteError> {
+    let header = reply
+        .as_slice()
+        .get(..HEADER_SIZE)
+        .and_then(|bytes| bytemuck::checked::try_from_bytes::<ReplyHeader>(bytes).ok())
+        .ok_or(PartitionWriteError::Rejected(IggyError::InvalidCommand))?;
+    if header.command != Command2::Reply {
+        return Err(PartitionWriteError::Rejected(IggyError::InvalidCommand));
+    }
+    if header.status != 0 {
+        return Err(PartitionWriteError::Rejected(IggyError::from_code(
+            header.status,
+        )));
+    }
+    if header.op == 0 {
+        return Err(PartitionWriteError::NotFound);
+    }
+    Ok(())
+}
+
+/// Classify a committed reply's leading result section and return the typed
+/// payload slice on success. Mirrors the SDK's `split_metadata_result`:
+/// `Some(0)` is success and the payload follows the result section; a nonzero
+/// first result is a committed business rejection carrying an `IggyError` code
+/// (e.g. a duplicate token name); a missing or short section is a malformed
+/// committed reply, mapped to an error rather than a false success. Shared by
+/// [`submit_write`] and [`create_pat`] so a committed rejection can never render
+/// as a 2xx.
+pub(in crate::http) fn committed_payload(
+    reply: &Message<GenericHeader>,
+) -> Result<&[u8], WriteError> {
+    let reply_body = reply_body(reply);
+    match result_code(reply_body) {
+        Some(0) => {
+            let payload_start = result_section_len(reply_body)
+                .ok_or(WriteError::Rejected(IggyError::InvalidCommand))?;
+            reply_body
+                .get(payload_start..)
+                .ok_or(WriteError::Rejected(IggyError::InvalidCommand))
+        }
+        Some(code) => Err(WriteError::Rejected(IggyError::from_code(code))),
+        None => Err(WriteError::Rejected(IggyError::InvalidCommand)),
+    }
+}
+
+/// True when a reply-shaped frame is the primary's pre-consensus
+/// `TransientNotCommitted` rejection (`[count=1][index=0][57]`, see
+/// `build_result_rejection_reply`): the op did not commit, so the write path
+/// must replay the same request id rather than grade it as a committed
+/// result or advance the session gate.
+pub(in crate::http) fn is_transient_not_committed(reply: &Message<GenericHeader>) -> bool {
+    result_code(reply_body(reply)) == Some(IggyError::TransientNotCommitted.as_code())
+}
+
+/// The reply body past the generic header, bounded by the header's `size`.
+fn reply_body(reply: &Message<GenericHeader>) -> &[u8] {
+    let size = reply.header().size as usize;
+    reply.as_slice().get(HEADER_SIZE..size).unwrap_or_default()
+}
+
+/// Decode the `GetStreamResponse` payload of a committed create-stream reply into
+/// `StreamDetails`. `payload` is the slice past the result section that
+/// [`submit_write`] already validated as a success.
+pub(in crate::http) fn decode_stream_details(payload: &[u8]) -> Result<StreamDetails, WriteError> {
+    let response = GetStreamResponse::decode_from(payload)
+        .map_err(|_| WriteError::Rejected(IggyError::InvalidCommand))?;
+    StreamDetails::try_from(response).map_err(WriteError::Rejected)
+}
+
+/// Decode the `GetTopicResponse` payload of a committed create-topic reply into
+/// `TopicDetails`. `payload` is the slice past the result section that
+/// [`submit_write`] already validated as a success.
+pub(in crate::http) fn decode_topic_details(payload: &[u8]) -> Result<TopicDetails, WriteError> {
+    let response = GetTopicResponse::decode_from(payload)
+        .map_err(|_| WriteError::Rejected(IggyError::InvalidCommand))?;
+    TopicDetails::try_from(response).map_err(WriteError::Rejected)
+}
+
+/// Decode the `UserDetailsResponse` payload of a committed create-user reply into
+/// `UserInfoDetails`. `payload` is the slice past the result section that
+/// [`submit_write`] already validated as a success.
+pub(in crate::http) fn decode_user_details(payload: &[u8]) -> Result<UserInfoDetails, WriteError> {
+    let response = UserDetailsResponse::decode_from(payload)
+        .map_err(|_| WriteError::Rejected(IggyError::InvalidCommand))?;
+    UserInfoDetails::try_from(response).map_err(WriteError::Rejected)
+}
+
+/// Decode the `ConsumerGroupDetailsResponse` payload of a committed
+/// create-consumer-group reply into `ConsumerGroupDetails`. `payload` is the
+/// slice past the result section that [`submit_write`] already validated as a
+/// success. The wire-to-domain conversion is infallible.
+pub(in crate::http) fn decode_consumer_group_details(
+    payload: &[u8],
+) -> Result<ConsumerGroupDetails, WriteError> {
+    let response = ConsumerGroupDetailsResponse::decode_from(payload)
+        .map_err(|_| WriteError::Rejected(IggyError::InvalidCommand))?;
+    Ok(ConsumerGroupDetails::from(response))
+}
+
+/// Extract the raw one-time token from a [`build_raw_pat_reply`] output. The
+/// spliced reply is framed like any committed metadata reply (a success result
+/// section, then the `RawPersonalAccessTokenResponse`) so the SDK's
+/// `split_metadata_result` can decode it; strip the section the same way here.
+pub(in crate::http) fn decode_raw_pat_token(
+    reply: &Message<GenericHeader>,
+) -> Result<String, WriteError> {
+    let payload = committed_payload(reply)?;
+    let response = RawPersonalAccessTokenResponse::decode_from(payload)
+        .map_err(|_| WriteError::Rejected(IggyError::InvalidCommand))?;
+    Ok(response.token.to_string())
+}
+
+/// Map an eviction frame to the same typed [`IggyError`] the SDK's
+/// `decode_eviction` produces, so an HTTP caller sees the identical status a TCP
+/// caller would (session-terminal reasons render as 401 -> re-authenticate).
+/// Reuses the shared [`EvictionHeader`] primitive rather than hand-decoding
+/// offsets; an unreadable frame falls back to re-authentication.
+pub(in crate::http) fn eviction_error(reply: &Message<GenericHeader>) -> IggyError {
+    let Some(eviction) = reply
+        .as_slice()
+        .get(..HEADER_SIZE)
+        .and_then(|bytes| bytemuck::checked::try_from_bytes::<EvictionHeader>(bytes).ok())
+    else {
+        return IggyError::Unauthenticated;
+    };
+    eviction_reason_to_error(
+        eviction.reason,
+        eviction.server_protocol_version,
+        eviction.server_protocol_version_min,
+    )
+}
+
+/// Grade a credential-verification failure onto the `IggyError` the legacy
+/// HTTP error map already maps to a status + body, so `CustomError` renders
+/// what the SDKs are tested against. `verify_*` only yield the first three
+/// variants; the tail is unreachable but kept terminal (401) for the
+/// `#[non_exhaustive]` enum.
+pub(in crate::http) const fn login_error_to_iggy(error: &LoginRegisterError) -> IggyError {
+    match error {
+        LoginRegisterError::InvalidCredentials => IggyError::InvalidCredentials,
+        LoginRegisterError::InvalidToken => IggyError::InvalidPersonalAccessToken,
+        LoginRegisterError::UserInactive => IggyError::UserInactive,
+        _ => IggyError::Unauthenticated,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+    use iggy_binary_protocol::Operation;
+    use iggy_binary_protocol::PrepareHeader;
+
+    use crate::responses::{
+        NonReplicatedResponse, build_deny_reply, build_empty_reply, build_reply_from_bytes,
+        build_reply_with_body,
+    };
+
+    use crate::http::wire::build_request_message;
+
+    // The dispatch-time deny frame: an empty body plus `ReplyHeader.status` set
+    // to the rule's error code, the request-level channel the SDK peeks before
+    // body decode. `build_empty_reply` (status 0) is the ok-shaped counterpart.
+    #[test]
+    fn deny_reply_stamps_status_over_an_empty_body() {
+        let request = build_request_message(Operation::SendMessages, 42, 7, 3, &[]);
+        let status = IggyError::Unauthorized.as_code();
+        let reply = build_deny_reply(request.header(), 42, 0, 9, status);
+        assert_eq!(
+            reply.header().size as usize,
+            HEADER_SIZE,
+            "deny body is empty (header-only)"
+        );
+        assert_eq!(
+            reply.header().status,
+            status,
+            "status carries the deny code"
+        );
+        assert_ne!(status, 0, "a deny status is nonzero so the SDK peek fires");
+        assert_eq!(reply.header().command, Command2::Reply);
+        // Echoes the request so the SDK routes it back to the waiting slot.
+        assert_eq!(reply.header().request, request.header().request);
+        assert_eq!(reply.header().operation, request.header().operation);
+    }
+
+    // Enforces the status contract: every ok-path reply builder leaves status
+    // 0, so a future builder that leaks a nonzero reserved tail (or sets
+    // status by mistake) trips here rather than silently shipping a fake
+    // denial. The deny builders (build_deny_reply here, the partition
+    // primary's consensus::build_deny_reply_from_request) are the only
+    // nonzero-status writers.
+    #[test]
+    fn only_the_deny_builder_emits_a_nonzero_status() {
+        let request = build_request_message(Operation::CreateStream, 42, 7, 3, &[]);
+        let header = request.header();
+        let commit = 9;
+        let body = Bytes::from_static(b"body");
+
+        // server-ng reply builders, all funnelled through build_reply_with_body.
+        for status in [
+            build_reply_with_body(header, 42, 7, commit, 0, |_| {})
+                .header()
+                .status,
+            build_empty_reply(header, 42, 7, commit).header().status,
+            build_reply_from_bytes(header, 42, 7, commit, &body)
+                .header()
+                .status,
+            NonReplicatedResponse::Empty
+                .into_reply(header, 42, 7, commit)
+                .header()
+                .status,
+            NonReplicatedResponse::Bytes(body.clone())
+                .into_reply(header, 42, 7, commit)
+                .header()
+                .status,
+        ] {
+            assert_eq!(status, 0, "ok-path reply builders must leave status 0");
+        }
+
+        // The consensus plane's committed-reply builder (plane_helpers path).
+        let prepare = PrepareHeader {
+            command: Command2::Prepare,
+            operation: Operation::SendMessages,
+            client: 42,
+            op: 1,
+            request: 1,
+            ..Default::default()
+        };
+        let committed = consensus::build_reply_message(&prepare, &Bytes::new());
+        assert_eq!(
+            committed.header().status,
+            0,
+            "committed replies carry status 0"
+        );
+
+        // The intentional deny writer stamps nonzero.
+        assert_ne!(
+            build_deny_reply(header, 42, 7, commit, IggyError::Unauthorized.as_code())
+                .header()
+                .status,
+            0,
+            "the deny builder must stamp a nonzero status"
+        );
+    }
+
+    fn frozen(reply: Message<iggy_binary_protocol::ReplyHeader>) -> BusMessage {
+        reply.into_generic().into_frozen()
+    }
+
+    #[test]
+    fn committed_partition_reply_classifies_as_success() {
+        let prepare = PrepareHeader {
+            command: Command2::Prepare,
+            operation: Operation::SendMessages,
+            client: 42,
+            op: 1,
+            request: 1,
+            ..Default::default()
+        };
+        let reply = frozen(consensus::build_reply_message(&prepare, &Bytes::new()));
+        assert!(classify_partition_reply(&reply).is_ok());
+    }
+
+    /// The 204 path of the offset write routes: a committed
+    /// `StoreConsumerOffset2` reply (op >= 1) classifies as success.
+    #[test]
+    fn committed_offset_write_reply_classifies_as_success() {
+        let prepare = PrepareHeader {
+            command: Command2::Prepare,
+            operation: Operation::StoreConsumerOffset2,
+            client: 42,
+            op: 3,
+            request: 2,
+            ..Default::default()
+        };
+        let reply = frozen(consensus::build_reply_message(&prepare, &Bytes::new()));
+        assert!(classify_partition_reply(&reply).is_ok());
+    }
+
+    #[test]
+    fn gate_failure_empty_reply_classifies_as_not_found() {
+        let request = build_request_message(Operation::SendMessages, 42, 7, 1, &[]);
+        let reply = frozen(build_empty_reply(request.header(), 42, 0, 9));
+        assert!(matches!(
+            classify_partition_reply(&reply),
+            Err(PartitionWriteError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn non_reply_frame_classifies_as_rejected() {
+        let request = build_request_message(Operation::SendMessages, 42, 7, 1, &[]);
+        assert!(matches!(
+            classify_partition_reply(&request.into_generic().into_frozen()),
+            Err(PartitionWriteError::Rejected(IggyError::InvalidCommand))
+        ));
+    }
+
+    /// The pre-consensus retry frame must classify as transient so the write
+    /// path replays the same request id instead of advancing the session gate
+    /// and grading it as a committed rejection (which rendered as a terminal
+    /// HTTP error).
+    #[test]
+    fn transient_rejection_frame_classifies_as_transient() {
+        let request = build_request_message(Operation::CreateStream, 42, 7, 3, &[]);
+        let reply = consensus::build_result_rejection_reply(
+            request.header(),
+            9,
+            IggyError::TransientNotCommitted.as_code(),
+        )
+        .into_generic();
+        assert!(is_transient_not_committed(&reply));
+        assert!(matches!(
+            committed_payload(&reply),
+            Err(WriteError::Rejected(IggyError::TransientNotCommitted))
+        ));
+    }
+
+    /// Genuine committed outcomes must advance the gate, so neither a success
+    /// reply nor a committed business rejection may trip the replay
+    /// classification.
+    #[test]
+    fn committed_replies_do_not_classify_as_transient() {
+        let request = build_request_message(Operation::CreateStream, 42, 7, 3, &[]);
+        // `[count=1][index=0][result=0]` success section, then the payload.
+        let mut body = Vec::new();
+        for word in [1u32, 0, 0] {
+            body.extend_from_slice(&word.to_le_bytes());
+        }
+        body.extend_from_slice(b"payload");
+        let success =
+            build_reply_from_bytes(request.header(), 42, 7, 9, &Bytes::from(body)).into_generic();
+        assert!(!is_transient_not_committed(&success));
+        let Ok(payload) = committed_payload(&success) else {
+            panic!("success section must grade ok");
+        };
+        assert_eq!(payload, b"payload");
+
+        let rejected = consensus::build_result_rejection_reply(
+            request.header(),
+            9,
+            IggyError::UserAlreadyExists.as_code(),
+        )
+        .into_generic();
+        assert!(!is_transient_not_committed(&rejected));
+        assert!(matches!(
+            committed_payload(&rejected),
+            Err(WriteError::Rejected(IggyError::UserAlreadyExists))
+        ));
+    }
+
+    /// The partition primary's typed pre-commit deny (delete of a missing
+    /// consumer offset) rides `ReplyHeader.status` and must classify as the
+    /// mapped `IggyError`, not as the generic op-0 not-found.
+    #[test]
+    fn status_bearing_deny_reply_classifies_as_typed_rejection() {
+        let request = build_request_message(Operation::DeleteConsumerOffset2, 42, 7, 1, &[]);
+        let mut deny = build_empty_reply(request.header(), 42, 0, 9);
+        let header = bytemuck::checked::try_from_bytes_mut::<ReplyHeader>(
+            &mut deny.as_mut_slice()[..HEADER_SIZE],
+        )
+        .expect("empty reply header is valid");
+        header.status = IggyError::ConsumerOffsetNotFound(0).as_code();
+        assert!(matches!(
+            classify_partition_reply(&frozen(deny)),
+            Err(PartitionWriteError::Rejected(
+                IggyError::ConsumerOffsetNotFound(_)
+            ))
+        ));
+    }
+}

--- a/core/server-ng/src/http/session.rs
+++ b/core/server-ng/src/http/session.rs
@@ -1,0 +1,386 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Per-credential VSR session state: the session entry, the first-use
+//! registration barrier, and the pure session-table sweep / forget / lookup
+//! helpers the state bridge drives.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::rc::Rc;
+
+use consensus::CLIENTS_TABLE_MAX;
+use futures::channel::oneshot;
+use message_bus::InstanceToken;
+use tokio::sync::Mutex;
+
+/// Hard cap on live per-credential sessions. A leak-guard, not a tuning knob:
+/// reaching it means this many distinct live tokens are in flight at once. New
+/// sessions past the cap are refused with a transient 503 rather than evicting
+/// a live one; the client retries. Expired entries are dropped first, so the
+/// cap only bites on live oversubscription.
+///
+/// Bounded by the shared VSR client table: HTTP sessions and the TCP/QUIC/WS
+/// virtual clients all Register into the one [`CLIENTS_TABLE_MAX`]-slot table,
+/// which LRU-evicts the oldest client when full. Capping HTTP at half that
+/// bound keeps this plane from crowding the others out and keeps the combined
+/// steady state under the shared bound, so a live idle HTTP session is not
+/// routinely evicted consensus-side. The residual eviction race (both planes
+/// busy) degrades gracefully: an evicted session's next control write is
+/// classified as an eviction and re-registers (see [`HttpInner::forget_session`]).
+pub(in crate::http) const MAX_HTTP_SESSIONS: usize = CLIENTS_TABLE_MAX / 2;
+
+/// First per-session request id the write path hands out. VSR request numbers
+/// are 1-based and strictly increasing within a session.
+pub(in crate::http) const FIRST_REQUEST_ID: u64 = 1;
+
+/// One VSR session established for a single login credential (a JWT `jti` or a
+/// PAT). Shared via `Rc` by every concurrent request bearing that credential,
+/// so the session granularity is per-login.
+pub(in crate::http) struct HttpSession {
+    /// Session-table key this entry lives under (`jwt:{jti}` / `pat:{sha}`).
+    /// Held so an eviction observed on the write path can remove exactly this
+    /// entry (see [`HttpInner::forget_session`]) without threading the key
+    /// through the whole write chain.
+    pub(in crate::http) key: String,
+    /// Shard-0 client id minted for this credential; its top 16 bits are 0, so
+    /// it shares the shard-0 id space with TCP virtual clients without
+    /// colliding. Fills `RequestHeader.client` on every write.
+    pub(in crate::http) client_id: u128,
+    /// Cluster session number returned by the VSR `Register` commit. Fills
+    /// `RequestHeader.session` on every write.
+    pub(in crate::http) session: u64,
+    /// User the credential authenticated as. Consumed by the write path for
+    /// authorization.
+    pub(in crate::http) user_id: u32,
+    /// Credential expiry in unix seconds (`u64::MAX` = never). Drives lazy
+    /// eviction of stale table entries.
+    pub(in crate::http) expiry: u64,
+    /// Serializes this session's writes: the guarded value is the NEXT request
+    /// id. A `tokio::sync::Mutex` because the write path holds it across the
+    /// submit `.await` so each session's request numbers reach the primary in
+    /// order and stay gap-free for the depth-1 consensus dedup.
+    pub(in crate::http) gate: Mutex<u64>,
+    /// Next data-plane request id. A separate, gate-free counter: partition ops
+    /// are at-least-once with no consensus dedup, so the id only correlates the
+    /// in-process reply slot and concurrent produces on one session are legal.
+    /// A plain `Cell` suffices on single-threaded shard 0; ids are minted
+    /// monotonically and never reused, which the slot-guard contract requires.
+    pub(in crate::http) data_request: Cell<u64>,
+    /// Registry token of this session's lazily-installed in-process reply
+    /// target (`None` until the first awaited partition write). Stored so
+    /// session eviction can tear the registry entry down fenced by the same
+    /// token.
+    pub(in crate::http) registry_token: Cell<Option<InstanceToken>>,
+    /// Awaited partition writes currently in flight on this session, gated by
+    /// [`MAX_IN_FLIGHT_WRITES_PER_SESSION`]. Only [`InFlightWriteGuard`]
+    /// touches it, so every admission is paired with exactly one release.
+    pub(in crate::http) in_flight_writes: Cell<u32>,
+}
+
+impl HttpSession {
+    /// Mint the next data-plane request id. Also consumed by the `?ack=none`
+    /// path, which installs no slot: sharing one counter keeps a shed reply's
+    /// id from ever colliding with a live awaited slot on this session.
+    pub(in crate::http) fn next_data_request_id(&self) -> u64 {
+        let id = self.data_request.get();
+        self.data_request.set(id + 1);
+        id
+    }
+}
+
+/// Serializes first-use VSR registration per credential key so a herd of
+/// concurrent first-requests for one token runs exactly one `Register` instead
+/// of N that each mint a client id and orphan N-1 slots last-writer-wins.
+///
+/// Shard 0 is single-threaded, so the whole check-or-claim is a synchronous
+/// `RefCell` critical section (no cross-thread machinery): the first caller for
+/// a key claims it and gets a [`RegistrationGuard`]; every later caller gets a
+/// waiter to park on until the registrant finishes. The guard clears the marker
+/// and wakes all waiters on drop - including a cancellation drop, so a
+/// disconnected registrant can never wedge its waiters.
+#[derive(Default)]
+pub(in crate::http) struct RegistrationBarrier {
+    /// Key -> waiters parked on the in-flight registration. Dropping a waiter's
+    /// sender wakes its receiver; the guard drops the whole vec at once.
+    inflight: RefCell<HashMap<String, Vec<oneshot::Sender<()>>>>,
+}
+
+/// Outcome of [`RegistrationBarrier::enter`]: lead the registration or wait for
+/// the caller that is already leading it.
+pub(in crate::http) enum BarrierEntry<'a> {
+    Lead(RegistrationGuard<'a>),
+    Wait(oneshot::Receiver<()>),
+}
+
+/// Held by the sole registrant for a key. On drop it removes the in-flight
+/// marker, which drops every parked waiter's sender and so wakes them to
+/// re-check the session table.
+pub(in crate::http) struct RegistrationGuard<'a> {
+    barrier: &'a RegistrationBarrier,
+    key: String,
+}
+
+impl RegistrationBarrier {
+    /// Claim `key` for registration, or return a waiter if another caller
+    /// already holds it. Synchronous and borrow-free of any `.await`.
+    pub(in crate::http) fn enter(&self, key: &str) -> BarrierEntry<'_> {
+        match self.inflight.borrow_mut().entry(key.to_owned()) {
+            Entry::Occupied(mut occupied) => {
+                let (sender, receiver) = oneshot::channel();
+                occupied.get_mut().push(sender);
+                BarrierEntry::Wait(receiver)
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(Vec::new());
+                BarrierEntry::Lead(RegistrationGuard {
+                    barrier: self,
+                    key: key.to_owned(),
+                })
+            }
+        }
+    }
+}
+
+impl Drop for RegistrationGuard<'_> {
+    fn drop(&mut self) {
+        // Dropping the vec of senders wakes every waiter (Canceled), which then
+        // re-checks the table for the session this registrant installed.
+        self.barrier.inflight.borrow_mut().remove(&self.key);
+    }
+}
+
+/// Drop every expired entry from the session table, returning the
+/// `(client_id, registry token)` of each dropped entry that had installed an
+/// in-process reply target so the caller can tear those down outside the
+/// borrow. A pure map operation (no shard), so the cap/expiry policy is
+/// unit-testable without a live consensus.
+pub(in crate::http) fn sweep_expired(
+    table: &mut HashMap<String, Rc<HttpSession>>,
+    now_secs: u64,
+) -> Vec<(u128, InstanceToken)> {
+    let mut torn = Vec::new();
+    table.retain(|_, session| {
+        if session.expiry > now_secs {
+            return true;
+        }
+        if let Some(token) = session.registry_token.get() {
+            torn.push((session.client_id, token));
+        }
+        false
+    });
+    torn
+}
+
+/// Remove `session` from the table only if it is still the current occupant of
+/// its key (`Rc::ptr_eq`), returning its reply target to tear down. A stale
+/// handle whose key was re-registered to a newer session removes nothing. Pure
+/// (no shard) so the eviction-recovery fencing is unit-testable.
+pub(in crate::http) fn forget_if_same(
+    table: &mut HashMap<String, Rc<HttpSession>>,
+    session: &Rc<HttpSession>,
+) -> Option<(u128, InstanceToken)> {
+    match table.get(&session.key) {
+        Some(current) if Rc::ptr_eq(current, session) => {
+            let torn = session
+                .registry_token
+                .get()
+                .map(|token| (session.client_id, token));
+            table.remove(&session.key);
+            torn
+        }
+        _ => None,
+    }
+}
+
+/// Borrow-and-clone a live table entry, or `None` if missing or expired. Shared
+/// by the fast path and the post-Register re-check so neither leaks a guard.
+pub(in crate::http) fn live_entry(
+    table: &HashMap<String, Rc<HttpSession>>,
+    key: &str,
+    now_secs: u64,
+) -> Option<Rc<HttpSession>> {
+    table
+        .get(key)
+        .filter(|session| session.expiry > now_secs)
+        .map(Rc::clone)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use iggy_common::defaults::DEFAULT_ROOT_USER_ID;
+
+    /// Pins the platform contract `submit_committed`'s cancellation safety
+    /// rests on: a detached compio task keeps running after the handler side
+    /// is gone, the gate advance it performs sticks, and sending the result
+    /// into a dropped oneshot receiver is an ignorable `Err`, never a panic.
+    /// The full hazard window (client disconnect between the consensus commit
+    /// and the id advance) needs a live commit round-trip, so it is covered by
+    /// construction plus the live cancellation smoke, not faked here.
+    #[compio::test]
+    async fn detached_task_advances_gate_and_ignores_dead_receiver() {
+        let session = Rc::new(HttpSession {
+            key: "jwt:test".to_owned(),
+            client_id: 7,
+            session: 1,
+            user_id: DEFAULT_ROOT_USER_ID,
+            expiry: u64::MAX,
+            gate: Mutex::new(FIRST_REQUEST_ID),
+            data_request: Cell::new(FIRST_REQUEST_ID),
+            registry_token: Cell::new(None),
+            in_flight_writes: Cell::new(0),
+        });
+        let (result_slot, committed) = oneshot::channel::<u64>();
+        // The handler future dies (client disconnect) before the task runs.
+        drop(committed);
+        let (done_slot, done) = oneshot::channel::<()>();
+        let task_session = Rc::clone(&session);
+        compio::runtime::spawn(async move {
+            let mut next_request_id = task_session.gate.lock().await;
+            *next_request_id += 1;
+            let _ = result_slot.send(*next_request_id);
+            drop(next_request_id);
+            let _ = done_slot.send(());
+        })
+        .detach();
+        done.await.expect("detached task must run to completion");
+        assert_eq!(*session.gate.lock().await, FIRST_REQUEST_ID + 1);
+    }
+
+    /// `InstanceToken` has no public constructor, so fixtures carry no reply
+    /// target; the token-teardown branch of the sweep/forget helpers is
+    /// exercised via their `Option` path, not fabricated here.
+    fn fake_session(key: &str, client_id: u128, expiry: u64) -> Rc<HttpSession> {
+        Rc::new(HttpSession {
+            key: key.to_owned(),
+            client_id,
+            session: 1,
+            user_id: DEFAULT_ROOT_USER_ID,
+            expiry,
+            gate: Mutex::new(FIRST_REQUEST_ID),
+            data_request: Cell::new(FIRST_REQUEST_ID),
+            registry_token: Cell::new(None),
+            in_flight_writes: Cell::new(0),
+        })
+    }
+
+    // The barrier is what makes a herd of concurrent first-requests for one
+    // credential run a single `Register`: only the leader reaches
+    // `register_session`; every other caller waits and reuses what it installs.
+    // A different credential leads independently, and the key frees on drop.
+    #[compio::test]
+    async fn registration_barrier_leads_one_caller_and_parks_the_rest() {
+        let barrier = RegistrationBarrier::default();
+
+        let BarrierEntry::Lead(leader) = barrier.enter("jwt:a") else {
+            panic!("first caller for a key must lead");
+        };
+        let mut waiters = Vec::new();
+        for _ in 0..4 {
+            match barrier.enter("jwt:a") {
+                BarrierEntry::Wait(waiter) => waiters.push(waiter),
+                BarrierEntry::Lead(_) => panic!("a concurrent caller must not lead the same key"),
+            }
+        }
+        assert!(
+            matches!(barrier.enter("jwt:b"), BarrierEntry::Lead(_)),
+            "a different credential leads independently"
+        );
+
+        // Leader finishing wakes every waiter and frees the key.
+        drop(leader);
+        for waiter in waiters {
+            let _ = waiter.await;
+        }
+        assert!(
+            matches!(barrier.enter("jwt:a"), BarrierEntry::Lead(_)),
+            "the freed key leads a fresh registration"
+        );
+    }
+
+    #[test]
+    fn sweep_expired_drops_only_expired_entries() {
+        let mut table = HashMap::new();
+        let live = fake_session("jwt:live", 1, 1_000);
+        let stale = fake_session("jwt:stale", 2, 10);
+        table.insert(live.key.clone(), Rc::clone(&live));
+        table.insert(stale.key.clone(), Rc::clone(&stale));
+
+        // now = 100: live.expiry(1000) > now stays, stale.expiry(10) <= now goes.
+        let torn = sweep_expired(&mut table, 100);
+
+        assert!(torn.is_empty(), "fixtures install no reply target");
+        assert!(table.contains_key("jwt:live"), "live session retained");
+        assert!(!table.contains_key("jwt:stale"), "expired session swept");
+    }
+
+    // At the cap the sweep only reclaims expired entries, never a live one, so
+    // an all-live table stays full and `resolve_session` refuses (503) rather
+    // than evicting a live session.
+    #[test]
+    fn sweep_never_evicts_live_sessions_so_a_full_table_stays_full() {
+        let mut table = HashMap::new();
+        for client_id in 0..8u128 {
+            let session = fake_session(&format!("jwt:{client_id}"), client_id, 1_000);
+            table.insert(session.key.clone(), session);
+        }
+        let torn = sweep_expired(&mut table, 100);
+        assert!(torn.is_empty());
+        assert_eq!(table.len(), 8, "no live session is evicted to make room");
+    }
+
+    #[test]
+    fn http_session_cap_leaves_headroom_below_the_shared_client_table_bound() {
+        const {
+            assert!(
+                MAX_HTTP_SESSIONS < CLIENTS_TABLE_MAX,
+                "HTTP must not claim the whole shared VSR client table"
+            );
+        }
+        assert_eq!(MAX_HTTP_SESSIONS, CLIENTS_TABLE_MAX / 2);
+    }
+
+    // Eviction recovery: forgetting the evicted session drops exactly its
+    // entry, and a stale handle never purges a session that re-registered under
+    // the same key in the meantime (the `Rc::ptr_eq` fence).
+    #[test]
+    fn forget_removes_the_evicted_session_but_spares_a_re_registration() {
+        let mut table = HashMap::new();
+        let evicted = fake_session("jwt:a", 1, u64::MAX);
+        table.insert(evicted.key.clone(), Rc::clone(&evicted));
+
+        assert!(forget_if_same(&mut table, &evicted).is_none());
+        assert!(!table.contains_key("jwt:a"), "evicted session removed");
+
+        let replacement = fake_session("jwt:a", 2, u64::MAX);
+        table.insert(replacement.key.clone(), Rc::clone(&replacement));
+        assert!(
+            forget_if_same(&mut table, &evicted).is_none(),
+            "a stale handle removes nothing"
+        );
+        assert!(
+            Rc::ptr_eq(
+                table.get("jwt:a").expect("replacement present"),
+                &replacement
+            ),
+            "the pointer fence spares the re-registered session"
+        );
+    }
+}

--- a/core/server-ng/src/http/state.rs
+++ b/core/server-ng/src/http/state.rs
@@ -1,0 +1,283 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shared shard-0 HTTP state: the [`HttpInner`] bridge (shard handle, JWT
+//! issuer, per-credential VSR session table, cluster roster) plus the axum
+//! `State` newtype and the per-response view-header stamp.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use axum::http::{HeaderName, HeaderValue};
+use axum::response::Response;
+use configs::system::SystemConfig;
+use consensus::{MetadataHandle, VsrConsensus};
+use iggy_common::{ClusterMetadata, IggyTimestamp};
+use message_bus::InstanceToken;
+use send_wrapper::SendWrapper;
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use crate::bootstrap::ServerNgShard;
+use crate::cluster_meta::ClusterRoster;
+use crate::dispatch::submit_register_on_owner;
+use crate::http::error::{AuthError, ReadError, primary_redirect_location};
+use crate::http::jwt::JwtManager;
+use crate::http::session::{
+    BarrierEntry, FIRST_REQUEST_ID, HttpSession, MAX_HTTP_SESSIONS, RegistrationBarrier,
+    forget_if_same, live_entry, sweep_expired,
+};
+
+/// Response header carrying the current VSR view number. Stamped by
+/// `insert_view_header` on success and redirect responses only (never on
+/// errors, and the router suppresses it on `/ping`) while this node has live
+/// consensus.
+const VIEW_HEADER: HeaderName = HeaderName::from_static("x-iggy-view");
+
+/// Axum router state: shard-0's [`HttpInner`] behind an `Rc`, `!Send` yet
+/// bridged into axum's `Send + Sync` requirement by `SendWrapper`. Sound
+/// because the listener and every handler run on shard 0's compio thread - the
+/// same thread that builds this state. Never touch it off that thread.
+pub(in crate::http) type HttpState = SendWrapper<Rc<HttpInner>>;
+
+/// Shared shard-0 HTTP state.
+///
+/// Groups the shard handle, the JWT issuer/verifier, and the per-credential VSR
+/// session table so every handler and the [`Authenticated`] extractor reach
+/// them through one axum `State`.
+pub(in crate::http) struct HttpInner {
+    pub(in crate::http) shard: Rc<ServerNgShard>,
+    pub(in crate::http) jwt: JwtManager,
+    /// Read-only server config for the snapshot collector (log directory +
+    /// runtime config paths); the shard does not expose config on the read
+    /// path.
+    pub(in crate::http) system_config: Arc<SystemConfig>,
+    /// Per-credential VSR sessions keyed by JWT `jti` / PAT hash. `RefCell` is
+    /// sound here - shard 0 is single-threaded and the `SendWrapper` state
+    /// bridge tolerates the `!Sync` interior - but the guard must never be held
+    /// across an `.await` (see [`HttpInner::resolve_session`]).
+    pub(in crate::http) sessions: RefCell<HashMap<String, Rc<HttpSession>>>,
+    /// Per-key registration barrier: prevents a thundering herd of first
+    /// requests for one credential from each running its own `Register`.
+    pub(in crate::http) registrations: RegistrationBarrier,
+    pub(in crate::http) roster: ClusterRoster,
+    /// Awaited partition writes currently in flight across all sessions, gated
+    /// by [`MAX_IN_FLIGHT_WRITES_GLOBAL`]. Only [`InFlightWriteGuard`] touches
+    /// it, so every admission is paired with exactly one release.
+    pub(in crate::http) in_flight_writes: Cell<u32>,
+}
+
+impl HttpInner {
+    /// True when this shard-0 node is the current VSR metadata primary, i.e.
+    /// `primary_index(current_view) == own_replica_id` - the check consensus
+    /// `is_primary` already encapsulates over the live view and this replica's
+    /// id. Absent consensus (never on shard 0 under VSR, only a no-replica
+    /// build) is treated as not-primary so a linearizable read fails closed
+    /// rather than serving possibly-stale local state as authoritative.
+    pub(in crate::http) fn is_metadata_primary(&self) -> bool {
+        self.shard
+            .plane
+            .metadata()
+            .consensus
+            .as_ref()
+            .is_some_and(VsrConsensus::is_primary)
+    }
+
+    /// Grade a linearizable read that reached a follower: redirect (307) to the
+    /// current VSR primary's HTTP address when it resolves from the roster, else
+    /// fail closed to the 503. The target is the roster node whose `replica_id`
+    /// equals `primary_index(view)`; an absent consensus, an unmatched id, or a
+    /// port-less node all fall back to [`ReadError::NotPrimary`].
+    pub(in crate::http) fn not_primary_read_error(&self, path_and_query: &str) -> ReadError {
+        let location = self
+            .shard
+            .plane
+            .metadata()
+            .consensus
+            .as_ref()
+            .and_then(|consensus| {
+                let primary_index = consensus.primary_index(consensus.view());
+                primary_redirect_location(&self.roster, primary_index, path_and_query)
+            });
+        location.map_or(ReadError::NotPrimary, ReadError::RedirectToPrimary)
+    }
+
+    /// Resolve the VSR session for `key`, minting and Registering one on first
+    /// use. Every later request bearing the same credential reuses it.
+    ///
+    /// Borrow discipline: the `RefCell` table guard is taken, read, and dropped
+    /// WITHOUT crossing the `.await`. Holding it across the Register suspend
+    /// would panic the moment a sibling shard-0 task borrowed the table while
+    /// this one is parked (single-threaded `RefCell` + cooperative scheduling).
+    pub(in crate::http) async fn resolve_session(
+        &self,
+        key: String,
+        user_id: u32,
+        expiry: u64,
+    ) -> Result<Rc<HttpSession>, AuthError> {
+        loop {
+            let now = IggyTimestamp::now().to_secs();
+            if let Some(session) = self.live_session(&key, now) {
+                return Ok(session);
+            }
+
+            // Miss. Serialize registration per credential so a herd of
+            // concurrent first-requests runs one `Register`, not N.
+            match self.registrations.enter(&key) {
+                BarrierEntry::Wait(waiter) => {
+                    // Another first-request is registering this credential.
+                    // Park until it finishes (its guard wakes us on drop),
+                    // then loop to re-check the table for what it installed.
+                    let _ = waiter.await;
+                }
+                BarrierEntry::Lead(_guard) => {
+                    // Sole registrant for this key: mint + Register with no
+                    // borrow held (an async VSR commit). The guard wakes any
+                    // waiters when this scope ends, cancellation drop included.
+                    let fresh = self.register_session(key.clone(), user_id, expiry).await?;
+                    // Resample after the await: the pre-await stamp is stale for
+                    // the expiry sweep and cap check below.
+                    let now = IggyTimestamp::now().to_secs();
+                    let (admitted, torn) = {
+                        let mut table = self.sessions.borrow_mut();
+                        let torn = sweep_expired(&mut table, now);
+                        if table.len() >= MAX_HTTP_SESSIONS {
+                            // Still full after dropping expired entries: too many
+                            // genuinely live sessions. Refuse rather than evict a
+                            // live one (its `fresh` client id is orphaned on the
+                            // peers until they evict it - a rare at-cap cost).
+                            (None, torn)
+                        } else {
+                            table.insert(key.clone(), Rc::clone(&fresh));
+                            (Some(fresh), torn)
+                        }
+                    };
+                    self.teardown_reply_targets(torn);
+                    return admitted.ok_or(AuthError::SessionUnavailable);
+                }
+            }
+        }
+    }
+
+    /// Clone the live (non-expired) entry for `key`, if present. Confines the
+    /// shared `RefCell` borrow to this call so it can never span an `.await`.
+    fn live_session(&self, key: &str, now_secs: u64) -> Option<Rc<HttpSession>> {
+        live_entry(&self.sessions.borrow(), key, now_secs)
+    }
+
+    /// Mint a shard-0 client id and run the VSR `Register` for a fresh session.
+    /// Holds no table borrow; the caller inserts the result under `key`.
+    async fn register_session(
+        &self,
+        key: String,
+        user_id: u32,
+        expiry: u64,
+    ) -> Result<Rc<HttpSession>, AuthError> {
+        let coordinator = self
+            .shard
+            .coordinator()
+            .ok_or(AuthError::SessionUnavailable)?;
+        // Reuse the TCP accept path's minter: it draws from the same shard-0
+        // `client_seq`, so an HTTP session id can never collide with a TCP
+        // virtual client's and the shard-0 tag (top 16 bits == 0) is preserved.
+        let client_id = coordinator.mint_shard_zero_client_id();
+        // The minter seeds at 1, so 0 is only reachable after a 2^112 wrap.
+        // Guard anyway: `submit_register_in_process` asserts `client_id != 0`,
+        // and an assert on this request path would be a panic.
+        if client_id == 0 {
+            return Err(AuthError::SessionUnavailable);
+        }
+        // Shared Register entry point; on shard 0 (always, for HTTP) it runs
+        // `submit_register_in_process` directly on the metadata owner.
+        let session = submit_register_on_owner(&self.shard, client_id, user_id)
+            .await
+            .map_err(|error| {
+                warn!(?error, "server-ng HTTP: VSR Register submit failed");
+                AuthError::SessionUnavailable
+            })?;
+        Ok(Rc::new(HttpSession {
+            key,
+            client_id,
+            session,
+            user_id,
+            expiry,
+            gate: Mutex::new(FIRST_REQUEST_ID),
+            data_request: Cell::new(FIRST_REQUEST_ID),
+            registry_token: Cell::new(None),
+            in_flight_writes: Cell::new(0),
+        }))
+    }
+
+    /// Drop the session table entry for `session`, but only if it is still the
+    /// current occupant of its key (pointer-fenced, so a later re-registration
+    /// under the same key is never purged). Also tears down its in-process
+    /// reply target. Called when a control write comes back evicted: the VSR
+    /// slot is gone, so leaving the entry would 401-loop every retry on the
+    /// same credential until the token expires; removing it makes the next
+    /// request re-register cleanly through the barrier.
+    pub(in crate::http) fn forget_session(&self, session: &Rc<HttpSession>) {
+        let torn = forget_if_same(&mut self.sessions.borrow_mut(), session);
+        self.teardown_reply_targets(torn.into_iter().collect());
+    }
+
+    /// Tear down the in-process reply targets of swept/forgotten sessions,
+    /// token-fenced so a stale teardown can never remove a later occupant's
+    /// registry entry. Runs outside the `sessions` borrow.
+    fn teardown_reply_targets(&self, torn: Vec<(u128, InstanceToken)>) {
+        for (client_id, token) in torn {
+            self.shard
+                .bus
+                .clients()
+                .remove_if_token_matches(client_id, token);
+        }
+    }
+
+    /// Build the live [`ClusterMetadata`] for `GET /cluster/metadata` through the
+    /// shared [`ClusterRoster`] assembly. The leader marking comes from this
+    /// shard's consensus view; the HTTP listener is shard-0-only, so consensus is
+    /// always present and every roster read carries real leader/follower roles.
+    pub(in crate::http) fn build_cluster_metadata(&self) -> ClusterMetadata {
+        let primary_index = self
+            .shard
+            .plane
+            .metadata()
+            .consensus
+            .as_ref()
+            .map(|consensus| consensus.primary_index(consensus.view()));
+        self.roster.cluster_metadata(primary_index)
+    }
+}
+
+/// Set the [`VIEW_HEADER`] to the current VSR view on a successful or redirect
+/// `response`. Omits the header on error responses and when this node has no
+/// live consensus: a missing header is unambiguous, whereas a fabricated view
+/// number would mislead.
+pub(in crate::http) fn insert_view_header(state: &HttpInner, mut response: Response) -> Response {
+    // The view is cluster-internal; error responses (notably pre-auth 401s)
+    // must not leak it. Success and the 307 primary-redirect still carry it.
+    if !(response.status().is_success() || response.status().is_redirection()) {
+        return response;
+    }
+    if let Some(consensus) = state.shard.plane.metadata().consensus.as_ref() {
+        response
+            .headers_mut()
+            .insert(VIEW_HEADER, HeaderValue::from(consensus.view()));
+    }
+    response
+}

--- a/core/server-ng/src/http/submit.rs
+++ b/core/server-ng/src/http/submit.rs
@@ -1,0 +1,404 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Write submission: the gate-serialized control-plane submit run on a
+//! detached task, the awaited/fire-and-forget partition write paths, and the
+//! session logout teardown.
+
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use futures::channel::oneshot;
+use iggy_binary_protocol::consensus::Command2;
+use iggy_binary_protocol::{GenericHeader, Operation, RequestHeader};
+use iggy_common::IggyError;
+use server_common::Message;
+use tracing::warn;
+
+use crate::bootstrap::ServerNgShard;
+use crate::dispatch::{
+    dispatch_partition_request, resolve_delete_segments_truncate, submit_client_request_on_owner,
+    submit_logout_on_owner,
+};
+use crate::http::admission::admit_partition_write;
+use crate::http::error::{PartitionWriteError, WriteError};
+use crate::http::reply::{
+    classify_partition_reply, committed_payload, eviction_error, is_transient_not_committed,
+};
+use crate::http::session::HttpSession;
+use crate::http::state::HttpInner;
+use crate::http::wire::build_request_message;
+use crate::pat::rewrite_pat_request_for_user;
+use crate::users::maybe_rewrite_user_password_request;
+use crate::wire::request_body;
+
+/// Bound on a partition write's (produce / consumer-offset write) wait for its
+/// committed reply. Long enough to ride out a view change (plus the dispatch
+/// gates' own routable-wait budget), short enough not to pin HTTP connections
+/// behind a dead consensus group. On expiry the caller gets 504 and must treat
+/// the outcome as unknown: the partition plane is at-least-once and the prepare
+/// may still commit after the wait gave up, so the server never retries on the
+/// caller's behalf.
+const PARTITION_WRITE_REPLY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Replay cadence for a control-plane write answered with the pre-consensus
+/// `TransientNotCommitted` frame (not-caught-up primary, pipeline pressure,
+/// or a view-change cancel). Mirrors the binary SDKs' in-client replay loop
+/// (each TCP/QUIC/WS client's `NOT_READY_RETRY_INTERVAL`):
+/// those transports absorb the frame client-side, HTTP has no SDK loop, so
+/// the server replays here for transport parity.
+const TRANSIENT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Total replay budget for one control-plane write, mirroring the binary
+/// SDKs' `RESPONSE_READ_TIMEOUT` bound on the same loop. On exhaustion the op
+/// has still not entered consensus, so the caller gets a retryable 503, never
+/// a terminal error.
+const TRANSIENT_RETRY_DEADLINE: Duration = Duration::from_secs(30);
+
+/// Run one authenticated control-plane write to commit and hand back the
+/// committed reply `Message`, the request header, and any raw PAT token minted
+/// along the way. Shared core of every HTTP write: [`submit_write`] decodes the
+/// reply body for the stream/topic/user routes, while [`create_pat`] needs the
+/// raw `Message` + request header to substitute the one-time token.
+///
+/// Control-plane writes are authorized in-apply on the metadata STM, so this
+/// runs no pre-submit gate; it drives the gate-locked submit
+/// ([`submit_gated`]) on a detached shard-0 task and awaits its outcome over a
+/// oneshot. Axum drops this handler future the moment the HTTP client
+/// disconnects; were the gate held here, that drop could land between the
+/// pump-driven consensus commit and the id advance, leaving the committed op's
+/// reply cached under an id the session still considers unused - the next
+/// write would collide into `Duplicate` and silently receive the prior op's
+/// reply. Detaching moves the whole critical section out of the cancellable
+/// future; a disconnect now only drops the receiver half.
+pub(in crate::http) async fn submit_committed(
+    state: &HttpInner,
+    session: &Rc<HttpSession>,
+    operation: Operation,
+    body: &[u8],
+) -> Result<(RequestHeader, Message<GenericHeader>, Option<String>), WriteError> {
+    // Control writes are authorized in-apply on the metadata STM: a denial
+    // comes back as `Unauthorized` in the committed result section, which
+    // `committed_payload` maps to a 403. No pre-submit gate here, so the
+    // in-apply check is the single source of truth. Self-scoped PAT ops (which
+    // the in-apply gate skips) reach here as any authenticated user, matching
+    // legacy parity.
+    let (result_slot, committed) = oneshot::channel();
+    let shard = Rc::clone(&state.shard);
+    let task_session = Rc::clone(session);
+    let body = body.to_vec();
+    // Detached so a client disconnect cannot split a commit from its id
+    // advance; both happen inside the task regardless of handler liveness.
+    compio::runtime::spawn(async move {
+        let result = submit_gated(&shard, &task_session, operation, &body).await;
+        // A failed send means the handler died mid-await. The id advance
+        // already happened above, which is the invariant that matters.
+        let _ = result_slot.send(result);
+    })
+    .detach();
+    // `Canceled` = the task was dropped before sending (runtime teardown), a
+    // transient server condition like an unanswered submit.
+    let outcome = committed.await.map_err(|_| WriteError::Unavailable)?;
+    // An eviction means this session's VSR slot is gone: forget the entry so
+    // the caller's next request re-registers instead of 401-looping on it.
+    if matches!(&outcome, Err(WriteError::Evicted(_))) {
+        state.forget_session(session);
+    }
+    outcome
+}
+
+/// Gate-locked core of [`submit_committed`], run on a task the HTTP client
+/// cannot cancel: serializes this session's writes behind its gate and holds
+/// it across the submit so request ids reach the primary strictly in order.
+/// The gate advances only on a genuine committed `Reply`: an unanswered
+/// submit, a `TransientNotCommitted` frame, or an eviction leaves the id
+/// free, which the depth-1 dedup requires (the next accepted request must be
+/// `committed + 1`, so a consumed-but-uncommitted id would wedge the session
+/// on `RequestGap`). A transient frame is replayed in place with the same id
+/// on the binary SDKs' cadence (see [`TRANSIENT_RETRY_INTERVAL`]). An
+/// eviction means the session is dead: mapped to 401, and [`submit_committed`]
+/// then forgets the entry so the caller's retry re-registers cleanly.
+///
+/// Both shard-0 request rewrites run here before consensus, mirroring the TCP
+/// dispatch path: the PAT rewrite mints a raw token and replicates only its hash
+/// (`CreatePersonalAccessToken`), and the user-password rewrite hashes the new
+/// password and, for `ChangePassword`, strips the current one and verifies it
+/// against the stored hash (`CreateUser` / `ChangePassword`). Both are no-ops
+/// for every other operation, so plaintext secrets never enter consensus on any
+/// write. A third resolution handles `DeleteSegments`, which is not itself a
+/// consensus op: it is rewritten to the metadata `TruncatePartition` that commits
+/// the trim (see [`resolve_delete_segments_truncate`]), so the truncate rides
+/// this session's gate id. On a rejection (a malformed body or an unresolved
+/// delete-segments namespace) the gate is released without advancing, leaving
+/// the id free. A failed current-password check is not a rejection here: the op
+/// still commits with an emptied new-password sentinel that the replicated
+/// apply grades to `InvalidCredentials`, so the id advances on the committed
+/// reply (see `verify_and_rewrite_change_password`).
+async fn submit_gated(
+    shard: &Rc<ServerNgShard>,
+    session: &HttpSession,
+    operation: Operation,
+    body: &[u8],
+) -> Result<(RequestHeader, Message<GenericHeader>, Option<String>), WriteError> {
+    let mut next_request_id = session.gate.lock().await;
+    let message = build_request_message(
+        operation,
+        session.client_id,
+        session.session,
+        *next_request_id,
+        body,
+    );
+    let (message, raw_token) =
+        rewrite_pat_request_for_user(session.user_id, message).map_err(WriteError::Rejected)?;
+    let message =
+        maybe_rewrite_user_password_request(shard, message).map_err(WriteError::Rejected)?;
+    // `DeleteSegments` is not itself a consensus op: resolve it to the metadata
+    // `TruncatePartition` that commits the trim before it reaches consensus,
+    // mirroring the TCP dispatch. The truncate rides this session's gate id, so
+    // the metadata request sequence stays contiguous; an unresolved namespace
+    // releases the gate without advancing, like a rejected rewrite.
+    let message = if message.header().operation == Operation::DeleteSegments {
+        let template = *message.header();
+        resolve_delete_segments_truncate(
+            shard,
+            &template,
+            session.client_id,
+            session.session,
+            request_body(&message),
+        )
+        .await
+        .map_err(WriteError::Rejected)?
+    } else {
+        message
+    };
+    let request_header = *message.header();
+    let deadline = Instant::now() + TRANSIENT_RETRY_DEADLINE;
+    let mut request = message;
+    let reply = loop {
+        // The submit consumes the request; keep a byte-identical copy for a
+        // possible replay. Re-running the rewrites instead would mint a fresh
+        // PAT token / password hash and break same-id dedup idempotency.
+        let retry_request = request.clone();
+        let Some(reply) = submit_client_request_on_owner(shard, request).await else {
+            return Err(WriteError::Unavailable);
+        };
+        if reply.header().command != Command2::Reply || !is_transient_not_committed(&reply) {
+            break reply;
+        }
+        // Pre-consensus `TransientNotCommitted`: replay the SAME request id,
+        // mirroring the binary SDKs' in-client loop. Safe to replay - the
+        // dominant emissions never entered the pipeline, and the view-change
+        // cancel is dedup-idempotent (the client table serves the cached
+        // reply). The gate stays held across the replay on purpose: the
+        // request keeps its serialization turn, and a queued same-session
+        // write would only hit the same transient.
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            // Budget exhausted with the op still not committed: surface the
+            // transient code, which renders as a retryable 503, never the
+            // catch-all 400.
+            return Err(WriteError::Rejected(IggyError::TransientNotCommitted));
+        }
+        compio::time::sleep(TRANSIENT_RETRY_INTERVAL.min(remaining)).await;
+        request = retry_request;
+    };
+
+    match reply.header().command {
+        Command2::Reply => {
+            *next_request_id += 1;
+            drop(next_request_id);
+            Ok((request_header, reply, raw_token))
+        }
+        Command2::Eviction => Err(WriteError::Evicted(eviction_error(&reply))),
+        _ => Err(WriteError::Rejected(IggyError::InvalidCommand)),
+    }
+}
+
+/// Run one authenticated control-plane write end to end and return the committed
+/// reply's typed payload. Wraps [`submit_committed`] and decodes the reply body
+/// via [`committed_payload`]: `create_stream` decodes the payload into an entity,
+/// the update/delete/purge routes ignore it (it is empty) and answer 204.
+pub(in crate::http) async fn submit_write(
+    state: &HttpInner,
+    session: &Rc<HttpSession>,
+    operation: Operation,
+    body: &[u8],
+) -> Result<Bytes, WriteError> {
+    let (_request_header, reply, _raw_token) =
+        submit_committed(state, session, operation, body).await?;
+    Ok(Bytes::copy_from_slice(committed_payload(&reply)?))
+}
+
+/// Tear down a caller's session for `DELETE /users/logout`: submit the VSR
+/// `Logout` that releases its client-table slot on every replica (the commit a
+/// TCP disconnect also submits), then forget the local session-table entry and
+/// its reply target so neither leaks.
+///
+/// Best-effort: a transient submit failure is logged and the local entry is
+/// dropped anyway, matching the disconnect path's contract that a logout never
+/// blocks on peer slot release (the orphaned slot LRU-evicts). The bearer is not
+/// revoked here - this listener's JWT half is issue+verify only, with no
+/// revocation list - so the SDK dropping the token client-side is what ends the
+/// credential; a caller that re-presents it just re-registers a fresh session.
+pub(in crate::http) async fn logout_session(state: &HttpInner, session: &Rc<HttpSession>) {
+    // Synthetic request id: the logout apply keys on (client, session) only and
+    // is terminal for this session, so it needs no gate-issued contiguous id
+    // (mirrors the disconnect path's `u64::MAX`).
+    const LOGOUT_REQUEST_ID: u64 = u64::MAX;
+    if let Err(error) = submit_logout_on_owner(
+        &state.shard,
+        session.client_id,
+        session.session,
+        LOGOUT_REQUEST_ID,
+    )
+    .await
+    {
+        warn!(
+            ?error,
+            "server-ng HTTP: VSR Logout submit failed; slot lingers until eviction"
+        );
+    }
+    state.forget_session(session);
+}
+
+/// Run one awaited partition write (produce / consumer-offset write) end to
+/// end: admit against the in-flight caps, install the reply slot, dispatch
+/// into the partition plane, and wait (bounded) for the committed reply.
+///
+/// Slot-before-dispatch is load-bearing: every pre-dispatch gate failure
+/// inside [`dispatch_partition_request`] replies through `send_to_client`,
+/// which fires an installed slot, so one slot catches every exit. The slot
+/// guard borrows the registry, which is why this whole future runs inside
+/// the caller's `SendWrapper` on shard 0.
+pub(in crate::http) async fn partition_write_replicated(
+    state: &HttpInner,
+    session: &HttpSession,
+    operation: Operation,
+    body: &[u8],
+) -> Result<(), PartitionWriteError> {
+    // Admission sits here rather than before body decode: axum's extractors
+    // already buffered and deserialized the body (bounded by the router-wide
+    // `DefaultBodyLimit`) before the handler ran, so the caps gate what is
+    // actually unbounded - the slot install, the dispatch, and the parked
+    // reply await that pins this request's buffers for up to the reply
+    // timeout. Held across every exit below; released by `Drop`.
+    let _in_flight = admit_partition_write(&session.in_flight_writes, &state.in_flight_writes)?;
+    ensure_in_process_reply_target(state, session);
+    let request_id = session.next_data_request_id();
+    let message = build_request_message(
+        operation,
+        session.client_id,
+        session.session,
+        request_id,
+        body,
+    );
+    let (guard, receiver) = state
+        .shard
+        .bus
+        .clients()
+        .install_reply_slot(session.client_id, request_id)
+        .map_err(|error| {
+            warn!(
+                ?error,
+                ?operation,
+                "server-ng HTTP: partition write reply slot install failed"
+            );
+            PartitionWriteError::Unavailable
+        })?;
+    dispatch_partition_request(
+        &state.shard,
+        message,
+        session.client_id,
+        session.session,
+        session.client_id,
+        Some(session.user_id),
+    )
+    .await;
+    let outcome = compio::time::timeout(PARTITION_WRITE_REPLY_TIMEOUT, receiver).await;
+    // Removes the slot unless the reply already fired, so a late commit
+    // reply after a timeout sheds at the bus instead of leaking a waiter.
+    drop(guard);
+    match outcome {
+        Ok(Ok(reply)) => classify_partition_reply(&reply),
+        // Cancelled (reply target torn down by session eviction mid-wait) or
+        // elapsed: same caller contract either way - outcome unknown, 504.
+        Ok(Err(_)) | Err(_) => Err(PartitionWriteError::Timeout(operation)),
+    }
+}
+
+/// Fire-and-forget produce (`?ack=none`): installs no reply slot and never
+/// awaits a commit. The commit still happens; its reply (and any gate-failure
+/// reply) targets a request id with no slot installed and is shed at the bus by
+/// design.
+///
+/// Admitted against the in-flight caps exactly like the acked path
+/// ([`partition_write_replicated`]): being reply-less does not make it free.
+/// The request still parks inside [`dispatch_partition_request`] for the
+/// routable-wait budget while pinning its buffered body, so it must count
+/// against the per-session and shard-global budgets or it would be an uncapped
+/// bypass. The in-flight guard is held across dispatch and released by `Drop`.
+/// A refusal is a synchronous 429/503, which is honest for `?ack=none`:
+/// admission runs before dispatch, so it is not a commit reply the caller
+/// opted out of - it is the request being turned away up front.
+pub(in crate::http) async fn produce_unacked(
+    state: &HttpInner,
+    session: &HttpSession,
+    body: &[u8],
+) -> Result<(), PartitionWriteError> {
+    let _in_flight = admit_partition_write(&session.in_flight_writes, &state.in_flight_writes)?;
+    let request_id = session.next_data_request_id();
+    let message = build_request_message(
+        Operation::SendMessages,
+        session.client_id,
+        session.session,
+        request_id,
+        body,
+    );
+    dispatch_partition_request(
+        &state.shard,
+        message,
+        session.client_id,
+        session.session,
+        session.client_id,
+        Some(session.user_id),
+    )
+    .await;
+    Ok(())
+}
+
+/// Install this session's in-process reply target on first data-plane use.
+///
+/// The registry key is the session's shard-0 client id - the same id stamped
+/// into `RequestHeader.client` - so a partition reply routed through
+/// `send_to_client` lands on this entry and resolves the request-keyed slot.
+/// `None` from the registry means the key is already occupied; treat it as
+/// installed but leave the token unset so this session never tears down an
+/// entry it does not own.
+fn ensure_in_process_reply_target(state: &HttpInner, session: &HttpSession) {
+    if session.registry_token.get().is_some() {
+        return;
+    }
+    if let Some(token) = state
+        .shard
+        .bus
+        .clients()
+        .insert_in_process(session.client_id)
+    {
+        session.registry_token.set(Some(token));
+    }
+}

--- a/core/server-ng/src/http/wire.rs
+++ b/core/server-ng/src/http/wire.rs
@@ -1,0 +1,544 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! HTTP -> wire request mappers: produce/poll/consumer-offset encoders and
+//! the control-plane [`Message<RequestHeader>`] builder shared by the write path.
+
+use bytes::{Bytes, BytesMut};
+use iggy_binary_protocol::consensus::{Command2, HEADER_SIZE};
+use iggy_binary_protocol::primitives::consumer::WireConsumer;
+use iggy_binary_protocol::primitives::polling_strategy::WirePollingStrategy;
+use iggy_binary_protocol::requests::consumer_offsets::{
+    DeleteConsumerOffset2Request, GetConsumerOffsetRequest, StoreConsumerOffset2Request,
+};
+use iggy_binary_protocol::requests::messages::{
+    PollMessagesRequest, RawMessage, SendMessagesEncoder,
+};
+use iggy_binary_protocol::{AckLevel, Operation, RequestHeader};
+use iggy_common::get_consumer_offset::GetConsumerOffset;
+use iggy_common::poll_messages::DEFAULT_PARTITION_ID;
+use iggy_common::store_consumer_offset::StoreConsumerOffset;
+use iggy_common::wire_conversions::{consumer_to_wire, identifier_to_wire, partitioning_to_wire};
+use iggy_common::{
+    Consumer, Identifier, IggyError, IggyMessageView, PollMessages, PolledMessages,
+    RESYNC_REQUIRED_PARTITION_SENTINEL, SendMessages,
+};
+use server_common::Message;
+
+/// Encode a validated HTTP `SendMessages` into the `SendMessagesRequest` wire
+/// body, mirroring the SDK's TCP produce encode: identifier + partitioning
+/// wire conversion, then `RawMessage` borrows into [`SendMessagesEncoder`].
+/// Balanced / messages-key partitioning passes through untouched; the
+/// dispatch gates resolve it to a concrete partition server-side.
+pub(in crate::http) fn encode_send_messages(
+    stream_id: &Identifier,
+    topic_id: &Identifier,
+    command: &SendMessages,
+) -> Result<Bytes, IggyError> {
+    let wire_stream_id = identifier_to_wire(stream_id)?;
+    let wire_topic_id = identifier_to_wire(topic_id)?;
+    let wire_partitioning = partitioning_to_wire(&command.partitioning)?;
+    // Two passes because the view accessors' return borrows are tied to the
+    // view value, not the batch buffer, so the views must outlive the borrows.
+    let views: Vec<IggyMessageView<'_>> = command.batch.iter().collect();
+    let raw_messages: Vec<RawMessage<'_>> = views
+        .iter()
+        .map(|view| RawMessage {
+            id: view.header().id(),
+            origin_timestamp: view.header().origin_timestamp(),
+            headers: view.user_headers(),
+            payload: view.payload(),
+        })
+        .collect();
+    let size = SendMessagesEncoder::encoded_size(
+        &wire_stream_id,
+        &wire_topic_id,
+        &wire_partitioning,
+        &raw_messages,
+    );
+    let mut buf = BytesMut::with_capacity(size);
+    SendMessagesEncoder::encode(
+        &mut buf,
+        &wire_stream_id,
+        &wire_topic_id,
+        &wire_partitioning,
+        &raw_messages,
+    );
+    Ok(buf.freeze())
+}
+
+/// Map a validated HTTP poll query onto the wire `PollMessagesRequest` the
+/// shared TCP resolver consumes, so both transports resolve one request shape.
+/// The query's consumer kind is structurally always `Consumer`
+/// (`Consumer::kind` is `#[serde(skip)]` - the flattened `kind` param names
+/// the polling strategy), matching the legacy HTTP server.
+pub(in crate::http) fn poll_wire_request(
+    stream_id: &Identifier,
+    topic_id: &Identifier,
+    query: &PollMessages,
+) -> Result<PollMessagesRequest, IggyError> {
+    Ok(PollMessagesRequest {
+        consumer: WireConsumer {
+            kind: query.consumer.kind.as_code(),
+            id: identifier_to_wire(&query.consumer.id)?,
+        },
+        stream_id: identifier_to_wire(stream_id)?,
+        topic_id: identifier_to_wire(topic_id)?,
+        partition_id: query.partition_id,
+        strategy: WirePollingStrategy {
+            kind: query.strategy.kind.as_code(),
+            value: query.strategy.value,
+        },
+        count: query.count,
+        auto_commit: query.auto_commit,
+    })
+}
+
+/// Map a validated HTTP consumer-offset query onto the wire
+/// `GetConsumerOffsetRequest` the shared TCP resolver consumes. An omitted
+/// `partition_id` defaults to partition 0, matching the legacy server's
+/// `resolve_consumer_with_partition_id` (`partition_id.unwrap_or(0)`).
+pub(in crate::http) fn consumer_offset_wire_request(
+    stream_id: &Identifier,
+    topic_id: &Identifier,
+    query: &GetConsumerOffset,
+) -> Result<GetConsumerOffsetRequest, IggyError> {
+    Ok(GetConsumerOffsetRequest {
+        consumer: WireConsumer {
+            kind: query.consumer.kind.as_code(),
+            id: identifier_to_wire(&query.consumer.id)?,
+        },
+        stream_id: identifier_to_wire(stream_id)?,
+        topic_id: identifier_to_wire(topic_id)?,
+        partition_id: Some(query.partition_id.unwrap_or(DEFAULT_PARTITION_ID)),
+    })
+}
+
+/// Map a validated HTTP store-offset body onto the v2 wire request
+/// (`StoreConsumerOffset2Request`), `ack` pinned to `Quorum` so the route can
+/// await the committed reply. The body's consumer kind is structurally always
+/// `Consumer` (`Consumer::kind` is `#[serde(skip)]`), matching the legacy HTTP
+/// server; `partition_id` passes through as the wire `Option` (flag byte +
+/// u32) for the server-side resolvers to ground.
+pub(in crate::http) fn store_offset_wire_request(
+    stream_id: &Identifier,
+    topic_id: &Identifier,
+    command: &StoreConsumerOffset,
+) -> Result<StoreConsumerOffset2Request, IggyError> {
+    Ok(StoreConsumerOffset2Request {
+        consumer: consumer_to_wire(&command.consumer)?,
+        stream_id: identifier_to_wire(stream_id)?,
+        topic_id: identifier_to_wire(topic_id)?,
+        partition_id: command.partition_id,
+        offset: command.offset,
+        ack: AckLevel::Quorum,
+    })
+}
+
+/// Map a validated HTTP delete-offset request onto the v2 wire request
+/// (`DeleteConsumerOffset2Request`), `ack` pinned to `Quorum` like
+/// [`store_offset_wire_request`].
+pub(in crate::http) fn delete_offset_wire_request(
+    stream_id: &Identifier,
+    topic_id: &Identifier,
+    consumer: &Consumer,
+    partition_id: Option<u32>,
+) -> Result<DeleteConsumerOffset2Request, IggyError> {
+    Ok(DeleteConsumerOffset2Request {
+        consumer: consumer_to_wire(consumer)?,
+        stream_id: identifier_to_wire(stream_id)?,
+        topic_id: identifier_to_wire(topic_id)?,
+        partition_id,
+        ack: AckLevel::Quorum,
+    })
+}
+
+/// The empty `PolledMessages` a fenced consumer-group poll answers, carrying
+/// the re-sync sentinel in `partition_id` exactly as the TCP dispatch replies
+/// it, so an SDK re-syncs its assignment instead of reading end-of-partition.
+pub(in crate::http) const fn resync_required_polled_messages() -> PolledMessages {
+    PolledMessages {
+        partition_id: RESYNC_REQUIRED_PARTITION_SENTINEL,
+        current_offset: 0,
+        count: 0,
+        messages: Vec::new(),
+    }
+}
+
+/// Build a `Message<RequestHeader>` for a control-plane write by filling a zeroed
+/// `#[repr(C)]` header, mirroring `wire::rewrite_request_body` and the partition
+/// reconciler's prepare builder. `body` is the already-encoded wire request,
+/// copied in after the header.
+pub(in crate::http) fn build_request_message(
+    operation: Operation,
+    client_id: u128,
+    session_id: u64,
+    request_id: u64,
+    body: &[u8],
+) -> Message<RequestHeader> {
+    let total = HEADER_SIZE + body.len();
+    let mut message = Message::<RequestHeader>::new(total);
+    message.as_mut_slice()[HEADER_SIZE..].copy_from_slice(body);
+    let header = bytemuck::checked::try_from_bytes_mut::<RequestHeader>(
+        &mut message.as_mut_slice()[..HEADER_SIZE],
+    )
+    .expect("zeroed bytes form a valid RequestHeader");
+    header.command = Command2::Request;
+    header.operation = operation;
+    header.client = client_id;
+    header.session = session_id;
+    header.request = request_id;
+    header.size = u32::try_from(total).expect("control-plane message size fits u32");
+    message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::Query;
+    use axum::http::Uri;
+
+    use iggy_binary_protocol::WireDecode;
+    use iggy_binary_protocol::WireEncode;
+    use iggy_binary_protocol::WireMessageIterator;
+    use iggy_binary_protocol::message_layout::WIRE_MESSAGE_INDEX_SIZE;
+    use iggy_binary_protocol::requests::messages::SendMessagesHeader;
+    use iggy_common::delete_consumer_offset::DeleteConsumerOffset;
+    use iggy_common::{
+        Consumer, ConsumerKind, IggyMessage, IggyMessagesBatch, IggyTimestamp, Partitioning,
+        PartitioningKind, PollingKind, PollingStrategy, Validatable,
+    };
+    use partitions::{Fragment, PollFragments};
+    use server_common::MESSAGE_ALIGN;
+    use server_common::iobuf::Owned;
+    use server_common::send_messages2::{
+        COMMAND_HEADER_SIZE, IggyMessage2, IggyMessage2Header, IggyMessages2, SendMessages2Header,
+        SendMessages2Owned,
+    };
+
+    use crate::http::error::{Consistency, ConsistencyQuery};
+    use crate::responses::build_polled_messages_body;
+
+    fn produce_command(partitioning: Partitioning) -> SendMessages {
+        let first = IggyMessage::builder()
+            .id(7)
+            .payload(Bytes::from_static(b"first"))
+            .build()
+            .expect("valid message");
+        // Raw pre-encoded user headers, mirroring the HTTP deserializer's
+        // base64 branch.
+        let mut second = IggyMessage::builder()
+            .id(8)
+            .payload(Bytes::from_static(b"second"))
+            .build()
+            .expect("valid message");
+        let raw_headers = Bytes::from_static(b"raw-header-bytes");
+        second.header.user_headers_length =
+            u32::try_from(raw_headers.len()).expect("test headers fit u32");
+        second.user_headers = Some(raw_headers);
+        let messages = vec![first, second];
+        SendMessages {
+            partitioning,
+            batch: IggyMessagesBatch::from(&messages),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn encode_send_messages_round_trips_through_wire_decoders() {
+        let stream_id = Identifier::from_str_value("1").expect("valid stream id");
+        let topic_id = Identifier::from_str_value("orders").expect("valid topic id");
+        let command = produce_command(Partitioning::partition_id(3));
+        let origin_timestamps: Vec<u64> = command
+            .batch
+            .iter()
+            .map(|view| view.header().origin_timestamp())
+            .collect();
+
+        let bytes = encode_send_messages(&stream_id, &topic_id, &command).expect("encodes");
+
+        let metadata_length =
+            u32::from_le_bytes(bytes[..4].try_into().expect("length prefix")) as usize;
+        let (header, consumed) =
+            SendMessagesHeader::decode(&bytes[4..4 + metadata_length]).expect("valid metadata");
+        assert_eq!(consumed, metadata_length);
+        assert_eq!(header.stream_id, identifier_to_wire(&stream_id).unwrap());
+        assert_eq!(header.topic_id, identifier_to_wire(&topic_id).unwrap());
+        assert_eq!(
+            header.partitioning,
+            partitioning_to_wire(&command.partitioning).unwrap()
+        );
+        assert_eq!(header.messages_count, 2);
+
+        let data_offset = 4 + metadata_length + 2 * WIRE_MESSAGE_INDEX_SIZE;
+        let views: Vec<_> = WireMessageIterator::new(&bytes[data_offset..], 2)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("valid message frames");
+        assert_eq!(views[0].id(), 7);
+        assert_eq!(views[0].payload(), b"first");
+        assert_eq!(views[0].user_headers(), b"");
+        assert_eq!(views[0].origin_timestamp(), origin_timestamps[0]);
+        assert_eq!(views[1].id(), 8);
+        assert_eq!(views[1].payload(), b"second");
+        assert_eq!(views[1].user_headers(), b"raw-header-bytes");
+        assert_eq!(views[1].origin_timestamp(), origin_timestamps[1]);
+    }
+
+    #[test]
+    fn send_messages_validate_rejects_oversized_partitioning_key() {
+        let command = produce_command(Partitioning {
+            kind: PartitioningKind::MessagesKey,
+            length: 0,
+            value: vec![0u8; 256],
+        });
+        assert!(command.validate().is_err());
+    }
+
+    #[test]
+    fn poll_query_parses_with_documented_defaults() {
+        let uri: Uri = "/streams/1/topics/1/messages?consumer_id=42"
+            .parse()
+            .expect("valid uri");
+        let Query(query) = Query::<PollMessages>::try_from_uri(&uri).expect("parses");
+        assert_eq!(query.consumer.kind, ConsumerKind::Consumer);
+        assert_eq!(
+            query.consumer.id,
+            Identifier::numeric(42).expect("valid id")
+        );
+        assert_eq!(query.partition_id, Some(0));
+        assert_eq!(query.strategy, PollingStrategy::offset(0));
+        assert_eq!(query.count, 10);
+        assert!(!query.auto_commit);
+    }
+
+    #[test]
+    fn poll_query_parses_explicit_strategy_count_and_tolerates_consistency_param() {
+        let uri: Uri = "/x?consumer_id=app&partition_id=3&kind=timestamp&value=42&count=5&auto_commit=true&consistency=linearizable"
+            .parse()
+            .expect("valid uri");
+        let Query(query) = Query::<PollMessages>::try_from_uri(&uri).expect("parses");
+        assert_eq!(
+            query.consumer.id,
+            Identifier::named("app").expect("valid id")
+        );
+        assert_eq!(query.partition_id, Some(3));
+        assert_eq!(
+            query.strategy,
+            PollingStrategy::timestamp(IggyTimestamp::from(42))
+        );
+        assert_eq!(query.count, 5);
+        assert!(query.auto_commit);
+        let Query(consistency) = Query::<ConsistencyQuery>::try_from_uri(&uri).expect("parses");
+        assert!(consistency.consistency == Consistency::Linearizable);
+    }
+
+    #[test]
+    fn poll_wire_request_maps_query_onto_tcp_request_shape() {
+        let stream_id = Identifier::from_str_value("orders").expect("valid stream id");
+        let topic_id = Identifier::from_str_value("1").expect("valid topic id");
+        let query = PollMessages {
+            consumer: Consumer {
+                kind: ConsumerKind::Consumer,
+                id: Identifier::numeric(9).expect("valid id"),
+            },
+            partition_id: Some(4),
+            strategy: PollingStrategy::next(),
+            count: 25,
+            auto_commit: true,
+            ..Default::default()
+        };
+        let wire = poll_wire_request(&stream_id, &topic_id, &query).expect("maps");
+        assert_eq!(wire.consumer.kind, 1);
+        assert_eq!(
+            wire.consumer.id,
+            identifier_to_wire(&query.consumer.id).unwrap()
+        );
+        assert_eq!(wire.stream_id, identifier_to_wire(&stream_id).unwrap());
+        assert_eq!(wire.topic_id, identifier_to_wire(&topic_id).unwrap());
+        assert_eq!(wire.partition_id, Some(4));
+        assert_eq!(wire.strategy.kind, PollingKind::Next.as_code());
+        assert_eq!(wire.strategy.value, 0);
+        assert_eq!(wire.count, 25);
+        assert!(wire.auto_commit);
+    }
+
+    #[test]
+    fn consumer_offset_wire_request_defaults_omitted_partition_to_zero() {
+        let stream_id = Identifier::numeric(1).expect("valid stream id");
+        let topic_id = Identifier::numeric(1).expect("valid topic id");
+        let query = GetConsumerOffset {
+            consumer: Consumer::new(Identifier::numeric(7).expect("valid id")),
+            partition_id: None,
+        };
+        let wire = consumer_offset_wire_request(&stream_id, &topic_id, &query).expect("maps");
+        assert_eq!(wire.partition_id, Some(DEFAULT_PARTITION_ID));
+        assert_eq!(wire.consumer.kind, 1);
+    }
+
+    #[test]
+    fn store_offset_wire_request_round_trips_with_quorum_ack() {
+        let stream_id = Identifier::numeric(1).expect("valid stream id");
+        let topic_id = Identifier::named("orders").expect("valid topic id");
+        let command = StoreConsumerOffset {
+            consumer: Consumer::new(Identifier::named("c1").expect("valid id")),
+            partition_id: Some(1),
+            offset: 42,
+        };
+        let request = store_offset_wire_request(&stream_id, &topic_id, &command).expect("maps");
+        let bytes = request.to_bytes();
+        assert_eq!(*bytes.last().expect("non-empty"), AckLevel::Quorum.as_u8());
+        let (decoded, consumed) =
+            StoreConsumerOffset2Request::decode(&bytes).expect("decodes as the server does");
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(decoded, request);
+        assert_eq!(decoded.consumer.kind, 1);
+        assert_eq!(decoded.partition_id, Some(1));
+        assert_eq!(decoded.offset, 42);
+        assert_eq!(decoded.ack, AckLevel::Quorum);
+    }
+
+    #[test]
+    fn store_offset_wire_request_passes_omitted_partition_through() {
+        let stream_id = Identifier::numeric(1).expect("valid stream id");
+        let topic_id = Identifier::numeric(2).expect("valid topic id");
+        let command = StoreConsumerOffset {
+            consumer: Consumer::new(Identifier::numeric(7).expect("valid id")),
+            partition_id: None,
+            offset: u64::MAX,
+        };
+        let request = store_offset_wire_request(&stream_id, &topic_id, &command).expect("maps");
+        let bytes = request.to_bytes();
+        let (decoded, consumed) =
+            StoreConsumerOffset2Request::decode(&bytes).expect("decodes as the server does");
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(decoded.partition_id, None);
+        assert_eq!(decoded.offset, u64::MAX);
+        assert_eq!(decoded.ack, AckLevel::Quorum);
+    }
+
+    #[test]
+    fn delete_offset_wire_request_round_trips_partition_variants() {
+        let stream_id = Identifier::named("stream-1").expect("valid stream id");
+        let topic_id = Identifier::numeric(2).expect("valid topic id");
+        for partition_id in [Some(1), None] {
+            let request = delete_offset_wire_request(
+                &stream_id,
+                &topic_id,
+                &Consumer::new(Identifier::named("c1").expect("valid id")),
+                partition_id,
+            )
+            .expect("maps");
+            let bytes = request.to_bytes();
+            assert_eq!(*bytes.last().expect("non-empty"), AckLevel::Quorum.as_u8());
+            let (decoded, consumed) =
+                DeleteConsumerOffset2Request::decode(&bytes).expect("decodes as the server does");
+            assert_eq!(consumed, bytes.len());
+            assert_eq!(decoded, request);
+            assert_eq!(decoded.consumer.kind, 1);
+            assert_eq!(decoded.partition_id, partition_id);
+            assert_eq!(decoded.ack, AckLevel::Quorum);
+        }
+    }
+
+    #[test]
+    fn delete_offset_query_parses_optional_partition_id() {
+        let uri: Uri = "/x?partition_id=3".parse().expect("valid uri");
+        let Query(query) = Query::<DeleteConsumerOffset>::try_from_uri(&uri).expect("parses");
+        assert_eq!(query.partition_id, Some(3));
+        let bare: Uri = "/x".parse().expect("valid uri");
+        let Query(query) = Query::<DeleteConsumerOffset>::try_from_uri(&bare).expect("parses");
+        assert_eq!(query.partition_id, None);
+    }
+
+    /// Wrap one stored `SendMessages2` batch (`[256B header][blob]`) as the
+    /// poll fragment the owning shard replies, the shape
+    /// `build_polled_messages_body` consumes.
+    fn fragment_from_stored_batch(header: &SendMessages2Header, blob: &[u8]) -> PollFragments {
+        let mut buffer = Owned::<MESSAGE_ALIGN>::zeroed(COMMAND_HEADER_SIZE + blob.len());
+        header.encode_into(buffer.as_mut_slice());
+        buffer.as_mut_slice()[COMMAND_HEADER_SIZE..].copy_from_slice(blob);
+        let mut fragments = PollFragments::new();
+        fragments.push(Fragment::whole(buffer.into()));
+        fragments
+    }
+
+    /// Round-trip the poll route's encode/decode seam: the store's own batch
+    /// writer (`SendMessages2Owned::from_messages`) is the encoder oracle,
+    /// `build_polled_messages_body` re-encodes to the legacy wire body, and
+    /// the SDK's `PolledMessages::from_bytes` must read back every field.
+    #[test]
+    fn polled_messages_body_decodes_into_common_polled_messages() {
+        let mut messages = IggyMessages2::with_capacity(2);
+        messages.push(IggyMessage2 {
+            header: IggyMessage2Header {
+                id: 7,
+                origin_timestamp: 1_000,
+                ..Default::default()
+            },
+            payload: Bytes::from_static(b"first"),
+            user_headers: None,
+        });
+        messages.push(IggyMessage2 {
+            header: IggyMessage2Header {
+                id: 8,
+                origin_timestamp: 1_050,
+                ..Default::default()
+            },
+            payload: Bytes::from_static(b"second"),
+            user_headers: Some(Bytes::from_static(b"raw-header-bytes")),
+        });
+        let namespace = server_common::sharding::IggyNamespace::new(0, 0, 3);
+        let stored =
+            SendMessages2Owned::from_messages(namespace, &messages).expect("encodes stored batch");
+        // The store stamps these on append; `from_messages` leaves them zero.
+        let mut header = stored.header;
+        header.base_offset = 41;
+        header.base_timestamp = 999_999;
+
+        let body =
+            build_polled_messages_body(3, 42, fragment_from_stored_batch(&header, &stored.blob))
+                .expect("re-encodes wire body");
+        let polled = PolledMessages::from_bytes(body).expect("decodes as the SDK does");
+
+        assert_eq!(polled.partition_id, 3);
+        assert_eq!(polled.current_offset, 42);
+        assert_eq!(polled.count, 2);
+        assert_eq!(polled.messages.len(), 2);
+        assert_eq!(polled.messages[0].header.id, 7);
+        assert_eq!(polled.messages[0].header.offset, 41);
+        assert_eq!(polled.messages[0].header.timestamp, 999_999);
+        assert_eq!(polled.messages[0].header.origin_timestamp, 1_000);
+        assert_eq!(polled.messages[0].payload.as_ref(), b"first");
+        assert!(polled.messages[0].user_headers.is_none());
+        assert_eq!(polled.messages[1].header.id, 8);
+        assert_eq!(polled.messages[1].header.offset, 42);
+        assert_eq!(polled.messages[1].header.origin_timestamp, 1_050);
+        assert_eq!(polled.messages[1].payload.as_ref(), b"second");
+        assert_eq!(
+            polled.messages[1].user_headers.as_deref(),
+            Some(b"raw-header-bytes".as_ref())
+        );
+    }
+
+    #[test]
+    fn resync_required_polled_messages_carries_sentinel_partition() {
+        let polled = resync_required_polled_messages();
+        assert_eq!(polled.partition_id, RESYNC_REQUIRED_PARTITION_SENTINEL);
+        assert_eq!(polled.count, 0);
+        assert!(polled.messages.is_empty());
+    }
+}

--- a/core/server-ng/src/lib.rs
+++ b/core/server-ng/src/lib.rs
@@ -24,9 +24,11 @@ pub const SEMANTIC_VERSION: SemanticVersion = SemanticVersion::parse_const(VERSI
 
 pub mod auth;
 pub mod bootstrap;
+pub(crate) mod cluster_meta;
 pub mod config_writer;
 pub mod consumer_group;
 pub mod dispatch;
+pub(crate) mod http;
 pub mod login_register;
 pub(crate) mod offset_recovery;
 pub mod partition_helpers;
@@ -38,5 +40,6 @@ pub(crate) mod segment_cleaner;
 pub(crate) mod segment_recovery;
 pub mod server_error;
 pub mod session_manager;
+pub(crate) mod snapshot;
 pub mod users;
 pub mod wire;

--- a/core/server-ng/src/pat.rs
+++ b/core/server-ng/src/pat.rs
@@ -42,18 +42,32 @@ pub(crate) fn maybe_rewrite_pat_request(
     transport_client_id: u128,
     request: Message<RequestHeader>,
 ) -> Result<(Message<RequestHeader>, Option<String>), IggyError> {
-    let operation = request.header().operation;
-    let user_id = match operation {
+    let user_id = match request.header().operation {
         Operation::CreatePersonalAccessToken | Operation::DeletePersonalAccessToken => sessions
             .borrow()
             .get_user_id(transport_client_id)
             .ok_or(IggyError::Unauthenticated)?,
         _ => return Ok((request, None)),
     };
+    rewrite_pat_request_for_user(user_id, request)
+}
 
+/// PAT rewrite for a caller that already holds the authenticated `user_id`.
+///
+/// The HTTP listener authenticates against its own session table rather than
+/// the transport `SessionManager`, so it resolves the id itself and calls this
+/// directly. `CreatePersonalAccessToken` mints the raw token + hash and hands
+/// the raw token back; `DeletePersonalAccessToken` is rewritten to the
+/// replicated form scoped to `user_id` (`only_if_expired` false); every other
+/// operation passes through unchanged with `None` (the HTTP write core routes
+/// all of its ops here, so the non-PAT arm is a no-op, not `unreachable`).
+pub(crate) fn rewrite_pat_request_for_user(
+    user_id: u32,
+    request: Message<RequestHeader>,
+) -> Result<(Message<RequestHeader>, Option<String>), IggyError> {
     let body = request_body(&request);
     let mut raw_token = None;
-    let rewritten = match operation {
+    let rewritten = match request.header().operation {
         Operation::CreatePersonalAccessToken => {
             let wire = WireCreatePersonalAccessTokenRequest::decode_from(body)
                 .map_err(|_| IggyError::InvalidCommand)?;
@@ -84,7 +98,7 @@ pub(crate) fn maybe_rewrite_pat_request(
             }
             .to_bytes()
         }
-        _ => unreachable!(),
+        _ => return Ok((request, None)),
     };
 
     Ok((rewrite_request_body(&request, &rewritten)?, raw_token))

--- a/core/server-ng/src/responses.rs
+++ b/core/server-ng/src/responses.rs
@@ -18,20 +18,22 @@
 //! Wire-response builders for the non-replicated read path.
 //!
 //! Assemble `get_me` / `get_clients` / `get_stream(s)` / `get_topic(s)` /
-//! `get_user(s)` / stats / cluster-metadata responses from per-shard
-//! session state and the metadata state machine, plus the
+//! `get_user(s)` / `get_personal_access_tokens` / stats / cluster-metadata
+//! responses from per-shard session state and the metadata state machine, plus the
 //! [`NonReplicatedResponse`] dispatch shim and the partition-namespace
 //! resolvers.
 
 use crate::bootstrap::ServerNgShard;
+use crate::cluster_meta::ClusterRoster;
 use crate::session_manager::SessionManager;
 use crate::wire::{transport_kind_to_wire, usize_to_u32};
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 use consensus::{MetadataHandle, VsrConsensus};
 use iggy_binary_protocol::codes::{
-    GET_CLUSTER_METADATA_CODE, GET_CONSUMER_GROUP_CODE, GET_CONSUMER_GROUPS_CODE, GET_STATS_CODE,
-    GET_STREAM_CODE, GET_STREAMS_CODE, GET_TOPIC_CODE, GET_TOPICS_CODE, GET_USER_CODE,
-    GET_USERS_CODE,
+    FLUSH_UNSAVED_BUFFER_CODE, GET_CLUSTER_METADATA_CODE, GET_CONSUMER_GROUP_CODE,
+    GET_CONSUMER_GROUPS_CODE, GET_PERSONAL_ACCESS_TOKENS_CODE, GET_SNAPSHOT_FILE_CODE,
+    GET_STATS_CODE, GET_STREAM_CODE, GET_STREAMS_CODE, GET_TOPIC_CODE, GET_TOPICS_CODE,
+    GET_USER_CODE, GET_USERS_CODE,
 };
 use iggy_binary_protocol::consensus::{RESULT_COUNT_LEN, result_code};
 use iggy_binary_protocol::primitives::consumer::WireConsumer;
@@ -43,6 +45,7 @@ use iggy_binary_protocol::requests::consumer_offsets::{
     StoreConsumerOffsetRequest,
 };
 use iggy_binary_protocol::requests::messages::SendMessagesHeader;
+use iggy_binary_protocol::requests::personal_access_tokens::GetPersonalAccessTokensRequest;
 use iggy_binary_protocol::requests::segments::DeleteSegmentsRequest;
 use iggy_binary_protocol::requests::streams::{GetStreamRequest, GetStreamsRequest};
 use iggy_binary_protocol::requests::topics::{GetTopicRequest, GetTopicsRequest};
@@ -74,7 +77,7 @@ use iggy_binary_protocol::{
     Command2, GenericHeader, IGGY_PROTOCOL_VERSION, KIND_CONSUMER_GROUP, Operation, ReplyHeader,
     RequestHeader, WireDecode, WireEncode, WireIdentifier, WireName, WirePartitioning,
 };
-use iggy_common::IggyError;
+use iggy_common::{Identifier, IggyError, IggyTimestamp, MaxTopicSize};
 use metadata::impls::metadata::StreamsFrontend;
 use partitions::PollFragments;
 use server_common::Message;
@@ -83,6 +86,8 @@ use server_common::sharding::IggyNamespace;
 use shard::ConnectedClientInfo;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::{Arc, OnceLock};
+use sysinfo::{Pid, ProcessesToUpdate, System as SysinfoSystem};
 
 /// Build the `get_me` reply for the requesting connection. Identity
 /// (`user_id`, transport kind, peer address) comes from the per-shard
@@ -404,14 +409,19 @@ pub(crate) fn resolve_partition_namespace(
         .ok_or(IggyError::InvalidIdentifier)
 }
 
+/// `user_id` is the authenticated caller, used only by the identity-scoped
+/// reads (currently the PAT list); every other arm ignores it. Authorization
+/// stays with the per-transport gates that run before this builder.
 pub(crate) fn build_non_replicated_response(
     shard: &Rc<ServerNgShard>,
     code: u32,
     body: &[u8],
+    user_id: Option<u32>,
+    roster: &ClusterRoster,
 ) -> Result<NonReplicatedResponse, IggyError> {
     match code {
         GET_CLUSTER_METADATA_CODE => Ok(NonReplicatedResponse::Bytes(
-            build_cluster_metadata_response().to_bytes(),
+            build_cluster_metadata_response(roster, shard).to_bytes(),
         )),
         GET_STATS_CODE => Ok(NonReplicatedResponse::Bytes(
             build_stats_response(shard)?.to_bytes(),
@@ -459,9 +469,27 @@ pub(crate) fn build_non_replicated_response(
                 })
             })
         }
+        GET_PERSONAL_ACCESS_TOKENS_CODE => {
+            let _ = GetPersonalAccessTokensRequest::decode_from(body)
+                .map_err(|_| IggyError::InvalidCommand)?;
+            // Caller-scoped: both transport gates reject unauthenticated
+            // callers before this read runs, so a missing id is a gate
+            // bug; fail closed rather than serve another scope.
+            let user_id = user_id.ok_or(IggyError::Unauthenticated)?;
+            let tokens = shard
+                .plane
+                .metadata()
+                .mux_stm
+                .users()
+                .read(|users| users.personal_access_tokens_of(user_id));
+            Ok(NonReplicatedResponse::Bytes(
+                personal_access_tokens_response(tokens)?.to_bytes(),
+            ))
+        }
         GET_CONSUMER_GROUP_CODE => {
             let request = GetConsumerGroupRequest::decode_from(body)
                 .map_err(|_| IggyError::InvalidCommand)?;
+            ensure_topic_exists(shard, &request.stream_id, &request.topic_id)?;
             let response = shard
                 .plane
                 .metadata()
@@ -475,6 +503,7 @@ pub(crate) fn build_non_replicated_response(
         GET_CONSUMER_GROUPS_CODE => {
             let request = GetConsumerGroupsRequest::decode_from(body)
                 .map_err(|_| IggyError::InvalidCommand)?;
+            ensure_topic_exists(shard, &request.stream_id, &request.topic_id)?;
             let groups = shard
                 .plane
                 .metadata()
@@ -485,6 +514,16 @@ pub(crate) fn build_non_replicated_response(
                 NonReplicatedResponse::Bytes(GetConsumerGroupsResponse { groups }.to_bytes())
             }))
         }
+        // server-ng has no on-demand flush primitive, so it denies honestly.
+        // The non-replicated catch-all's empty-ok would otherwise attest a
+        // durability guarantee the server never gave.
+        FLUSH_UNSAVED_BUFFER_CODE => Err(IggyError::FeatureUnavailable),
+        // Snapshot collection blocks on shell-outs, so the dedicated dispatch
+        // and HTTP handlers await it off-thread; this synchronous builder
+        // cannot, and reaching it here is a routing bug. Fail closed rather
+        // than let the catch-all's empty-ok attest an artifact that was never
+        // produced.
+        GET_SNAPSHOT_FILE_CODE => Err(IggyError::InvalidCommand),
         _ => match iggy_binary_protocol::dispatch::lookup_command(code) {
             Some(meta) if !meta.is_replicated() => Ok(NonReplicatedResponse::Empty),
             Some(_) => Err(IggyError::FeatureUnavailable),
@@ -493,19 +532,37 @@ pub(crate) fn build_non_replicated_response(
     }
 }
 
-fn build_cluster_metadata_response() -> ClusterMetadataResponse {
+/// Build the binary `GetClusterMetadata` reply from the shared roster assembly.
+/// The leader marking comes from this shard's consensus view; a shard without
+/// consensus (any shard but 0) still serves the full roster, only with no node
+/// marked leader.
+fn build_cluster_metadata_response(
+    roster: &ClusterRoster,
+    shard: &Rc<ServerNgShard>,
+) -> ClusterMetadataResponse {
+    let primary_index = shard
+        .plane
+        .metadata()
+        .consensus
+        .as_ref()
+        .map(|consensus| consensus.primary_index(consensus.view()));
+    let metadata = roster.cluster_metadata(primary_index);
     ClusterMetadataResponse {
-        name: "server-ng".to_owned(),
-        nodes: vec![ClusterNodeResponse {
-            name: "node-0".to_owned(),
-            ip: "127.0.0.1".to_owned(),
-            tcp_port: 0,
-            quic_port: 0,
-            http_port: 0,
-            websocket_port: 0,
-            role: 0,
-            status: 0,
-        }],
+        name: metadata.name,
+        nodes: metadata
+            .nodes
+            .into_iter()
+            .map(|node| ClusterNodeResponse {
+                name: node.name,
+                ip: node.ip,
+                tcp_port: node.endpoints.tcp,
+                quic_port: node.endpoints.quic,
+                http_port: node.endpoints.http,
+                websocket_port: node.endpoints.websocket,
+                role: node.role as u8,
+                status: node.status as u8,
+            })
+            .collect(),
     }
 }
 
@@ -561,35 +618,147 @@ fn build_stats_response(shard: &Rc<ServerNgShard>) -> Result<StatsResponse, Iggy
             .consumer_group_count(),
     )?;
 
+    let system = probe_system_stats();
     Ok(StatsResponse {
-        process_id: std::process::id(),
-        cpu_usage: 0.0,
-        total_cpu_usage: 0.0,
-        memory_usage: 0,
-        total_memory: 0,
-        available_memory: 0,
-        run_time: 0,
-        start_time: 0,
-        read_bytes: 0,
-        written_bytes: 0,
+        process_id: system.process_id,
+        cpu_usage: system.cpu_usage,
+        total_cpu_usage: system.total_cpu_usage,
+        memory_usage: system.memory_usage,
+        total_memory: system.total_memory,
+        available_memory: system.available_memory,
+        run_time: system.run_time,
+        start_time: system.start_time,
+        read_bytes: system.read_bytes,
+        written_bytes: system.written_bytes,
         messages_size_bytes,
         streams_count,
         topics_count,
         partitions_count,
         segments_count,
         messages_count,
+        // Connected clients are per-shard `SessionManager` state, aggregated
+        // across shards only by the async `ListClients` broadcast (see
+        // `get_clients`). This sync single-shard read can't gather it, and one
+        // shard's local count is a fraction of the total, so report 0 rather
+        // than a misleading partial.
         clients_count: 0,
         consumer_groups_count,
-        hostname: "unknown_hostname".to_owned(),
-        os_name: "unknown_os_name".to_owned(),
-        os_version: "unknown_os_version".to_owned(),
-        kernel_version: "unknown_kernel_version".to_owned(),
+        hostname: system.hostname,
+        os_name: system.os_name,
+        os_version: system.os_version,
+        kernel_version: system.kernel_version,
         iggy_server_version: crate::VERSION.to_owned(),
         iggy_server_semver: crate::SEMANTIC_VERSION.get_numeric_version().ok(),
         cache_metrics: Vec::new(),
-        threads_count: 0,
+        threads_count: system.threads_count,
+        // Disk space needs the configured data directory (legacy reads
+        // `config.system.path`); the shard doesn't expose server config on the
+        // read path, so report 0 rather than probe an unrelated mount.
         free_disk_space: 0,
         total_disk_space: 0,
+    })
+}
+
+/// Process- and host-level portion of the stats reply, probed via `sysinfo`.
+/// These describe the whole process, not shard or metadata state, so any one
+/// shard can serve them without aggregation. The CPU fields are deltas over the
+/// serving thread's own [`SYSINFO`] refresh history, so they vary by serving
+/// shard (a shard's first probe reports zero CPU).
+struct SystemStats {
+    process_id: u32,
+    cpu_usage: f32,
+    total_cpu_usage: f32,
+    memory_usage: u64,
+    total_memory: u64,
+    available_memory: u64,
+    run_time: u64,
+    start_time: u64,
+    read_bytes: u64,
+    written_bytes: u64,
+    threads_count: u32,
+    hostname: String,
+    os_name: String,
+    os_version: String,
+    kernel_version: String,
+}
+
+thread_local! {
+    // `cpu_usage` is a delta since the previous refresh, so the sampled
+    // `System` is kept alive across `GetStats` calls (a freshly created one
+    // reports zero CPU). Mirrors the legacy shard-0 stats path.
+    static SYSINFO: RefCell<Option<SysinfoSystem>> = const { RefCell::new(None) };
+}
+
+/// Host / OS identity is process-static (unlike the per-call CPU and memory
+/// samples), so probe it once and clone from the cache on each `GetStats`
+/// rather than re-querying sysinfo every call. Process-global, so a `OnceLock`
+/// fits better than the per-thread [`SYSINFO`] cell.
+struct HostIdentity {
+    hostname: String,
+    os_name: String,
+    os_version: String,
+    kernel_version: String,
+}
+
+impl HostIdentity {
+    fn probe() -> Self {
+        Self {
+            hostname: SysinfoSystem::host_name().unwrap_or_else(|| "unknown_hostname".to_owned()),
+            os_name: SysinfoSystem::name().unwrap_or_else(|| "unknown_os_name".to_owned()),
+            os_version: SysinfoSystem::long_os_version()
+                .unwrap_or_else(|| "unknown_os_version".to_owned()),
+            kernel_version: SysinfoSystem::kernel_version()
+                .unwrap_or_else(|| "unknown_kernel_version".to_owned()),
+        }
+    }
+}
+
+static HOST_IDENTITY: OnceLock<HostIdentity> = OnceLock::new();
+
+fn probe_system_stats() -> SystemStats {
+    let process_id = std::process::id();
+    let host = HOST_IDENTITY.get_or_init(HostIdentity::probe);
+    SYSINFO.with_borrow_mut(|slot| {
+        let sys = slot.get_or_insert_with(SysinfoSystem::new_all);
+        sys.refresh_cpu_all();
+        sys.refresh_memory();
+        sys.refresh_processes(ProcessesToUpdate::Some(&[Pid::from_u32(process_id)]), true);
+
+        let mut stats = SystemStats {
+            process_id,
+            cpu_usage: 0.0,
+            total_cpu_usage: sys.global_cpu_usage(),
+            memory_usage: 0,
+            total_memory: sys.total_memory(),
+            available_memory: sys.available_memory(),
+            run_time: 0,
+            start_time: 0,
+            read_bytes: 0,
+            written_bytes: 0,
+            threads_count: 0,
+            hostname: host.hostname.clone(),
+            os_name: host.os_name.clone(),
+            os_version: host.os_version.clone(),
+            kernel_version: host.kernel_version.clone(),
+        };
+
+        if let Some(process) = sys.process(Pid::from_u32(process_id)) {
+            stats.cpu_usage = process.cpu_usage();
+            stats.memory_usage = process.memory();
+            // sysinfo reports whole seconds; the wire fields are micros (the
+            // SDK decodes them via `IggyDuration` / `IggyTimestamp::from`, both
+            // micro-based).
+            stats.run_time = process.run_time().saturating_mul(1_000_000);
+            stats.start_time = process.start_time().saturating_mul(1_000_000);
+            let disk_usage = process.disk_usage();
+            stats.read_bytes = disk_usage.total_read_bytes;
+            stats.written_bytes = disk_usage.total_written_bytes;
+            stats.threads_count = process
+                .tasks()
+                .map_or(0, |tasks| u32::try_from(tasks.len()).unwrap_or(u32::MAX));
+        }
+
+        stats
     })
 }
 
@@ -597,6 +766,7 @@ fn build_get_stream_response(
     shard: &Rc<ServerNgShard>,
     stream_id: &WireIdentifier,
 ) -> Result<Option<GetStreamResponse>, IggyError> {
+    let default_max_topic_size = shard.plane.metadata().default_max_topic_size();
     shard.plane.metadata().mux_stm.streams().read(|streams| {
         let Some(stream_id) = resolve_stream_id(streams, stream_id) else {
             return Ok(None);
@@ -610,7 +780,7 @@ fn build_get_stream_response(
             topics: stream
                 .topics
                 .iter()
-                .map(|(_, topic)| topic_header(topic))
+                .map(|(_, topic)| topic_header(topic, default_max_topic_size))
                 .collect::<Result<Vec<_>, _>>()?,
         }))
     })
@@ -674,11 +844,29 @@ fn build_get_user_response(
     })
 }
 
+fn personal_access_tokens_response(
+    tokens: Vec<(Arc<str>, Option<IggyTimestamp>)>,
+) -> Result<GetPersonalAccessTokensResponse, IggyError> {
+    let tokens = tokens
+        .into_iter()
+        .map(|(name, expiry_at)| {
+            Ok(PersonalAccessTokenResponse {
+                name: WireName::new(name.as_ref()).map_err(|_| IggyError::InvalidFormat)?,
+                // 0 is the wire encoding for a never-expiring token, matching
+                // the legacy handler and the SDK-side decode.
+                expiry_at: expiry_at.map_or(0, |expiry_at| expiry_at.as_micros()),
+            })
+        })
+        .collect::<Result<Vec<_>, IggyError>>()?;
+    Ok(GetPersonalAccessTokensResponse { tokens })
+}
+
 fn build_get_topic_response(
     shard: &Rc<ServerNgShard>,
     stream_id: &WireIdentifier,
     topic_id: &WireIdentifier,
 ) -> Result<Option<GetTopicResponse>, IggyError> {
+    let default_max_topic_size = shard.plane.metadata().default_max_topic_size();
     shard.plane.metadata().mux_stm.streams().read(|streams| {
         let Some(stream_id) = resolve_stream_id(streams, stream_id) else {
             return Ok(None);
@@ -695,7 +883,7 @@ fn build_get_topic_response(
             .get(topic_id)
             .ok_or(IggyError::InvalidIdentifier)?;
         Ok(Some(GetTopicResponse {
-            topic: topic_header(topic)?,
+            topic: topic_header(topic, default_max_topic_size)?,
             partitions: topic
                 .partitions
                 .iter()
@@ -709,24 +897,66 @@ fn build_get_topics_response(
     shard: &Rc<ServerNgShard>,
     stream_id: &WireIdentifier,
 ) -> Result<GetTopicsResponse, IggyError> {
+    let default_max_topic_size = shard.plane.metadata().default_max_topic_size();
     shard.plane.metadata().mux_stm.streams().read(|streams| {
-        let Some(stream_id) = resolve_stream_id(streams, stream_id) else {
-            return Ok(GetTopicsResponse { topics: Vec::new() });
-        };
+        let resolved_stream =
+            resolve_stream_id(streams, stream_id).ok_or_else(|| stream_not_found(stream_id))?;
         let stream = streams
             .items
-            .get(stream_id)
+            .get(resolved_stream)
             .ok_or(IggyError::InvalidIdentifier)?;
         stream
             .topics
             .iter()
-            .map(|(_, topic)| topic_header(topic))
+            .map(|(_, topic)| topic_header(topic, default_max_topic_size))
             .collect::<Result<Vec<_>, _>>()
             .map(|topics| GetTopicsResponse { topics })
     })
 }
 
-fn resolve_stream_id(
+/// Reject a consumer-group read whose parent stream/topic is absent with the
+/// legacy typed error naming the level that missed; the group itself missing
+/// stays the shared not-found reply (empty over TCP, 404 over HTTP).
+fn ensure_topic_exists(
+    shard: &Rc<ServerNgShard>,
+    stream_id: &WireIdentifier,
+    topic_id: &WireIdentifier,
+) -> Result<(), IggyError> {
+    shard.plane.metadata().mux_stm.streams().read(|streams| {
+        let resolved_stream =
+            resolve_stream_id(streams, stream_id).ok_or_else(|| stream_not_found(stream_id))?;
+        resolve_topic_id(streams, resolved_stream, topic_id)
+            .ok_or_else(|| topic_not_found(stream_id, topic_id))?;
+        Ok(())
+    })
+}
+
+/// Convert a `WireIdentifier` to the domain `Identifier`.
+fn wire_id_to_identifier(wire: &WireIdentifier) -> Result<Identifier, IggyError> {
+    match wire {
+        WireIdentifier::Numeric(id) => Identifier::numeric(*id),
+        WireIdentifier::String(name) => Identifier::named(name.as_str()),
+    }
+}
+
+/// Typed miss for a read's parent stream, matching the legacy servers' error
+/// shape. The identifier only feeds the error message; a wire form with no
+/// domain equivalent (numeric 0 is a live slab id here but not a legacy id)
+/// falls back to the default identifier.
+fn stream_not_found(stream_id: &WireIdentifier) -> IggyError {
+    IggyError::StreamIdNotFound(wire_id_to_identifier(stream_id).unwrap_or_default())
+}
+
+/// Typed miss for a read's parent topic; see [`stream_not_found`]. The variant's
+/// display order is (topic, stream).
+fn topic_not_found(stream_id: &WireIdentifier, topic_id: &WireIdentifier) -> IggyError {
+    IggyError::TopicIdNotFound(
+        wire_id_to_identifier(topic_id).unwrap_or_default(),
+        wire_id_to_identifier(stream_id).unwrap_or_default(),
+    )
+}
+
+pub(crate) fn resolve_stream_id(
     streams: &metadata::stm::stream::StreamsInner,
     identifier: &WireIdentifier,
 ) -> Option<usize> {
@@ -739,7 +969,7 @@ fn resolve_stream_id(
     }
 }
 
-fn resolve_topic_id(
+pub(crate) fn resolve_topic_id(
     streams: &metadata::stm::stream::StreamsInner,
     stream_id: usize,
     identifier: &WireIdentifier,
@@ -765,14 +995,32 @@ fn stream_response(stream: &metadata::stm::stream::Stream) -> Result<StreamRespo
     })
 }
 
-fn topic_header(topic: &metadata::stm::stream::Topic) -> Result<StreamTopicHeader, IggyError> {
+/// Resolve a topic's stored [`MaxTopicSize`] to the wire byte value, mapping
+/// the `ServerDefault` sentinel to this node's configured default. Replicated
+/// apply stores the sentinel verbatim so commit stays config-independent across
+/// a cluster; the per-node default is applied here on read, matching the legacy
+/// "what this server treats the limit as" semantics. Primary admission stamps
+/// the same default before replication, so this only bites topics whose stored
+/// size predates that stamping (older snapshot / WAL data). Explicit `Custom`
+/// and `Unlimited` values pass through.
+fn resolve_max_topic_size(max_topic_size: MaxTopicSize, default_bytes: u64) -> u64 {
+    match max_topic_size {
+        MaxTopicSize::ServerDefault => default_bytes,
+        resolved => resolved.as_bytes_u64(),
+    }
+}
+
+fn topic_header(
+    topic: &metadata::stm::stream::Topic,
+    default_max_topic_size: u64,
+) -> Result<StreamTopicHeader, IggyError> {
     Ok(StreamTopicHeader {
         id: usize_to_u32(topic.id)?,
         created_at: topic.created_at.as_micros(),
         partitions_count: usize_to_u32(topic.partitions.len())?,
         message_expiry: u64::from(topic.message_expiry),
         compression_algorithm: topic.compression_algorithm.as_code(),
-        max_topic_size: topic.max_topic_size.as_bytes_u64(),
+        max_topic_size: resolve_max_topic_size(topic.max_topic_size, default_max_topic_size),
         replication_factor: topic.replication_factor,
         size_bytes: topic.stats.size_bytes_inconsistent(),
         messages_count: topic.stats.messages_count_inconsistent(),
@@ -843,6 +1091,30 @@ pub(crate) fn build_empty_reply(
     build_reply_with_body(request_header, client_id, session, commit, 0, |_| {})
 }
 
+/// Build an empty reply that denies a dispatch-time authorization check: the
+/// same request echo as [`build_empty_reply`] but with `ReplyHeader.status`
+/// set to the rule's error code -- the request-level failure channel the SDK
+/// peeks before any body decode. Every deny frame shares this shape (empty
+/// body, nonzero status); op carries the builder's session argument like every
+/// reply, and only the partition primary's pre-pipeline deny pins it to 0,
+/// stamped through `consensus::build_deny_reply_from_request`.
+pub(crate) fn build_deny_reply(
+    request_header: &RequestHeader,
+    client_id: u128,
+    session: u64,
+    commit: u64,
+    status: u32,
+) -> Message<ReplyHeader> {
+    let mut reply = build_empty_reply(request_header, client_id, session, commit);
+    let header_len = std::mem::size_of::<ReplyHeader>();
+    let header = bytemuck::checked::try_from_bytes_mut::<ReplyHeader>(
+        &mut reply.as_mut_slice()[..header_len],
+    )
+    .expect("empty reply header is a valid ReplyHeader");
+    header.status = status;
+    reply
+}
+
 /// Server build version advertised in the login-register response.
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -894,11 +1166,12 @@ pub(crate) fn build_reply_from_bytes(
     )
 }
 
-/// If a raw PAT token was minted (`CreatePersonalAccessToken`), replace the
-/// committed reply -- whose body is empty because the raw token never entered
-/// consensus -- with a `RawPersonalAccessTokenResponse`, reusing the confirmed
-/// commit position from the committed reply. Otherwise the committed reply
-/// passes through unchanged.
+/// If a raw PAT token was minted (`CreatePersonalAccessToken`) and the commit
+/// succeeded, replace the committed reply -- whose body is empty because the
+/// raw token never entered consensus -- with a `RawPersonalAccessTokenResponse`,
+/// reusing the confirmed commit position from the committed reply. Otherwise
+/// (no token, a committed business rejection, or an eviction frame) the
+/// committed reply passes through unchanged.
 pub(crate) fn build_raw_pat_reply(
     request_header: &RequestHeader,
     committed: Message<GenericHeader>,
@@ -918,36 +1191,39 @@ pub(crate) fn build_raw_pat_reply(
         return Ok(committed);
     }
     let header_len = std::mem::size_of::<ReplyHeader>();
-    // A `Reply` whose result section is nonzero is not a successful commit but a
-    // committed business rejection or a `TransientNotCommitted` retry frame, both
-    // with no payload and no token to ship. Pass it through so the client decodes
-    // the typed result (and, for a transient, replays) instead of having a raw
-    // token grafted onto a rejection body.
-    if result_code(&committed.as_slice()[header_len..]) != Some(0) {
-        return Ok(committed);
-    }
     let committed_header =
         bytemuck::checked::try_from_bytes::<ReplyHeader>(&committed.as_slice()[..header_len])
             .map_err(|_| IggyError::InvalidFormat)?;
     let commit = committed_header.commit;
+    let size = committed_header.size as usize;
+    // A committed create can still be a business rejection (duplicate name,
+    // invalid expiry) whose reply body carries a nonzero result code. Splice
+    // the secret only into a genuine success; pass everything else through
+    // untouched so the client decodes the committed error instead of a
+    // success-shaped token reply (the minted raw secret is simply dropped).
+    // Mirrors the HTTP handler's `committed_payload` gate.
+    let reply_body = committed
+        .as_slice()
+        .get(header_len..size)
+        .unwrap_or_default();
+    if result_code(reply_body) != Some(0) {
+        return Ok(committed);
+    }
     let token = WireName::new(raw.as_str()).map_err(|_| IggyError::InvalidFormat)?;
-    let token_payload = RawPersonalAccessTokenResponse { token }.to_bytes();
-    // Metadata reply bodies are framed `[result_count:u32][payload]`; a success
-    // is `count == 0` followed by the payload (see `ApplyReply::write_reply_body`
-    // / `result_code`). The committed reply carried an empty payload with this
-    // same framing, so reproduce it here - prepend the zero result-count rather
-    // than shipping a bare `RawPersonalAccessTokenResponse`, which the client
-    // would misread as the result-count and reject as a bogus error.
-    let mut framed = Vec::with_capacity(RESULT_COUNT_LEN + token_payload.len());
-    framed.extend_from_slice(&[0u8; RESULT_COUNT_LEN]);
-    framed.extend_from_slice(&token_payload);
-    let body = Bytes::from(framed);
+    let response = RawPersonalAccessTokenResponse { token };
+    // The SDK strips a leading result section from every metadata reply
+    // (`split_metadata_result`), so the spliced body must carry the success
+    // section like any committed metadata reply; a bare token body would be
+    // read as a garbage result code.
+    let mut body = BytesMut::with_capacity(RESULT_COUNT_LEN + response.encoded_size());
+    body.put_u32_le(0);
+    response.encode(&mut body);
     let reply = build_reply_from_bytes(
         request_header,
         request_header.client,
         request_header.session,
         commit,
-        &body,
+        &body.freeze(),
     );
     Ok(reply.into_generic())
 }
@@ -1021,6 +1297,10 @@ pub(crate) fn build_polled_messages_body(
     current_offset: u64,
     fragments: PollFragments,
 ) -> Result<Bytes, IggyError> {
+    // Body head: [partition_id:4][current_offset:8][count:4]. `count` sits at
+    // COUNT_OFFSET and is backpatched once the walk below knows it.
+    const HEAD_LEN: usize = 16;
+    const COUNT_OFFSET: usize = 12;
     // Batches may arrive split across fragments (rewritten command header +
     // sliced blob); concatenate into one stream before walking batches.
     let mut stream: Vec<u8> = Vec::new();
@@ -1029,7 +1309,13 @@ pub(crate) fn build_polled_messages_body(
         stream.extend_from_slice(frozen.as_slice());
     }
 
-    let mut messages: Vec<u8> = Vec::with_capacity(stream.len());
+    // Reserve the head and encode the messages straight into `body`; encoding
+    // directly avoids a separate messages buffer and its copy-through into the
+    // head.
+    let mut body: Vec<u8> = Vec::with_capacity(HEAD_LEN + stream.len());
+    body.extend_from_slice(&partition_id.to_le_bytes());
+    body.extend_from_slice(&current_offset.to_le_bytes());
+    body.extend_from_slice(&[0u8; 4]); // count placeholder, backpatched below
     let mut count: u32 = 0;
     let mut position = 0usize;
     while position < stream.len() {
@@ -1072,25 +1358,25 @@ pub(crate) fn build_polled_messages_body(
             let timestamp = batch.base_timestamp;
             let origin_timestamp = batch.origin_timestamp + u64::from(timestamp_delta);
 
-            messages.extend_from_slice(checksum);
-            messages.extend_from_slice(id);
-            messages.extend_from_slice(&offset.to_le_bytes());
-            messages.extend_from_slice(&timestamp.to_le_bytes());
-            messages.extend_from_slice(&origin_timestamp.to_le_bytes());
-            messages.extend_from_slice(
+            body.extend_from_slice(checksum);
+            body.extend_from_slice(id);
+            body.extend_from_slice(&offset.to_le_bytes());
+            body.extend_from_slice(&timestamp.to_le_bytes());
+            body.extend_from_slice(&origin_timestamp.to_le_bytes());
+            body.extend_from_slice(
                 &u32::try_from(user_headers_length)
                     .expect("length came from u32")
                     .to_le_bytes(),
             );
-            messages.extend_from_slice(
+            body.extend_from_slice(
                 &u32::try_from(payload_length)
                     .expect("length came from u32")
                     .to_le_bytes(),
             );
-            messages.extend_from_slice(&0u64.to_le_bytes()); // reserved
+            body.extend_from_slice(&0u64.to_le_bytes()); // reserved
             // Stored sections are already in legacy order
             // (`[payload][user_headers]`): copy through contiguously.
-            messages.extend_from_slice(&stream[sections_start..sections_end]);
+            body.extend_from_slice(&stream[sections_start..sections_end]);
 
             count += 1;
             cursor = sections_end;
@@ -1098,11 +1384,7 @@ pub(crate) fn build_polled_messages_body(
         position = batch_end;
     }
 
-    let mut body = Vec::with_capacity(16 + messages.len());
-    body.extend_from_slice(&partition_id.to_le_bytes());
-    body.extend_from_slice(&current_offset.to_le_bytes());
-    body.extend_from_slice(&count.to_le_bytes());
-    body.extend_from_slice(&messages);
+    body[COUNT_OFFSET..HEAD_LEN].copy_from_slice(&count.to_le_bytes());
     Ok(Bytes::from(body))
 }
 
@@ -1118,4 +1400,159 @@ pub(crate) fn build_consumer_offset_body(
     body.extend_from_slice(&current_offset.to_le_bytes());
     body.extend_from_slice(&stored_offset.to_le_bytes());
     Bytes::from(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pat_request_header() -> RequestHeader {
+        let zeroed = [0u8; std::mem::size_of::<RequestHeader>()];
+        let mut header = *bytemuck::checked::try_from_bytes::<RequestHeader>(&zeroed)
+            .expect("zeroed bytes form a valid RequestHeader");
+        header.command = Command2::Request;
+        header.operation = Operation::CreatePersonalAccessToken;
+        header.client = 42;
+        header.session = 7;
+        header.request = 3;
+        header
+    }
+
+    /// A committed metadata reply whose body is the given result section
+    /// (`[count][{index, result}]*`), as the commit path emits it.
+    fn committed_reply(result_body: &[u8]) -> Message<GenericHeader> {
+        let request_header = pat_request_header();
+        build_reply_from_bytes(
+            &request_header,
+            42,
+            7,
+            9,
+            &Bytes::copy_from_slice(result_body),
+        )
+        .into_generic()
+    }
+
+    #[test]
+    fn raw_pat_reply_splices_token_into_a_committed_success() {
+        let success = committed_reply(&0u32.to_le_bytes());
+        let reply =
+            build_raw_pat_reply(&pat_request_header(), success, Some("raw-token".to_owned()))
+                .expect("splice succeeds");
+        let header_len = std::mem::size_of::<ReplyHeader>();
+        let body = &reply.as_slice()[header_len..reply.header().size as usize];
+        // Framed like every committed metadata reply: the SDK reads the result
+        // section first, then decodes the token payload past it.
+        assert_eq!(result_code(body), Some(0));
+        let response = RawPersonalAccessTokenResponse::decode_from(&body[RESULT_COUNT_LEN..])
+            .expect("token body decodes");
+        assert_eq!(response.token.as_str(), "raw-token");
+    }
+
+    #[test]
+    fn raw_pat_reply_passes_a_committed_rejection_through_untouched() {
+        let rejection_code =
+            IggyError::PersonalAccessTokenAlreadyExists(String::new(), 0).as_code();
+        let mut result_body = Vec::new();
+        result_body.extend_from_slice(&1u32.to_le_bytes());
+        result_body.extend_from_slice(&0u32.to_le_bytes());
+        result_body.extend_from_slice(&rejection_code.to_le_bytes());
+        let rejection = committed_reply(&result_body);
+        let original = rejection.as_slice().to_vec();
+
+        let reply = build_raw_pat_reply(
+            &pat_request_header(),
+            rejection,
+            Some("raw-token".to_owned()),
+        )
+        .expect("pass-through succeeds");
+        assert_eq!(
+            reply.as_slice(),
+            original.as_slice(),
+            "a committed rejection must not be rewritten into a token reply"
+        );
+    }
+
+    #[test]
+    fn raw_pat_reply_without_a_token_passes_through() {
+        let success = committed_reply(&0u32.to_le_bytes());
+        let original = success.as_slice().to_vec();
+        let reply =
+            build_raw_pat_reply(&pat_request_header(), success, None).expect("pass-through");
+        assert_eq!(reply.as_slice(), original.as_slice());
+    }
+
+    #[test]
+    fn personal_access_tokens_response_preserves_order_and_encodes_never_as_zero() {
+        let expiry = IggyTimestamp::from(123_456u64);
+        let tokens: Vec<(Arc<str>, Option<IggyTimestamp>)> = vec![
+            (Arc::from("alpha"), Some(expiry)),
+            (Arc::from("zeta"), None),
+        ];
+
+        let response = personal_access_tokens_response(tokens).expect("mapping succeeds");
+
+        assert_eq!(response.tokens.len(), 2);
+        assert_eq!(response.tokens[0].name.as_str(), "alpha");
+        assert_eq!(response.tokens[0].expiry_at, expiry.as_micros());
+        assert_eq!(response.tokens[1].name.as_str(), "zeta");
+        assert_eq!(response.tokens[1].expiry_at, 0);
+    }
+
+    #[test]
+    fn personal_access_tokens_response_encodes_empty_list_as_empty_body() {
+        let response = personal_access_tokens_response(Vec::new()).expect("mapping succeeds");
+        // An empty body is the wire shape the SDK decodes as "no tokens"; it
+        // must stay `Bytes` (not the not-found `Empty` variant) end to end.
+        assert!(response.to_bytes().is_empty());
+    }
+
+    #[test]
+    fn probe_system_stats_reports_this_process_and_host_memory() {
+        let stats = probe_system_stats();
+        // Straight from `sysinfo`, independent of shard state: the pid is our
+        // own and any host the test runs on has nonzero total memory. A zero
+        // here means the probe wired nothing (the pre-fix stubbed literal).
+        assert_eq!(stats.process_id, std::process::id());
+        assert!(stats.total_memory > 0);
+        assert!(!stats.hostname.is_empty());
+    }
+
+    #[test]
+    fn topic_header_resolves_server_default_and_passes_explicit_sizes_through() {
+        use iggy_common::{CompressionAlgorithm, IggyExpiry, StreamStats, TopicStats};
+        use std::sync::atomic::AtomicUsize;
+
+        const NODE_DEFAULT: u64 = 4 * 1024 * 1024 * 1024;
+
+        let parent = Arc::new(StreamStats::default());
+        let topic_with = |max_topic_size| metadata::stm::stream::Topic {
+            id: 0,
+            name: Arc::from("topic"),
+            created_at: IggyTimestamp::from(1u64),
+            replication_factor: 1,
+            message_expiry: IggyExpiry::NeverExpire,
+            compression_algorithm: CompressionAlgorithm::None,
+            max_topic_size,
+            stats: Arc::new(TopicStats::new(parent.clone())),
+            partitions: Vec::new(),
+            round_robin_counter: Arc::new(AtomicUsize::new(0)),
+            consumer_groups: ahash::AHashMap::default(),
+            consumer_group_index: ahash::AHashMap::default(),
+            next_consumer_group_id: 0,
+        };
+
+        // ServerDefault (0 on the wire) resolves to this node's configured
+        // default, not the raw 0 the pre-fix read path echoed.
+        let resolved = topic_header(&topic_with(MaxTopicSize::ServerDefault), NODE_DEFAULT)
+            .expect("topic header builds");
+        assert_eq!(resolved.max_topic_size, NODE_DEFAULT);
+
+        // Explicit sizes round-trip unchanged, independent of the node default.
+        let custom = topic_header(&topic_with(MaxTopicSize::from(1024u64)), NODE_DEFAULT)
+            .expect("topic header builds");
+        assert_eq!(custom.max_topic_size, 1024);
+        let unlimited = topic_header(&topic_with(MaxTopicSize::Unlimited), NODE_DEFAULT)
+            .expect("topic header builds");
+        assert_eq!(unlimited.max_topic_size, u64::MAX);
+    }
 }

--- a/core/server-ng/src/session_manager.rs
+++ b/core/server-ng/src/session_manager.rs
@@ -25,10 +25,12 @@
 //! in the consensus layer. This module tracks the binding between a
 //! transport connection and the consensus-level `(client_id, session)` pair.
 
+use crate::cluster_meta::ClusterRoster;
 use message_bus::installer::conn_info::ClientTransportKind;
 use shard::ConnectedClientInfo;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 /// Connection lifecycle states.
@@ -97,6 +99,11 @@ pub struct SessionManager {
     /// Reverse index: `client_id` → `connection_id` for fast lookup when
     /// a consensus reply arrives and needs routing to the right connection.
     client_to_connection: HashMap<u128, u128>,
+    /// This shard's copy of the configured cluster roster, served by the
+    /// pre-auth `GetClusterMetadata` read. Lives here because it is the
+    /// per-shard context already threaded to the non-replicated read path;
+    /// installed once at bootstrap, disabled until then.
+    cluster_roster: Rc<ClusterRoster>,
 }
 
 impl SessionManager {
@@ -105,7 +112,19 @@ impl SessionManager {
         Self {
             connections: HashMap::new(),
             client_to_connection: HashMap::new(),
+            cluster_roster: Rc::new(ClusterRoster::disabled()),
         }
+    }
+
+    /// Install this shard's configured cluster roster (once, at bootstrap).
+    pub fn set_cluster_roster(&mut self, roster: Rc<ClusterRoster>) {
+        self.cluster_roster = roster;
+    }
+
+    /// The configured cluster roster for the `GetClusterMetadata` read.
+    #[must_use]
+    pub fn cluster_roster(&self) -> Rc<ClusterRoster> {
+        Rc::clone(&self.cluster_roster)
     }
 
     pub fn ensure_connection(

--- a/core/server-ng/src/snapshot.rs
+++ b/core/server-ng/src/snapshot.rs
@@ -1,0 +1,295 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Diagnostic snapshot collection (`GET_SNAPSHOT_FILE` / `POST /snapshot`).
+
+mod procdump;
+
+use std::io;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Instant;
+
+use async_zip::base::write::ZipFileWriter;
+use async_zip::{Compression, ZipEntryBuilder};
+use configs::system::SystemConfig;
+use futures::channel::oneshot;
+use iggy_common::{IggyDuration, IggyError, SnapshotCompression, SystemSnapshotType};
+use tracing::{error, info, warn};
+
+/// Single-flight admission for snapshot collection. Each collection detaches
+/// an uncancellable OS thread plus `ps`/`top` child processes; neither
+/// transport's request-admission path bounds this, so `collect` refuses a
+/// second concurrent collection rather than let privileged requests pile up
+/// unbounded threads.
+static SNAPSHOT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Collect a diagnostic snapshot as an in-memory ZIP archive.
+///
+/// Collection shells out to system tools (`top -H -b -n 1` alone runs for
+/// seconds) and walks `/proc`, so it runs on a dedicated OS thread: every
+/// shard drives its compio event loop (shard 0 additionally drives
+/// consensus) and must never block, and the runtime's blocking fallback
+/// pool is disabled (`thread_pool_limit(0)`), which rules out
+/// `spawn_blocking` and `compio::process`. The caller only awaits the
+/// result handoff, so its task parks without stalling the shard.
+///
+/// Single-flight: at most one collection runs at a time (see
+/// [`SNAPSHOT_IN_PROGRESS`]); a concurrent request busy-rejects with
+/// [`IggyError::SnapshotFileCompletionFailed`].
+pub async fn collect(
+    system_config: Arc<SystemConfig>,
+    compression: SnapshotCompression,
+    snapshot_types: Vec<SystemSnapshotType>,
+) -> Result<Vec<u8>, IggyError> {
+    let snapshot_types = if snapshot_types.contains(&SystemSnapshotType::All) {
+        if snapshot_types.len() > 1 {
+            error!("when using the `all` snapshot type, no other types can be specified");
+            return Err(IggyError::InvalidCommand);
+        }
+        SystemSnapshotType::all_snapshot_types()
+    } else {
+        snapshot_types
+    };
+
+    // Deliberate busy-reject: a collection is already running. Reuses the
+    // snapshot-domain error (no dedicated busy code) so both transports surface
+    // the same "no archive produced" outcome.
+    let Some(in_progress) = SnapshotInProgressGuard::acquire() else {
+        return Err(IggyError::SnapshotFileCompletionFailed);
+    };
+
+    let (result_sender, result_receiver) = oneshot::channel();
+    thread::Builder::new()
+        .name("iggy-snapshot".to_string())
+        .spawn(move || {
+            // Held for the whole collection: the guard releases the single-flight
+            // flag when this thread exits (any exit, including panic). Moving it
+            // in (rather than holding it in the awaiting future) keeps the flag
+            // set even if the requester disconnects and drops the receiver, so a
+            // detached-but-still-running collector still blocks a second one.
+            let _in_progress = in_progress;
+            // A dropped receiver means the requester disconnected while
+            // collecting; there is nobody left to deliver to.
+            let _ = result_sender.send(collect_blocking(
+                &system_config,
+                compression,
+                &snapshot_types,
+            ));
+        })
+        // On spawn failure the closure is dropped, dropping `in_progress` and
+        // releasing the flag, so a failed spawn cannot wedge it set.
+        .map_err(|error| {
+            error!(%error, "failed to spawn snapshot collector thread");
+            IggyError::SnapshotFileCompletionFailed
+        })?;
+    result_receiver
+        .await
+        .map_err(|_| IggyError::SnapshotFileCompletionFailed)?
+}
+
+/// RAII guard for the [`SNAPSHOT_IN_PROGRESS`] single-flight flag. Releasing on
+/// drop (rather than a manual store) means a panicking or early-returning
+/// collector thread cannot leave the flag stuck `true` and lock out every
+/// future snapshot.
+struct SnapshotInProgressGuard;
+
+impl SnapshotInProgressGuard {
+    /// Acquire the flag, or `None` if a collection is already in progress.
+    fn acquire() -> Option<Self> {
+        SNAPSHOT_IN_PROGRESS
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+            .then_some(Self)
+    }
+}
+
+impl Drop for SnapshotInProgressGuard {
+    fn drop(&mut self) {
+        SNAPSHOT_IN_PROGRESS.store(false, Ordering::Release);
+    }
+}
+
+fn collect_blocking(
+    system_config: &SystemConfig,
+    compression: SnapshotCompression,
+    snapshot_types: &[SystemSnapshotType],
+) -> Result<Vec<u8>, IggyError> {
+    let started = Instant::now();
+    let mut entries = Vec::with_capacity(snapshot_types.len());
+    for snapshot_type in snapshot_types {
+        match capture(snapshot_type, system_config) {
+            Ok(content) => entries.push((format!("{snapshot_type}.txt"), content)),
+            // Parity with the legacy collector: a failed section is logged and
+            // skipped so the rest of the archive still ships.
+            Err(error) => {
+                error!(%snapshot_type, %error, "failed to capture snapshot section");
+            }
+        }
+    }
+    let archive = build_zip(&entries, compression)?;
+    info!(
+        types = ?snapshot_types,
+        size = archive.len(),
+        elapsed = %IggyDuration::new(started.elapsed()),
+        "snapshot collected"
+    );
+    Ok(archive)
+}
+
+fn capture(
+    snapshot_type: &SystemSnapshotType,
+    system_config: &SystemConfig,
+) -> io::Result<Vec<u8>> {
+    match snapshot_type {
+        SystemSnapshotType::FilesystemOverview => {
+            command_stdout(Command::new("ls").args(["-la", "/tmp", "/proc"]))
+        }
+        SystemSnapshotType::ProcessList => process_list(),
+        SystemSnapshotType::ResourceUsage => {
+            command_stdout(Command::new("top").args(["-H", "-b", "-n", "1"]))
+        }
+        SystemSnapshotType::Test => command_stdout(Command::new("echo").arg("test")),
+        SystemSnapshotType::ServerLogs => server_logs(system_config),
+        SystemSnapshotType::ServerConfig => server_config(system_config),
+        // `collect` expands `All` before handing off to the collector.
+        SystemSnapshotType::All => Err(io::Error::other("`all` must be expanded by the caller")),
+    }
+}
+
+fn command_stdout(command: &mut Command) -> io::Result<Vec<u8>> {
+    let output = command.output()?;
+    if !output.stderr.is_empty() {
+        warn!(
+            program = ?command.get_program(),
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "snapshot command reported errors"
+        );
+    }
+    Ok(output.stdout)
+}
+
+fn process_list() -> io::Result<Vec<u8>> {
+    let ps_output = Command::new("ps").arg("aux").output()?;
+    let mut content = b"=== Process List (ps aux) ===\n".to_vec();
+    content.extend_from_slice(&ps_output.stdout);
+    content.extend_from_slice(b"\n\n=== Detailed Process Information ===\n");
+    content.extend_from_slice(procdump::proc_info()?.as_bytes());
+    Ok(content)
+}
+
+fn server_logs(system_config: &SystemConfig) -> io::Result<Vec<u8>> {
+    // Mirror the logger's path derivation (server_common `Logging::late_init`):
+    // it canonicalizes the configured subdirectory before joining the system
+    // path, so a relative `logging.path` that already exists resolves against the
+    // CWD. Skipping the canonicalize here would read a different (often empty)
+    // directory than the one the logger actually writes to.
+    let logs_subdirectory = PathBuf::from(&system_config.logging.path);
+    let logs_subdirectory = logs_subdirectory
+        .canonicalize()
+        .unwrap_or(logs_subdirectory);
+    let logs_path = PathBuf::from(system_config.get_system_path()).join(logs_subdirectory);
+    let mut log_files = Vec::new();
+    for entry in std::fs::read_dir(&logs_path)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.is_file() {
+            log_files.push((metadata.modified()?, entry.path()));
+        }
+    }
+    // Oldest first, so the concatenation reads chronologically (the legacy
+    // collector's `ls -tr | xargs cat`).
+    log_files.sort_by_key(|(modified, _)| *modified);
+    let mut content = Vec::new();
+    for (_, path) in log_files {
+        content.extend_from_slice(&std::fs::read(&path)?);
+    }
+    Ok(content)
+}
+
+fn server_config(system_config: &SystemConfig) -> io::Result<Vec<u8>> {
+    let config_path = PathBuf::from(system_config.get_runtime_path()).join("current_config.toml");
+    std::fs::read(config_path)
+}
+
+fn build_zip(
+    entries: &[(String, Vec<u8>)],
+    compression: SnapshotCompression,
+) -> Result<Vec<u8>, IggyError> {
+    let compression = zip_compression(compression);
+    // The writer targets an in-memory Vec, so every poll completes
+    // immediately; `block_on` never parks the collector thread on I/O.
+    futures::executor::block_on(async {
+        let mut zip_writer = ZipFileWriter::new(Vec::new());
+        for (filename, content) in entries {
+            let entry = ZipEntryBuilder::new(filename.clone().into(), compression);
+            zip_writer
+                .write_entry_whole(entry, content)
+                .await
+                .map_err(|error| {
+                    error!(filename, %error, "failed to write snapshot zip entry");
+                    IggyError::SnapshotFileCompletionFailed
+                })?;
+        }
+        zip_writer.close().await.map_err(|error| {
+            error!(%error, "failed to finalize snapshot zip");
+            IggyError::SnapshotFileCompletionFailed
+        })
+    })
+}
+
+const fn zip_compression(compression: SnapshotCompression) -> Compression {
+    match compression {
+        SnapshotCompression::Stored => Compression::Stored,
+        SnapshotCompression::Deflated => Compression::Deflate,
+        SnapshotCompression::Bzip2 => Compression::Bz,
+        SnapshotCompression::Zstd => Compression::Zstd,
+        SnapshotCompression::Lzma => Compression::Lzma,
+        SnapshotCompression::Xz => Compression::Xz,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn given_a_collection_in_progress_when_collecting_then_it_busy_rejects() {
+        // Hold the single-flight flag to stand in for a running collection, then
+        // assert a concurrent `collect` refuses (returning without spawning a
+        // second collector thread) rather than piling up threads.
+        let held = SnapshotInProgressGuard::acquire().expect("flag starts free");
+        let result = futures::executor::block_on(collect(
+            Arc::new(SystemConfig::default()),
+            SnapshotCompression::Stored,
+            vec![SystemSnapshotType::Test],
+        ));
+        assert!(matches!(
+            result,
+            Err(IggyError::SnapshotFileCompletionFailed)
+        ));
+        // Dropping the guard releases the flag for the next collection.
+        drop(held);
+        assert!(
+            SnapshotInProgressGuard::acquire().is_some(),
+            "flag must be free after the guard drops"
+        );
+    }
+}

--- a/core/server-ng/src/snapshot/procdump.rs
+++ b/core/server-ng/src/snapshot/procdump.rs
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! `/proc` dump for the process-list snapshot section. Synchronous by design:
+//! it runs on the dedicated snapshot collector thread, never on a shard.
+
+// `fmt::Write` for `String` is infallible, so the `writeln!` results below are
+// discarded.
+use std::fmt::Write;
+
+/// Get detailed information about the system's processes and related /proc data.
+pub(super) fn proc_info() -> Result<String, std::io::Error> {
+    let static_proc_files = [
+        "/proc/uptime",
+        "/proc/cpuinfo",
+        "/proc/stat",
+        "/proc/meminfo",
+        "/proc/interrupts",
+        "/proc/softirqs",
+        "/proc/latency",
+        "/proc/buddyinfo",
+        "/proc/slabinfo",
+        "/proc/vmstat",
+        "/proc/loadavg",
+        "/proc/cmdline",
+        "/proc/version",
+        "/proc/net/sockstat",
+        "/proc/net/snmp",
+        "/proc/net/netlink",
+        "/proc/net/netstat",
+        "/proc/net/dev",
+        "/proc/net/packet",
+        "/proc/net/tcp",
+        "/proc/net/tcp6",
+        "/proc/net/udp",
+        "/proc/net/udp6",
+        "/proc/net/raw",
+        "/proc/net/raw6",
+        "/proc/net/icmp",
+        "/proc/net/icmp6",
+        "/proc/net/udplite",
+        "/proc/net/udplite6",
+        "/proc/net/unix",
+        "/proc/net/softnet_stat",
+        "/proc/tty/drivers",
+        "/proc/sys/kernel/pid_max",
+        "/proc/sys/kernel/random/boot_id",
+        "/proc/mounts",
+        "/proc/modules",
+    ];
+
+    let mut result = String::new();
+    for path in static_proc_files {
+        dump_file(&mut result, path);
+    }
+
+    let mut proc_dir = std::fs::read_dir("/proc")?;
+    while let Some(Ok(entry)) = proc_dir.next() {
+        let file_type = entry.file_type()?;
+        if file_type.is_dir()
+            && let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>()
+        {
+            let pid_paths = [
+                format!("/proc/{pid}/cmdline"),
+                format!("/proc/{pid}/statm"),
+                format!("/proc/{pid}/cgroup"),
+                format!("/proc/{pid}/task/{pid}/stat"),
+                format!("/proc/{pid}/task/{pid}/status"),
+                format!("/proc/{pid}/task/{pid}/wchan"),
+                format!("/proc/{pid}/task/{pid}/syscall"),
+                format!("/proc/{pid}/task/{pid}/fd"),
+            ];
+            for path in &pid_paths {
+                dump_file(&mut result, path);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+fn dump_file(result: &mut String, path: &str) {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let _ = writeln!(result, "=== {path} ===");
+            if path.ends_with("/stat") && path.contains("/task/") {
+                result.push_str(&parse_stat(&contents));
+            } else {
+                result.push_str(&contents);
+            }
+            result.push_str("\n\n");
+        }
+        Err(error) => {
+            // `/proc/[pid]/fd` is a directory of symlinks, not a readable
+            // file; render the link targets instead of an error line.
+            if let Ok(metadata) = std::fs::metadata(path)
+                && metadata.is_dir()
+                && path.ends_with("/fd")
+            {
+                let _ = writeln!(result, "=== {path} (directory) ===");
+                if let Ok(mut entries) = std::fs::read_dir(path) {
+                    while let Some(Ok(entry)) = entries.next() {
+                        let fd_path = entry.path();
+                        match std::fs::read_link(&fd_path) {
+                            Ok(link) => {
+                                let _ =
+                                    writeln!(result, "{} -> {}", fd_path.display(), link.display());
+                            }
+                            Err(_) => {
+                                let _ =
+                                    writeln!(result, "{} (unreadable symlink)", fd_path.display());
+                            }
+                        }
+                    }
+                }
+                result.push('\n');
+            } else {
+                let _ = writeln!(result, "=== {path} ERROR: {error} ===\n");
+            }
+        }
+    }
+}
+
+/// Parse the contents of a /proc/[pid]/task/[tid]/stat file into a
+/// human-readable format.
+fn parse_stat(contents: &str) -> String {
+    let fields: Vec<&str> = contents.split_whitespace().collect();
+    if fields.len() < 52 {
+        return format!("Invalid stat format: {contents}");
+    }
+
+    // Extract `comm` from between the parens in `pid (comm) state ...`. Guard the
+    // ordering: a malformed line where ')' precedes '(' (or a paren is missing)
+    // would panic on the reversed slice range and take down the collector thread.
+    let comm = match (contents.find('('), contents.rfind(')')) {
+        (Some(start), Some(end)) if start < end => &contents[start + 1..end],
+        _ => return format!("Invalid stat format: {contents}"),
+    };
+
+    let mut result = String::new();
+    let _ = writeln!(result, "PID: {}", fields[0]);
+    let _ = writeln!(result, "Command: {comm}");
+    let _ = writeln!(
+        result,
+        "State: {} ({})",
+        fields[2],
+        match fields[2] {
+            "R" => "Running",
+            "S" => "Sleeping (interruptible)",
+            "D" => "Waiting in uninterruptible disk sleep",
+            "Z" => "Zombie",
+            "T" => "Stopped",
+            "t" => "Tracing stop",
+            "W" => "Paging",
+            "X" | "x" => "Dead",
+            "K" => "Wakekill",
+            "P" => "Parked",
+            _ => "Unknown",
+        }
+    );
+    let _ = writeln!(result, "Parent PID: {}", fields[3]);
+    let _ = writeln!(result, "Process Group: {}", fields[4]);
+    let _ = writeln!(result, "Session ID: {}", fields[5]);
+    let _ = writeln!(result, "TTY: {}", fields[6]);
+    let _ = writeln!(result, "Foreground Process Group: {}", fields[7]);
+    let _ = writeln!(result, "Kernel Flags: {}", fields[8]);
+    let _ = writeln!(result, "Minor Faults: {}", fields[9]);
+    let _ = writeln!(result, "Children Minor Faults: {}", fields[10]);
+    let _ = writeln!(result, "Major Faults: {}", fields[11]);
+    let _ = writeln!(result, "Children Major Faults: {}", fields[12]);
+    let _ = writeln!(result, "User Mode Time: {} ticks", fields[13]);
+    let _ = writeln!(result, "System Mode Time: {} ticks", fields[14]);
+    let _ = writeln!(result, "Children User Mode Time: {} ticks", fields[15]);
+    let _ = writeln!(result, "Children System Mode Time: {} ticks", fields[16]);
+    let _ = writeln!(result, "Priority: {}", fields[17]);
+    let _ = writeln!(result, "Nice Value: {}", fields[18]);
+    let _ = writeln!(result, "Number of Threads: {}", fields[19]);
+    let _ = writeln!(result, "Real-time Priority: {}", fields[39]);
+    let _ = writeln!(
+        result,
+        "Policy: {} ({})",
+        fields[40],
+        match fields[40] {
+            "0" => "SCHED_NORMAL/OTHER",
+            "1" => "SCHED_FIFO",
+            "2" => "SCHED_RR",
+            "3" => "SCHED_BATCH",
+            "5" => "SCHED_IDLE",
+            "6" => "SCHED_DEADLINE",
+            _ => "Unknown",
+        }
+    );
+    let _ = writeln!(result, "Aggregated Block I/O Delays: {} ticks", fields[41]);
+    let _ = writeln!(result, "Guest Time: {} ticks", fields[42]);
+    let _ = writeln!(result, "Children Guest Time: {} ticks", fields[43]);
+
+    result
+}

--- a/core/server-ng/src/users.rs
+++ b/core/server-ng/src/users.rs
@@ -25,19 +25,39 @@
 //! replica and diverge state (and a raw password would never parse,
 //! panicking `verify_password`). So the primary hashes once here and
 //! replicates the hash, mirroring the PAT mint in [`crate::pat`].
+//!
+//! `ChangePassword` also verifies the caller-supplied `current_password`
+//! against the target's stored hash before the op replicates (the legacy
+//! server does this for self- and admin-initiated changes alike), and it
+//! always empties that field, so no plaintext credential ever rides the
+//! replicated prepare/WAL. A mismatch is committed as a rejecting no-op
+//! (signalled by an empty new password) rather than denied pre-consensus, so
+//! the caller's request sequence stays contiguous; see
+//! [`verify_and_rewrite_change_password`].
 
+use crate::bootstrap::ServerNgShard;
 use crate::wire::{request_body, rewrite_request_body};
+use bytes::Bytes;
+use consensus::MetadataHandle;
 use iggy_binary_protocol::codec::{WireDecode, WireEncode};
 use iggy_binary_protocol::requests::users::{ChangePasswordRequest, CreateUserRequest};
 use iggy_binary_protocol::{Operation, RequestHeader};
 use iggy_common::IggyError;
+use metadata::impls::metadata::StreamsFrontend;
 use server_common::{Message, crypto};
+use std::rc::Rc;
 
-/// Replace a raw wire password with its Argon2 hash before replication.
+/// Rewrite a raw wire password request before replication.
 ///
-/// Only touches `CreateUser` and `ChangePassword`; every other operation
-/// passes through unchanged.
+/// `CreateUser` hashes the new password. `ChangePassword` strips the current
+/// password unconditionally (so no plaintext enters consensus) and verifies it
+/// against the target's stored hash when the target resolves; a mismatch is
+/// signalled to the replicated apply as a committed `InvalidCredentials`
+/// rejection (see [`verify_and_rewrite_change_password`]). Every other operation
+/// passes through unchanged. Returns [`IggyError::InvalidCommand`] only on an
+/// undecodable password body.
 pub(crate) fn maybe_rewrite_user_password_request(
+    shard: &Rc<ServerNgShard>,
     request: Message<RequestHeader>,
 ) -> Result<Message<RequestHeader>, IggyError> {
     let operation = request.header().operation;
@@ -52,11 +72,137 @@ pub(crate) fn maybe_rewrite_user_password_request(
         Operation::ChangePassword => {
             let mut wire =
                 ChangePasswordRequest::decode_from(body).map_err(|_| IggyError::InvalidCommand)?;
-            wire.new_password = crypto::hash_password(&wire.new_password);
-            wire.to_bytes()
+            let stored_hash = shard
+                .plane
+                .metadata()
+                .mux_stm
+                .users()
+                .read(|users| users.password_hash_of(&wire.user_id));
+            verify_and_rewrite_change_password(&mut wire, stored_hash.as_deref())
         }
         _ => return Ok(request),
     };
 
     rewrite_request_body(&request, &rewritten)
+}
+
+/// Strip the current password, then re-encode the body for replication.
+///
+/// When the target resolves (`stored_hash` is `Some`) the supplied
+/// `current_password` is verified against it first. A mismatch does NOT deny
+/// pre-consensus: that would consume the client's request id without advancing
+/// the replicated `ClientTable`, gapping the sequence so the next replicated op
+/// is dropped (`RequestGap`) and the caller stalls. Instead the new password is
+/// emptied, which signals the committed apply to reject with
+/// `InvalidCredentials` (a committed no-op that keeps the sequence contiguous).
+///
+/// Either way the current password is stripped and the accepted new one hashed,
+/// so no plaintext credential ever enters consensus. An unresolved target keeps
+/// its hashed new password and the replicated apply rejects it with
+/// `UserNotFound`. ACCEPTED RESIDUAL: if the target is created in the narrow
+/// window between this rewrite and the apply, the current-password check is
+/// skipped for that one op; RBAC still gates cross-user changes. Concurrent
+/// same-user `ChangePassword` ops each verify against the hash read here, so
+/// the last to commit wins over a now-stale predecessor; there is no
+/// compare-and-swap, which is benign and inherent to distributed submission.
+fn verify_and_rewrite_change_password(
+    wire: &mut ChangePasswordRequest,
+    stored_hash: Option<&str>,
+) -> Bytes {
+    let credentials_ok = match stored_hash {
+        Some(stored_hash) => crypto::verify_password(&wire.current_password, stored_hash),
+        None => true,
+    };
+    wire.current_password = String::new();
+    wire.new_password = if credentials_ok {
+        crypto::hash_password(&wire.new_password)
+    } else {
+        // Empty hash is a reserved sentinel the committed apply reads as
+        // InvalidCredentials. Unambiguous only because `hash_password` is total
+        // and its Argon2 PHC output is never empty, so no real hash collides
+        // with it.
+        String::new()
+    };
+    wire.to_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iggy_binary_protocol::WireIdentifier;
+
+    const CURRENT_PASSWORD: &str = "current-password";
+    const NEW_PASSWORD: &str = "brand-new-password";
+
+    fn change_password_request() -> ChangePasswordRequest {
+        ChangePasswordRequest {
+            user_id: WireIdentifier::numeric(7),
+            current_password: CURRENT_PASSWORD.to_owned(),
+            new_password: NEW_PASSWORD.to_owned(),
+        }
+    }
+
+    #[test]
+    fn given_wrong_current_password_when_rewrite_should_signal_reject() {
+        let stored_hash = crypto::hash_password("some-other-password");
+        let mut wire = change_password_request();
+
+        let body = verify_and_rewrite_change_password(&mut wire, Some(&stored_hash));
+
+        let decoded =
+            ChangePasswordRequest::decode_from(&body).expect("re-encoded body round-trips");
+        assert!(
+            decoded.current_password.is_empty(),
+            "current password must be stripped before replication"
+        );
+        // An empty new password is the reject signal the committed apply turns
+        // into InvalidCredentials, never a raw or hashed plaintext.
+        assert!(
+            decoded.new_password.is_empty(),
+            "a wrong current password must signal reject via an empty new password"
+        );
+    }
+
+    #[test]
+    fn given_correct_current_password_when_rewrite_should_strip_and_hash() {
+        let stored_hash = crypto::hash_password(CURRENT_PASSWORD);
+        let mut wire = change_password_request();
+
+        let body = verify_and_rewrite_change_password(&mut wire, Some(&stored_hash));
+
+        let decoded =
+            ChangePasswordRequest::decode_from(&body).expect("re-encoded body round-trips");
+        assert!(
+            decoded.current_password.is_empty(),
+            "current password must be stripped before replication"
+        );
+        assert_ne!(
+            decoded.new_password, NEW_PASSWORD,
+            "new password must be hashed, not replicated raw"
+        );
+        assert!(
+            crypto::verify_password(NEW_PASSWORD, &decoded.new_password),
+            "hashed new password must verify against the raw input"
+        );
+    }
+
+    #[test]
+    fn given_unresolved_target_when_rewrite_should_hash_and_strip_without_verify() {
+        let mut wire = change_password_request();
+
+        // No stored hash: nothing to verify against, but the plaintext must
+        // still never reach consensus, so the body is rewritten regardless.
+        let body = verify_and_rewrite_change_password(&mut wire, None);
+
+        let decoded =
+            ChangePasswordRequest::decode_from(&body).expect("re-encoded body round-trips");
+        assert!(
+            decoded.current_password.is_empty(),
+            "current password must be stripped even for an unresolved target"
+        );
+        assert!(
+            crypto::verify_password(NEW_PASSWORD, &decoded.new_password),
+            "new password must still be hashed for an unresolved target"
+        );
+    }
 }

--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -143,6 +143,7 @@ pub fn channel<T: Send + 'static>(capacity: usize) -> (Sender<T>, Receiver<T>) {
 pub enum MetadataSubmit {
     Register {
         vsr_client_id: u128,
+        user_id: u32,
         reply: Sender<Option<u64>>,
     },
     Logout {

--- a/core/simulator/src/lib.rs
+++ b/core/simulator/src/lib.rs
@@ -324,7 +324,10 @@ impl Simulator {
                 "partition not found for namespace {namespace:?} on replica {replica_idx}"
             )));
         };
-        let (fragments, _commit_offset) = futures::executor::block_on(plan.execute());
+        // The simulator drives partitions directly, so it never replicates a
+        // poll's auto-commit (that is the serving shard's job in the real
+        // server); the surfaced offset is discarded here.
+        let (fragments, _commit_offset, _auto_commit) = futures::executor::block_on(plan.execute());
         Ok(fragments)
     }
 

--- a/core/simulator/src/replica.rs
+++ b/core/simulator/src/replica.rs
@@ -47,6 +47,10 @@ pub type Replica = shard::IggyShard<
 
 pub fn new_replica(id: u8, name: String, bus: &Arc<SimOutbox>, replica_count: u8) -> Replica {
     let users: Users = UsersInner::new().into();
+    // Seed the root user at slab id 0, matching production bootstrap
+    // (`ensure_root_user`). Root is undeletable in-apply, so keeping it in slot
+    // 0 leaves the workload's users at slab id 1+ and out of any delete attempt.
+    users.ensure_root_user("iggy", "hash");
     let streams: Streams = StreamsInner::new().into();
     let mux = SimMuxStateMachine::new(variadic!(users, streams));
 

--- a/core/simulator/src/workload/ops/change_password.rs
+++ b/core/simulator/src/workload/ops/change_password.rs
@@ -62,6 +62,8 @@ pub fn sample(
             current_password: String::new(),
             new_password: "pw-missing".to_string(),
         }),
+        // Not a targeted outcome (absent from `OUTCOMES`); never sampled.
+        Outcome::InvalidCredentials => None,
     }
 }
 
@@ -86,6 +88,8 @@ pub fn predicted_effect(input: &Input, outcome: Outcome) -> Effect {
             user: input.user.clone(),
             new_password: input.new_password.clone(),
         },
-        Outcome::UserNotFound => Effect::None,
+        // A committed rejection is a no-op: a missing user, or (never targeted)
+        // a wrong current password, leaves the shadow unchanged.
+        Outcome::UserNotFound | Outcome::InvalidCredentials => Effect::None,
     }
 }

--- a/core/simulator/src/workload/ops/create_consumer_group.rs
+++ b/core/simulator/src/workload/ops/create_consumer_group.rs
@@ -15,8 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! `CreateConsumerGroup` op. Targets `Ok` (fresh group under a live
-//! stream/topic) or `NameAlreadyExists` (an existing group name).
+//! `CreateConsumerGroup` op.
+//!
+//! Targets `Ok` (fresh group under a live stream/topic), `StreamNotFound`
+//! (a fabricated parent stream), `TopicNotFound` (a live stream with a
+//! fabricated topic), or `NameAlreadyExists` (an existing group name).
 
 use iggy_binary_protocol::RequestHeader;
 use rand_xoshiro::Xoshiro256Plus;
@@ -36,7 +39,12 @@ pub struct Input {
     pub name: String,
 }
 
-pub const OUTCOMES: &[Outcome] = &[Outcome::Ok, Outcome::NameAlreadyExists];
+pub const OUTCOMES: &[Outcome] = &[
+    Outcome::Ok,
+    Outcome::StreamNotFound,
+    Outcome::TopicNotFound,
+    Outcome::NameAlreadyExists,
+];
 
 pub fn sample(
     shadow: &mut Shadow,
@@ -52,6 +60,19 @@ pub fn sample(
                 stream,
                 topic,
                 name,
+            })
+        }
+        Outcome::StreamNotFound => Some(Input {
+            stream: shadow.fabricate_absent_name("stream"),
+            topic: shadow.fabricate_absent_name("topic"),
+            name: shadow.fresh_name("cg"),
+        }),
+        Outcome::TopicNotFound => {
+            let stream = shadow.pick_stream_name(prng)?;
+            Some(Input {
+                stream,
+                topic: shadow.fabricate_absent_name("topic"),
+                name: shadow.fresh_name("cg"),
             })
         }
         Outcome::NameAlreadyExists => {
@@ -87,6 +108,10 @@ pub fn predicted_effect(input: &Input, outcome: Outcome) -> Effect {
             topic: input.topic.clone(),
             name: input.name.clone(),
         },
-        Outcome::NameAlreadyExists => Effect::None,
+        // A committed rejection is a no-op: an absent parent stream or topic, or
+        // a duplicate group name, leaves the shadow unchanged.
+        Outcome::StreamNotFound | Outcome::TopicNotFound | Outcome::NameAlreadyExists => {
+            Effect::None
+        }
     }
 }

--- a/core/simulator/src/workload/ops/create_user.rs
+++ b/core/simulator/src/workload/ops/create_user.rs
@@ -47,6 +47,9 @@ pub fn sample(
     let username = match outcome {
         Outcome::Ok => shadow.fresh_name("user"),
         Outcome::UserAlreadyExists => shadow.pick_user_name(prng)?,
+        // Not a targeted outcome (absent from `OUTCOMES`); the shadow only ever
+        // mints in-bounds names, so an invalid-length username is never sampled.
+        Outcome::InvalidUsername => return None,
     };
     Some(Input {
         password: format!("pw-{username}"),
@@ -75,6 +78,6 @@ pub fn predicted_effect(input: &Input, outcome: Outcome) -> Effect {
         Outcome::Ok => Effect::AddUser {
             name: input.username.clone(),
         },
-        Outcome::UserAlreadyExists => Effect::None,
+        Outcome::UserAlreadyExists | Outcome::InvalidUsername => Effect::None,
     }
 }

--- a/core/simulator/src/workload/ops/delete_user.rs
+++ b/core/simulator/src/workload/ops/delete_user.rs
@@ -47,6 +47,8 @@ pub fn sample(
         Outcome::UserNotFound => Some(Input {
             user: shadow.fabricate_absent_name("user"),
         }),
+        // Not a targeted outcome (absent from `OUTCOMES`); never sampled.
+        Outcome::CannotDeleteUser => None,
     }
 }
 
@@ -70,6 +72,9 @@ pub fn predicted_effect(input: &Input, outcome: Outcome) -> Effect {
         Outcome::Ok => Effect::RemoveUser {
             name: input.user.clone(),
         },
-        Outcome::UserNotFound => Effect::None,
+        // `CannotDeleteUser` is never targeted (the workload's users live at
+        // slab id 1+, never root), but effects dispatch on the committed
+        // outcome, so the arm is required: a rejected delete removes nothing.
+        Outcome::UserNotFound | Outcome::CannotDeleteUser => Effect::None,
     }
 }

--- a/core/simulator/src/workload/ops/update_permissions.rs
+++ b/core/simulator/src/workload/ops/update_permissions.rs
@@ -47,6 +47,8 @@ pub fn sample(
         Outcome::UserNotFound => Some(Input {
             user: shadow.fabricate_absent_name("user"),
         }),
+        // Not a targeted outcome (absent from `OUTCOMES`); never sampled.
+        Outcome::CannotChangePermissions => None,
     }
 }
 

--- a/core/simulator/src/workload/ops/update_user.rs
+++ b/core/simulator/src/workload/ops/update_user.rs
@@ -67,6 +67,9 @@ pub fn sample(
         Outcome::UsernameAlreadyExists => {
             unreachable!("update_user does not target UsernameAlreadyExists")
         }
+        Outcome::InvalidUsername => {
+            unreachable!("update_user does not target InvalidUsername")
+        }
     }
 }
 
@@ -95,6 +98,8 @@ pub fn predicted_effect(input: &Input, outcome: Outcome) -> Effect {
                 new: new.clone(),
                 password: input.current_password.clone(),
             }),
-        _ => Effect::None,
+        Outcome::UserNotFound | Outcome::UsernameAlreadyExists | Outcome::InvalidUsername => {
+            Effect::None
+        }
     }
 }


### PR DESCRIPTION
server-ng had no HTTP transport, and the legacy HTTP stack is
single-node-coupled with no notion of views, leaders, or replicated
authorization.

Make HTTP a regular client of the dispatch spine. Control writes
await the committed reply; the data plane gets one new primitive, a
request-keyed in-process reply sink on the connection registry.
Auth is stateless JWT/PAT verification bound to a VSR session, with
a per-session gate keeping request ids gap-free; HTTP control
writes are at-least-once since retries mint fresh ids. Per-op RBAC
is enforced in the metadata apply and at dispatch time on every
transport. Reads default to serializable-local; linearizable reads
serve on the primary or 307-redirect. submit_gated replays
TransientNotCommitted server-side (HTTP has no client retry loop).
Produce honors ack=none behind the same admission caps as the acked
path.

GetSnapshot is implemented across binary and HTTP:
authorization-gated on read_servers || manage_servers from day one,
collected on a dedicated OS thread so the compio event loop never
stalls, single-flight, with a typed reject past the 64 MiB binary
frame cap.

Replication fixes ride along. Poll auto_commit offsets replicate
through consensus with a monotone commit-apply, so a late
fire-and-forget op cannot rewind the offset and re-deliver. The
commit-path offset reader tolerates torn files instead of
crash-looping. ChangePassword rejects a wrong current password as a
committed no-op, keeping request ids contiguous. Username bounds
are enforced inside the replicated apply, which raw clients cannot
bypass.

Parity: typed denies replace silent drops and fake successes, PAT
framing is SDK-decodable, legacy login opcodes evict instead of
stalling, re-login works on a live connection, GetClusterMetadata
serves the real roster, the missing partition and segment HTTP
routes are wired, create routes uniformly answer 200.

In the test harness HTTP becomes a first-class VSR transport;
authorization coverage consolidates into one permissions scenario
asserting exact error codes over all four transports; snapshot
tests and the mcp suite run fully under vsr.
