### PR TITLE
feat(cli): support vsr and enable the CLI suite under server-ng

### DIFF
--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -51,6 +51,7 @@ login-session = [
     "dep:apple-native-keyring-store",
     "dep:windows-native-keyring-store",
 ]
+vsr = ["iggy/vsr"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/core/cli/src/commands/binary_system/login.rs
+++ b/core/cli/src/commands/binary_system/login.rs
@@ -22,9 +22,21 @@ use anyhow::Context;
 use async_trait::async_trait;
 use iggy_common::Client;
 use iggy_common::SEC_IN_MICRO;
+use iggy_common::{IggyTimestamp, PersonalAccessTokenInfo};
 use tracing::{Level, event};
 
 const DEFAULT_LOGIN_SESSION_TIMEOUT: u64 = SEC_IN_MICRO * 15 * 60;
+
+/// A stored login session is dead once the server-side PAT backing it is gone
+/// or past its expiry. The server lists expired tokens until a background
+/// cleaner prunes them, so a freshly expired session is caught here rather than
+/// waiting for the token to disappear from the listing.
+fn session_pat_expired(pat: &PersonalAccessTokenInfo) -> bool {
+    match pat.expiry_at {
+        None => false,
+        Some(expiry) => expiry.as_micros() <= IggyTimestamp::now().as_micros(),
+    }
+}
 
 pub struct LoginCmd {
     server_session: ServerSession,
@@ -46,12 +58,11 @@ impl CliCommand for LoginCmd {
         "login command".to_owned()
     }
 
-    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
-        if self.server_session.is_active() {
-            event!(target: PRINT_TARGET, Level::INFO, "Already logged into Iggy server {}", self.server_session.get_server_address());
-            return Ok(());
-        }
+    fn prefer_explicit_credentials(&self) -> bool {
+        true
+    }
 
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
         let tokens = client.get_personal_access_tokens().await.with_context(|| {
             format!(
                 "Problem getting personal access tokens from server: {}",
@@ -59,13 +70,26 @@ impl CliCommand for LoginCmd {
             )
         })?;
 
-        // If local keyring is empty and server has the token for login session, then something
-        // went wrong, and we should delete the token from the server and recreate login session
-        // from scratch - token on the server and local keyring should be in sync.
-        if let Some(token) = tokens
+        let server_token = tokens
             .iter()
-            .find(|pat| pat.name == self.server_session.get_token_name())
-        {
+            .find(|pat| pat.name == self.server_session.get_token_name());
+
+        // A local keyring entry proves a token was stored once, not that it
+        // still authenticates. Report "already logged in" only when the server
+        // still holds a matching, unexpired PAT; a keyring entry left behind by
+        // an expired session is dropped so login recreates it below.
+        if self.server_session.is_active() {
+            if server_token.is_some_and(|pat| !session_pat_expired(pat)) {
+                event!(target: PRINT_TARGET, Level::INFO, "Already logged into Iggy server {}", self.server_session.get_server_address());
+                return Ok(());
+            }
+            self.server_session.delete()?;
+        }
+
+        // Local keyring is empty (or was just cleared for a dead session). If the
+        // server still has the token for the login session, delete it so token on
+        // the server and local keyring stay in sync, then recreate from scratch.
+        if let Some(token) = server_token {
             client
                 .delete_personal_access_token(&token.name)
                 .await

--- a/core/cli/src/commands/cli_command.rs
+++ b/core/cli/src/commands/cli_command.rs
@@ -33,5 +33,13 @@ pub trait CliCommand {
     fn connection_required(&self) -> bool {
         true
     }
+    /// Whether explicitly supplied credentials take precedence over a cached
+    /// login-session token. `iggy login` (re)establishes that session, so it
+    /// must authenticate with the provided username/password and can recreate
+    /// the session even after the cached token expired. Every other command
+    /// keeps reusing the cached token so users need not re-enter credentials.
+    fn prefer_explicit_credentials(&self) -> bool {
+        false
+    }
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error>;
 }

--- a/core/cli/src/credentials.rs
+++ b/core/cli/src/credentials.rs
@@ -60,6 +60,7 @@ impl<'a> IggyCredentials<'a> {
         cli_options: &CliOptions,
         iggy_args: &Args,
         login_required: bool,
+        prefer_explicit_credentials: bool,
     ) -> anyhow::Result<Self, anyhow::Error> {
         if !login_required {
             return Ok(Self {
@@ -69,18 +70,25 @@ impl<'a> IggyCredentials<'a> {
             });
         }
 
-        if let Some(server_address) = iggy_args.get_server_address() {
-            let server_session = ServerSession::new(server_address.clone());
-            if let Some(token) = server_session.get_token() {
-                return Ok(Self {
-                    credentials: Some(Credentials::SessionWithToken(
-                        SecretString::from(token),
-                        server_address,
-                    )),
-                    iggy_client: None,
-                    login_required,
-                });
-            }
+        let session_credentials = || -> Option<Credentials> {
+            let server_address = iggy_args.get_server_address()?;
+            let token = ServerSession::new(server_address.clone()).get_token()?;
+            Some(Credentials::SessionWithToken(
+                SecretString::from(token),
+                server_address,
+            ))
+        };
+
+        // Non-login commands reuse the cached session token first. `iggy login`
+        // sets `prefer_explicit_credentials` so freshly supplied credentials win
+        // over a possibly-expired cached token; it falls back to the cached
+        // token below only when no explicit credentials were provided.
+        if !prefer_explicit_credentials && let Some(credentials) = session_credentials() {
+            return Ok(Self {
+                credentials: Some(credentials),
+                iggy_client: None,
+                login_required,
+            });
         }
 
         #[cfg(feature = "login-session")]
@@ -143,6 +151,15 @@ impl<'a> IggyCredentials<'a> {
                     username: var(ENV_IGGY_USERNAME)?,
                     password: SecretString::from(var(ENV_IGGY_PASSWORD)?),
                 })),
+                iggy_client: None,
+                login_required,
+            })
+        } else if let Some(credentials) = session_credentials() {
+            // `iggy login` with no explicit credentials: reuse the cached
+            // session token so a still-valid session reports "already logged in"
+            // instead of demanding credentials for a no-op.
+            Ok(Self {
+                credentials: Some(credentials),
                 iggy_client: None,
                 login_required,
             })

--- a/core/cli/src/main.rs
+++ b/core/cli/src/main.rs
@@ -398,7 +398,12 @@ async fn main() -> Result<(), IggyCmdError> {
     let mut command = get_command(command, &cli_options, &iggy_args);
 
     // Create credentials based on command line arguments and command
-    let mut credentials = IggyCredentials::new(&cli_options, &iggy_args, command.login_required())?;
+    let mut credentials = IggyCredentials::new(
+        &cli_options,
+        &iggy_args,
+        command.login_required(),
+        command.prefer_explicit_credentials(),
+    )?;
 
     let encryptor = match iggy_args.encryption_key.is_empty() {
         true => None,

--- a/core/integration/src/harness/handle/server.rs
+++ b/core/integration/src/harness/handle/server.rs
@@ -904,11 +904,11 @@ impl TestBinary for ServerHandle {
         // Release the reservation BEFORE spawning. Production listeners
         // set `SO_REUSEPORT` in theory, but holding the reservation across
         // child startup races with `bind()` on the child side and
-        // sporadically returns `CannotBindToSocket`. The narrow TOCTOU
-        // window between `release` and the child's `bind` is bounded by
-        // process start latency and harness-controlled environment;
-        // hubcio's TODO in `socket_opts.rs` retires the whole
-        // reservation-socket dance.
+        // sporadically returns `CannotBindToSocket`. Dropping the socket lets
+        // the child bind; the per-port advisory lock the reserver keeps past
+        // this release (see `port_reserver`) still fends off any concurrent
+        // test process until the child has bound. hubcio's TODO in
+        // `socket_opts.rs` retires the whole reservation-socket dance.
         if let Some(reserver) = self.port_reserver.take() {
             reserver.release();
         }

--- a/core/integration/src/harness/port_reserver.rs
+++ b/core/integration/src/harness/port_reserver.rs
@@ -29,21 +29,41 @@ use crate::harness::config::{IpAddrKind, TestServerConfig};
 use crate::harness::error::TestBinaryError;
 use socket2::{Domain, Protocol, Socket, Type};
 use std::collections::HashSet;
+use std::fs::{File, OpenOptions, TryLockError};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::sync::Mutex;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 
-/// Ports already handed out by any reservation in this process.
+/// Ports this process must not hand out: either it reserved them, or it saw
+/// another process holding the cross-process lock (see [`PORT_LOCKS`]).
 ///
-/// The reservation sockets set `SO_REUSEPORT` so the server can later bind the
-/// same port the reserver held. But `SO_REUSEPORT` also lets the kernel assign
-/// the *same* ephemeral port to two `bind(0)` calls from different threads, so
-/// under a multi-threaded test run two clusters can reserve the same port and
-/// the second server aborts on the cluster config's port-conflict validator.
-/// Tracking every handed-out port and rebinding on collision makes reservations
-/// unique across the whole process. Ports are claimed for the process lifetime
-/// (never returned to the pool): a release frees the socket so the server can
-/// bind, but re-handing the number out could still collide with that server.
+/// `SO_REUSEPORT` (needed so the server can later bind the port the reserver
+/// held) also lets the kernel hand the *same* ephemeral port to two `bind(0)`
+/// calls, so two reservations can land on one port. This set rejects the
+/// duplicate within a process; [`PORT_LOCKS`] extends the guarantee across the
+/// concurrent test processes. Entries are never removed: a release frees the
+/// socket so the server can bind, but re-handing the number out could still
+/// collide with that server, and a number seen held elsewhere stays off-limits
+/// (the ephemeral range dwarfs what one test consumes).
 static RESERVED_PORTS: Mutex<Option<HashSet<u16>>> = Mutex::new(None);
+
+/// Advisory file locks held for the process lifetime, one per reserved port.
+///
+/// `RESERVED_PORTS` dedups only within a process, but `nextest` runs each test
+/// in its own process and they reserve ports concurrently. An exclusive `flock`
+/// on a per-port file in a shared temp dir makes a claim visible to every other
+/// test process: one that `bind(0)`s onto the same ephemeral port fails the lock
+/// and rebinds. The lock is kept past the socket release (see
+/// [`ReservedPort::release`]) so it also covers the window between releasing the
+/// reservation socket and the server binding the port. The OS drops the locks on
+/// process exit, so a crash never leaks a claim.
+///
+/// One file descriptor is held per reserved port for the process lifetime. That
+/// is bounded because `nextest` gives each test its own short-lived process (a
+/// test reserves at most a few dozen ports); a single-process run of the whole
+/// suite would instead accumulate them, so this reserver assumes the per-test
+/// process model.
+static PORT_LOCKS: Mutex<Vec<File>> = Mutex::new(Vec::new());
 
 /// Bind retries before giving up. The ephemeral range dwarfs the ports a single
 /// test run consumes, so a fresh port is found almost immediately; the cap only
@@ -59,10 +79,55 @@ fn claim_port(port: u16) -> bool {
         .insert(port)
 }
 
-/// A socket bound to a specific port, held to prevent reuse until released.
+/// Shared directory holding the per-port advisory lock files, created once.
+fn port_lock_dir() -> &'static PathBuf {
+    static PORT_LOCK_DIR: OnceLock<PathBuf> = OnceLock::new();
+    PORT_LOCK_DIR.get_or_init(|| {
+        let dir = std::env::temp_dir().join("iggy-test-port-locks");
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    })
+}
+
+/// Outcome of trying to take a port's cross-process advisory lock.
+enum PortClaim {
+    /// Exclusive lock held; keep the file alive while the port is in use.
+    Locked(File),
+    /// Another test process holds the port; the caller must rebind.
+    Contended,
+    /// The lock directory is unusable (cannot create/open/lock the file), so no
+    /// cross-process coordination is available. The caller keeps the port and
+    /// degrades to the in-process guard alone rather than failing the run.
+    Unsupported,
+}
+
+/// Try to take an exclusive cross-process lock on `port`.
+fn lock_port(port: u16) -> PortClaim {
+    let path = port_lock_dir().join(format!("{port}.lock"));
+    let Ok(file) = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+    else {
+        return PortClaim::Unsupported;
+    };
+    match file.try_lock() {
+        Ok(()) => PortClaim::Locked(file),
+        Err(TryLockError::WouldBlock) => PortClaim::Contended,
+        Err(TryLockError::Error(_)) => PortClaim::Unsupported,
+    }
+}
+
+/// A socket bound to a specific port, held to prevent reuse until released,
+/// plus the cross-process advisory lock on that port (see [`PORT_LOCKS`]), or
+/// `None` when the lock directory is unusable and only the in-process guard
+/// applies.
 struct ReservedPort {
     socket: Socket,
     addr: SocketAddr,
+    lock: Option<File>,
 }
 
 impl ReservedPort {
@@ -136,9 +201,30 @@ impl ReservedPort {
                 })?;
 
             // SO_REUSEPORT lets the kernel reuse a port another reservation
-            // already holds; rebind (dropping this socket) until the claim wins.
+            // already holds; rebind (dropping this socket) until the claim wins
+            // both in-process and across the concurrent test processes.
             if claim_port(addr.port()) {
-                return Ok(Self { socket, addr });
+                match lock_port(addr.port()) {
+                    PortClaim::Locked(lock) => {
+                        return Ok(Self {
+                            socket,
+                            addr,
+                            lock: Some(lock),
+                        });
+                    }
+                    // Lock infra unavailable: keep the in-process claim and run
+                    // without the cross-process guard rather than fail the run.
+                    PortClaim::Unsupported => {
+                        return Ok(Self {
+                            socket,
+                            addr,
+                            lock: None,
+                        });
+                    }
+                    // Held by another process; the number stays claimed (so we
+                    // do not retry it) and we rebind to a different port.
+                    PortClaim::Contended => {}
+                }
             }
         }
 
@@ -152,7 +238,18 @@ impl ReservedPort {
     }
 
     fn release(self) {
-        drop(self.socket);
+        // Drop the reservation socket so the server can bind the port, but move
+        // the advisory lock (when held) into the process-wide registry so it
+        // outlives the socket and keeps concurrent test processes off the port
+        // until the server has bound it.
+        let Self { socket, lock, .. } = self;
+        if let Some(lock) = lock {
+            PORT_LOCKS
+                .lock()
+                .expect("port-locks mutex poisoned")
+                .push(lock);
+        }
+        drop(socket);
     }
 }
 

--- a/core/integration/tests/cli/message/test_message_flush_command.rs
+++ b/core/integration/tests/cli/message/test_message_flush_command.rs
@@ -24,6 +24,9 @@ use iggy::prelude::Client;
 use iggy::prelude::Identifier;
 use iggy::prelude::IggyExpiry;
 use iggy::prelude::MaxTopicSize;
+#[cfg(feature = "vsr")]
+use predicates::str::contains;
+#[cfg(not(feature = "vsr"))]
 use predicates::str::diff;
 use serial_test::parallel;
 use std::str::FromStr;
@@ -142,11 +145,21 @@ impl IggyCmdTestCase for TestMessageFetchCmd {
             }
         );
 
-        let message = format!(
-            "Executing flush messages {identification_part}\nFlushed messages {identification_part}\n"
-        );
+        // server-ng has no on-demand flush primitive: FLUSH_UNSAVED_BUFFER
+        // surfaces a typed FeatureUnavailable (see flush_vsr.rs), so the CLI
+        // reports a flush problem instead of success.
+        #[cfg(feature = "vsr")]
+        command_state.failure().stderr(contains(format!(
+            "Problem flushing messages {identification_part}"
+        )));
 
-        command_state.success().stdout(diff(message));
+        #[cfg(not(feature = "vsr"))]
+        {
+            let message = format!(
+                "Executing flush messages {identification_part}\nFlushed messages {identification_part}\n"
+            );
+            command_state.success().stdout(diff(message));
+        }
     }
 
     async fn verify_server_state(&self, client: &dyn Client) {

--- a/core/integration/tests/cli/stream/test_stream_purge_command.rs
+++ b/core/integration/tests/cli/stream/test_stream_purge_command.rs
@@ -115,12 +115,24 @@ impl IggyCmdTestCase for TestStreamPurgeCmd {
     }
 
     async fn verify_server_state(&self, client: &dyn Client) {
-        let stream_state = client
-            .get_stream(&self.stream_name.clone().try_into().unwrap())
-            .await;
-        assert!(stream_state.is_ok());
-        let stream_state = stream_state.unwrap().expect("Stream not found");
-        assert_eq!(stream_state.size, 0);
+        // server-ng purge is eventually consistent: the partition reset (and
+        // its stats zeroing) runs in the reconciler after the metadata commit
+        // the purge command awaited. Legacy is synchronous and satisfies this
+        // on the first poll.
+        let mut purged = false;
+        for _ in 0..60 {
+            let stream_state = client
+                .get_stream(&self.stream_name.clone().try_into().unwrap())
+                .await
+                .expect("get stream")
+                .expect("Stream not found");
+            if stream_state.size == 0 {
+                purged = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(purged, "stream size should reach 0 after purge");
 
         let stream_delete = client
             .delete_stream(&self.stream_name.clone().try_into().unwrap())

--- a/core/integration/tests/cli/system/test_cli_session_scenario.rs
+++ b/core/integration/tests/cli/system/test_cli_session_scenario.rs
@@ -87,10 +87,21 @@ pub async fn should_be_successful() {
     // not provided in this case).
     // Command shall be executed without credentials and should fail with proper
     // error message.
+    let recovery_address = server_address.clone();
     iggy_cmd_test
         .execute_test(TestMeCmd::new(
             TransportProtocol::Tcp,
             Scenario::FailureDueToSessionTimeout(server_address),
+        ))
+        .await;
+    // After the session timed out, logging in again with username and password
+    // must recover: the CLI drops the dead session token and recreates it,
+    // rather than wedging on the expired credential (regression for server-ng,
+    // where the terminal auth failure is opaque and self-heal never happened).
+    iggy_cmd_test
+        .execute_test(TestLoginCmd::new(
+            recovery_address,
+            TestLoginCmdType::RecoverExpiredSession,
         ))
         .await;
 }

--- a/core/integration/tests/cli/system/test_cluster_metadata_command.rs
+++ b/core/integration/tests/cli/system/test_cluster_metadata_command.rs
@@ -63,7 +63,6 @@ impl IggyCmdTestCase for TestClusterMetadataCmd {
                         "Executing get cluster metadata in table mode\n",
                     ))
                     .stdout(contains("Cluster name:"))
-                    .stdout(contains("single-node"))
                     .stdout(contains("Name"))
                     .stdout(contains("IP"))
                     .stdout(contains("TCP"))
@@ -72,7 +71,6 @@ impl IggyCmdTestCase for TestClusterMetadataCmd {
                     .stdout(contains("WebSocket"))
                     .stdout(contains("Role"))
                     .stdout(contains("Status"))
-                    .stdout(contains("iggy-node"))
                     .stdout(contains("leader"))
                     .stdout(contains("healthy"));
             }
@@ -81,8 +79,6 @@ impl IggyCmdTestCase for TestClusterMetadataCmd {
                     .success()
                     .stdout(starts_with("Executing get cluster metadata in list mode\n"))
                     .stdout(contains("Cluster name:"))
-                    .stdout(contains("single-node"))
-                    .stdout(contains("iggy-node"))
                     .stdout(contains("leader"))
                     .stdout(contains("healthy"));
             }

--- a/core/integration/tests/cli/system/test_login_cmd.rs
+++ b/core/integration/tests/cli/system/test_login_cmd.rs
@@ -29,6 +29,9 @@ pub enum TestLoginCmdType {
     SuccessWithTimeout(u64),
     AlreadyLoggedIn,
     AlreadyLoggedInWithToken,
+    /// Re-login after the stored session expired: the CLI must recreate the
+    /// session instead of failing on the dead token.
+    RecoverExpiredSession,
 }
 
 #[derive(Debug)]
@@ -76,6 +79,9 @@ impl IggyCmdTestCase for TestLoginCmd {
                     .await;
                 assert!(pat.is_ok());
             }
+            // State is whatever the preceding session-timeout step left behind
+            // (differs per transport), so nothing is asserted up front.
+            TestLoginCmdType::RecoverExpiredSession => {}
         }
     }
 
@@ -93,7 +99,8 @@ impl IggyCmdTestCase for TestLoginCmd {
         match self.login_type {
             TestLoginCmdType::Success
             | TestLoginCmdType::AlreadyLoggedInWithToken
-            | TestLoginCmdType::SuccessWithTimeout(_) => {
+            | TestLoginCmdType::SuccessWithTimeout(_)
+            | TestLoginCmdType::RecoverExpiredSession => {
                 command_state.success().stdout(diff(format!(
                     "Executing login command\nSuccessfully logged into Iggy server {}\n",
                     self.server_address

--- a/core/integration/tests/cli/system/test_me_command.rs
+++ b/core/integration/tests/cli/system/test_me_command.rs
@@ -100,7 +100,18 @@ impl IggyCmdTestCase for TestMeCmd {
                     .stderr(diff("Error: CommandError(Iggy command line tool error\n\nCaused by:\n    Missing iggy server credentials)\n"));
             }
             Scenario::FailureDueToSessionTimeout(server_address) => {
+                #[cfg(not(feature = "vsr"))]
                 command_state.failure().stderr(diff(format!("Error: CommandError(Login session expired for Iggy server: {server_address}, please login again or use other authentication method)\n")));
+                // server-ng maps an expired/invalid stored session to a generic
+                // login-with-token failure rather than the legacy "session
+                // expired" message.
+                #[cfg(feature = "vsr")]
+                {
+                    let _ = server_address;
+                    command_state.failure().stderr(diff(
+                        "Error: CommandError(Problem with server login with token)\n",
+                    ));
+                }
             }
         }
     }

--- a/core/integration/tests/cli/topic/test_topic_purge_command.rs
+++ b/core/integration/tests/cli/topic/test_topic_purge_command.rs
@@ -141,15 +141,27 @@ impl IggyCmdTestCase for TestTopicPurgeCmd {
     }
 
     async fn verify_server_state(&self, client: &dyn Client) {
-        let topic_state = client
-            .get_topic(
-                &self.stream_name.clone().try_into().unwrap(),
-                &self.topic_name.clone().try_into().unwrap(),
-            )
-            .await;
-        assert!(topic_state.is_ok());
-        let topic_state = topic_state.unwrap().expect("Topic not found");
-        assert_eq!(topic_state.size, 0);
+        // server-ng purge is eventually consistent: the partition reset (and
+        // its stats zeroing) runs in the reconciler after the metadata commit
+        // the purge command awaited. Legacy is synchronous and satisfies this
+        // on the first poll.
+        let mut purged = false;
+        for _ in 0..60 {
+            let topic_state = client
+                .get_topic(
+                    &self.stream_name.clone().try_into().unwrap(),
+                    &self.topic_name.clone().try_into().unwrap(),
+                )
+                .await
+                .expect("get topic")
+                .expect("Topic not found");
+            if topic_state.size == 0 {
+                purged = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(purged, "topic size should reach 0 after purge");
 
         let topic_delete = client
             .delete_topic(

--- a/core/integration/tests/mod.rs
+++ b/core/integration/tests/mod.rs
@@ -30,11 +30,11 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, fmt};
 
-// Drives the `iggy` CLI binary against a running server. Probed against
-// server-ng 2026-07-15: ~109/170 pass; the ~42 failures + hangs cluster in
-// `context` (12), `system` (7), `message` (6), `stream` (5) plus scattered
-// others -- needs a dedicated triage pass before un-gating.
-#[cfg(not(feature = "vsr"))]
+// Drives the `iggy` CLI binary against a running server, in both legacy and
+// vsr/server-ng modes. Under vsr, single-node and the default 3-node cluster
+// both pass. A few cases are mode-split where server-ng diverges from legacy by
+// design: flush returns FeatureUnavailable, the session-timeout message
+// differs, and purge is eventually consistent so server state is polled.
 mod cli;
 // A single `#[ignore]`d multi-node ping matrix stub; none of its cells run in
 // either mode today.

--- a/core/metadata/src/impls/metadata.rs
+++ b/core/metadata/src/impls/metadata.rs
@@ -2029,24 +2029,28 @@ where
             Operation::CreateTopicWithAssignments => {
                 let request = PersistedCreateTopicRequest::decode_from(body)
                     .expect("create topic with assignments prepare must decode");
-                let highest_consensus_group_id = request
+                // A topic may be created with zero partitions and grown later,
+                // so there may be no consensus group to observe yet.
+                if let Some(highest_consensus_group_id) = request
                     .partitions
                     .iter()
                     .map(|partition| partition.consensus_group_id)
                     .max()
-                    .expect("create topic with assignments must allocate partitions");
-                self.allocator.observe(highest_consensus_group_id);
+                {
+                    self.allocator.observe(highest_consensus_group_id);
+                }
             }
             Operation::CreatePartitionsWithAssignments => {
                 let request = PersistedCreatePartitionsRequest::decode_from(body)
                     .expect("create partitions with assignments prepare must decode");
-                let highest_consensus_group_id = request
+                if let Some(highest_consensus_group_id) = request
                     .partitions
                     .iter()
                     .map(|partition| partition.consensus_group_id)
                     .max()
-                    .expect("create partitions with assignments must allocate partitions");
-                self.allocator.observe(highest_consensus_group_id);
+                {
+                    self.allocator.observe(highest_consensus_group_id);
+                }
             }
             _ => {}
         }

--- a/core/server-ng/Cargo.toml
+++ b/core/server-ng/Cargo.toml
@@ -43,7 +43,6 @@ ignored = [
     "err_trail",
     "error_set",
     "figlet-rs",
-    "fs2",
     "hash32",
     "human-repr",
     "hwlocality",

--- a/core/server-ng/Dockerfile
+++ b/core/server-ng/Dockerfile
@@ -47,8 +47,11 @@ ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
 RUN apk add --no-cache zig make autoconf automake libtool pkgconfig hwloc-dev xz-dev xz-static nodejs npm && \
-    cargo install cargo-zigbuild --version '=0.22.1' --locked && \
-    rustup target add \
+    cargo install cargo-zigbuild --version '=0.22.1' --locked
+
+COPY rust-toolchain.toml rust-toolchain.toml
+
+RUN rustup target add \
     x86_64-unknown-linux-musl \
     aarch64-unknown-linux-musl \
     x86_64-unknown-linux-gnu \
@@ -71,10 +74,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
     esac && \
     if [ "$PROFILE" = "debug" ]; then \
     cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild \
-      -p server-ng -p iggy-cli; \
+      --features vsr -p server-ng -p iggy-cli; \
     else \
     cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild --release \
-      -p server-ng -p iggy-cli; \
+      --features vsr -p server-ng -p iggy-cli; \
     fi
 
 COPY . .
@@ -93,11 +96,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
     *) echo "Unsupported $TARGETPLATFORM/$LIBC" && exit 1 ;; \
     esac && \
     if [ "$PROFILE" = "debug" ]; then \
-    cargo zigbuild --locked --target ${RUST_TARGET} --bin iggy-server-ng --bin iggy && \
+    cargo zigbuild --locked --target ${RUST_TARGET} --features vsr --bin iggy-server-ng --bin iggy && \
     cp /app/target/${RUST_TARGET}/debug/iggy-server-ng /app/iggy-server-ng && \
     cp /app/target/${RUST_TARGET}/debug/iggy /app/iggy; \
     else \
-    cargo zigbuild --locked --target ${RUST_TARGET} --bin iggy-server-ng --bin iggy --release && \
+    cargo zigbuild --locked --target ${RUST_TARGET} --features vsr --bin iggy-server-ng --bin iggy --release && \
     cp /app/target/${RUST_TARGET}/release/iggy-server-ng /app/iggy-server-ng && \
     cp /app/target/${RUST_TARGET}/release/iggy /app/iggy; \
     fi

--- a/core/server-ng/src/bootstrap.rs
+++ b/core/server-ng/src/bootstrap.rs
@@ -633,6 +633,9 @@ pub fn bootstrap(
     current_replica_id: Option<u8>,
 ) -> Result<ShardHandles, ServerNgError> {
     warm_dummy_password_hash();
+    // The sync GetStats read path has no access to server config, so capture
+    // the data directory here for its disk-usage reporting.
+    crate::responses::init_stats_data_path(config.system.get_system_path().into());
     let (assignments, total_shards) = resolve_shard_assignments(&config.system.sharding)?;
     let shards_count = assignments.len();
 

--- a/core/server-ng/src/responses.rs
+++ b/core/server-ng/src/responses.rs
@@ -87,6 +87,7 @@ use server_common::send_messages2::{COMMAND_HEADER_SIZE, SendMessages2Header};
 use server_common::sharding::IggyNamespace;
 use shard::ConnectedClientInfo;
 use std::cell::RefCell;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
 use sysinfo::System as SysinfoSystem;
@@ -701,6 +702,15 @@ where
     )?;
 
     let system = probe_system_stats();
+    // Disk usage of the volume holding iggy data. The data directory is
+    // captured process-globally at bootstrap (the shard doesn't carry server
+    // config on the read path); absent that, or on a probe error, report 0.
+    let (free_disk_space, total_disk_space) = STATS_DATA_PATH.get().map_or((0, 0), |path| {
+        (
+            fs2::available_space(path).unwrap_or(0),
+            fs2::total_space(path).unwrap_or(0),
+        )
+    });
     Ok(StatsResponse {
         process_id: system.process_id,
         cpu_usage: system.cpu_usage,
@@ -733,11 +743,8 @@ where
         iggy_server_semver: crate::SEMANTIC_VERSION.get_numeric_version().ok(),
         cache_metrics: Vec::new(),
         threads_count: system.threads_count,
-        // Disk space needs the configured data directory (legacy reads
-        // `config.system.path`); the shard doesn't expose server config on the
-        // read path, so report 0 rather than probe an unrelated mount.
-        free_disk_space: 0,
-        total_disk_space: 0,
+        free_disk_space,
+        total_disk_space,
     })
 }
 
@@ -796,6 +803,17 @@ impl HostIdentity {
 }
 
 static HOST_IDENTITY: OnceLock<HostIdentity> = OnceLock::new();
+
+/// Configured data directory, captured once at bootstrap so the sync stats
+/// read path can report disk usage of the volume that holds iggy data rather
+/// than an unrelated mount. Unset (disk stats fall back to 0) until bootstrap.
+static STATS_DATA_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Capture the configured data directory for `GetStats` disk reporting.
+/// Idempotent: only the first call (process bootstrap) takes effect.
+pub(crate) fn init_stats_data_path(path: PathBuf) {
+    let _ = STATS_DATA_PATH.set(path);
+}
 
 fn probe_system_stats() -> SystemStats {
     let host = HOST_IDENTITY.get_or_init(HostIdentity::probe);

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -46,8 +46,11 @@ ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
 RUN apk add --no-cache bash curl tar zig make autoconf automake libtool pkgconfig hwloc-dev xz-dev xz-static nodejs npm && \
-    cargo install cargo-zigbuild --version '=0.22.1' --locked && \
-    rustup target add \
+    cargo install cargo-zigbuild --version '=0.22.1' --locked
+
+COPY rust-toolchain.toml rust-toolchain.toml
+
+RUN rustup target add \
     x86_64-unknown-linux-musl \
     aarch64-unknown-linux-musl \
     x86_64-unknown-linux-gnu \


### PR DESCRIPTION
The CLI integration suite was gated off under the vsr feature, so
the `iggy` CLI was never exercised against server-ng. Enabling it
surfaced real gaps that this change fixes.

Un-gate the suite and add a `vsr` feature to iggy-cli; the
server-ng Docker image now builds with `--features vsr`.

Creating a topic (or partitions) with a zero partition count
aborted shard-0 on server-ng: the allocator's `.expect()` on the
highest consensus-group id panicked when no partitions were
assigned, taking the whole process down with SIGABRT. This was
client-triggerable. Skip the observe call when the assignment set
is empty.

The stats response hardcoded free/total disk space to 0. Resolve
both from the server's data path via fs2.

Harden the harness port reserver against a cross-process race.
`RESERVED_PORTS` dedups only within a process, but nextest runs
each test in its own process; concurrent 3-node startups raced for
the same ephemeral port at the release->bind window and failed with
CannotBindToSocket. Claim each port with an exclusive advisory file
lock held for the process lifetime, making the claim visible across
processes; the OS drops it on exit so a crash never leaks a port.

Recover an expired CLI login session instead of wedging. On
server-ng an expired login-session PAT returns InvalidToken (no
expiry oracle) and, on TCP/QUIC, an opaque empty reply, so the
stored session was never cleared and `iggy login` refused with
"already logged in" until a manual logout. `iggy login` now prefers
explicitly supplied credentials (other commands keep reusing the
cached token) and validates the session against the server's PAT
list, recreating it when dead; the credential delete-set is left
untouched so a transient failure never drops a valid session.

A few CLI cases are mode-split where server-ng diverges from legacy
by design: flush returns FeatureUnavailable, the session-timeout
message differs, and purge is eventually consistent so server state
is polled.
