### PR TITLE
feat(python): expose structured IggyError in Python SDK

### DIFF
--- a/foreign/python/apache_iggy.pyi
+++ b/foreign/python/apache_iggy.pyi
@@ -33,6 +33,7 @@ __all__ = [
     "ConsumerGroupMember",
     "IggyClient",
     "IggyConsumer",
+    "IggyError",
     "PollingStrategy",
     "ReceiveMessage",
     "SendMessage",
@@ -40,6 +41,23 @@ __all__ = [
     "Topic",
     "TopicDetails",
 ]
+
+
+class IggyError(Exception):
+    r"""Structured error for all Iggy-specific failures.
+
+    Attributes:
+        code (int): Numeric error code matching the Rust ``IggyError`` discriminant.
+        name (str): Stable ``snake_case`` identifier for the error variant.
+        message (str): Human-readable error text.
+    """
+
+    code: int
+    name: str
+    message: str
+
+    def __init__(self, code: int, name: str, message: str) -> None: ...
+    def __str__(self) -> str: ...
 
 class AutoCommit:
     r"""

--- a/foreign/python/src/client.rs
+++ b/foreign/python/src/client.rs
@@ -32,6 +32,7 @@ use crate::consumer::{
     AutoCommit, ConsumerGroup as PyConsumerGroup, ConsumerGroupDetails as PyConsumerGroupDetails,
     IggyConsumer, py_delta_to_iggy_duration,
 };
+use crate::error::into_pyerr;
 use crate::identifier::PyIdentifier;
 use crate::receive_message::{PollingStrategy, ReceiveMessage};
 use crate::send_message::SendMessage;
@@ -63,7 +64,7 @@ impl IggyClient {
             .with_tcp()
             .with_server_address(conn.unwrap_or("127.0.0.1:8090".to_string()))
             .build()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+            .map_err(|e| into_pyerr(e))?;
         Ok(IggyClient {
             inner: Arc::new(client),
         })
@@ -80,7 +81,7 @@ impl IggyClient {
         connection_string: String,
     ) -> PyResult<Self> {
         let client = RustIggyClient::from_connection_string(&connection_string)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+            .map_err(|e| into_pyerr(e))?;
         Ok(Self {
             inner: Arc::new(client),
         })
@@ -96,7 +97,7 @@ impl IggyClient {
             inner
                 .ping()
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
+                .map_err(|e| into_pyerr(e))
         })
     }
 
@@ -114,7 +115,7 @@ impl IggyClient {
             inner
                 .login_user(&username, &password)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -128,7 +129,7 @@ impl IggyClient {
             inner
                 .connect()
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -143,7 +144,7 @@ impl IggyClient {
             inner
                 .create_stream(&name)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -163,7 +164,7 @@ impl IggyClient {
             let stream = inner
                 .get_stream(&stream_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(stream.map(StreamDetails::from))
         })
     }
@@ -193,7 +194,7 @@ impl IggyClient {
     ) -> PyResult<Bound<'a, PyAny>> {
         let compression_algorithm = match compression_algorithm {
             Some(algo) => CompressionAlgorithm::from_str(&algo)
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?,
+                .map_err(|e| into_pyerr(e))?,
             None => CompressionAlgorithm::default(),
         };
 
@@ -219,7 +220,7 @@ impl IggyClient {
                     max_size,
                 )
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -241,7 +242,7 @@ impl IggyClient {
             let topic = inner
                 .get_topic(&stream_id, &topic_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(topic.map(TopicDetails::from))
         })
     }
@@ -269,7 +270,7 @@ impl IggyClient {
             let topics = inner
                 .get_topics(&stream_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(topics.into_iter().map(Topic::from).collect::<Vec<_>>())
         })
     }
@@ -316,7 +317,7 @@ impl IggyClient {
     ) -> PyResult<Bound<'a, PyAny>> {
         let compression_algorithm = match compression_algorithm {
             Some(algo) => CompressionAlgorithm::from_str(&algo)
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?,
+                .map_err(|e| into_pyerr(e))?,
             None => CompressionAlgorithm::default(),
         };
 
@@ -343,7 +344,7 @@ impl IggyClient {
                     max_size,
                 )
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -374,7 +375,7 @@ impl IggyClient {
             inner
                 .delete_topic(&stream_id, &topic_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -405,7 +406,7 @@ impl IggyClient {
             inner
                 .purge_topic(&stream_id, &topic_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -439,7 +440,7 @@ impl IggyClient {
             inner
                 .create_consumer_group(&stream_id, &topic_id, &name)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -475,7 +476,7 @@ impl IggyClient {
             let group = inner
                 .get_consumer_group(&stream_id, &topic_id, &group_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(group.map(PyConsumerGroupDetails::from))
         })
     }
@@ -507,7 +508,7 @@ impl IggyClient {
             let groups = inner
                 .get_consumer_groups(&stream_id, &topic_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(groups
                 .into_iter()
                 .map(PyConsumerGroup::from)
@@ -545,7 +546,7 @@ impl IggyClient {
             inner
                 .delete_consumer_group(&stream_id, &topic_id, &group_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -583,7 +584,7 @@ impl IggyClient {
             inner
                 .join_consumer_group(&stream_id, &topic_id, &group_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -623,7 +624,7 @@ impl IggyClient {
             inner
                 .leave_consumer_group(&stream_id, &topic_id, &group_id)
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -660,7 +661,7 @@ impl IggyClient {
             inner
                 .send_messages(&stream, &topic, &partitioning, messages.as_mut())
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(())
         })
     }
@@ -698,7 +699,7 @@ impl IggyClient {
                     auto_commit,
                 )
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             let messages = polled_messages
                 .messages
                 .into_iter()
@@ -759,7 +760,7 @@ impl IggyClient {
         let mut builder = self
             .inner
             .consumer_group(name, stream, topic)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?
+            .map_err(|e| into_pyerr(e))?
             .without_encryptor()
             .partition(partition_id);
 
@@ -792,12 +793,12 @@ impl IggyClient {
                 builder.polling_retry_interval(py_delta_to_iggy_duration(&polling_retry_interval))
         }
         if init_retries.is_some() && init_retry_interval.is_none() {
-            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
                 "'init_retry_interval' is required if 'init_retries' is set",
             ));
         }
         if init_retries.is_none() && init_retry_interval.is_some() {
-            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
                 "'init_retries' is required if 'init_retry_interval' is set",
             ));
         }
@@ -817,7 +818,7 @@ impl IggyClient {
             consumer
                 .init()
                 .await
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+                .map_err(|e| into_pyerr(e))?;
             Ok(IggyConsumer {
                 inner: Arc::new(Mutex::new(consumer)),
             })

--- a/foreign/python/src/error.rs
+++ b/foreign/python/src/error.rs
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use iggy::error::IggyError;
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+
+create_exception!(apache_iggy, PyIggyError, PyException);
+
+impl From<IggyError> for PyErr {
+    fn from(err: IggyError) -> Self {
+        let code = err.as_code() as u32;
+        let name = err.as_string().to_string();
+        let message = err.to_string();
+        PyIggyError::new_err((code, name, message))
+    }
+}
+
+pub fn into_pyerr(err: IggyError) -> PyErr {
+    err.into()
+}

--- a/foreign/python/src/lib.rs
+++ b/foreign/python/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod client;
 mod consumer;
+pub mod error;
 mod identifier;
 mod receive_message;
 mod send_message;
@@ -28,6 +29,7 @@ use consumer::{
     AutoCommit, AutoCommitAfter, AutoCommitWhen, ConsumerGroup, ConsumerGroupDetails,
     ConsumerGroupMember, IggyConsumer, ReceiveMessageIterator,
 };
+use error::PyIggyError;
 use pyo3::prelude::*;
 use receive_message::{PollingStrategy, ReceiveMessage};
 use send_message::SendMessage;
@@ -37,6 +39,7 @@ use topic::{Topic, TopicDetails};
 /// A Python module implemented in Rust.
 #[pymodule]
 fn apache_iggy(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("IggyError", _py.get_type::<PyIggyError>())?;
     m.add_class::<SendMessage>()?;
     m.add_class::<ReceiveMessage>()?;
     m.add_class::<IggyClient>()?;


### PR DESCRIPTION
## Description

Exposes a structured `apache_iggy.IggyError` exception in the Python SDK, replacing ad hoc `PyRuntimeError` mappings with a single `From<IggyError>` conversion.

### What changed

- **New file** `foreign/python/src/error.rs`: Defines `PyIggyError` (exported as `IggyError`) with `code`, `name`, and `message` attributes, and a `From<IggyError> for PyErr` implementation.
- **`lib.rs`**: Registers the `IggyError` exception in the pymodule.
- **`client.rs`**: Replaced all `PyErr::new::<PyRuntimeError, _>(e.to_string())` calls with `into_pyerr(e)`. Python-level validation errors (`init_retries`/`init_retry_interval` mismatch) changed to `PyValueError`.
- **`apache_iggy.pyi`**: Added `IggyError` class with type annotations.

### Python usage

```python
from apache_iggy import IggyError

try:
    await client.get_stream("nonexistent")
except IggyError as e:
    print(f"code={e.code}, name={e.name}, message={e.message}")
    # code=20, name=resource_not_found, message=Resource with key: nonexistent was not found.
```

### Attributes

| Attribute | Type | Description |
|-----------|------|-------------|
| `code` | `int` | Numeric error code matching the Rust `IggyError` discriminant |
| `name` | `str` | Stable `snake_case` identifier for the error variant |
| `message` | `str` | Human-readable error text |

`str(error) == error.message` is preserved.

Fixes #3618
