### PR TITLE
ci(python): bump setup-uv to ASF-allowlisted v8.3.2

### DIFF
--- a/.github/actions/python-maturin/post-merge/action.yml
+++ b/.github/actions/python-maturin/post-merge/action.yml
@@ -153,7 +153,7 @@ runs:
 
     - name: Install uv
       if: inputs.dry_run == 'false'
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
     - name: Publish to PyPI
       if: inputs.dry_run == 'false'

--- a/.github/actions/python-maturin/pre-merge/action.yml
+++ b/.github/actions/python-maturin/pre-merge/action.yml
@@ -41,7 +41,7 @@ runs:
         tool: cargo-llvm-cov
 
     - name: Install uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
     - name: Cache uv
       uses: actions/cache@v5


### PR DESCRIPTION
ASF removed astral-sh/setup-uv v8.0.0 (cec20831) from the
approved_patterns.yml in apache/infrastructure-actions, so every
job using the python-maturin composite actions now fails with
"action is not allowed in apache/iggy". Dependabot never bumped
these two pins because the github-actions ecosystem only scans
.github/workflows, not nested composite actions.

Pin the newest allowlisted release (v8.3.2) to maximize time
before the approval window slides past it again.
