### PR TITLE
test(bdd): run Rust BDD against iggy-server-ng with VSR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,7 @@
 /target
 !/target/debug/iggy
 !/target/debug/iggy-server
+!/target/debug/iggy-server-ng
 !/target/debug/iggy-mcp
 !/target/debug/iggy-connectors
 /web/node_modules

--- a/.github/config/components.yml
+++ b/.github/config/components.yml
@@ -300,6 +300,7 @@ components:
       - "bdd/docker-compose.server.yml"
       - "bdd/docker-compose.cluster.yml"
       - "bdd/docker-compose.coverage.yml"
+      - "bdd/docker-compose.vsr.yml"
 
   # Individual BDD tests per SDK - only run when specific SDK changes
   bdd-rust:
@@ -311,7 +312,7 @@ components:
     paths:
       - "bdd/rust/**"
       - "bdd/scenarios/**"
-    tasks: ["bdd-rust"]
+    tasks: ["bdd-rust", "bdd-rust-vsr"]
 
   bdd-python:
     depends_on:

--- a/.github/workflows/_test_bdd.yml
+++ b/.github/workflows/_test_bdd.yml
@@ -51,18 +51,28 @@ jobs:
       - name: Build server for BDD tests
         if: startsWith(inputs.component, 'bdd-') && startsWith(inputs.task, 'bdd-')
         run: |
-          echo "Building server binary and CLI for BDD tests..."
-          cargo build --locked --bin iggy-server --bin iggy
+          if [ "${{ inputs.task }}" = "bdd-rust-vsr" ]; then
+            # server-ng lane: the vsr feature must be enabled on both the
+            # server and the CLI, otherwise the CLI cannot frame requests
+            # for the VSR wire protocol (healthcheck ping would fail).
+            SERVER_BIN="iggy-server-ng"
+            echo "Building server-ng binary and CLI (--features vsr) for BDD tests..."
+            cargo build --locked --bin iggy-server-ng --bin iggy --features vsr
+          else
+            SERVER_BIN="iggy-server"
+            echo "Building server binary and CLI for BDD tests..."
+            cargo build --locked --bin iggy-server --bin iggy
+          fi
 
-          echo "Server binary built at: target/debug/iggy-server"
-          ls -lh target/debug/iggy-server
+          echo "Server binary built at: target/debug/${SERVER_BIN}"
+          ls -lh "target/debug/${SERVER_BIN}"
 
           echo "CLI binary built at: target/debug/iggy"
           ls -lh target/debug/iggy
 
           # Verify the binary exists and is executable
-          if [ ! -f "target/debug/iggy-server" ]; then
-            echo "ERROR: Server binary not found at target/debug/iggy-server"
+          if [ ! -f "target/debug/${SERVER_BIN}" ]; then
+            echo "ERROR: Server binary not found at target/debug/${SERVER_BIN}"
             exit 1
           fi
 
@@ -74,12 +84,21 @@ jobs:
       - name: Run BDD tests
         if: startsWith(inputs.component, 'bdd-') && startsWith(inputs.task, 'bdd-')
         run: |
-          # Extract SDK name from task (format: bdd-<sdk>)
+          # Extract SDK name from task (format: bdd-<sdk>, or bdd-<sdk>-vsr
+          # for the server-ng lane)
           SDK_NAME=$(echo "${{ inputs.task }}" | sed 's/^bdd-//')
+          EXTRA_FLAGS=()
+          if [ "$SDK_NAME" = "rust-vsr" ]; then
+            SDK_NAME="rust"
+            EXTRA_FLAGS+=(--vsr)
+            export IGGY_SERVER_NG_PATH="target/debug/iggy-server-ng"
+            echo "Server binary location: $(ls -lh target/debug/iggy-server-ng)"
+          else
+            echo "Server binary location: $(ls -lh target/debug/iggy-server)"
+          fi
 
           echo "Running BDD tests for SDK: $SDK_NAME"
           echo "Current directory: $(pwd)"
-          echo "Server binary location: $(ls -lh target/debug/iggy-server)"
           echo "CLI binary location: $(ls -lh target/debug/iggy)"
 
           # Export path to the pre-built server and cli binaries (relative to repo root)
