### PR TITLE
test(cpp): poll for session removal instead of asserting once

### DIFF
--- a/foreign/cpp/tests/client/low_level_e2e.cpp
+++ b/foreign/cpp/tests/client/low_level_e2e.cpp
@@ -20,9 +20,11 @@
 // TODO(slbotbm): Add tests for store_consumer_offset, get_consumer_offset, and delete_consumer_offset functions
 // attached to client after implementing consumer group functions
 // TODO(slbotbm): Add tests for update_permissions after creating create_user, get_user, etc. functions
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <thread>
 #include <unordered_set>
 
 #include <gtest/gtest.h>
@@ -31,6 +33,30 @@
 #include "tests/common/test_helpers.hpp"
 
 class LowLevelE2E_Client : public E2ETestFixture {};
+
+namespace {
+// A session is removed server-side when the server observes the closed
+// connection, which can lag the client's disconnect/shutdown call. Poll
+// get_clients from the observing connection until the id is gone rather than
+// asserting once immediately.
+bool WaitForClientRemoved(iggy::ffi::Client *observer, std::uint32_t client_id) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    do {
+        bool present = false;
+        for (const auto &client : observer->get_clients()) {
+            if (client.client_id == client_id) {
+                present = true;
+                break;
+            }
+        }
+        if (!present) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return false;
+}
+}  // namespace
 
 TEST_F(LowLevelE2E_Client, ConnectAndLogin) {
     RecordProperty("description", "Connects and logs in successfully using each supported connection string format.");
@@ -397,21 +423,11 @@ TEST_F(LowLevelE2E_Client, GetClientsReflectsSessionRemovalAfterShutdown) {
     iggy::ffi::Client *second_client = GetLoggedInClient();
 
     iggy::ffi::ClientInfoDetails first_me{};
-    rust::Vec<iggy::ffi::ClientInfo> clients_after_shutdown;
     ASSERT_NO_THROW({ first_me = first_client->get_me(); });
 
     ASSERT_NO_THROW(first_client->shutdown());
-    ASSERT_NO_THROW({ clients_after_shutdown = second_client->get_clients(); });
 
-    bool found_first = false;
-    for (const auto &client : clients_after_shutdown) {
-        if (client.client_id == first_me.client_id) {
-            found_first = true;
-            break;
-        }
-    }
-
-    EXPECT_FALSE(found_first);
+    EXPECT_TRUE(WaitForClientRemoved(second_client, first_me.client_id));
     ASSERT_THROW(second_client->get_client(first_me.client_id), std::exception);
 }
 
@@ -422,21 +438,11 @@ TEST_F(LowLevelE2E_Client, GetClientsReflectsSessionRemovalAfterDisconnect) {
     iggy::ffi::Client *second_client = GetLoggedInClient();
 
     iggy::ffi::ClientInfoDetails first_me{};
-    rust::Vec<iggy::ffi::ClientInfo> clients_after_disconnect;
     ASSERT_NO_THROW({ first_me = first_client->get_me(); });
 
     ASSERT_NO_THROW(first_client->disconnect());
-    ASSERT_NO_THROW({ clients_after_disconnect = second_client->get_clients(); });
 
-    bool found_first = false;
-    for (const auto &client : clients_after_disconnect) {
-        if (client.client_id == first_me.client_id) {
-            found_first = true;
-            break;
-        }
-    }
-
-    EXPECT_FALSE(found_first);
+    EXPECT_TRUE(WaitForClientRemoved(second_client, first_me.client_id));
     ASSERT_THROW(second_client->get_client(first_me.client_id), std::exception);
 }
 


### PR DESCRIPTION
## Which issue does this PR address?

Closes #3710

## Rationale

`GetClientsReflectsSessionRemovalAfter{Disconnect,Shutdown}` are the single most common CI flake: of the last 60 `Pre-merge` runs, 14 failed, and 11 of those were exactly these two tests, across 7 unrelated branches.

## What changed?

Both tests disconnected a client and then asserted, over a second connection, that the session was already absent from `get_clients()`. Removal is server-side and happens when the server observes the closed connection ([tcp_listener.rs#L159](https://github.com/apache/iggy/blob/master/core/server/src/tcp/tcp_listener.rs#L159)), which can lag the client's `disconnect`/`shutdown` call. The single immediate assertion therefore raced.

They now poll `get_clients()` until the id disappears, with a 5s timeout, via a small `WaitForClientRemoved` helper. Server behaviour is unchanged; only the test synchronisation is fixed.

## Local Execution

- The change is test-only. I could not build the C++ SDK locally (no bazel toolchain set up here), so I have **not** run it locally and am relying on CI to exercise it - flagging that explicitly rather than claiming a local run I did not do.
- The diagnosis is backed by a study of the last 60 `Pre-merge` runs (11/14 recent failures were these two tests, on unrelated branches) and by reading the server-side session-cleanup path.

## AI Usage

1. **Which tools?** Claude (Claude Code).
2. **Scope of usage?** Diagnosed the flake from CI history and wrote the test change.
3. **How did you verify the generated code works correctly?** Reviewed the diff and the server cleanup path; the C++ build/tests were not run locally (no toolchain) and rely on CI.
4. **Can you explain every line of the code if asked?** Yes.
