### PR TITLE
fix(sdk): rejoin consumer group after membership loss under vsr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7424,7 +7424,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "server",
- "socket2 0.6.4",
  "sqlx",
  "sysinfo 0.39.5",
  "tempfile",

--- a/core/common/src/consumer_group_client_state.rs
+++ b/core/common/src/consumer_group_client_state.rs
@@ -164,6 +164,17 @@ impl ConsumerGroupClientState {
             .remove(key);
     }
 
+    /// True if the last assignment sync observed this client as a member. A
+    /// member mid-rebalance or holding zero partitions is still registered, so
+    /// this is a different question than [`Self::has_assignment`].
+    #[must_use]
+    pub fn is_registered(&self, key: &str) -> bool {
+        self.joined_groups
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains_key(key)
+    }
+
     /// Identifiers of every group the client has joined on this transport.
     #[must_use]
     pub fn registered_groups(&self) -> Vec<(Identifier, Identifier, Identifier)> {
@@ -215,5 +226,20 @@ mod tests {
         let state = ConsumerGroupClientState::new();
         assert!(!state.has_assignment("s|t|g"));
         assert_eq!(state.next_group_partition("s|t|g"), None);
+    }
+
+    #[test]
+    fn member_holding_no_partitions_stays_registered() {
+        let state = ConsumerGroupClientState::new();
+        let id = Identifier::named("g").unwrap();
+        state.register_group("s|t|g".to_owned(), id.clone(), id.clone(), id);
+        state.set_assignment("s|t|g".to_owned(), 1, Vec::new());
+        // A poll distinguishes "member, nothing assigned" from "not a member"
+        // by membership alone, so the two must not track each other.
+        assert!(!state.has_assignment("s|t|g"));
+        assert!(state.is_registered("s|t|g"));
+
+        state.deregister_group("s|t|g");
+        assert!(!state.is_registered("s|t|g"));
     }
 }

--- a/core/common/src/traits/binary_impls/messages.rs
+++ b/core/common/src/traits/binary_impls/messages.rs
@@ -59,7 +59,7 @@ fn topic_cache_key(stream_id: &Identifier, topic_id: &Identifier) -> String {
 }
 
 /// Sync the requesting member's assignment from the coordinator into the