@@ -87,7 +106,7 @@ jobs:
           export IGGY_CLI_PATH="target/debug/iggy"
           export IGGY_ROOT_USERNAME="iggy"
           export IGGY_ROOT_PASSWORD="iggy"
-          ./scripts/run-bdd-tests.sh "$SDK_NAME"
+          ./scripts/run-bdd-tests.sh "${EXTRA_FLAGS[@]}" "$SDK_NAME"
 
       - name: Clean up Docker resources (BDD)
         if: always() && startsWith(inputs.component, 'bdd-') && startsWith(inputs.task, 'bdd-')

--- a/bdd/README.md
+++ b/bdd/README.md
@@ -39,6 +39,7 @@ bdd/
 ├── docker-compose.server.yml   # Single iggy-server test setup
 ├── docker-compose.cluster.yml  # Leader + follower test setup
 ├── docker-compose.coverage.yml # Coverage collection overlay
+├── docker-compose.vsr.yml      # server-ng (VSR) overlay, Rust SDK only
 ├── Dockerfile                  # Debug build of Iggy server
 └── README.md
 ```
@@ -69,6 +70,15 @@ bdd/
 
 # Run only leader_redirection
 ../scripts/run-bdd-tests.sh all leader_redirection
+
+# Run against iggy-server-ng with VSR (Rust SDK only; other SDKs do not
+# speak the VSR wire protocol yet). Build the vsr binaries first:
+#   cargo build --bin iggy-server-ng --bin iggy --features vsr
+# NOTE: `target/debug/iggy` is shared between lanes and the vsr flavour
+# speaks a different wire protocol. When switching back to the legacy
+# lane, rebuild without `--features vsr` first, or the in-container
+# healthcheck ping cannot talk to the legacy server.
+../scripts/run-bdd-tests.sh --vsr rust
 
 # Clean up Docker resources
 ../scripts/run-bdd-tests.sh clean

--- a/bdd/docker-compose.coverage.yml
+++ b/bdd/docker-compose.coverage.yml
@@ -32,9 +32,9 @@ services:
         rustup component add llvm-tools-preview \
         && cargo install cargo-llvm-cov \
         && case "$$BDD_FEATURE" in
-          basic_messaging)    cargo llvm-cov test -p bdd --features bdd --test basic_messaging --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
-          leader_redirection) cargo llvm-cov test -p bdd --features bdd --test leader_redirection --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
-          *)                  cargo llvm-cov test -p bdd --features bdd --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
+          basic_messaging)    cargo llvm-cov test -p bdd --features "$$BDD_RUST_FEATURES" --test basic_messaging --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
+          leader_redirection) cargo llvm-cov test -p bdd --features "$$BDD_RUST_FEATURES" --test leader_redirection --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
+          *)                  cargo llvm-cov test -p bdd --features "$$BDD_RUST_FEATURES" --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
         esac
 
   python-bdd:

--- a/bdd/docker-compose.vsr.yml
+++ b/bdd/docker-compose.vsr.yml
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# server-ng (VSR) override. Swaps the legacy iggy-server binary for
+# iggy-server-ng built with `--features vsr` and adapts args, credentials,
+# and cluster topology to server-ng semantics:
+#   - server-ng takes no `--fresh` / `--with-default-root-credentials` /
+#     `--follower` flags; the only CLI arg is `--replica-id <N>`.
+#   - Root credentials come from IGGY_ROOT_USERNAME / IGGY_ROOT_PASSWORD
+#     (mandatory when the cluster is enabled).
+#   - `cluster.nodes[*].ip` is parsed as a strict IpAddr (no hostnames)
+#     and cluster listeners bind to that roster IP, so nodes get static
+#     IPs and node healthchecks ping the roster address, not loopback.
+#   - Replica-to-replica consensus requires `ports.tcp_replica`.
+# The leader_redirection feature runs a REAL 2-node VSR cluster here
+# (initial leader = replica 0), not the legacy mock `--follower` server.
+#
+# Activated by: ./scripts/run-bdd-tests.sh --vsr rust [feature]
+# Must be passed LAST so its overrides win over the server/cluster files.
+
+x-server-ng-image: &server-ng-image
+  image: iggy-bdd-server-ng
+  build:
+    context: ..
+    dockerfile: core/server-ng/Dockerfile
+    target: runtime-prebuilt
+    args:
+      PREBUILT_IGGY_SERVER_NG: ${IGGY_SERVER_NG_PATH:-target/debug/iggy-server-ng}
+      PREBUILT_IGGY_CLI: ${IGGY_CLI_PATH:-target/debug/iggy}
+
+x-vsr-cluster-env: &vsr-cluster-env
+  IGGY_ROOT_USERNAME: iggy
+  IGGY_ROOT_PASSWORD: iggy
+  IGGY_CLUSTER_NODES_0_IP: 172.28.0.101
+  IGGY_CLUSTER_NODES_1_IP: 172.28.0.102
+  IGGY_CLUSTER_NODES_0_PORTS_TCP_REPLICA: "8191"
+  IGGY_CLUSTER_NODES_1_PORTS_TCP_REPLICA: "8192"
+
+services:
+  iggy-server:
+    <<: *server-ng-image
+    command: []
+    environment:
+      - IGGY_ROOT_USERNAME=iggy
+      - IGGY_ROOT_PASSWORD=iggy
+
+  iggy-leader:
+    <<: *server-ng-image
+    command: [ "--replica-id", "0" ]
+    environment:
+      <<: *vsr-cluster-env
+    networks:
+      iggy-bdd-network:
+        ipv4_address: 172.28.0.101
+    healthcheck:
+      test: [ "CMD", "/usr/local/bin/iggy", "--tcp-server-address", "172.28.0.101:8091", "ping" ]
+
+  iggy-follower:
+    <<: *server-ng-image
+    command: [ "--replica-id", "1" ]
+    environment:
+      <<: *vsr-cluster-env
+    networks:
+      iggy-bdd-network:
+        ipv4_address: 172.28.0.102
+    healthcheck:
+      test: [ "CMD", "/usr/local/bin/iggy", "--tcp-server-address", "172.28.0.102:8092", "ping" ]
+
+networks:
+  iggy-bdd-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24

--- a/bdd/docker-compose.yml
+++ b/bdd/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - IGGY_ROOT_USERNAME=iggy
       - IGGY_ROOT_PASSWORD=iggy
       - BDD_FEATURE=${BDD_FEATURE:-all}
+      - BDD_RUST_FEATURES=${BDD_RUST_FEATURES:-bdd}
       - RUST_LOG=debug
       - RUSTFLAGS=-C linker=gcc
     volumes:
@@ -36,10 +37,10 @@ services:
       - -c
       - |
         case "$$BDD_FEATURE" in
-          basic_messaging)    cargo test -p bdd --features bdd --test basic_messaging ;;
-          leader_redirection) cargo test -p bdd --features bdd --test leader_redirection ;;
-          raw_command)        cargo test -p bdd --features bdd --test raw_command ;;
-          *)                  cargo test -p bdd --features bdd ;;
+          basic_messaging)    cargo test -p bdd --features "$$BDD_RUST_FEATURES" --test basic_messaging ;;
+          leader_redirection) cargo test -p bdd --features "$$BDD_RUST_FEATURES" --test leader_redirection ;;
+          raw_command)        cargo test -p bdd --features "$$BDD_RUST_FEATURES" --test raw_command ;;
+          *)                  cargo test -p bdd --features "$$BDD_RUST_FEATURES" ;;
         esac
     networks:
       - iggy-bdd-network

--- a/bdd/rust/Cargo.toml
+++ b/bdd/rust/Cargo.toml
@@ -25,6 +25,7 @@ publish = false
 
 [features]
 bdd = []
+vsr = ["iggy/vsr"]
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/core/server-ng/Cargo.toml
+++ b/core/server-ng/Cargo.toml
@@ -88,6 +88,7 @@ default = ["mimalloc", "iggy-web"]
 disable-mimalloc = []
 mimalloc = ["dep:mimalloc"]
 iggy-web = ["dep:rust-embed", "dep:mime_guess"]
+vsr = ["iggy_common/vsr"]
 
 [dependencies]
 ahash = { workspace = true }

--- a/scripts/run-bdd-tests.sh
+++ b/scripts/run-bdd-tests.sh
@@ -19,10 +19,12 @@
 set -Eeuo pipefail
 
 COVERAGE=0
+VSR=0
 ARGS=()
 for arg in "$@"; do
   case "$arg" in
     --coverage) COVERAGE=1 ;;
+    --vsr) VSR=1 ;;
     *) ARGS+=("$arg") ;;
   esac
 done
@@ -33,17 +35,31 @@ FEATURE="${ARGS[1]:-all}"
 log(){ printf "%b\n" "$*"; }
 
 usage(){
-  log "Usage: $0 [--coverage] <sdk> [feature]"
+  log "Usage: $0 [--coverage] [--vsr] <sdk> [feature]"
   log ""
   log "  sdk:     rust | python | php | go | go-race | node | csharp | java | cpp | all | clean (default: all)"
   log "  feature: basic_messaging | leader_redirection | raw_command | all  (default: all)"
+  log "  --vsr:   run against iggy-server-ng built with --features vsr (rust only);"
+  log "           expects IGGY_SERVER_NG_PATH (default: target/debug/iggy-server-ng)"
+  log "           and a vsr-built iggy CLI at IGGY_CLI_PATH"
   log ""
   log "Examples:"
   log "  $0 rust                         # run all features for Rust"
   log "  $0 rust basic_messaging         # run only basic_messaging for Rust"
   log "  $0 all leader_redirection       # run leader_redirection for all supporting SDKs"
+  log "  $0 --vsr rust                   # run all features for Rust against server-ng"
   log "  $0 --coverage go basic_messaging"
 }
+
+if [ "$VSR" = "1" ]; then
+  case "$SDK" in
+    rust|clean) ;;
+    *)
+      log "❌ --vsr supports only the Rust SDK (server-ng speaks the VSR wire protocol)"
+      usage
+      exit 2 ;;
+  esac
+fi
 
 case "$FEATURE" in
   basic_messaging|leader_redirection|raw_command|all) ;;
@@ -62,6 +78,7 @@ ALL_COMPOSE_FILES=(
   -f docker-compose.server.yml
   -f docker-compose.cluster.yml
   -f docker-compose.coverage.yml
+  -f docker-compose.vsr.yml
 )
 
 COMPOSE_FILES=(-f docker-compose.yml)
@@ -77,6 +94,11 @@ if [ "$COVERAGE" = "1" ]; then
   COMPOSE_FILES+=(-f docker-compose.coverage.yml)
   mkdir -p ../reports
 fi
+# vsr overrides must come last to win over the server/cluster/coverage files.
+if [ "$VSR" = "1" ]; then
+  COMPOSE_FILES+=(-f docker-compose.vsr.yml)
+  export BDD_RUST_FEATURES="bdd,vsr"
+fi
 
 cleanup(){
   log "🧹  cleaning up containers & volumes…"
@@ -86,6 +108,9 @@ trap cleanup EXIT INT TERM
 
 log "🧪 Running BDD tests for SDK: ${SDK}"
 log "📁 Feature file: ${FEATURE}"
+if [ "$VSR" = "1" ]; then
+  log "🗳️ Server: iggy-server-ng (--features vsr)"
+fi
 if [ "$COVERAGE" = "1" ]; then
   log "📊 Coverage collection enabled → reports will be in ./reports/"
 fi


### PR DESCRIPTION
BDD suites only exercised the legacy iggy-server, leaving
server-ng (its future replacement) without any BDD coverage.
Only the Rust SDK speaks the VSR wire protocol, so the lane
is Rust-only for now.

Add a --vsr flag to run-bdd-tests.sh backed by a compose
overlay that swaps in iggy-server-ng built with --features
vsr. server-ng takes no legacy boot flags, reads root
credentials from the environment, parses cluster.nodes[*].ip
as a strict IpAddr, binds cluster listeners to the roster IP,
and requires a tcp_replica consensus port; the overlay pins
static node IPs, points healthchecks at the roster address,
and supplies the replica ports. leader_redirection now runs
a real 2-node VSR cluster instead of the legacy --follower
mock.

The vsr feature forwards iggy_common/vsr on server-ng and
iggy/vsr on the bdd crate; rust-bdd cargo features are
parametrized via BDD_RUST_FEATURES so legacy and coverage
lanes stay unchanged. CI gains a bdd-rust-vsr task building
the vsr binaries.
