### PR TITLE
fix(python): fix flaky python test

### DIFF
--- a/foreign/python/tests/test_topic.py
+++ b/foreign/python/tests/test_topic.py
@@ -605,7 +605,7 @@ class TestGetTopics:
         # Reverse-alphabetical names so that id-ascending (creation) order
         # and name order disagree, proving the list isn't accidentally
         # name-sorted.
-        topic_names = [f"{unique_name()}-{i}" for i in range(topic_count, 0, -1)]
+        topic_names = [unique_name() for _ in range(topic_count, 0, -1)]
 
         await iggy_client.create_stream(stream_name)
         for name in topic_names:


### PR DESCRIPTION
#3624 post merge codecov workflow surfaced a failed test in python sdk. The reason for the failure was that the fixture `unique_name()` creates random names with a max length of 255 characters. In the referenced test, the names were being with names like "unique_name()-1", "unique_name()-2", ..., which could have violated iggy's identifier constraint of name < 255 bytes. This PR fixes that.

context: https://discord.com/channels/1144142576266530928/1144143392075423744/1524044270732836938