### PR TITLE
ci: bump docker/build-push-action to allowlisted v7.3.0

### DIFF
--- a/.github/actions/utils/docker-buildx/action.yml
+++ b/.github/actions/utils/docker-buildx/action.yml
@@ -338,7 +338,7 @@ runs:
     - name: Build and push (by digest)
       id: build-push
       if: steps.config.outputs.should_push == 'true'
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: ${{ steps.ctx.outputs.context }}
         file: ${{ steps.config.outputs.dockerfile }}
@@ -353,7 +353,7 @@ runs:
     - name: Build only (dry-run)
       id: build-only
       if: steps.config.outputs.should_push != 'true'
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: ${{ steps.ctx.outputs.context }}
         file: ${{ steps.config.outputs.dockerfile }}


### PR DESCRIPTION
The ASF org allowlist (approved_patterns.yml in
apache/infrastructure-actions) gates every third-party action by
pinned SHA. Its periodic "Remove Expired Refs" job de-listed the
v7.0.0 SHA we pinned, so all post-merge Docker publish jobs failed
with "action is not allowed in apache/iggy".

Bump to v7.3.0 (53b7df9), the newest SHA currently on the
allowlist, to restore image publishing.