-/// transport cache. An empty reply means the member holds no partitions.
+/// transport cache. An empty reply means the client is not a member.
 #[cfg(feature = "vsr")]
 async fn sync_group_assignment<B: BinaryClient>(
     client: &B,
@@ -77,14 +77,15 @@ async fn sync_group_assignment<B: BinaryClient>(
         .await?;
     let key = group_cache_key(stream_id, topic_id, group_id);
     if response.is_empty() {
-        // Empty reply = the client is not a member of this group (or holds no
-        // partitions). Record the empty assignment but do NOT `register_group`:
-        // registering would make the heartbeat re-sync it for the connection's
-        // lifetime and leak a `joined_groups` entry per distinct non-member
-        // group ever polled. Only a real membership (non-empty reply) registers.
-        client
-            .consumer_group_state()
-            .set_assignment(key, 0, Vec::new());
+        // Empty reply = not a member: the coordinator sends an assignment
+        // header for any member, including one holding zero partitions.
+        // Registering only on a non-empty reply keeps a non-member group from
+        // leaking a `joined_groups` entry, and the deregister is the only thing
+        // that observes a server-side removal (group deleted, member evicted):
+        // without it `is_registered` latches true and every later poll returns
+        // empty instead of surfacing 5006.
+        client.consumer_group_state().invalidate_assignment(&key);
+        client.consumer_group_state().deregister_group(&key);
         return Ok(());
     }
     let (assignment, _) =
@@ -195,7 +196,18 @@ async fn poll_group_messages<B: BinaryClient>(
     }
     for _ in 0..GROUP_POLL_MAX_ATTEMPTS {
         let Some(partition_id) = client.consumer_group_state().next_group_partition(&key) else {
-            // Synced but holds no partitions: not a member, or none assigned.
+            // Nothing to poll, but the two causes need opposite handling and
+            // only membership tells them apart: a real member can legitimately
+            // hold zero partitions, while a non-member must surface 5006 or
+            // `IggyConsumer` polls an empty assignment forever instead of
+            // rejoining. The client id is not known client-side.
+            if !client.consumer_group_state().is_registered(&key) {
+                return Err(IggyError::ConsumerGroupMemberNotFound(
+                    0,
+                    consumer.id.clone(),
+                    topic_id.clone(),
+                ));
+            }
             return Ok(PolledMessages::empty());
         };
         let request = PollMessagesRequest {

--- a/core/common/src/traits/message_client.rs
+++ b/core/common/src/traits/message_client.rs
@@ -26,6 +26,8 @@ pub trait MessageClient {
     /// Poll given amount of messages using the specified consumer and strategy from the specified stream and topic by unique IDs or names.
     ///
     /// Authentication is required, and the permission to poll the messages.
+    ///
+    /// Under the `vsr` feature, polling a consumer group the client is not (or no longer) a member of fails with `ConsumerGroupMemberNotFound` rather than returning an empty batch, so the caller can rejoin.
     #[allow(clippy::too_many_arguments)]
     async fn poll_messages(
         &self,

--- a/core/integration/Cargo.toml
+++ b/core/integration/Cargo.toml
@@ -81,7 +81,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 server = { workspace = true }
-socket2 = { workspace = true }
 sqlx = { workspace = true }
 sysinfo = { workspace = true }
 tempfile = { workspace = true }

--- a/core/integration/src/harness/handle/connectors_runtime.rs
+++ b/core/integration/src/harness/handle/connectors_runtime.rs
@@ -44,7 +44,7 @@ pub struct ConnectorsRuntimeHandle {
     iggy_address: Option<SocketAddr>,
     stdout_path: Option<PathBuf>,
     stderr_path: Option<PathBuf>,
-    port_reserver: Option<SinglePortReserver>,
+    _port_reserver: SinglePortReserver,
 }
 
 impl std::fmt::Debug for ConnectorsRuntimeHandle {
@@ -127,7 +127,7 @@ impl ConnectorsRuntimeHandle {
             iggy_address: None,
             stdout_path: None,
             stderr_path: None,
-            port_reserver: Some(reserver),
+            _port_reserver: reserver,
         }
     }
 }
@@ -243,16 +243,6 @@ impl IggyServerDependent for ConnectorsRuntimeHandle {
     }
 
     async fn wait_ready(&mut self) -> Result<(), TestBinaryError> {
-        // Release port reservation just before health-checking. The reservation
-        // holds the port while the child process initializes, preventing another
-        // process from claiming it. By the time we reach here the child has had
-        // enough time to bind (or will bind within the first few health-check
-        // retries). This matches the server handle pattern where the reservation
-        // is held until the process has bound.
-        if let Some(reserver) = self.port_reserver.take() {
-            reserver.release();
-        }
-
         let http_address = self.http_url();
         let client = reqwest::Client::new();
 
@@ -283,6 +273,9 @@ impl IggyServerDependent for ConnectorsRuntimeHandle {
 
 impl Drop for ConnectorsRuntimeHandle {
     fn drop(&mut self) {
+        // Reap the child before `_port_reserver` drops: `Child::drop` detaches
+        // without waiting, so the freed slot could be reused while this runtime
+        // still holds its ports.
         let _ = self.stop();
         common::dump_logs_on_panic("Iggy connectors", &self.stdout_path, &self.stderr_path);
     }

--- a/core/integration/src/harness/handle/mcp.rs
+++ b/core/integration/src/harness/handle/mcp.rs
@@ -52,7 +52,7 @@ pub struct McpHandle {
     iggy_address: Option<SocketAddr>,
     stdout_path: Option<PathBuf>,
     stderr_path: Option<PathBuf>,
-    port_reserver: Option<SinglePortReserver>,
+    _port_reserver: SinglePortReserver,
 }
 
 impl std::fmt::Debug for McpHandle {
@@ -143,7 +143,7 @@ impl McpHandle {
             iggy_address: None,
             stdout_path: None,
             stderr_path: None,
-            port_reserver: Some(reserver),
+            _port_reserver: reserver,
         }
     }
 }
@@ -242,12 +242,6 @@ impl IggyServerDependent for McpHandle {
     }
 
     async fn wait_ready(&mut self) -> Result<(), TestBinaryError> {
-        // Release port reservation just before health-checking. Holds the port
-        // while the child initializes, matching the server handle pattern.
-        if let Some(reserver) = self.port_reserver.take() {
-            reserver.release();
-        }
-
         let http_address = format!(
             "http://{}:{}",
             self.server_address.ip(),
@@ -282,6 +276,9 @@ impl IggyServerDependent for McpHandle {
 
 impl Drop for McpHandle {
     fn drop(&mut self) {
+        // Reap the child before `_port_reserver` drops: `Child::drop` detaches
+        // without waiting, so the freed slot could be reused while this MCP
+        // server still holds its ports.
         let _ = self.stop();
         common::dump_logs_on_panic("Iggy MCP server", &self.stdout_path, &self.stderr_path);
     }

--- a/core/integration/src/harness/handle/server.rs
+++ b/core/integration/src/harness/handle/server.rs
@@ -901,18 +901,6 @@ impl TestBinary for ServerHandle {
             self.stderr_path = Some(fs::canonicalize(&stderr_path)?);
         }
 
-        // Release the reservation BEFORE spawning. Production listeners
-        // set `SO_REUSEPORT` in theory, but holding the reservation across
-        // child startup races with `bind()` on the child side and
-        // sporadically returns `CannotBindToSocket`. Dropping the socket lets
-        // the child bind; the per-port advisory lock the reserver keeps past
-        // this release (see `port_reserver`) still fends off any concurrent
-        // test process until the child has bound. hubcio's TODO in
-        // `socket_opts.rs` retires the whole reservation-socket dance.
-        if let Some(reserver) = self.port_reserver.take() {
-            reserver.release();
-        }
-
         let child = command.spawn().map_err(|e| TestBinaryError::ProcessSpawn {
             binary: launched_binary,
             source: e,
@@ -992,6 +980,9 @@ impl Restartable for ServerHandle {
 
 impl Drop for ServerHandle {
     fn drop(&mut self) {
+        // Reap the child before `port_reserver` drops: `Child::drop` detaches
+        // without waiting, so the freed slot could be reused while this server
+        // still holds its ports.
         let _ = self.stop();
         super::common::dump_logs_on_panic("Iggy server", &self.stdout_path, &self.stderr_path);
     }

--- a/core/integration/src/harness/port_reserver.rs
+++ b/core/integration/src/harness/port_reserver.rs
@@ -15,270 +15,258 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Port pre-allocation to eliminate TOCTOU race conditions during server startup.
+//! Port pre-allocation for test binaries.
 //!
-//! When starting a test server with ephemeral ports (port 0), there's a race window:
-//! 1. Server binds to port 0, OS assigns a port
-//! 2. Server writes the port to config file
-//! 3. Test harness reads config file to discover port
+//! A reserver takes an exclusive advisory lock on one slot of a fixed port band
+//! and derives its ports from the slot index, so the harness knows every port
+//! before the server starts and never has to discover one from a config file.
 //!
-//! By pre-reserving ports with SO_REUSEADDR/SO_REUSEPORT before server start,
-//! we know the ports immediately and only need to wait for server readiness.
+//! The lock is the allocator. `flock` conflicts between concurrent test
+//! processes and, because each open file description is independent, between
+//! concurrent tests inside a single process, so one slot maps to at most one
+//! live reserver either way. The slot returns to the pool when the guard drops
+//! at test teardown, and the OS drops it too if the process dies, so a crash
+//! leaks nothing.
+//!
+//! Two properties this deliberately does not have:
+//!
+//! - Nothing binds a socket. A placeholder socket races the server's own
+//!   `bind()` on release, and it costs a file descriptor per port rather than
+//!   per live test.
+//! - Nothing remembers a port it handed out. A registry keyed by port only ever
+//!   grows, which is fine for one process per test but exhausts a single-process
+//!   `cargo test` run of the whole suite.
+//!
+//! The band sits clear of the kernel's ephemeral range, so `bind(0)` in an
+//! unrelated process can never be handed a port the harness has promised to a
+//! server: below the range by preference, above it when the range is tuned too
+//! low to leave any room below. The range is read from the running kernel where
+//! that is possible and assumed to be the Linux default otherwise.
 
 use crate::harness::config::{IpAddrKind, TestServerConfig};
 use crate::harness::error::TestBinaryError;
-use socket2::{Domain, Protocol, Socket, Type};
-use std::collections::HashSet;
 use std::fs::{File, OpenOptions, TryLockError};
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
-/// Ports this process must not hand out: either it reserved them, or it saw
-/// another process holding the cross-process lock (see [`PORT_LOCKS`]).
-///
-/// `SO_REUSEPORT` (needed so the server can later bind the port the reserver
-/// held) also lets the kernel hand the *same* ephemeral port to two `bind(0)`
-/// calls, so two reservations can land on one port. This set rejects the
-/// duplicate within a process; [`PORT_LOCKS`] extends the guarantee across the
-/// concurrent test processes. Entries are never removed: a release frees the
-/// socket so the server can bind, but re-handing the number out could still
-/// collide with that server, and a number seen held elsewhere stays off-limits
-/// (the ephemeral range dwarfs what one test consumes).
-static RESERVED_PORTS: Mutex<Option<HashSet<u16>>> = Mutex::new(None);
+/// First port of the primary band, which runs from here up to the ephemeral
+/// floor. Clear of the privileged range.
+const BAND_START: u16 = 20000;
 
-/// Advisory file locks held for the process lifetime, one per reserved port.
-///
-/// `RESERVED_PORTS` dedups only within a process, but `nextest` runs each test
-/// in its own process and they reserve ports concurrently. An exclusive `flock`
-/// on a per-port file in a shared temp dir makes a claim visible to every other
-/// test process: one that `bind(0)`s onto the same ephemeral port fails the lock
-/// and rebinds. The lock is kept past the socket release (see
-/// [`ReservedPort::release`]) so it also covers the window between releasing the
-/// reservation socket and the server binding the port. The OS drops the locks on
-/// process exit, so a crash never leaks a claim.
-///
-/// One file descriptor is held per reserved port for the process lifetime. That
-/// is bounded because `nextest` gives each test its own short-lived process (a
-/// test reserves at most a few dozen ports); a single-process run of the whole
-/// suite would instead accumulate them, so this reserver assumes the per-test
-/// process model.
-static PORT_LOCKS: Mutex<Vec<File>> = Mutex::new(Vec::new());
+/// Last port of the fallback band, which runs from just above the ephemeral
+/// ceiling up to here.
+const FALLBACK_BAND_END: u16 = u16::MAX;
 
-/// Bind retries before giving up. The ephemeral range dwarfs the ports a single
-/// test run consumes, so a fresh port is found almost immediately; the cap only
-/// guards against a pathological kernel that keeps returning claimed ports.
-const MAX_BIND_ATTEMPTS: usize = 100;
+/// Ports one slot owns. A server reserver hands out at most five (tcp,
+/// tcp_replica, quic, http, websocket); [`SINGLE_PORT_OFFSET`] sits above
+/// those, and the rest is room for another protocol.
+const PORTS_PER_SLOT: u16 = 8;
 
-/// Claim `port` process-wide. Returns `false` if it was already handed out.
-fn claim_port(port: u16) -> bool {
-    RESERVED_PORTS
-        .lock()
-        .expect("reserved-ports mutex poisoned")
-        .get_or_insert_with(HashSet::new)
-        .insert(port)
+/// Offset of the one port a [`SinglePortReserver`] hands out. Deliberately
+/// clear of the server offsets (0..=4): its consumers (MCP, connectors
+/// runtime) bind plain `SO_REUSEADDR` listeners, the server's TCP listener
+/// binds `SO_REUSEPORT` without `SO_REUSEADDR`, and a TIME_WAIT socket left
+/// by either flavor rejects binds of the other for a full TIME_WAIT interval
+/// after teardown. Slots are reused back-to-back, so the two kinds of
+/// listener must never share a port number.
+const SINGLE_PORT_OFFSET: u16 = 5;
+
+/// Ephemeral range assumed when the kernel's cannot be read, matching the Linux
+/// default.
+const DEFAULT_EPHEMERAL_RANGE: (u16, u16) = (32768, 60999);
+
+const IP_LOCAL_PORT_RANGE: &str = "/proc/sys/net/ipv4/ip_local_port_range";
+
+/// Index of the concurrency lane `cargo nextest` is running this test in. Lanes
+/// are reused as tests finish, which makes it a good first guess at a free slot.
+/// Only ever a guess: the lock decides, so an absent or bogus value costs a few
+/// extra probes and nothing else.
+const NEXTEST_SLOT_ENV: &str = "NEXTEST_TEST_GLOBAL_SLOT";
+
+/// A run of whole slots, clear of the kernel's ephemeral range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PortBand {
+    start: u16,
+    slots: u16,
 }
 
-/// Shared directory holding the per-port advisory lock files, created once.
-fn port_lock_dir() -> &'static PathBuf {
-    static PORT_LOCK_DIR: OnceLock<PathBuf> = OnceLock::new();
-    PORT_LOCK_DIR.get_or_init(|| {
-        let dir = std::env::temp_dir().join("iggy-test-port-locks");
-        let _ = std::fs::create_dir_all(&dir);
-        dir
+impl PortBand {
+    /// The slots `[start, end]` holds, or `None` if it has room for none.
+    fn fit(start: u16, end: u16) -> Option<Self> {
+        let span = (u32::from(end) + 1).checked_sub(u32::from(start))?;
+        let slots = u16::try_from(span / u32::from(PORTS_PER_SLOT)).ok()?;
+        (slots > 0).then_some(Self { start, slots })
+    }
+
+    fn base_port(self, slot: u16) -> u16 {
+        self.start + slot * PORTS_PER_SLOT
+    }
+
+    fn end(self) -> u16 {
+        self.base_port(self.slots - 1) + PORTS_PER_SLOT - 1
+    }
+}
+
+/// The band to reserve from, given the kernel's ephemeral range. Below the
+/// floor by preference; above the ceiling when the floor is too low to leave
+/// room there, which is the only thing that lets a box tuned for high
+/// connection counts (`1024 65535` and the like) run the suite at all.
+fn band_for(floor: u16, ceiling: u16) -> Result<PortBand, TestBinaryError> {
+    let below = floor
+        .checked_sub(1)
+        .and_then(|end| PortBand::fit(BAND_START, end));
+    let above = ceiling
+        .checked_add(1)
+        .and_then(|start| PortBand::fit(start, FALLBACK_BAND_END));
+    below.or(above).ok_or_else(|| TestBinaryError::InvalidState {
+        message: format!(
+            "The kernel's ephemeral range [{floor}, {ceiling}] leaves room for a test port band \
+             on neither side: not below {floor} starting at {BAND_START}, nor above {ceiling} up \
+             to {FALLBACK_BAND_END}. Narrow the range, for example \
+             `sysctl -w net.ipv4.ip_local_port_range='32768 60999'`."
+        ),
     })
 }
 
-/// Outcome of trying to take a port's cross-process advisory lock.
-enum PortClaim {
-    /// Exclusive lock held; keep the file alive while the port is in use.
-    Locked(File),
-    /// Another test process holds the port; the caller must rebind.
-    Contended,
-    /// The lock directory is unusable (cannot create/open/lock the file), so no
-    /// cross-process coordination is available. The caller keeps the port and
-    /// degrades to the in-process guard alone rather than failing the run.
-    Unsupported,
+fn parse_ephemeral_range(range: &str) -> Option<(u16, u16)> {
+    let mut bounds = range.split_whitespace();
+    let floor = bounds.next()?.parse().ok()?;
+    let ceiling = bounds.next()?.parse().ok()?;
+    Some((floor, ceiling))
 }
 
-/// Try to take an exclusive cross-process lock on `port`.
-fn lock_port(port: u16) -> PortClaim {
-    let path = port_lock_dir().join(format!("{port}.lock"));
-    let Ok(file) = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(path)
-    else {
-        return PortClaim::Unsupported;
-    };
-    match file.try_lock() {
-        Ok(()) => PortClaim::Locked(file),
-        Err(TryLockError::WouldBlock) => PortClaim::Contended,
-        Err(TryLockError::Error(_)) => PortClaim::Unsupported,
-    }
+/// The range the kernel picks `bind(0)` ports from, read once.
+fn ephemeral_range() -> (u16, u16) {
+    static RANGE: OnceLock<(u16, u16)> = OnceLock::new();
+    *RANGE.get_or_init(|| {
+        std::fs::read_to_string(IP_LOCAL_PORT_RANGE)
+            .ok()
+            .as_deref()
+            .and_then(parse_ephemeral_range)
+            .unwrap_or(DEFAULT_EPHEMERAL_RANGE)
+    })
 }
 
-/// A socket bound to a specific port, held to prevent reuse until released,
-/// plus the cross-process advisory lock on that port (see [`PORT_LOCKS`]), or
-/// `None` when the lock directory is unusable and only the in-process guard
-/// applies.
-struct ReservedPort {
-    socket: Socket,
-    addr: SocketAddr,
-    lock: Option<File>,
+/// Shared directory holding the per-slot lock files, created once. A failure to
+/// create it is not reported here; [`SlotGuard::acquire`] then finds no slot it
+/// can open and fails with this path in its message.
+fn lock_dir() -> &'static Path {
+    static LOCK_DIR: OnceLock<PathBuf> = OnceLock::new();
+    LOCK_DIR
+        .get_or_init(|| {
+            let dir = std::env::temp_dir().join("iggy-test-port-locks");
+            let _ = std::fs::create_dir_all(&dir);
+            dir
+        })
+        .as_path()
 }
 
-impl ReservedPort {
-    fn tcp(ip_kind: IpAddrKind) -> Result<Self, TestBinaryError> {
-        Self::reserve_unique(ip_kind, Type::STREAM, Protocol::TCP)
-    }
+/// Exclusive claim on one slot of the band, released when dropped.
+struct SlotGuard {
+    base_port: u16,
+    next_offset: u16,
+    /// Held for its lock alone; closing the file frees the slot.
+    _lock: File,
+}
 
-    fn udp(ip_kind: IpAddrKind) -> Result<Self, TestBinaryError> {
-        Self::reserve_unique(ip_kind, Type::DGRAM, Protocol::UDP)
-    }
+impl SlotGuard {
+    fn acquire() -> Result<Self, TestBinaryError> {
+        let (floor, ceiling) = ephemeral_range();
+        let band = band_for(floor, ceiling)?;
+        let first = std::env::var(NEXTEST_SLOT_ENV)
+            .ok()
+            .and_then(|lane| lane.parse::<u16>().ok())
+            .unwrap_or(0)
+            % band.slots;
 
-    /// Bind an ephemeral port and claim it process-wide, rebinding until the
-    /// kernel hands back a port no other reservation holds (see
-    /// [`RESERVED_PORTS`]).
-    fn reserve_unique(
-        ip_kind: IpAddrKind,
-        sock_type: Type,
-        protocol: Protocol,
-    ) -> Result<Self, TestBinaryError> {
-        let domain = match ip_kind {
-            IpAddrKind::V4 => Domain::IPV4,
-            IpAddrKind::V6 => Domain::IPV6,
-        };
-        let bind_addr: SocketAddr = match ip_kind {
-            IpAddrKind::V4 => SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0),
-            IpAddrKind::V6 => SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 0),
-        };
+        let mut opened_any = false;
+        for step in 0..band.slots {
+            let slot = (first + step) % band.slots;
+            let path = lock_dir().join(format!("slot-{slot}.lock"));
+            // Skip a slot whose lock file will not open rather than failing the
+            // run: one run as root leaves files behind that a later run as a
+            // normal user cannot open, and those must not hide the slots after
+            // them.
+            let Ok(file) = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&path)
+            else {
+                continue;
+            };
+            opened_any = true;
 
-        for _ in 0..MAX_BIND_ATTEMPTS {
-            let socket = Socket::new(domain, sock_type, Some(protocol)).map_err(|e| {
-                TestBinaryError::InvalidState {
-                    message: format!("Failed to create socket: {e}"),
+            match file.try_lock() {
+                Ok(()) => {
+                    return Ok(Self {
+                        base_port: band.base_port(slot),
+                        next_offset: 0,
+                        _lock: file,
+                    });
                 }
-            })?;
-
-            socket
-                .set_reuse_address(true)
-                .map_err(|e| TestBinaryError::InvalidState {
-                    message: format!("Failed to set SO_REUSEADDR: {e}"),
-                })?;
-
-            #[cfg(unix)]
-            socket
-                .set_reuse_port(true)
-                .map_err(|e| TestBinaryError::InvalidState {
-                    message: format!("Failed to set SO_REUSEPORT: {e}"),
-                })?;
-
-            socket
-                .bind(&bind_addr.into())
-                .map_err(|e| TestBinaryError::InvalidState {
-                    message: format!("Failed to bind socket: {e}"),
-                })?;
-
-            // Bind WITHOUT listen: a listening reservation joins the port's
-            // SO_REUSEPORT group and accepts early dials into a backlog nobody
-            // drains. During cluster startup a peer's replica connector dials
-            // ports whose reservations are still held (release happens per-node
-            // right before spawn), so each such dial used to wedge until the
-            // 2s handshake-ack timeout. A bound-only socket still holds the
-            // port against ephemeral allocation but answers RST, so dialers
-            // fail fast and the reconnect sweep retries cleanly.
-            let addr = socket
-                .local_addr()
-                .map_err(|e| TestBinaryError::InvalidState {
-                    message: format!("Failed to get local address: {e}"),
-                })?
-                .as_socket()
-                .ok_or_else(|| TestBinaryError::InvalidState {
-                    message: "Socket address is not an IP address".to_string(),
-                })?;
-
-            // SO_REUSEPORT lets the kernel reuse a port another reservation
-            // already holds; rebind (dropping this socket) until the claim wins
-            // both in-process and across the concurrent test processes.
-            if claim_port(addr.port()) {
-                match lock_port(addr.port()) {
-                    PortClaim::Locked(lock) => {
-                        return Ok(Self {
-                            socket,
-                            addr,
-                            lock: Some(lock),
-                        });
-                    }
-                    // Lock infra unavailable: keep the in-process claim and run
-                    // without the cross-process guard rather than fail the run.
-                    PortClaim::Unsupported => {
-                        return Ok(Self {
-                            socket,
-                            addr,
-                            lock: None,
-                        });
-                    }
-                    // Held by another process; the number stays claimed (so we
-                    // do not retry it) and we rebind to a different port.
-                    PortClaim::Contended => {}
+                Err(TryLockError::WouldBlock) => {}
+                // A slot index is only exclusive while the lock works. Handing
+                // the ports out anyway would give two servers the same numbers,
+                // so there is no degraded mode to fall back to.
+                Err(TryLockError::Error(e)) => {
+                    return Err(TestBinaryError::InvalidState {
+                        message: format!(
+                            "Failed to lock port slot {}: {e}. Test port slots need a filesystem \
+                             with working advisory locks. Redirecting TMPDIR at one is not a fix: \
+                             every runner on the host has to share a single lock directory, and a \
+                             second one hands out the same slots, so the same ports.",
+                            path.display()
+                        ),
+                    });
                 }
             }
         }
 
+        if !opened_any {
+            return Err(TestBinaryError::InvalidState {
+                message: format!(
+                    "None of the {} test port slot locks under {} could be opened. Check the \
+                     directory's ownership and permissions: a run as root leaves lock files that \
+                     a later run as a normal user cannot open.",
+                    band.slots,
+                    lock_dir().display()
+                ),
+            });
+        }
+
         Err(TestBinaryError::InvalidState {
-            message: format!("Failed to reserve a unique port after {MAX_BIND_ATTEMPTS} attempts"),
+            message: format!(
+                "All {} test port slots in [{}, {}] are in use. Lower the test concurrency, or \
+                 widen the band by narrowing the kernel's ephemeral range \
+                 (net.ipv4.ip_local_port_range).",
+                band.slots,
+                band.start,
+                band.end()
+            ),
         })
     }
 
-    fn addr(&self) -> SocketAddr {
-        self.addr
-    }
-
-    fn release(self) {
-        // Drop the reservation socket so the server can bind the port, but move
-        // the advisory lock (when held) into the process-wide registry so it
-        // outlives the socket and keeps concurrent test processes off the port
-        // until the server has bound it.
-        let Self { socket, lock, .. } = self;
-        if let Some(lock) = lock {
-            PORT_LOCKS
-                .lock()
-                .expect("port-locks mutex poisoned")
-                .push(lock);
+    fn next_addr(&mut self, ip_kind: IpAddrKind) -> Result<SocketAddr, TestBinaryError> {
+        if self.next_offset >= PORTS_PER_SLOT {
+            return Err(TestBinaryError::InvalidState {
+                message: format!(
+                    "A port slot owns {PORTS_PER_SLOT} ports and this reserver has taken all of \
+                     them. Widen PORTS_PER_SLOT rather than spilling into the next slot."
+                ),
+            });
         }
-        drop(socket);
-    }
-}
 
-/// Pre-allocated ports for all enabled protocols.
-pub struct PortReserver {
-    tcp: Option<ReservedPort>,
-    tcp_replica: Option<ReservedPort>,
-    quic: Option<ReservedPort>,
-    http: Option<ReservedPort>,
-    websocket: Option<ReservedPort>,
-}
+        let port = self.base_port + self.next_offset;
+        self.next_offset += 1;
 
-/// Single port reservation for simpler binaries (MCP, connectors).
-pub struct SinglePortReserver {
-    reserved: ReservedPort,
-}
-
-impl SinglePortReserver {
-    pub fn new() -> Result<Self, TestBinaryError> {
-        let reserved = ReservedPort::tcp(IpAddrKind::V4)?;
-        Ok(Self { reserved })
-    }
-
-    pub fn address(&self) -> SocketAddr {
-        self.reserved.addr()
-    }
-
-    pub fn release(self) {
-        self.reserved.release();
+        let ip: IpAddr = match ip_kind {
+            IpAddrKind::V4 => Ipv4Addr::LOCALHOST.into(),
+            IpAddrKind::V6 => Ipv6Addr::LOCALHOST.into(),
+        };
+        Ok(SocketAddr::new(ip, port))
     }
 }
 
@@ -290,6 +278,37 @@ pub struct ProtocolAddresses {
     pub quic: Option<SocketAddr>,
     pub http: Option<SocketAddr>,
     pub websocket: Option<SocketAddr>,
+}
+
+/// Pre-allocated ports for all protocols enabled in the config.
+///
+/// Keep this alive for as long as the server owns the ports: dropping it hands
+/// the slot to the next test.
+pub struct PortReserver {
+    addresses: ProtocolAddresses,
+    _slot: SlotGuard,
+}
+
+/// Single port reservation for simpler binaries (MCP, connectors).
+pub struct SinglePortReserver {
+    address: SocketAddr,
+    _slot: SlotGuard,
+}
+
+impl SinglePortReserver {
+    pub fn new() -> Result<Self, TestBinaryError> {
+        let mut slot = SlotGuard::acquire()?;
+        slot.next_offset = SINGLE_PORT_OFFSET;
+        let address = slot.next_addr(IpAddrKind::V4)?;
+        Ok(Self {
+            address,
+            _slot: slot,
+        })
+    }
+
+    pub fn address(&self) -> SocketAddr {
+        self.address
+    }
 }
 
 /// Pre-allocated ports for a cluster of servers.
@@ -328,63 +347,203 @@ impl PortReserver {
         ip_kind: IpAddrKind,
         config: &TestServerConfig,
     ) -> Result<Self, TestBinaryError> {
-        let tcp = Some(ReservedPort::tcp(ip_kind)?);
-        let tcp_replica = Some(ReservedPort::tcp(ip_kind)?);
+        let mut slot = SlotGuard::acquire()?;
+
+        let tcp = Some(slot.next_addr(ip_kind)?);
+        let tcp_replica = Some(slot.next_addr(ip_kind)?);
 
         let quic = if config.quic_enabled {
-            Some(ReservedPort::udp(ip_kind)?)
+            Some(slot.next_addr(ip_kind)?)
         } else {
             None
         };
 
         let http = if config.http_enabled {
-            Some(ReservedPort::tcp(ip_kind)?)
+            Some(slot.next_addr(ip_kind)?)
         } else {
             None
         };
 
         let websocket = if config.websocket_enabled {
-            Some(ReservedPort::tcp(ip_kind)?)
+            Some(slot.next_addr(ip_kind)?)
         } else {
             None
         };
 
         Ok(Self {
-            tcp,
-            tcp_replica,
-            quic,
-            http,
-            websocket,
+            addresses: ProtocolAddresses {
+                tcp,
+                tcp_replica,
+                quic,
+                http,
+                websocket,
+            },
+            _slot: slot,
         })
     }
 
-    /// Get the bound addresses for environment variable configuration.
+    /// Get the reserved addresses for environment variable configuration.
     pub fn addresses(&self) -> ProtocolAddresses {
-        ProtocolAddresses {
-            tcp: self.tcp.as_ref().map(ReservedPort::addr),
-            tcp_replica: self.tcp_replica.as_ref().map(ReservedPort::addr),
-            quic: self.quic.as_ref().map(ReservedPort::addr),
-            http: self.http.as_ref().map(ReservedPort::addr),
-            websocket: self.websocket.as_ref().map(ReservedPort::addr),
+        self.addresses.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ports_of(reserver: &PortReserver) -> Vec<u16> {
+        let addresses = reserver.addresses();
+        [
+            addresses.tcp,
+            addresses.tcp_replica,
+            addresses.quic,
+            addresses.http,
+            addresses.websocket,
+        ]
+        .into_iter()
+        .flatten()
+        .map(|addr| addr.port())
+        .collect()
+    }
+
+    #[test]
+    fn given_a_readable_range_when_parsed_should_take_both_bounds() {
+        assert_eq!(
+            parse_ephemeral_range("32768\t60999\n"),
+            Some((32768, 60999))
+        );
+        assert_eq!(parse_ephemeral_range("1024 65535"), Some((1024, 65535)));
+        assert_eq!(parse_ephemeral_range(""), None);
+        assert_eq!(parse_ephemeral_range("32768"), None);
+        assert_eq!(parse_ephemeral_range("garbage 60999"), None);
+    }
+
+    #[test]
+    fn given_room_below_the_floor_when_choosing_a_band_should_take_it() {
+        for (floor, ceiling) in [
+            DEFAULT_EPHEMERAL_RANGE,
+            (BAND_START + PORTS_PER_SLOT + 1, 60999),
+            // Nothing above the ceiling either, so below is the only answer.
+            (49152, FALLBACK_BAND_END),
+        ] {
+            let band = band_for(floor, ceiling).expect("range leaves room below the floor");
+            assert_eq!(band.start, BAND_START);
+            assert!(
+                band.end() < floor,
+                "band [{}, {}] runs into the ephemeral range [{floor}, {ceiling}]",
+                band.start,
+                band.end()
+            );
         }
     }
 
-    /// Release all held sockets. Call after server has successfully bound.
-    pub fn release(self) {
-        if let Some(tcp) = self.tcp {
-            tcp.release();
+    /// A floor tuned under the band start is not fatal on its own: the ports
+    /// above the ceiling are just as clear of the kernel's picks, and a box
+    /// tuned that way could not run the suite at all otherwise.
+    #[test]
+    fn given_no_room_below_the_floor_when_choosing_a_band_should_fall_back_above_the_ceiling() {
+        for (floor, ceiling) in [
+            (1024, 60999),
+            (1024, 32767),
+            (BAND_START, 60999),
+            (0, 60999),
+        ] {
+            let band = band_for(floor, ceiling).expect("range leaves room above the ceiling");
+            assert!(band.slots >= 1);
+            assert!(
+                band.start > ceiling,
+                "band [{}, {}] runs into the ephemeral range [{floor}, {ceiling}]",
+                band.start,
+                band.end()
+            );
         }
-        if let Some(tcp_replica) = self.tcp_replica {
-            tcp_replica.release();
+    }
+
+    /// A range that spans both sides has no safe answer: every port the harness
+    /// could hand out is one the kernel can hand out too.
+    #[test]
+    fn given_no_room_on_either_side_when_choosing_a_band_should_fail_loudly() {
+        for (floor, ceiling) in [
+            (1024, FALLBACK_BAND_END),
+            (0, FALLBACK_BAND_END),
+            (BAND_START, FALLBACK_BAND_END),
+        ] {
+            assert!(
+                band_for(floor, ceiling).is_err(),
+                "range [{floor}, {ceiling}] leaves no usable band and must be rejected"
+            );
         }
-        if let Some(quic) = self.quic {
-            quic.release();
+    }
+
+    #[test]
+    fn given_a_slot_when_drained_should_refuse_to_spill_into_the_next() {
+        let mut slot = SlotGuard::acquire().expect("a free slot");
+        let base = slot.base_port;
+
+        for offset in 0..PORTS_PER_SLOT {
+            let addr = slot.next_addr(IpAddrKind::V4).expect("slot owns this port");
+            assert_eq!(addr.port(), base + offset);
         }
-        if let Some(http) = self.http {
-            http.release();
+
+        assert!(
+            slot.next_addr(IpAddrKind::V4).is_err(),
+            "a drained slot must not hand out the next slot's ports"
+        );
+    }
+
+    /// The allocator rests on `flock` conflicting between two open file
+    /// descriptions in one process, which is what a single-process `cargo test`
+    /// run of the suite relies on.
+    #[test]
+    fn given_two_live_reservers_when_reserved_in_one_process_should_not_share_a_port() {
+        // Enabled explicitly: this test is about ports, and must not go red
+        // because a protocol's default flipped.
+        let config = TestServerConfig::builder()
+            .quic_enabled(true)
+            .http_enabled(true)
+            .websocket_enabled(true)
+            .build();
+        let first = PortReserver::reserve(IpAddrKind::V4, &config).expect("first reserver");
+        let second = PortReserver::reserve(IpAddrKind::V4, &config).expect("second reserver");
+
+        let first_ports = ports_of(&first);
+        let second_ports = ports_of(&second);
+
+        assert_eq!(
+            first_ports.len(),
+            5,
+            "tcp, tcp_replica, quic, http and websocket"
+        );
+        for port in &first_ports {
+            assert!(
+                !second_ports.contains(port),
+                "port {port} handed to two live reservers"
+            );
         }
-        if let Some(websocket) = self.websocket {
-            websocket.release();
+    }
+
+    /// The single-port consumers bind a different socket-option flavor than
+    /// the server's TCP listener, and a TIME_WAIT socket of one flavor blocks
+    /// binds of the other, so their port must stay off the server offsets.
+    #[test]
+    fn given_a_single_port_reserver_when_reserved_should_stay_off_the_server_offsets() {
+        let (floor, ceiling) = ephemeral_range();
+        let band = band_for(floor, ceiling).expect("a usable band");
+        let reserver = SinglePortReserver::new().expect("a free slot");
+        let offset = (reserver.address().port() - band.start) % PORTS_PER_SLOT;
+        assert_eq!(offset, SINGLE_PORT_OFFSET);
+    }
+
+    /// Reserving more times than the band has slots only works if a drop puts
+    /// the slot back, which is what the whole suite running in one process does.
+    #[test]
+    fn given_more_reservations_than_slots_when_each_is_dropped_should_keep_succeeding() {
+        let (floor, ceiling) = ephemeral_range();
+        let band = band_for(floor, ceiling).expect("a usable band");
+        for round in 0..usize::from(band.slots) + 16 {
+            SinglePortReserver::new()
+                .unwrap_or_else(|e| panic!("round {round} found no free slot: {e}"));
         }
     }
 }

--- a/core/integration/src/harness/traits.rs
+++ b/core/integration/src/harness/traits.rs
@@ -47,7 +47,6 @@ pub trait IggyServerDependent: TestBinary {
     fn set_iggy_address(&mut self, addr: SocketAddr);
 
     /// Wait until the dependent service is ready to accept requests.
-    /// May release internal resources (e.g., port reservations) once ready.
     fn wait_ready(
         &mut self,
     ) -> impl std::future::Future<Output = Result<(), TestBinaryError>> + Send;

--- a/core/integration/tests/cli/common/keyring.rs
+++ b/core/integration/tests/cli/common/keyring.rs
@@ -17,6 +17,8 @@
 
 #[cfg(all(feature = "login-session", secret_service_keyring))]
 mod backend {
+    use iggy_cli::commands::binary_system::session::ServerSession;
+    use std::net::SocketAddr;
     use std::sync::OnceLock;
     use zbus_secret_service_keyring_store::store::Store;
 
@@ -26,8 +28,8 @@ mod backend {
     /// verbatim instead.
     static KEYRING_INIT: OnceLock<Result<(), String>> = OnceLock::new();
 
-    pub(crate) fn ensure_keyring_store() {
-        let result = KEYRING_INIT.get_or_init(|| match Store::new() {
+    fn init_store() -> &'static Result<(), String> {
+        KEYRING_INIT.get_or_init(|| match Store::new() {
             Ok(store) => {
                 keyring_core::set_default_store(store);
                 Ok(())
@@ -37,16 +39,36 @@ mod backend {
                  Ensure DBUS_SESSION_BUS_ADDRESS is set and a secret-service \
                  provider (gnome-keyring-daemon, KWallet, KeePassXC) is running."
             )),
-        });
-        if let Err(msg) = result {
+        })
+    }
+
+    pub(crate) fn ensure_keyring_store() {
+        if let Err(msg) = init_store() {
             panic!("{msg}");
         }
     }
+
+    /// Drop the CLI's stored session token for `address`, if one is there.
+    ///
+    /// Runs on both the setup and teardown paths. Errors are swallowed rather
+    /// than asserted on: an absent entry is the normal case, and on teardown a
+    /// panic during unwind aborts the process and buries the failure under test.
+    pub(crate) fn clear_session_entry(address: SocketAddr) {
+        if init_store().is_err() {
+            return;
+        }
+        let _ = ServerSession::new(address.to_string()).delete();
+    }
 }
 
-#[cfg(all(feature = "login-session", secret_service_keyring))]
-pub(crate) use backend::ensure_keyring_store;
-
 #[cfg(not(all(feature = "login-session", secret_service_keyring)))]
-#[allow(dead_code)]
-pub(crate) fn ensure_keyring_store() {}
+mod backend {
+    use std::net::SocketAddr;
+
+    pub(crate) fn ensure_keyring_store() {}
+
+    pub(crate) fn clear_session_entry(_address: SocketAddr) {}
+}
+
+#[allow(unused_imports)]
+pub(crate) use backend::{clear_session_entry, ensure_keyring_store};

--- a/core/integration/tests/cli/common/mod.rs
+++ b/core/integration/tests/cli/common/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod keyring;
 pub(crate) use crate::cli::common::command::IggyCmdCommand;
 pub(crate) use crate::cli::common::help::{CLAP_INDENT, TestHelpCmd, USAGE_PREFIX};
 #[allow(unused_imports)]
-pub(crate) use crate::cli::common::keyring::ensure_keyring_store;
+pub(crate) use crate::cli::common::keyring::{clear_session_entry, ensure_keyring_store};
 use assert_cmd::assert::{Assert, OutputAssertExt};
 use assert_cmd::prelude::CommandCargoExt;
 use async_trait::async_trait;
@@ -119,6 +119,32 @@ impl IggyCmdTest {
                 .start()
                 .await
                 .expect("Failed to start test harness");
+        }
+        self.clear_session_keyring();
+    }
+
+    /// Drop any CLI session token the OS keyring holds for this server's
+    /// addresses.
+    ///
+    /// The CLI keys a stored session by server address, the harness recycles its
+    /// port slots, and nothing scopes a keyring to one test run. An entry left
+    /// behind therefore reaches the next test on that address, which then
+    /// replays a token the server it reaches never issued.
+    ///
+    /// Both sides: on setup the leftover may predate this process, on teardown
+    /// so a real keyring is not polluted in the first place.
+    fn clear_session_keyring(&self) {
+        let server = self.harness.server();
+        for address in [
+            server.tcp_addr(),
+            server.quic_addr(),
+            server.http_addr(),
+            server.websocket_addr(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            clear_session_entry(address);
         }
     }
 
@@ -246,5 +272,11 @@ impl IggyCmdTest {
 impl Default for IggyCmdTest {
     fn default() -> Self {
         Self::new(true)
+    }
+}
+
+impl Drop for IggyCmdTest {
+    fn drop(&mut self) {
+        self.clear_session_keyring();
     }
 }

--- a/core/integration/tests/connectors/doris/doris_sink.rs
+++ b/core/integration/tests/connectors/doris/doris_sink.rs
@@ -251,24 +251,57 @@ async fn given_replayed_label_should_dedupe(harness: &TestHarness, fixture: Dori
         .expect("count before");
     assert_eq!(row_before, message_count as i64);
 
-    // Replay the same offsets => same label => Doris dedupes server-side.
-    // Reuse the connector's own `build_label` so the test cannot drift from
-    // the production label format.
-    let label = iggy_connector_doris_sink::build_label(
-        "iggy_test",
-        seeds::names::STREAM,
-        seeds::names::TOPIC,
-        0,
-        0,
-        (message_count - 1) as u64,
-    );
-
-    let body = serde_json::to_vec(&test_messages).expect("serialize replay body");
-
     let client_http = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap();
+
+    // The connector labels each Stream Load with the batch's offset range,
+    // and a multi-node cluster can flush the 5 messages in several splits at
+    // the commit watermark (e.g. offsets 0-1 + 2-4), so predicting a single
+    // 0-4 label is wrong. Enumerate every contiguous range's candidate label
+    // via the connector's own `build_label` (so the test cannot drift from
+    // the production format) and keep those Doris actually recorded. Stream
+    // Loads never show up in `SHOW LOAD` (and `SHOW STREAM LOAD` requires a
+    // non-default BE config), so probe the FE's db-scoped load-state API.
+    let last_offset = (message_count - 1) as u64;
+    let mut observed_labels = Vec::new();
+    for first in 0..=last_offset {
+        for last in first..=last_offset {
+            let candidate = iggy_connector_doris_sink::build_label(
+                "iggy_test",
+                seeds::names::STREAM,
+                seeds::names::TOPIC,
+                0,
+                first,
+                last,
+            );
+            let state_url = format!(
+                "{}/api/{db}/get_load_state?label={candidate}",
+                fixture.container().fe_url()
+            );
+            let state: serde_json::Value = client_http
+                .get(&state_url)
+                .basic_auth("root", Some(""))
+                .send()
+                .await
+                .expect("get_load_state request")
+                .json()
+                .await
+                .expect("get_load_state response");
+            if state["data"] == "VISIBLE" {
+                observed_labels.push(candidate);
+            }
+        }
+    }
+    eprintln!("observed Doris stream load labels: {observed_labels:?}");
+
+    // Replay one observed label => Doris must dedupe server-side.
+    let label = observed_labels
+        .pop()
+        .expect("connector should have produced at least one visible stream load");
+
+    let body = serde_json::to_vec(&test_messages).expect("serialize replay body");
 
     let url = format!(
         "{}/api/{db}/{TEST_TABLE}/_stream_load",
@@ -316,10 +349,10 @@ async fn given_replayed_label_should_dedupe(harness: &TestHarness, fixture: Dori
         break resp;
     };
     let body_text = response.text().await.expect("body");
-    // Require Doris to report dedupe explicitly. A `"Success"` here would
-    // mean the label drifted from what the connector built — which doubles
-    // rows and is caught by `row_after == message_count`, but we want the
-    // dedupe path itself to be load-bearing in this test.
+    // Require Doris to report dedupe explicitly. The label was just observed
+    // as a VISIBLE load, so anything but "Label Already Exists" is a dedupe
+    // regression; a "Success" would also double rows, which the count check
+    // below catches.
     assert!(
         body_text.contains("Label Already Exists"),
         "expected Doris to dedupe by label, got: {body_text}"

--- a/core/integration/tests/sdk/consumer_group_membership.rs
+++ b/core/integration/tests/sdk/consumer_group_membership.rs
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use iggy::prelude::*;
+use integration::iggy_harness;
+use tokio::time::timeout;
+
+const STREAM_NAME: &str = "cg-membership-stream";
+const TOPIC_NAME: &str = "cg-membership-topic";
+const CONSUMER_GROUP_NAME: &str = "cg-membership-group";
+
+// A member holding zero partitions polls empty forever, so a short wait is
+// enough to let it sync (registering its membership) and then park.
+const PARK_TIMEOUT: Duration = Duration::from_secs(2);
+// Generous bound: on regression the poll hangs until this elapses.
+const RESOLVE_TIMEOUT: Duration = Duration::from_secs(10);
+
+// A consumer-group member holding zero partitions has the same empty client-side
+// assignment as a non-member; only membership tells them apart. When the group
+// is deleted under such a member, the poll must surface an error (driving a
+// rejoin) rather than treating the empty assignment as "nothing to poll" and
+// hanging forever.
+#[iggy_harness(test_client_transport = [Tcp, WebSocket, Quic])]
+async fn given_group_member_holds_no_partitions_when_group_deleted_should_surface_error_not_hang(
+    harness: &TestHarness,
+) {
+    let stream_id = Identifier::named(STREAM_NAME).unwrap();
+    let topic_id = Identifier::named(TOPIC_NAME).unwrap();
+    let group_id = Identifier::named(CONSUMER_GROUP_NAME).unwrap();
+
+    // One connection administers the group and is the member that will hold the
+    // single partition; the other backs the consumer under test.
+    let mut clients = harness
+        .root_clients(2)
+        .await
+        .expect("Failed to create root clients");
+    let admin = clients.remove(0);
+    let consumer_client = clients.remove(0);
+
+    admin.create_stream(STREAM_NAME).await.unwrap();
+    admin
+        .create_topic(
+            &stream_id,
+            TOPIC_NAME,
+            1,
+            CompressionAlgorithm::default(),
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+    admin
+        .create_consumer_group(&stream_id, &topic_id, CONSUMER_GROUP_NAME)
+        .await
+        .unwrap();
+
+    // The first member to join keeps the topic's only partition, leaving the
+    // second member (the consumer under test) with none.
+    admin
+        .join_consumer_group(&stream_id, &topic_id, &group_id)
+        .await
+        .unwrap();
+
+    let mut consumer = consumer_client
+        .consumer_group(CONSUMER_GROUP_NAME, STREAM_NAME, TOPIC_NAME)
+        .unwrap()
+        .batch_length(1)
+        .poll_interval(IggyDuration::new(Duration::from_millis(100)))
+        .auto_join_consumer_group()
+        .do_not_create_consumer_group_if_not_exists()
+        .build();
+    consumer.init().await.unwrap();
+
+    let group = admin
+        .get_consumer_group(&stream_id, &topic_id, &group_id)
+        .await
+        .unwrap()
+        .expect("Consumer group should exist");
+    assert_eq!(group.members_count, 2);
+    let partition_counts: Vec<u32> = group
+        .members
+        .iter()
+        .map(|member| member.partitions_count)
+        .collect();
+    assert!(
+        partition_counts.contains(&0) && partition_counts.contains(&1),
+        "expected one member to hold the single partition and one to hold none, got {partition_counts:?}"
+    );
+
+    // Alive group: a zero-partition member is a legitimate member, so its poll
+    // parks (yields nothing) instead of surfacing an error or churning.
+    match timeout(PARK_TIMEOUT, consumer.next()).await {
+        Err(_elapsed) => {}
+        Ok(Some(Ok(_))) => {
+            panic!("a zero-partition member must not receive a message while its group is alive")
+        }
+        Ok(Some(Err(error))) => panic!(
+            "a zero-partition member must not surface an error while its group is alive, got {error:?}"
+        ),
+        Ok(None) => panic!("consumer stream closed unexpectedly while the group is alive"),
+    }
+
+    admin
+        .delete_consumer_group(&stream_id, &topic_id, &group_id)
+        .await
+        .unwrap();
+
+    // Deleted group: the member is no longer registered, so the poll must fail
+    // fast (the rejoin surfaces the missing group) rather than hang.
+    let item = timeout(RESOLVE_TIMEOUT, consumer.next())
+        .await
+        .expect("poll must not hang after the group is deleted")
+        .expect("consumer stream should remain open");
+    match item {
+        Err(IggyError::ConsumerGroupNameNotFound(..)) => {}
+        Err(other) => {
+            panic!("expected ConsumerGroupNameNotFound after group deletion, got error {other:?}")
+        }
+        Ok(_) => panic!("expected an error after group deletion, got a message"),
+    }
+}

--- a/core/integration/tests/sdk/mod.rs
+++ b/core/integration/tests/sdk/mod.rs
@@ -16,6 +16,8 @@
 // under the License.
 
 mod consumer_group;
+#[cfg(feature = "vsr")]
+mod consumer_group_membership;
 mod hello_world;
 #[cfg(feature = "vsr")]
 mod http_refresh;

--- a/core/message_bus/src/client_listener/quic.rs
+++ b/core/message_bus/src/client_listener/quic.rs
@@ -64,11 +64,12 @@ pub fn bind(
     addr: SocketAddr,
     server_config: ServerConfig,
 ) -> Result<(Endpoint, SocketAddr), IggyError> {
-    // QUIC remains shard-0 terminal; this only enables coexistence with the
-    // harness's placeholder UDP socket during process startup.
+    // QUIC remains shard-0 terminal, so nothing here needs the load balancing
+    // `SO_REUSEPORT` exists for; it only widens what the bind accepts.
     //
-    // TODO: remove `SO_REUSEPORT` again once the integration harness stops
-    // holding placeholder reservation sockets open across child startup.
+    // TODO: work out whether this listener needs `SO_REUSEPORT` at all. Dropping
+    // it would make a stale process holding the port a loud bind failure instead
+    // of two live sockets silently splitting inbound datagrams.
     let socket = Socket::new(Domain::for_address(addr), Type::DGRAM, Some(Protocol::UDP))
         .map_err(|e| IggyError::IoError(e.to_string()))?;
     socket

--- a/core/message_bus/src/socket_opts.rs
+++ b/core/message_bus/src/socket_opts.rs
@@ -45,15 +45,14 @@ pub fn apply_nodelay_for_connection(stream: &TcpStream) -> io::Result<()> {
     SockRef::from(stream).set_tcp_nodelay(true)
 }
 
-/// Build a TCP listener compatible with the harness's pre-bound reservation
-/// sockets.
+/// Build a TCP listener that tolerates another socket already holding the port.
 ///
-/// Only shard 0 binds the real listener; `SO_REUSEPORT` is enabled here solely
-/// so the server process can claim a port already held open by the integration
-/// harness during startup.
+/// Only shard 0 binds the real listener, so nothing here needs the load
+/// balancing `SO_REUSEPORT` exists for; it only widens what the bind accepts.
 ///
-/// TODO: remove `SO_REUSEPORT` again once the integration harness stops
-/// holding placeholder reservation sockets open across child startup.
+/// TODO: work out whether these listeners need `SO_REUSEPORT` at all. Dropping
+/// it would make a stale process holding the port a loud bind failure instead
+/// of two live listeners silently splitting the accept queue.
 pub fn bind_reusable_tcp_listener(addr: SocketAddr) -> io::Result<TcpListener> {
     let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))?;
     socket.set_reuse_address(true)?;
@@ -92,8 +91,9 @@ mod tests {
             not(any(target_os = "illumos", target_os = "solaris", target_os = "cygwin"))
         ))]
         socket.set_reuse_port(true).expect("reserve reuseport");
-        // Bound, not listening: mirrors the harness's PortReserver, which
-        // holds ports without joining the SO_REUSEPORT accept group.
+        // Bound, not listening: a port held without joining the accept group,
+        // which is what the reuse flags have to tolerate and what a plain bind
+        // would reject.
         socket.bind(&reserve_addr.into()).expect("reserve bind");
         let addr = socket
             .local_addr()

--- a/justfile
+++ b/justfile
@@ -43,6 +43,9 @@ reap_test_containers := "docker ps -aqf 'name=^iggy-test-' | xargs -r docker rm 
 build:
   cargo build
 
+build-vsr:
+  cargo build --features vsr
+
 test: build
   #!/usr/bin/env bash
   set -euo pipefail
@@ -60,6 +63,17 @@ nextest: build
   set -euo pipefail
   trap "{{reap_test_containers}}" EXIT
   cargo nextest run
+
+# Like `nextest` but with the `vsr` feature; builds vsr first so the
+# harness-spawned iggy-server-ng carries the vsr wire format. `--no-fail-fast`
+# because nextest otherwise cancels the run on the first red, which on a loaded
+# box means a stray flake hides most of the suite and the reported counts
+# understate what actually ran.
+nextest-vsr: build-vsr
+  #!/usr/bin/env bash
+  set -euo pipefail
+  trap "{{reap_test_containers}}" EXIT
+  cargo nextest run --features vsr --no-fail-fast
 
 nextests TEST: build
   #!/usr/bin/env bash


### PR DESCRIPTION
A consumer polling a group it was no longer a member of hung
forever: the client swallowed the server's zero-length SYNC
reply (member not found) and kept polling with a stale
registration. Key client registration off group membership
(joined_groups), never off partition assignment - a live
member holding zero partitions also has no assignment and
must not churn-rejoin. Deregister on the server's answer so
the next poll re-joins. New integration test fails on the
old code (silent 10s hang) and guards both edits.

Enabling the vsr suite single-process also exposed the test
harness: the probe-and-retry port reserver held placeholder
sockets and one lock file per port ever reserved, cascading
'Failed to reserve a unique port' 582 times under one cargo
test process and EMFILE at ulimit 1024. Replace it with an
arithmetic band allocator (one flock per slot, nothing
bound, fd cost ~1 per live reserver). Deterministic ports
then surfaced OS-keyring pollution in CLI tests - entries
are keyed by host:port and outlive tests - so CLI tests now
isolate the keyring. SO_REUSEPORT TODOs in message_bus are
re-scoped: the placeholder sockets they waited on are gone,
removal is a separate change.

The vsr suite also exposed the doris replay-dedupe test: it
predicted the connector's Stream Load label for offsets 0-4,
but a 3-node cluster can flush the batch in splits at the
commit watermark (e.g. 0-1 + 2-4), so the predicted label
never existed and Doris answered Success instead of Label
Already Exists. The test now probes every candidate
offset-range label through the FE's get_load_state API
(stream loads never appear in SHOW LOAD) and replays a label
the connector actually used.
