### PR TITLE
fix(go): complete TCP client teardown when conn.Close fails

### DIFF
--- a/foreign/go/client/tcp/tcp_core.go
+++ b/foreign/go/client/tcp/tcp_core.go
@@ -433,10 +433,18 @@ func (c *IggyTcpClient) sendLocked(wirePayload []byte) ([]byte, error) {
 
 // invalidateConnLocked closes the connection and marks it as disconnected
 func (c *IggyTcpClient) invalidateConnLocked() {
-	if c.conn != nil {
-		_ = c.conn.Close()
-	}
+	_ = c.closeConnLocked()
 	c.state = iggcon.StateDisconnected
+}
+
+// closeConnLocked closes and drops the current connection.
+func (c *IggyTcpClient) closeConnLocked() error {
+	if c.conn == nil {
+		return nil
+	}
+	err := c.conn.Close()
+	c.conn = nil
+	return err
 }
 
 func (c *IggyTcpClient) GetConnectionInfo() *iggcon.ConnectionInfo {
@@ -610,22 +618,17 @@ func (c *IggyTcpClient) disconnect() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	if c.state == iggcon.StateDisconnected {
+	if c.state == iggcon.StateDisconnected || c.state == iggcon.StateShutdown {
 		return nil
 	}
 
 	c.logger.Info("Iggy client is disconnecting from server...", slog.String("client_address", c.clientAddress))
 	c.state = iggcon.StateDisconnected
-
-	if c.conn != nil {
-		if err := c.conn.Close(); err != nil {
-			return err
-		}
-	}
+	err := c.closeConnLocked()
 
 	c.logger.Info("Iggy client has disconnected from server.", slog.String("client_address", c.clientAddress))
 	// TODO event pushing logic
-	return nil
+	return err
 }
 
 func (c *IggyTcpClient) shutdown() error {
@@ -638,16 +641,12 @@ func (c *IggyTcpClient) shutdown() error {
 
 	c.logger.Info("Shutting down the Iggy TCP client...", slog.String("client_address", c.clientAddress))
 
-	if c.conn != nil {
-		if err := c.conn.Close(); err != nil {
-			return err
-		}
-	}
-
+	err := c.closeConnLocked()
 	c.state = iggcon.StateShutdown
+
 	c.logger.Info("Iggy TCP client has been shutdown.", slog.String("client_address", c.clientAddress))
 	// TODO push shutdown event
-	return nil
+	return err
 }
 
 func (c *IggyTcpClient) Close() error {

--- a/foreign/go/client/tcp/tcp_core_test.go
+++ b/foreign/go/client/tcp/tcp_core_test.go
@@ -272,3 +272,60 @@ func TestNewIggyTcpClient_StoresProvidedLogger(t *testing.T) {
 		t.Errorf("expected logger output to contain 'source=tcp', got: %q", output)
 	}
 }
+
+var errCloseFailed = errors.New("close failed")
+
+// failingCloseConn is a connection whose Close always fails, standing in for a
+// socket whose teardown reports an error the client cannot act on.
+type failingCloseConn struct {
+	net.Conn
+	closes int
+}
+
+func (f *failingCloseConn) Close() error {
+	f.closes++
+	return errCloseFailed
+}
+
+func TestShutdown_FailedCloseStillCompletesTeardown(t *testing.T) {
+	c, _ := newTestClient(t)
+	conn := &failingCloseConn{Conn: c.conn}
+	c.conn = conn
+
+	if err := c.shutdown(); !errors.Is(err, errCloseFailed) {
+		t.Fatalf("got %v, want %v", err, errCloseFailed)
+	}
+	if c.state != iggcon.StateShutdown {
+		t.Errorf("expected state %v, got %v", iggcon.StateShutdown, c.state)
+	}
+	if c.conn != nil {
+		t.Error("expected the closed connection to be dropped")
+	}
+
+	if err := c.shutdown(); err != nil {
+		t.Errorf("expected the second shutdown to be a no-op, got %v", err)
+	}
+	if conn.closes != 1 {
+		t.Errorf("expected the connection to be closed once, got %d", conn.closes)
+	}
+}
+
+func TestDisconnect_ShutdownClientIsNotResurrected(t *testing.T) {
+	c, _ := newTestClient(t)
+
+	if err := c.shutdown(); err != nil {
+		t.Fatalf("unexpected shutdown error: %v", err)
+	}
+	if err := c.disconnect(); err != nil {
+		t.Fatalf("unexpected disconnect error: %v", err)
+	}
+
+	if c.state != iggcon.StateShutdown {
+		t.Errorf("expected state to stay %v, got %v", iggcon.StateShutdown, c.state)
+	}
+
+	_, err := c.sendWireAndFetchResponse(context.Background(), emptyWireReq)
+	if !errors.Is(err, ierror.ErrClientShutdown) {
+		t.Errorf("got %v, want %v", err, ierror.ErrClientShutdown)
+	}
+}


### PR DESCRIPTION
## Which issue does this PR address?

<!--
We generally require a GitHub issue for all bug fixes and enhancements. Link it with GitHub syntax, keep the line that applies and delete the other:
- `Closes #123` auto-closes the issue when this PR merges (full fix).
- `Relates to #123` links without closing (partial or related work).
-->
Relates to https://github.com/apache/iggy/pull/3652#discussion_r3568472401
Relates to https://github.com/apache/iggy/pull/3621#discussion_r3575236369
## Rationale

<!--
Why is this change needed? If the issue explains it well, a one-liner is fine.
-->

Golang SDK TCP client return the error directly when `c.conn.Close()` return an error. This stop it from finishing the disconnect and shutdown process.

## What changed?

<!--
2-4 sentences. Problem first (before), then solution (after).

GOOD:

"Messages were unavailable when background message_saver committed the
journal and started async disk I/O before completion. Polling during
this window found neither journal nor disk data.

The fix freezes journal batches in the in-flight buffer before async persist."

GOOD:

"When many small messages accumulate in the journal, the flush passes
thousands of IO vectors to writev(), exceeding IOV_MAX (1024 on Linux)."

BAD:
- Walls of text
- "This PR adds..." (we can see the diff)
-->


1. instead of return err directly, we keep the error, finish the process of shutdown/disconnect, return the error
2. when close the connection, set the `c.conn` to `nil`
3. In disconnect method, now we return nil directly when the status is shutdown too.(or caller can use disconnect->connect to revive a client that was shutdown before) 

## Local Execution

- Passed
- Pre-commit hooks ran 

<!--
You must run your code locally before submitting.
"Relying on CI" is not acceptable - PRs from authors who haven't run the code will be closed.

Did you have `prek` installed? It runs automatically on commit and covers all project languages. See [CONTRIBUTING.md](https://github.com/apache/iggy/blob/master/CONTRIBUTING.md).
-->


## AI Usage

<!--
If AI tools were used, please answer:
1. Which tools? (e.g., GitHub Copilot, Claude, ChatGPT)
5. Scope of usage? (e.g., autocomplete, generated functions, entire implementation)
6. How did you verify the generated code works correctly?
7. Can you explain every line of the code if asked?

If no AI tools were used, write "None" or delete this section.
-->
1. Claude Opus 4.8
2. implementaiton
3. Reviewed it
5. yes
