### PR TITLE
test(bdd): fail Go BDD runner on undefined steps

### DIFF
--- a/bdd/go/tests/suite_test.go
+++ b/bdd/go/tests/suite_test.go
@@ -37,6 +37,7 @@ func TestFeatures(t *testing.T) {
 			Options: &godog.Options{
 				Format:   "pretty",
 				Paths:    []string{"../../scenarios/basic_messaging.feature"},
+				Strict:   true,
 				TestingT: t,
 			},
 		})
@@ -47,6 +48,7 @@ func TestFeatures(t *testing.T) {
 			Options: &godog.Options{
 				Format:   "pretty",
 				Paths:    []string{"../../scenarios/leader_redirection.feature"},
+				Strict:   true,
 				TestingT: t,
 			},
 		})


### PR DESCRIPTION
Follow-up to #3554 — Go half of #3634 (Rust half in #3680).

godog is non-strict by default and neither `godog.Options` block set `Strict`, so a step without a matching definition in the Go runner is reported as undefined while `go test` still exits 0 and CI stays green. Both suites now set `Strict: true`; the existing `s.Run() != 0` check turns that into a test failure.

Verification (local server with `--with-default-root-credentials`, fresh data dir per run):
- green path: `BDD_FEATURE=basic_messaging go test -count=1 ./tests/` → exit 0, `17 steps (17 passed)`
- red path (repro from #3634: bogus step appended to the feature): exit 1, `1 scenarios (1 undefined)` → FAIL
- `gofmt` / `go vet` clean

Refs #3634