### PR TITLE
feat(server-ng): serve web UI, honor topic expiry default

### DIFF
--- a/core/configs/src/server_ng_config/validators.rs
+++ b/core/configs/src/server_ng_config/validators.rs
@@ -31,6 +31,7 @@ use crate::ConfigurationError;
 use err_trail::ErrContext;
 use iggy_common::{IggyExpiry, MaxTopicSize, Validatable};
 use server_common::sharding::IggyNamespace;
+use tracing::warn;
 
 impl Validatable<ConfigurationError> for ServerNgConfig {
     fn validate(&self) -> Result<(), ConfigurationError> {
@@ -105,6 +106,17 @@ impl Validatable<ConfigurationError> for ServerNgConfig {
             return Err(ConfigurationError::InvalidConfigurationValue);
         }
 
+        // A zero duration encodes to wire value 0, the same value the wire uses
+        // for ServerDefault, so it would silently collide with that sentinel.
+        if let IggyExpiry::ExpireDuration(duration) = self.system.topic.message_expiry
+            && duration.as_micros() == 0
+        {
+            eprintln!(
+                "system.topic.message_expiry is a zero duration, which collides with the server-default sentinel on the wire; use \"none\" to never expire or a positive duration"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
         if self.http.enabled
             && let IggyExpiry::ServerDefault = self.http.jwt.access_token_expiry
         {
@@ -131,8 +143,98 @@ impl Validatable<ConfigurationError> for ServerNgConfig {
             format!("{COMPONENT_NG} (error: {e}) - failed to validate quic config")
         })?;
 
+        reject_unsupported_and_warn_inert(self)?;
+
         Ok(())
     }
+}
+
+/// server-ng parses the whole legacy config surface but does not yet honor
+/// every knob. Make the still-inert ones loud at boot: reject the unsupported
+/// features (all off by default, so only a deliberate opt-in trips this) and
+/// warn once for tuning knobs server-ng silently ignores. Warnings fire only
+/// when a knob deviates from its [`ServerNgConfig::default`] baseline, so a
+/// pristine config.toml boots without noise. Baseline caveat: only the tcp/quic
+/// fork sections take that default from the ng config.toml. The reused legacy
+/// sections (`system.*`, `consumer_group.*`, `message_saver.*`) take theirs from
+/// the legacy server config.toml; those match ng's shipped values today but are
+/// not schema-locked, so editing such a knob in the ng config.toml could surface
+/// a spurious warn. The guard test below pins the compared knobs against drift.
+fn reject_unsupported_and_warn_inert(config: &ServerNgConfig) -> Result<(), ConfigurationError> {
+    if config.system.message_deduplication.enabled {
+        eprintln!("system.message_deduplication.enabled is not supported in server-ng");
+        return Err(ConfigurationError::InvalidConfigurationValue);
+    }
+    if config.system.segment.archive_expired {
+        eprintln!("system.segment.archive_expired is not supported in server-ng");
+        return Err(ConfigurationError::InvalidConfigurationValue);
+    }
+    if config.system.recovery.recreate_missing_state {
+        eprintln!("system.recovery.recreate_missing_state is not supported in server-ng");
+        return Err(ConfigurationError::InvalidConfigurationValue);
+    }
+
+    let defaults = ServerNgConfig::default();
+
+    if config.tcp.socket.override_defaults {
+        warn!("tcp.socket tuning is set but not applied in server-ng");
+    }
+    if config.quic.socket.override_defaults {
+        warn!("quic.socket tuning is set but not applied in server-ng");
+    }
+    if config.tcp.ipv6 {
+        warn!(
+            "tcp.ipv6 is ignored in server-ng; IPv4 vs IPv6 is decided by the tcp.address string"
+        );
+    }
+    if config.tcp.socket_migration != defaults.tcp.socket_migration {
+        warn!("tcp.socket_migration is not implemented in server-ng");
+    }
+    if config.system.segment.cache_indexes != defaults.system.segment.cache_indexes {
+        warn!("system.segment.cache_indexes is not applied in server-ng");
+    }
+    if config.system.logging.sysinfo_print_interval
+        != defaults.system.logging.sysinfo_print_interval
+    {
+        warn!("system.logging.sysinfo_print_interval is not applied in server-ng");
+    }
+    if config.system.backup.path != defaults.system.backup.path
+        || config.system.backup.compatibility.path != defaults.system.backup.compatibility.path
+    {
+        warn!("backup is not supported in server-ng");
+    }
+    // default_algorithm deviation is already warned by the delegated legacy
+    // CompressionConfig::validate; only allow_override needs a signal here.
+    if config.system.compression.allow_override != defaults.system.compression.allow_override {
+        warn!(
+            "system.compression.allow_override is inert in server-ng; live compression is per-topic from the request"
+        );
+    }
+    if config.system.state.enforce_fsync != defaults.system.state.enforce_fsync
+        || config.system.state.max_file_operation_retries
+            != defaults.system.state.max_file_operation_retries
+        || config.system.state.retry_delay != defaults.system.state.retry_delay
+    {
+        warn!(
+            "system.state tuning (enforce_fsync, max_file_operation_retries, retry_delay) is not applied in server-ng"
+        );
+    }
+    if config.consumer_group.rebalancing_check_interval
+        != defaults.consumer_group.rebalancing_check_interval
+    {
+        warn!(
+            "consumer_group.rebalancing_check_interval is not applied in server-ng; rebalancing cadence uses system.sharding.reconcile_periodic_interval"
+        );
+    }
+    if config.message_saver.interval != defaults.message_saver.interval
+        || config.message_saver.enforce_fsync != defaults.message_saver.enforce_fsync
+    {
+        warn!(
+            "periodic message_saver is not implemented in server-ng; only shutdown-flush is active"
+        );
+    }
+
+    Ok(())
 }
 
 impl Validatable<ConfigurationError> for ExtraConfig {
@@ -152,5 +254,123 @@ impl Validatable<ConfigurationError> for NamespaceConfig {
                 ConfigurationError::InvalidConfigurationValue
             })?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use figment::Figment;
+    use figment::providers::{Format, Toml};
+
+    const DEFAULT_CONFIG: &str = include_str!("../../../server-ng/config.toml");
+
+    /// Deep-merge a partial override over the shipped default, mirroring the
+    /// file-over-embedded layering the runtime loader performs.
+    fn config_with_override(override_toml: &str) -> ServerNgConfig {
+        Figment::new()
+            .merge(Toml::string(DEFAULT_CONFIG))
+            .merge(Toml::string(override_toml))
+            .extract()
+            .expect("config deserializes")
+    }
+
+    #[test]
+    fn given_shipped_default_config_when_validating_should_pass() {
+        let config: ServerNgConfig = Figment::new()
+            .merge(Toml::string(DEFAULT_CONFIG))
+            .extract()
+            .expect("default config deserializes");
+        config
+            .validate()
+            .expect("pristine server-ng config must validate");
+    }
+
+    #[test]
+    fn given_message_deduplication_enabled_when_validating_should_reject() {
+        let config = config_with_override("[system.message_deduplication]\nenabled = true\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_web_ui_enabled_when_validating_should_pass() {
+        let config = config_with_override("[http]\nweb_ui = true\n");
+        config
+            .validate()
+            .expect("web_ui is now served by server-ng and must validate");
+    }
+
+    #[test]
+    fn given_archive_expired_enabled_when_validating_should_reject() {
+        let config = config_with_override("[system.segment]\narchive_expired = true\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_recreate_missing_state_enabled_when_validating_should_reject() {
+        let config = config_with_override("[system.recovery]\nrecreate_missing_state = true\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_zero_message_expiry_when_validating_should_reject() {
+        let config = config_with_override("[system.topic]\nmessage_expiry = \"0s\"\n");
+        assert!(config.validate().is_err());
+    }
+
+    /// The warn-helper baseline is [`ServerNgConfig::default`], but the reused
+    /// legacy sections source that default from the legacy server config.toml,
+    /// not this NG file. Pin the knobs the helper compares so any drift between
+    /// the two config.toml files fails here instead of as a spurious boot warn.
+    #[test]
+    fn given_shipped_ng_config_when_compared_to_default_should_match_warned_knobs() {
+        let shipped: ServerNgConfig = Figment::new()
+            .merge(Toml::string(DEFAULT_CONFIG))
+            .extract()
+            .expect("default config deserializes");
+        let defaults = ServerNgConfig::default();
+
+        assert_eq!(shipped.tcp.socket_migration, defaults.tcp.socket_migration);
+        assert_eq!(
+            shipped.system.segment.cache_indexes,
+            defaults.system.segment.cache_indexes
+        );
+        assert_eq!(
+            shipped.system.logging.sysinfo_print_interval,
+            defaults.system.logging.sysinfo_print_interval
+        );
+        assert_eq!(shipped.system.backup.path, defaults.system.backup.path);
+        assert_eq!(
+            shipped.system.backup.compatibility.path,
+            defaults.system.backup.compatibility.path
+        );
+        assert_eq!(
+            shipped.system.compression.allow_override,
+            defaults.system.compression.allow_override
+        );
+        assert_eq!(
+            shipped.system.state.enforce_fsync,
+            defaults.system.state.enforce_fsync
+        );
+        assert_eq!(
+            shipped.system.state.max_file_operation_retries,
+            defaults.system.state.max_file_operation_retries
+        );
+        assert_eq!(
+            shipped.system.state.retry_delay,
+            defaults.system.state.retry_delay
+        );
+        assert_eq!(
+            shipped.consumer_group.rebalancing_check_interval,
+            defaults.consumer_group.rebalancing_check_interval
+        );
+        assert_eq!(
+            shipped.message_saver.interval,
+            defaults.message_saver.interval
+        );
+        assert_eq!(
+            shipped.message_saver.enforce_fsync,
+            defaults.message_saver.enforce_fsync
+        );
     }
 }

--- a/core/metadata/src/impls/metadata.rs
+++ b/core/metadata/src/impls/metadata.rs
@@ -391,6 +391,11 @@ pub struct IggyMetadata<C, J, S, M> {
     /// server config at bootstrap ([`Self::set_default_max_topic_size`]);
     /// defaults to unlimited, matching the shipped server config.
     default_max_topic_size: Cell<u64>,
+    /// Resolved micros value for `IggyExpiry::ServerDefault` (`0` on the wire).
+    /// Same admission-time sentinel resolution as [`Self::default_max_topic_size`];
+    /// set from server config at bootstrap ([`Self::set_default_message_expiry`]).
+    /// Defaults to never-expire, matching the shipped server config.
+    default_message_expiry: Cell<u64>,
 }
 
 impl<C, J, S, M> IggyMetadata<C, J, S, M>
@@ -422,6 +427,7 @@ where
             client_table: RefCell::new(ClientTable::new(CLIENTS_TABLE_MAX)),
             commit_notifier: RefCell::new(None),
             default_max_topic_size: Cell::new(u64::MAX),
+            default_message_expiry: Cell::new(u64::MAX),
         }
     }
 }
@@ -445,6 +451,19 @@ impl<C, J, S, M> IggyMetadata<C, J, S, M> {
     #[must_use]
     pub const fn default_max_topic_size(&self) -> u64 {
         self.default_max_topic_size.get()
+    }
+
+    /// Install the resolved micros value used for `IggyExpiry::ServerDefault`.
+    /// Server-ng bootstrap calls this with `system.topic.message_expiry` on every
+    /// shard (responses read it too); only shard 0's copy feeds admission.
+    pub fn set_default_message_expiry(&self, message_expiry_micros: u64) {
+        self.default_message_expiry.set(message_expiry_micros);
+    }
+
+    /// Resolved micros value for `IggyExpiry::ServerDefault`.
+    #[must_use]
+    pub const fn default_message_expiry(&self) -> u64 {
+        self.default_message_expiry.get()
     }
 
     /// Fire post-commit notifier. Clones the `Rc` out under a short
@@ -1775,6 +1794,9 @@ where
                 if request.max_topic_size == 0 {
                     request.max_topic_size = self.default_max_topic_size.get();
                 }
+                if request.message_expiry == 0 {
+                    request.message_expiry = self.default_message_expiry.get();
+                }
                 let partitions = self
                     .allocator
                     .allocate_many(request.partitions_count as usize)
@@ -1836,9 +1858,17 @@ where
             Operation::UpdateTopic => {
                 let mut request = WireUpdateTopicRequest::decode_from(body)
                     .map_err(|_| IggyError::InvalidCommand)?;
+                // Same `ServerDefault` resolution as `CreateTopic` above; rebuild
+                // the prepare only if a sentinel actually needs stamping, else
+                // project the untouched buffer zero-copy.
+                let needs_rewrite = request.max_topic_size == 0 || request.message_expiry == 0;
                 if request.max_topic_size == 0 {
-                    // Same `ServerDefault` resolution as `CreateTopic` above.
                     request.max_topic_size = self.default_max_topic_size.get();
+                }
+                if request.message_expiry == 0 {
+                    request.message_expiry = self.default_message_expiry.get();
+                }
+                if needs_rewrite {
                     let body = request.to_bytes();
                     return Ok(build_prepare_message(
                         consensus,
@@ -2614,6 +2644,38 @@ mod tests {
             prepare.header().user_id,
             ACTING_USER,
             "prepare must carry the ClientTable identity, not the wire value"
+        );
+    }
+
+    #[test]
+    fn prepare_request_stamps_create_topic_message_expiry_default() {
+        // A `CreateTopic` carrying the `ServerDefault` sentinel (0) must be
+        // rewritten at primary admission to the configured default, so the
+        // replicated prepare -- and thus every replica's commit -- holds a
+        // concrete expiry. Mirrors the `max_topic_size` sentinel resolution.
+        const CLIENT: u128 = 1;
+        const SESSION: u64 = 10;
+        const ACTING_USER: u32 = 7;
+        const CONFIGURED_EXPIRY_MICROS: u64 = 7_200_000_000;
+        let plane = metadata_plane();
+        plane.set_default_message_expiry(CONFIGURED_EXPIRY_MICROS);
+        plane.client_table.borrow_mut().commit_register(
+            CLIENT,
+            ACTING_USER,
+            register_reply(CLIENT, SESSION),
+            |_| false,
+        );
+
+        // `create_topic_request` builds the body with `message_expiry == 0`.
+        let prepare = plane
+            .prepare_request(create_topic_request(CLIENT, ACTING_USER))
+            .expect("CreateTopic is client-allowed");
+        let body = &prepare.as_slice()[size_of::<PrepareHeader>()..prepare.header().size as usize];
+        let persisted = PersistedCreateTopicRequest::decode_from(body)
+            .expect("create topic with assignments prepare must decode");
+        assert_eq!(
+            persisted.request.message_expiry, CONFIGURED_EXPIRY_MICROS,
+            "ServerDefault expiry must be stamped to the configured default at admission"
         );
     }
 }

--- a/core/server-ng/config.toml
+++ b/core/server-ng/config.toml
@@ -518,6 +518,7 @@ size_of_messages_required_to_save = "1 MiB"
 size = "1 GiB"
 
 # Configures whether expired segments are archived (boolean) or just deleted without archiving.
+# Unsupported in server-ng: setting this to `true` aborts boot.
 archive_expired = false
 
 # Controls whether to cache indexes (time and positional) for segment access.
@@ -532,6 +533,7 @@ cache_indexes = "open_segment"
 # Controls whether message deduplication is enabled (boolean).
 # `true` activates deduplication, ignoring messages with duplicate IDs.
 # `false` treats each message as unique, even if IDs are duplicated.
+# Unsupported in server-ng: setting this to `true` aborts boot.
 enabled = false
 # Maximum number of ID entries in the deduplication cache (u64).
 max_entries = 10000
@@ -541,6 +543,7 @@ expiry = "1 m"
 # Recovery configuration in case of lost data
 [system.recovery]
 # Controls whether streams/topics/partitions should be recreated if the expected data for existing state is missing (boolean).
+# Unsupported in server-ng: setting this to `true` aborts boot.
 recreate_missing_state = false
 
 # Memory pool configuration

--- a/core/server-ng/src/bootstrap.rs
+++ b/core/server-ng/src/bootstrap.rs
@@ -886,9 +886,10 @@ async fn shard_main(
         mux_stm,
         Some(PathBuf::from(&config.system.path)),
     );
-    // Shard 0's copy resolves the `MaxTopicSize::ServerDefault` sentinel at
-    // admission; every shard's copy backs the same resolution in responses.
+    // Shard 0's copy resolves the `ServerDefault` sentinels (max topic size and
+    // message expiry) at admission; every shard's copy backs the same resolution in responses.
     metadata.set_default_max_topic_size(config.system.topic.max_size.as_bytes_u64());
+    metadata.set_default_message_expiry(u64::from(config.system.topic.message_expiry));
 
     let shard_metrics = ShardMetrics::for_shard();
     // Notifier install deferred until after tick handler wires below.

--- a/core/server-ng/src/http.rs
+++ b/core/server-ng/src/http.rs
@@ -133,7 +133,7 @@ pub async fn start(
     // >4 GiB value) clamps to the largest enforceable cap instead of wrapping.
     let max_request_size =
         usize::try_from(http_config.max_request_size.as_bytes_u64()).unwrap_or(usize::MAX);
-    let router = router(state, max_request_size, cors);
+    let router = router(state, max_request_size, cors, http_config.web_ui);
 
     let shutdown = shard.bus.token();
     let handle = compio::runtime::spawn(async move {
@@ -169,7 +169,12 @@ const PING_PATH: &str = "/ping";
 /// 405 if it reached the router; the outermost `CorsLayer` answers it first
 /// instead, and stamps the CORS response headers over every reply, including
 /// the inner layer's `x-iggy-view`.
-fn router(state: HttpState, max_request_size: usize, cors: Option<CorsLayer>) -> Router {
+fn router(
+    state: HttpState,
+    max_request_size: usize,
+    cors: Option<CorsLayer>,
+    web_ui: bool,
+) -> Router {
     // Cloned for the response layer so `X-Iggy-View` reads the live view per
     // response; the original `state` is moved into `with_state` below.
     let view_source = state.clone();
@@ -263,10 +268,42 @@ fn router(state: HttpState, max_request_size: usize, cors: Option<CorsLayer>) ->
                 }
             }
         }));
-    match cors {
+    let router = match cors {
         Some(cors) => router.layer(cors),
         None => router,
+    };
+
+    merge_web_ui(router, web_ui)
+}
+
+/// Merge the unauthenticated `/ui` static-asset surface when `web_ui` is set.
+///
+/// The caller merges this outermost - after `with_state`, the body limit, the
+/// view-header layer, and CORS - mirroring the legacy server. Staying past the
+/// view-header layer also keeps the cluster-internal view number off these
+/// unauthenticated responses, the same anon-leak gate `/ping` gets above.
+///
+/// Without the `iggy-web` feature the assets are not compiled in, so an enabled
+/// flag only warns instead of serving.
+fn merge_web_ui(router: Router, web_ui: bool) -> Router {
+    #[cfg(feature = "iggy-web")]
+    let router = if web_ui {
+        info!("Web UI enabled at /ui");
+        router.merge(crate::web::router())
+    } else {
+        router
+    };
+
+    #[cfg(not(feature = "iggy-web"))]
+    if web_ui {
+        tracing::warn!(
+            "Web UI is enabled in configuration (http.web_ui = true) but the server \
+             was not compiled with 'iggy-web' feature. The Web UI will not be available. \
+             To enable it, rebuild the server with: cargo build --features iggy-web"
+        );
     }
+
+    router
 }
 
 /// Build the [`CorsLayer`] from `[http.cors]`, porting the legacy server's

--- a/core/server-ng/src/lib.rs
+++ b/core/server-ng/src/lib.rs
@@ -42,4 +42,6 @@ pub mod server_error;
 pub mod session_manager;
 pub(crate) mod snapshot;
 pub mod users;
+#[cfg(feature = "iggy-web")]
+pub(crate) mod web;
 pub mod wire;

--- a/core/server-ng/src/responses.rs
+++ b/core/server-ng/src/responses.rs
@@ -77,7 +77,7 @@ use iggy_binary_protocol::{
     Command2, GenericHeader, IGGY_PROTOCOL_VERSION, KIND_CONSUMER_GROUP, Operation, ReplyHeader,
     RequestHeader, WireDecode, WireEncode, WireIdentifier, WireName, WirePartitioning,
 };
-use iggy_common::{EncryptorKind, Identifier, IggyError, IggyTimestamp, MaxTopicSize};
+use iggy_common::{EncryptorKind, Identifier, IggyError, IggyExpiry, IggyTimestamp, MaxTopicSize};
 use metadata::impls::metadata::StreamsFrontend;
 use partitions::PollFragments;
 use server_common::Message;
@@ -761,6 +761,7 @@ fn build_get_stream_response(
     stream_id: &WireIdentifier,
 ) -> Result<Option<GetStreamResponse>, IggyError> {
     let default_max_topic_size = shard.plane.metadata().default_max_topic_size();
+    let default_message_expiry = shard.plane.metadata().default_message_expiry();
     shard.plane.metadata().mux_stm.streams().read(|streams| {
         let Some(stream_id) = resolve_stream_id(streams, stream_id) else {
             return Ok(None);
@@ -774,7 +775,9 @@ fn build_get_stream_response(
             topics: stream
                 .topics
                 .iter()
-                .map(|(_, topic)| topic_header(topic, default_max_topic_size))
+                .map(|(_, topic)| {
+                    topic_header(topic, default_max_topic_size, default_message_expiry)
+                })
                 .collect::<Result<Vec<_>, _>>()?,
         }))
     })
@@ -861,6 +864,7 @@ fn build_get_topic_response(
     topic_id: &WireIdentifier,
 ) -> Result<Option<GetTopicResponse>, IggyError> {
     let default_max_topic_size = shard.plane.metadata().default_max_topic_size();
+    let default_message_expiry = shard.plane.metadata().default_message_expiry();
     shard.plane.metadata().mux_stm.streams().read(|streams| {
         let Some(stream_id) = resolve_stream_id(streams, stream_id) else {
             return Ok(None);
@@ -877,7 +881,7 @@ fn build_get_topic_response(
             .get(topic_id)
             .ok_or(IggyError::InvalidIdentifier)?;
         Ok(Some(GetTopicResponse {
-            topic: topic_header(topic, default_max_topic_size)?,
+            topic: topic_header(topic, default_max_topic_size, default_message_expiry)?,
             partitions: topic
                 .partitions
                 .iter()
@@ -892,6 +896,7 @@ fn build_get_topics_response(
     stream_id: &WireIdentifier,
 ) -> Result<GetTopicsResponse, IggyError> {
     let default_max_topic_size = shard.plane.metadata().default_max_topic_size();
+    let default_message_expiry = shard.plane.metadata().default_message_expiry();
     shard.plane.metadata().mux_stm.streams().read(|streams| {
         let resolved_stream =
             resolve_stream_id(streams, stream_id).ok_or_else(|| stream_not_found(stream_id))?;
@@ -902,7 +907,7 @@ fn build_get_topics_response(
         stream
             .topics
             .iter()
-            .map(|(_, topic)| topic_header(topic, default_max_topic_size))
+            .map(|(_, topic)| topic_header(topic, default_max_topic_size, default_message_expiry))
             .collect::<Result<Vec<_>, _>>()
             .map(|topics| GetTopicsResponse { topics })
     })
@@ -1004,15 +1009,31 @@ fn resolve_max_topic_size(max_topic_size: MaxTopicSize, default_bytes: u64) -> u
     }
 }
 
+/// Resolve a topic's stored [`IggyExpiry`] to the wire micros value, mapping the
+/// `ServerDefault` sentinel to this node's configured default. Mirrors
+/// [`resolve_max_topic_size`]: replicated apply stores the sentinel verbatim so
+/// commit stays config-independent across a cluster, and the per-node default is
+/// applied here on read. Primary admission stamps the same default before
+/// replication, so this only bites topics whose stored expiry predates that
+/// stamping (older snapshot / WAL data). Explicit durations and never-expire pass
+/// through.
+fn resolve_message_expiry(message_expiry: IggyExpiry, default_micros: u64) -> u64 {
+    match message_expiry {
+        IggyExpiry::ServerDefault => default_micros,
+        resolved => u64::from(resolved),
+    }
+}
+
 fn topic_header(
     topic: &metadata::stm::stream::Topic,
     default_max_topic_size: u64,
+    default_message_expiry: u64,
 ) -> Result<StreamTopicHeader, IggyError> {
     Ok(StreamTopicHeader {
         id: usize_to_u32(topic.id)?,
         created_at: topic.created_at.as_micros(),
         partitions_count: usize_to_u32(topic.partitions.len())?,
-        message_expiry: u64::from(topic.message_expiry),
+        message_expiry: resolve_message_expiry(topic.message_expiry, default_message_expiry),
         compression_algorithm: topic.compression_algorithm.as_code(),
         max_topic_size: resolve_max_topic_size(topic.max_topic_size, default_max_topic_size),
         replication_factor: topic.replication_factor,
@@ -1549,19 +1570,22 @@ mod tests {
     }
 
     #[test]
-    fn topic_header_resolves_server_default_and_passes_explicit_sizes_through() {
-        use iggy_common::{CompressionAlgorithm, IggyExpiry, StreamStats, TopicStats};
+    fn topic_header_resolves_server_default_and_passes_explicit_values_through() {
+        use iggy_common::{
+            CompressionAlgorithm, IggyDuration, IggyExpiry, StreamStats, TopicStats,
+        };
         use std::sync::atomic::AtomicUsize;
 
         const NODE_DEFAULT: u64 = 4 * 1024 * 1024 * 1024;
+        const EXPIRY_DEFAULT_MICROS: u64 = 3_600_000_000;
 
         let parent = Arc::new(StreamStats::default());
-        let topic_with = |max_topic_size| metadata::stm::stream::Topic {
+        let topic_with = |max_topic_size, message_expiry| metadata::stm::stream::Topic {
             id: 0,
             name: Arc::from("topic"),
             created_at: IggyTimestamp::from(1u64),
             replication_factor: 1,
-            message_expiry: IggyExpiry::NeverExpire,
+            message_expiry,
             compression_algorithm: CompressionAlgorithm::None,
             max_topic_size,
             stats: Arc::new(TopicStats::new(parent.clone())),
@@ -1573,17 +1597,36 @@ mod tests {
         };
 
         // ServerDefault (0 on the wire) resolves to this node's configured
-        // default, not the raw 0 the pre-fix read path echoed.
-        let resolved = topic_header(&topic_with(MaxTopicSize::ServerDefault), NODE_DEFAULT)
-            .expect("topic header builds");
+        // default for both size and expiry, not the raw 0 the pre-fix read path
+        // echoed.
+        let resolved = topic_header(
+            &topic_with(MaxTopicSize::ServerDefault, IggyExpiry::ServerDefault),
+            NODE_DEFAULT,
+            EXPIRY_DEFAULT_MICROS,
+        )
+        .expect("topic header builds");
         assert_eq!(resolved.max_topic_size, NODE_DEFAULT);
+        assert_eq!(resolved.message_expiry, EXPIRY_DEFAULT_MICROS);
 
-        // Explicit sizes round-trip unchanged, independent of the node default.
-        let custom = topic_header(&topic_with(MaxTopicSize::from(1024u64)), NODE_DEFAULT)
-            .expect("topic header builds");
+        // Explicit values round-trip unchanged, independent of the node default.
+        let custom = topic_header(
+            &topic_with(
+                MaxTopicSize::from(1024u64),
+                IggyExpiry::ExpireDuration(IggyDuration::from(5_000_000u64)),
+            ),
+            NODE_DEFAULT,
+            EXPIRY_DEFAULT_MICROS,
+        )
+        .expect("topic header builds");
         assert_eq!(custom.max_topic_size, 1024);
-        let unlimited = topic_header(&topic_with(MaxTopicSize::Unlimited), NODE_DEFAULT)
-            .expect("topic header builds");
+        assert_eq!(custom.message_expiry, 5_000_000);
+        let unlimited = topic_header(
+            &topic_with(MaxTopicSize::Unlimited, IggyExpiry::NeverExpire),
+            NODE_DEFAULT,
+            EXPIRY_DEFAULT_MICROS,
+        )
+        .expect("topic header builds");
         assert_eq!(unlimited.max_topic_size, u64::MAX);
+        assert_eq!(unlimited.message_expiry, u64::MAX);
     }
 }

--- a/core/server-ng/src/web.rs
+++ b/core/server-ng/src/web.rs
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::Path;
+use axum::http::{Response, StatusCode, header};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use rust_embed::{Embed, EmbeddedFile};
+
+#[derive(Embed)]
+#[folder = "../../web/build/static/"]
+#[allow_missing = true]
+struct WebAssets;
+
+impl WebAssets {
+    fn get_file(path: &str) -> Option<EmbeddedFile> {
+        <Self as Embed>::get(path)
+    }
+}
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/ui/{*wildcard}", get(serve_web_asset))
+        .route("/ui", get(serve_index))
+        .route("/ui/", get(serve_index))
+}
+
+async fn serve_index() -> impl IntoResponse {
+    serve_file("index.html")
+}
+
+async fn serve_web_asset(Path(wildcard): Path<String>) -> impl IntoResponse {
+    if let Some(response) = try_serve_file(&wildcard) {
+        return response;
+    }
+
+    if !wildcard.contains('.') {
+        return serve_file("index.html");
+    }
+
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::from("Not Found"))
+        .unwrap()
+}
+
+fn try_serve_file(path: &str) -> Option<Response<Body>> {
+    let asset = WebAssets::get_file(path)?;
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+
+    Some(
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, mime.as_ref())
+            .body(Body::from(asset.data.into_owned()))
+            .unwrap(),
+    )
+}
+
+fn serve_file(path: &str) -> Response<Body> {
+    try_serve_file(path).unwrap_or_else(|| {
+        Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::from("Not Found"))
+            .unwrap()
+    })
+}


### PR DESCRIPTION
server-ng parses the full legacy config surface but silently
ignored a large subset at runtime: an operator set a knob and
nothing happened, with no error or warning. Address the whole
set - honor it, or fail loud.

Serve the embedded Web UI at /ui when http.web_ui is enabled,
porting the legacy rust-embed handler (assets baked in from
web/build/static). server-ng previously rejected the flag at
boot. The UI is served unauthenticated - a login shell must
load before a token exists - and outside the view-header layer
so anonymous requests do not leak the cluster view number.

Honor system.topic.message_expiry: topics created with the
ServerDefault sentinel kept it unresolved, which the segment
cleaner treats as never-expire, so a server-wide retention
setting produced unbounded disk growth on SDK-default topics.
Store the default in a metadata cell at boot and rewrite the
sentinel to the concrete value at primary admission, mirroring
the existing max_topic_size path.

For knobs server-ng still does not implement, turn the silent
ignore into a loud boot failure: reject message deduplication,
segment archive_expired, and recovery.recreate_missing_state
when enabled, and warn when an inert tuning knob is set away
from its default.
