### PR TITLE
feat(sdk): let raw binary requests declare their replication kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6611,7 +6611,7 @@ checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "iggy"
-version = "0.10.3-edge.2"
+version = "0.10.3-edge.3"
 dependencies = [
  "async-broadcast",
  "async-dropper",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cli"
-version = "0.13.1-edge.1"
+version = "0.13.1-edge.2"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -6821,7 +6821,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_binary_protocol"
-version = "0.10.3-edge.2"
+version = "0.10.3-edge.3"
 dependencies = [
  "aligned-vec",
  "bytemuck",
@@ -6833,7 +6833,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_common"
-version = "0.10.3-edge.2"
+version = "0.10.3-edge.3"
 dependencies = [
  "aes-gcm",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,10 +196,10 @@ hyper-util = { version = "0.1.20", features = ["server-auto", "service"] }
 iceberg = "0.9.1"
 iceberg-catalog-rest = "0.9.1"
 iceberg-storage-opendal = "0.9.1"
-iggy = { path = "core/sdk", version = "0.10.3-edge.2" }
-iggy-cli = { path = "core/cli", version = "0.13.1-edge.1" }
-iggy_binary_protocol = { path = "core/binary_protocol", version = "0.10.3-edge.2" }
-iggy_common = { path = "core/common", version = "0.10.3-edge.2" }
+iggy = { path = "core/sdk", version = "0.10.3-edge.3" }
+iggy-cli = { path = "core/cli", version = "0.13.1-edge.2" }
+iggy_binary_protocol = { path = "core/binary_protocol", version = "0.10.3-edge.3" }
+iggy_common = { path = "core/common", version = "0.10.3-edge.3" }
 iggy_connector_sdk = { path = "core/connectors/sdk", version = "0.3.1-edge.1" }
 indexmap = "2.14.0"
 integration = { path = "core/integration" }

--- a/bdd/cpp/features/step_definitions/raw_command_steps.cpp
+++ b/bdd/cpp/features/step_definitions/raw_command_steps.cpp
@@ -25,18 +25,35 @@
 
 #include <cstdint>
 #include <exception>
+#include <stdexcept>
 #include <string>
 
 #include "world.hpp"
 
-WHEN("^I send a raw command with code ([0-9]+) and an empty payload$") {
+namespace {
+
+iggy::ffi::BinaryRequestKind parse_request_kind(const std::string &kind) {
+    if (kind == "non_replicated") {
+        return iggy::ffi::BinaryRequestKind::NonReplicated;
+    }
+    if (kind == "replicated") {
+        return iggy::ffi::BinaryRequestKind::Replicated;
+    }
+    throw std::invalid_argument("unknown binary request kind: " + kind);
+}
+
+}  // namespace
+
+WHEN("^I send a raw (\\w+) command with code ([0-9]+) and an empty payload$") {
+    REGEX_PARAM(std::string, kind);
     REGEX_PARAM(std::uint32_t, code);
     cucumber::ScenarioScope<bdd::GlobalContext> context;
 
     context->raw_response.clear();
     context->raw_error.clear();
     try {
-        const auto response = context->client->send_binary_request(code, rust::Vec<std::uint8_t>());
+        const auto response =
+            context->client->send_binary_request(parse_request_kind(kind), code, rust::Vec<std::uint8_t>());
         context->raw_response.assign(response.begin(), response.end());
     } catch (const std::exception &error) {
         context->raw_error = error.what();
@@ -62,4 +79,11 @@ THEN("^the raw command should fail with an invalid command error$") {
 
     EXPECT_TRUE(context->raw_response.empty());
     EXPECT_NE(context->raw_error.find("Invalid command"), std::string::npos);
+}
+
+THEN("^the raw command should fail$") {
+    cucumber::ScenarioScope<bdd::GlobalContext> context;
+
+    EXPECT_TRUE(context->raw_response.empty());
+    EXPECT_FALSE(context->raw_error.empty());
 }

--- a/bdd/cpp/features/step_definitions/raw_command_steps.cpp
+++ b/bdd/cpp/features/step_definitions/raw_command_steps.cpp
@@ -30,20 +30,6 @@
 
 #include "world.hpp"
 
-namespace {
-
-iggy::ffi::BinaryRequestKind parse_request_kind(const std::string &kind) {
-    if (kind == "non_replicated") {
-        return iggy::ffi::BinaryRequestKind::NonReplicated;
-    }
-    if (kind == "replicated") {
-        return iggy::ffi::BinaryRequestKind::Replicated;
-    }
-    throw std::invalid_argument("unknown binary request kind: " + kind);
-}
-
-}  // namespace
-
 WHEN("^I send a raw (\\w+) command with code ([0-9]+) and an empty payload$") {
     REGEX_PARAM(std::string, kind);
     REGEX_PARAM(std::uint32_t, code);
@@ -52,8 +38,14 @@ WHEN("^I send a raw (\\w+) command with code ([0-9]+) and an empty payload$") {
     context->raw_response.clear();
     context->raw_error.clear();
     try {
+        auto request_kind = iggy::ffi::BinaryRequestKind::NonReplicated;
+        if (kind == "replicated") {
+            request_kind = iggy::ffi::BinaryRequestKind::Replicated;
+        } else if (kind != "non_replicated") {
+            throw std::invalid_argument("unknown binary request kind: " + kind);
+        }
         const auto response =
-            context->client->send_binary_request(parse_request_kind(kind), code, rust::Vec<std::uint8_t>());
+            context->client->send_binary_request(request_kind, code, rust::Vec<std::uint8_t>());
         context->raw_response.assign(response.begin(), response.end());
     } catch (const std::exception &error) {
         context->raw_error = error.what();

--- a/bdd/go/tests/raw_command.go
+++ b/bdd/go/tests/raw_command.go
@@ -70,9 +70,24 @@ func (rawCommandSteps) givenAuthenticationAsRoot(ctx context.Context) error {
 	return nil
 }
 
-func (rawCommandSteps) whenSendRawCommand(ctx context.Context, code uint32) error {
+func parseRequestKind(kind string) (iggcon.BinaryRequestKind, error) {
+	switch kind {
+	case "non_replicated":
+		return iggcon.BinaryRequestKindNonReplicated, nil
+	case "replicated":
+		return iggcon.BinaryRequestKindReplicated, nil
+	default:
+		return 0, fmt.Errorf("unknown binary request kind: %s", kind)
+	}
+}
+
+func (rawCommandSteps) whenSendRawCommand(ctx context.Context, kind string, code uint32) error {
+	requestKind, err := parseRequestKind(kind)
+	if err != nil {
+		return err
+	}
 	state := getRawCommandCtx(ctx)
-	state.lastResponse, state.lastError = state.client.SendBinaryRequest(ctx, code, nil)
+	state.lastResponse, state.lastError = state.client.SendBinaryRequest(ctx, requestKind, code, nil)
 	return nil
 }
 
@@ -105,6 +120,17 @@ func (rawCommandSteps) thenInvalidCommand(ctx context.Context) error {
 	return nil
 }
 
+func (rawCommandSteps) thenFailure(ctx context.Context) error {
+	state := getRawCommandCtx(ctx)
+	if state.lastError == nil {
+		return errors.New("expected the raw command to fail")
+	}
+	if len(state.lastResponse) != 0 {
+		return fmt.Errorf("expected no response alongside the failure, got %d bytes", len(state.lastResponse))
+	}
+	return nil
+}
+
 func initRawCommandScenario(sc *godog.ScenarioContext) {
 	sc.Before(func(context.Context, *godog.Scenario) (context.Context, error) {
 		return context.WithValue(context.Background(), rawCommandCtxKey{}, &rawCommandCtx{}), nil
@@ -112,10 +138,11 @@ func initRawCommandScenario(sc *godog.ScenarioContext) {
 	steps := rawCommandSteps{}
 	sc.Step(`I have a running Iggy server`, steps.givenRunningServer)
 	sc.Step(`I am authenticated as the root user`, steps.givenAuthenticationAsRoot)
-	sc.Step(`^I send a raw command with code (\d+) and an empty payload$`, steps.whenSendRawCommand)
+	sc.Step(`^I send a raw (\w+) command with code (\d+) and an empty payload$`, steps.whenSendRawCommand)
 	sc.Step(`the raw command should succeed with an empty response`, steps.thenEmptyResponse)
 	sc.Step(`the raw command should succeed with a non-empty response`, steps.thenNonEmptyResponse)
-	sc.Step(`the raw command should fail with an invalid command error`, steps.thenInvalidCommand)
+	sc.Step(`^the raw command should fail with an invalid command error$`, steps.thenInvalidCommand)
+	sc.Step(`^the raw command should fail$`, steps.thenFailure)
 	sc.After(func(ctx context.Context, _ *godog.Scenario, scenarioError error) (context.Context, error) {
 		state := getRawCommandCtx(ctx)
 		if state.client != nil {

--- a/bdd/java/src/test/java/org/apache/iggy/bdd/BasicMessagingSteps.java
+++ b/bdd/java/src/test/java/org/apache/iggy/bdd/BasicMessagingSteps.java
@@ -22,6 +22,7 @@ package org.apache.iggy.bdd;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.apache.iggy.client.BinaryRequestKind;
 import org.apache.iggy.client.blocking.IggyBaseClient;
 import org.apache.iggy.client.blocking.tcp.IggyTcpClient;
 import org.apache.iggy.exception.IggyErrorCode;
@@ -212,10 +213,11 @@ public class BasicMessagingSteps {
         assertEquals(context.lastSentMessage, lastPayload, "Last message should match sent message");
     }
 
-    @When("I send a raw command with code {int} and an empty payload")
-    public void sendRawCommand(int code) {
+    @When("I send a raw {word} command with code {int} and an empty payload")
+    public void sendRawCommand(String kind, int code) {
         try {
-            context.lastRawResponse = getClient().sendBinaryRequest(code, new byte[0]);
+            context.lastRawResponse =
+                    getClient().sendBinaryRequest(BinaryRequestKind.fromName(kind), code, new byte[0]);
             context.lastRawError = null;
         } catch (RuntimeException error) {
             context.lastRawResponse = null;
@@ -243,6 +245,12 @@ public class BasicMessagingSteps {
         assertTrue(context.lastRawError instanceof IggyServerException, "Expected an Iggy server error");
         IggyServerException error = (IggyServerException) context.lastRawError;
         assertEquals(IggyErrorCode.INVALID_COMMAND, error.getErrorCode());
+    }
+
+    @Then("the raw command should fail")
+    public void rawCommandFails() {
+        assertNull(context.lastRawResponse, "Raw response should be absent");
+        assertNotNull(context.lastRawError, "Raw command should fail");
     }
 
     private IggyBaseClient getClient() {

--- a/bdd/php/tests/RawCommandFeatureTest.php
+++ b/bdd/php/tests/RawCommandFeatureTest.php
@@ -64,9 +64,9 @@ final class RawCommandFeatureTest extends TestCase
             );
             return;
         }
-        if (preg_match('/^I send a raw command with code (\d+) and an empty payload$/', $step, $matches) === 1) {
+        if (preg_match('/^I send a raw (\w+) command with code (\d+) and an empty payload$/', $step, $matches) === 1) {
             try {
-                $this->lastResponse = $this->requireClient()->sendBinaryRequest((int) $matches[1], '');
+                $this->lastResponse = $this->requireClient()->sendBinaryRequest($matches[1], (int) $matches[2], '');
                 $this->lastError = null;
             } catch (Throwable $error) {
                 $this->lastResponse = null;
@@ -88,6 +88,11 @@ final class RawCommandFeatureTest extends TestCase
             assert_same(null, $this->lastResponse);
             assert_instance_of(IggyException::class, $this->lastError);
             assert_true(str_contains(strtolower((string) $this->lastError?->getMessage()), 'invalid command'));
+            return;
+        }
+        if ($step === 'the raw command should fail') {
+            assert_same(null, $this->lastResponse);
+            assert_instance_of(IggyException::class, $this->lastError);
             return;
         }
 

--- a/bdd/python/tests/test_raw_command.py
+++ b/bdd/python/tests/test_raw_command.py
@@ -18,7 +18,7 @@
 import asyncio
 import socket
 
-from apache_iggy import IggyClient
+from apache_iggy import BinaryRequestKind, IggyClient
 from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("/app/features/raw_command.feature")
@@ -48,12 +48,20 @@ def authenticated_root_user(context):
     asyncio.run(login())
 
 
-@when(parsers.parse("I send a raw command with code {code:d} and an empty payload"))
-def send_raw_command(context, code):
+KINDS = {
+    "non_replicated": BinaryRequestKind.NonReplicated,
+    "replicated": BinaryRequestKind.Replicated,
+}
+
+
+@when(
+    parsers.parse("I send a raw {kind} command with code {code:d} and an empty payload")
+)
+def send_raw_command(context, kind, code):
     async def send():
         try:
             context.last_raw_response = await context.client.send_binary_request(
-                code, b""
+                KINDS[kind], code, b""
             )
             context.last_raw_error = None
         except RuntimeError as error:
@@ -80,3 +88,9 @@ def raw_command_fails_with_invalid_command(context):
     assert context.last_raw_response is None
     assert context.last_raw_error is not None
     assert "invalid command" in str(context.last_raw_error).lower()
+
+
+@then("the raw command should fail")
+def raw_command_fails(context):
+    assert context.last_raw_response is None
+    assert context.last_raw_error is not None

--- a/bdd/python/uv.lock
+++ b/bdd/python/uv.lock
@@ -8,7 +8,7 @@ exclude-newer-span = "P7D"
 
 [[package]]
 name = "apache-iggy"
-version = "0.8.1.dev3"
+version = "0.8.1.dev4"
 source = { directory = "../../foreign/python" }
 
 [package.metadata]

--- a/bdd/rust/tests/steps/raw_command.rs
+++ b/bdd/rust/tests/steps/raw_command.rs
@@ -18,12 +18,14 @@
 use crate::common::global_context::GlobalContext;
 use bytes::Bytes;
 use cucumber::{then, when};
-use iggy::prelude::IggyError;
+use iggy::prelude::{BinaryRequestKind, IggyError};
+use std::str::FromStr;
 
-#[when(regex = r"^I send a raw command with code (\d+) and an empty payload$")]
-pub async fn when_send_raw_command(world: &mut GlobalContext, code: u32) {
+#[when(regex = r"^I send a raw (\w+) command with code (\d+) and an empty payload$")]
+pub async fn when_send_raw_command(world: &mut GlobalContext, kind: String, code: u32) {
+    let kind = BinaryRequestKind::from_str(&kind).expect("Kind should be a known request kind");
     let client = world.client.as_ref().expect("Client should be available");
-    world.last_raw_result = Some(client.send_binary_request(code, Bytes::new()).await);
+    world.last_raw_result = Some(client.send_binary_request(kind, code, Bytes::new()).await);
 }
 
 #[then("the raw command should succeed with an empty response")]
@@ -57,4 +59,14 @@ pub async fn then_raw_command_fails_with_invalid_command_error(world: &mut Globa
         .as_ref()
         .expect_err("Raw command should have failed");
     assert_eq!(*error, IggyError::InvalidCommand);
+}
+
+#[then("the raw command should fail")]
+pub async fn then_raw_command_fails(world: &mut GlobalContext) {
+    world
+        .last_raw_result
+        .as_ref()
+        .expect("Should have sent a raw command")
+        .as_ref()
+        .expect_err("Raw command should have failed");
 }

--- a/bdd/scenarios/raw_command.feature
+++ b/bdd/scenarios/raw_command.feature
@@ -26,16 +26,30 @@ Feature: Raw Command API
     And I am authenticated as the root user
 
   Scenario: Known command codes round-trip
-    When I send a raw command with code 1 and an empty payload
+    When I send a raw non_replicated command with code 1 and an empty payload
     Then the raw command should succeed with an empty response
 
-    When I send a raw command with code 10 and an empty payload
+    When I send a raw non_replicated command with code 10 and an empty payload
     Then the raw command should succeed with a non-empty response
 
   Scenario: Unknown command code is rejected
-    When I send a raw command with code 60000 and an empty payload
+    When I send a raw non_replicated command with code 60000 and an empty payload
     Then the raw command should fail with an invalid command error
 
   Scenario: Session control command code is rejected
-    When I send a raw command with code 38 and an empty payload
+    When I send a raw non_replicated command with code 38 and an empty payload
     Then the raw command should fail with an invalid command error
+
+    When I send a raw replicated command with code 38 and an empty payload
+    Then the raw command should fail with an invalid command error
+
+  Scenario: Replicated vendor command code has no handler
+    When I send a raw replicated command with code 60000 and an empty payload
+    Then the raw command should fail
+
+  Scenario: Connection survives a rejected raw command
+    When I send a raw non_replicated command with code 60000 and an empty payload
+    Then the raw command should fail with an invalid command error
+
+    When I send a raw non_replicated command with code 1 and an empty payload
+    Then the raw command should succeed with an empty response

--- a/core/binary_protocol/Cargo.toml
+++ b/core/binary_protocol/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_binary_protocol"
-version = "0.10.3-edge.2"
+version = "0.10.3-edge.3"
 description = "Wire protocol types and codec for the Iggy binary protocol. Shared between server and SDK."
 edition = "2024"
 rust-version.workspace = true

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy-cli"
-version = "0.13.1-edge.1"
+version = "0.13.1-edge.2"
 edition = "2024"
 rust-version.workspace = true
 authors = ["bartosz.ciesla@gmail.com"]

--- a/core/common/Cargo.toml
+++ b/core/common/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy_common"
-version = "0.10.3-edge.2"
+version = "0.10.3-edge.3"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 rust-version.workspace = true

--- a/core/common/src/lib.rs
+++ b/core/common/src/lib.rs
@@ -72,6 +72,7 @@ pub use traits::topic_client::TopicClient;
 pub use traits::user_client::UserClient;
 pub use traits::validatable::Validatable;
 pub use types::args::*;
+pub use types::binary_request_kind::BinaryRequestKind;
 pub use types::client::client_info::*;
 pub use types::client_state::ClientState;
 pub use types::cluster::*;

--- a/core/common/src/traits/binary_transport.rs
+++ b/core/common/src/traits/binary_transport.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{ClientState, DiagnosticEvent, IggyDuration, IggyError};
+use crate::{BinaryRequestKind, ClientState, DiagnosticEvent, IggyDuration, IggyError};
 use async_trait::async_trait;
 use bytes::Bytes;
 #[cfg(feature = "vsr")]
@@ -28,7 +28,18 @@ pub trait BinaryTransport {
     /// Sets the state of the client.
     async fn set_state(&self, state: ClientState);
     async fn publish_event(&self, event: DiagnosticEvent);
+    /// Send a standard command. The protocol tables classify `code`, so the
+    /// caller declares no execution model; every typed SDK method lands here.
     async fn send_raw_with_response(&self, code: u32, payload: Bytes) -> Result<Bytes, IggyError>;
+    /// Send a raw command whose `code` the SDK need not know, with the caller
+    /// declaring how it executes. A code the tables do know keeps its own
+    /// class and a conflicting `kind` is rejected.
+    async fn send_binary_request(
+        &self,
+        kind: BinaryRequestKind,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError>;
     fn get_heartbeat_interval(&self) -> IggyDuration;
 
     /// Per-transport consumer-group + partitioning cache used to resolve

--- a/core/common/src/types/binary_request_kind.rs
+++ b/core/common/src/types/binary_request_kind.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use strum::{Display, EnumString};
+
+/// How a raw binary request executes on the server.
+///
+/// A vendor command code is unknown to the SDK, so the caller has to say whether
+/// it runs outside consensus or is replicated through it. The declaration is
+/// never authoritative: a code the protocol tables already know keeps its own
+/// class, and the server independently rejects a declaration it disagrees with.
+///
+/// Classic framing carries `[length][code][payload]` with no operation field, so
+/// the kind is inert there and both variants encode identical bytes. It only
+/// selects a wire path under VSR.
+///
+/// The string form is the cross-SDK spelling the shared BDD scenarios and the
+/// PHP binding use.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Display, EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum BinaryRequestKind {
+    /// Runs on the receiving node only, outside consensus. Reads, pings, and
+    /// vendor commands that own no replicated state.
+    NonReplicated,
+    /// Replicated through consensus before it takes effect.
+    ///
+    /// Only the standard replicated commands are supported today. A vendor code
+    /// declared `Replicated` yields [`crate::IggyError::FeatureUnavailable`]:
+    /// the protocol has no deterministic handler registry, replicated state
+    /// ownership, or snapshot contract for one yet.
+    Replicated,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::BinaryRequestKind;
+
+    #[test]
+    fn given_display_output_when_parsed_should_round_trip() {
+        for kind in [
+            BinaryRequestKind::NonReplicated,
+            BinaryRequestKind::Replicated,
+        ] {
+            assert_eq!(
+                BinaryRequestKind::from_str(&kind.to_string()).unwrap(),
+                kind
+            );
+        }
+    }
+
+    #[test]
+    fn given_cross_sdk_names_when_parsed_should_match_the_other_bindings() {
+        assert_eq!(
+            BinaryRequestKind::NonReplicated.to_string(),
+            "non_replicated"
+        );
+        assert_eq!(BinaryRequestKind::Replicated.to_string(), "replicated");
+    }
+
+    #[test]
+    fn given_unknown_text_when_parsed_should_fail() {
+        assert!(BinaryRequestKind::from_str("auto").is_err());
+    }
+}

--- a/core/common/src/types/mod.rs
+++ b/core/common/src/types/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 pub(crate) mod args;
+pub(crate) mod binary_request_kind;
 pub(crate) mod client;
 pub(crate) mod client_state;
 pub(crate) mod cluster;

--- a/core/integration/tests/sdk/raw.rs
+++ b/core/integration/tests/sdk/raw.rs
@@ -22,6 +22,15 @@ use iggy_binary_protocol::codes::{GET_STATS_CODE, LOGIN_USER_CODE, PING_CODE};
 use iggy_binary_protocol::requests::system::{GetStatsRequest, PingRequest};
 use integration::iggy_harness;
 
+/// A code no server registers a handler for, well past every range the protocol
+/// assigns, so it stays a vendor code as the command table grows.
+const VENDOR_CODE: u32 = 60_001;
+
+const KINDS: [BinaryRequestKind; 2] = [
+    BinaryRequestKind::NonReplicated,
+    BinaryRequestKind::Replicated,
+];
+
 #[cfg(not(feature = "vsr"))]
 #[iggy_harness(test_client_transport = [Tcp, Quic, Http, WebSocket])]
 async fn given_authenticated_client_when_sending_raw_request_should_round_trip(
@@ -60,42 +69,20 @@ async fn assert_raw_round_trip(client: &IggyClient) {
                 .expect("authenticated HTTP request should return a body");
             assert!(!stats.is_empty());
 
-            let error = client
-                .send_binary_request(PING_CODE, PingRequest.to_bytes())
-                .await
-                .expect_err("binary command must be unavailable on HTTP");
-            assert_eq!(error, IggyError::FeatureUnavailable);
+            for kind in KINDS {
+                let error = client
+                    .send_binary_request(kind, PING_CODE, PingRequest.to_bytes())
+                    .await
+                    .expect_err("binary command must be unavailable on HTTP");
+                assert_eq!(error, IggyError::FeatureUnavailable);
+            }
         }
         _ => {
-            let response = client
-                .send_binary_request(PING_CODE, PingRequest.to_bytes())
-                .await
-                .expect("binary ping request should succeed");
-            assert!(response.is_empty());
-
-            let stats = client
-                .send_binary_request(GET_STATS_CODE, GetStatsRequest.to_bytes())
-                .await
-                .expect("authenticated binary command should return a body");
-            assert!(!stats.is_empty());
-
-            // Rejected before the wire (guards the VSR consensus-session panic
-            // when a login code is sent raw on a bound client).
-            let error = client
-                .send_binary_request(LOGIN_USER_CODE, Bytes::new())
-                .await
-                .expect_err("session-control codes must be rejected by the raw path");
-            assert_eq!(error, IggyError::InvalidCommand);
-
-            // VSR encoder is closed-world: unknown code rejected at encode time.
-            #[cfg(feature = "vsr")]
-            {
-                let error = client
-                    .send_binary_request(60_000, Bytes::new())
-                    .await
-                    .expect_err("unknown code must be rejected under VSR");
-                assert_eq!(error, IggyError::InvalidCommand);
-            }
+            assert_standard_codes_round_trip(client).await;
+            assert_session_control_codes_are_rejected(client).await;
+            assert_vendor_code_reaches_the_server(client).await;
+            assert_replicated_declaration_is_honored(client).await;
+            assert_conflicting_declaration_is_honored(client).await;
 
             let error = client
                 .send_http_request(HttpMethod::Get, "/ping", None)
@@ -104,4 +91,106 @@ async fn assert_raw_round_trip(client: &IggyClient) {
             assert_eq!(error, IggyError::FeatureUnavailable);
         }
     }
+}
+
+async fn assert_standard_codes_round_trip(client: &IggyClient) {
+    let response = client
+        .send_binary_request(
+            BinaryRequestKind::NonReplicated,
+            PING_CODE,
+            PingRequest.to_bytes(),
+        )
+        .await
+        .expect("binary ping request should succeed");
+    assert!(response.is_empty());
+
+    let stats = client
+        .send_binary_request(
+            BinaryRequestKind::NonReplicated,
+            GET_STATS_CODE,
+            GetStatsRequest.to_bytes(),
+        )
+        .await
+        .expect("authenticated binary command should return a body");
+    assert!(!stats.is_empty());
+}
+
+/// Rejected before the wire whatever the declaration, which also guards the VSR
+/// consensus-session panic a raw login on a bound client used to trigger.
+async fn assert_session_control_codes_are_rejected(client: &IggyClient) {
+    for kind in KINDS {
+        let error = client
+            .send_binary_request(kind, LOGIN_USER_CODE, Bytes::new())
+            .await
+            .expect_err("session-control codes must be rejected by the raw path");
+        assert_eq!(error, IggyError::InvalidCommand);
+    }
+}
+
+/// A non-replicated vendor code leaves the SDK, so the rejection comes from the
+/// server rather than the encoder, and the connection survives it.
+async fn assert_vendor_code_reaches_the_server(client: &IggyClient) {
+    let error = client
+        .send_binary_request(
+            BinaryRequestKind::NonReplicated,
+            VENDOR_CODE,
+            Bytes::from_static(b"vendor-body"),
+        )
+        .await
+        .expect_err("no server registers a handler for the vendor code");
+    assert_eq!(error, IggyError::InvalidCommand);
+
+    client
+        .ping()
+        .await
+        .expect("connection must stay usable after a request-level rejection");
+}
+
+/// Under VSR a replicated vendor code has no deterministic handler registry, so
+/// it fails in the encoder. Classic framing has no operation field, so the same
+/// call reaches the server and is rejected there.
+async fn assert_replicated_declaration_is_honored(client: &IggyClient) {
+    let error = client
+        .send_binary_request(
+            BinaryRequestKind::Replicated,
+            VENDOR_CODE,
+            Bytes::from_static(b"vendor-body"),
+        )
+        .await
+        .expect_err("a replicated vendor code has no handler on either protocol");
+
+    #[cfg(feature = "vsr")]
+    assert_eq!(error, IggyError::FeatureUnavailable);
+    #[cfg(not(feature = "vsr"))]
+    assert_eq!(error, IggyError::InvalidCommand);
+
+    client
+        .ping()
+        .await
+        .expect("connection must stay usable after a rejected declaration");
+}
+
+/// A declaration that disagrees with a standard code cannot redirect it. Under
+/// VSR the encoder rejects the pair; classic framing ignores the declaration and
+/// emits the same bytes it would for the matching one.
+async fn assert_conflicting_declaration_is_honored(client: &IggyClient) {
+    let result = client
+        .send_binary_request(
+            BinaryRequestKind::Replicated,
+            GET_STATS_CODE,
+            GetStatsRequest.to_bytes(),
+        )
+        .await;
+
+    #[cfg(feature = "vsr")]
+    assert_eq!(
+        result.expect_err("a read declared replicated must be rejected"),
+        IggyError::InvalidCommand
+    );
+    #[cfg(not(feature = "vsr"))]
+    assert!(
+        !result
+            .expect("classic framing ignores the declaration")
+            .is_empty()
+    );
 }

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy"
-version = "0.10.3-edge.2"
+version = "0.10.3-edge.3"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2024"
 rust-version.workspace = true

--- a/core/sdk/src/binary/mod.rs
+++ b/core/sdk/src/binary/mod.rs
@@ -15,4 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use iggy_binary_protocol::codes::{
+    LOGIN_REGISTER_CODE, LOGIN_REGISTER_WITH_PAT_CODE, LOGIN_USER_CODE,
+    LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, LOGOUT_USER_CODE,
+};
+use iggy_common::IggyError;
 pub use iggy_common::{BinaryClient, BinaryTransport};
+
+/// Auth/session codes rejected by the raw binary path. Must go through the
+/// typed `login_user` / `logout_user` methods to keep session state correct.
+pub(crate) const SESSION_CONTROL_CODES: [u32; 5] = [
+    LOGIN_USER_CODE,
+    LOGOUT_USER_CODE,
+    LOGIN_REGISTER_CODE,
+    LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE,
+    LOGIN_REGISTER_WITH_PAT_CODE,
+];
+
+pub(crate) fn validate_binary_request_code(code: u32) -> Result<(), IggyError> {
+    if SESSION_CONTROL_CODES.contains(&code) {
+        Err(IggyError::InvalidCommand)
+    } else {
+        Ok(())
+    }
+}

--- a/core/sdk/src/clients/client.rs
+++ b/core/sdk/src/clients/client.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::binary::validate_binary_request_code;
 use crate::client_wrappers::client_wrapper::ClientWrapper;
 use crate::client_wrappers::connection_info::ConnectionInfo;
 use crate::clients::client_builder::IggyClientBuilder;
@@ -30,13 +31,9 @@ use crate::websocket::websocket_client::WebSocketClient;
 use async_broadcast::Receiver;
 use async_trait::async_trait;
 use bytes::Bytes;
-use iggy_binary_protocol::codes::{
-    LOGIN_REGISTER_CODE, LOGIN_REGISTER_WITH_PAT_CODE, LOGIN_USER_CODE,
-    LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, LOGOUT_USER_CODE,
-};
 use iggy_common::Consumer;
 use iggy_common::locking::{IggyRwLock, IggyRwLockFn};
-use iggy_common::{BinaryTransport, Client, HttpMethod, SystemClient};
+use iggy_common::{BinaryRequestKind, BinaryTransport, Client, HttpMethod, SystemClient};
 use iggy_common::{ConnectionStringUtils, DiagnosticEvent, Partitioner, TransportProtocol};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -44,16 +41,6 @@ use tokio::spawn;
 use tokio::time::sleep;
 use tracing::log::warn;
 use tracing::{debug, error, info};
-
-/// Auth/session codes rejected by the raw binary path. Must go through the
-/// typed `login_user` / `logout_user` methods to keep session state correct.
-const SESSION_CONTROL_CODES: [u32; 5] = [
-    LOGIN_USER_CODE,
-    LOGOUT_USER_CODE,
-    LOGIN_REGISTER_CODE,
-    LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE,
-    LOGIN_REGISTER_WITH_PAT_CODE,
-];
 
 /// The main client struct which implements all the `Client` traits and wraps the underlying low-level client for the specific transport.
 ///
@@ -201,20 +188,35 @@ impl IggyClient {
     /// Send a raw binary command (`code` + serialized `payload`), returning the
     /// raw response. Binary transports only (HTTP yields `FeatureUnavailable`).
     ///
+    /// `kind` declares how a vendor `code` executes. A code the protocol tables
+    /// already know keeps its own class, so a conflicting `kind` is rejected
+    /// with `InvalidCommand` rather than redirecting a shipped command.
+    ///
     /// Login and logout codes are rejected with `InvalidCommand`. Use the
     /// `login_user` / `logout_user` methods so SDK session state stays correct.
     ///
-    /// Custom codes only work on the classic protocol. Under `vsr` the encoder
-    /// is closed-world: an unknown code yields `InvalidCommand`, a replicated
-    /// code with no mapping yields `UnknownReplicatedCommand`.
-    pub async fn send_binary_request(&self, code: u32, payload: Bytes) -> Result<Bytes, IggyError> {
-        if SESSION_CONTROL_CODES.contains(&code) {
-            return Err(IggyError::InvalidCommand);
-        }
+    /// Classic framing has no operation field, so both kinds encode identical
+    /// bytes and the server decides how the command runs. Under `vsr` an
+    /// unknown [`BinaryRequestKind::NonReplicated`] code rides
+    /// `Operation::NonReplicated`, while an unknown
+    /// [`BinaryRequestKind::Replicated`] code yields `FeatureUnavailable` until
+    /// the protocol grows a replicated extension registry.
+    pub async fn send_binary_request(
+        &self,
+        kind: BinaryRequestKind,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
+        // Also enforced by the binary transports, but repeated here so the
+        // HTTP wrapper answers a session-control code with `InvalidCommand`
+        // rather than its blanket `FeatureUnavailable`.
+        validate_binary_request_code(code)?;
         match &*self.client.read().await {
-            ClientWrapper::Tcp(client) => client.send_raw_with_response(code, payload).await,
-            ClientWrapper::Quic(client) => client.send_raw_with_response(code, payload).await,
-            ClientWrapper::WebSocket(client) => client.send_raw_with_response(code, payload).await,
+            ClientWrapper::Tcp(client) => client.send_binary_request(kind, code, payload).await,
+            ClientWrapper::Quic(client) => client.send_binary_request(kind, code, payload).await,
+            ClientWrapper::WebSocket(client) => {
+                client.send_binary_request(kind, code, payload).await
+            }
             ClientWrapper::Http(_) | ClientWrapper::Iggy(_) => Err(IggyError::FeatureUnavailable),
         }
     }
@@ -289,6 +291,7 @@ impl Client for IggyClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::binary::SESSION_CONTROL_CODES;
 
     #[test]
     fn should_fail_with_empty_connection_string() {
@@ -480,19 +483,26 @@ mod tests {
     async fn should_reject_binary_request_on_http_transport() {
         let client =
             IggyClient::from_connection_string("iggy+http://user:secret@127.0.0.1:1234").unwrap();
-        let result = client.send_binary_request(0, Bytes::new()).await;
+        let result = client
+            .send_binary_request(BinaryRequestKind::NonReplicated, 0, Bytes::new())
+            .await;
         assert!(matches!(result, Err(IggyError::FeatureUnavailable)));
     }
 
     #[tokio::test]
     async fn should_reject_session_control_codes_on_binary_request() {
         let client = IggyClient::default();
-        for code in SESSION_CONTROL_CODES {
-            let result = client.send_binary_request(code, Bytes::new()).await;
-            assert!(
-                matches!(result, Err(IggyError::InvalidCommand)),
-                "code {code} must be rejected before reaching the transport"
-            );
+        for kind in [
+            BinaryRequestKind::NonReplicated,
+            BinaryRequestKind::Replicated,
+        ] {
+            for code in SESSION_CONTROL_CODES {
+                let result = client.send_binary_request(kind, code, Bytes::new()).await;
+                assert!(
+                    matches!(result, Err(IggyError::InvalidCommand)),
+                    "code {code} declared {kind} must be rejected before reaching the transport"
+                );
+            }
         }
     }
 }

--- a/core/sdk/src/prelude.rs
+++ b/core/sdk/src/prelude.rs
@@ -48,12 +48,12 @@ pub use crate::stream_builder::{IggyStream, IggyStreamConfig};
 pub use crate::tcp::tcp_client::TcpClient;
 pub use crate::websocket::websocket_client::WebSocketClient;
 pub use iggy_common::{
-    Aes256GcmEncryptor, Args, ArgsOptional, AutoLogin, CacheMetrics, CacheMetricsKey, ClientError,
-    ClientInfoDetails, ClusterMetadata, ClusterNode, ClusterNodeRole, ClusterNodeStatus,
-    CompressionAlgorithm, Consumer, ConsumerGroup, ConsumerGroupDetails, ConsumerGroupMember,
-    ConsumerKind, EncryptorKind, GlobalPermissions, HeaderKey, HeaderKind, HeaderValue,
-    HttpClientConfig, HttpClientConfigBuilder, HttpMethod, IdKind, Identifier, IdentityInfo,
-    IggyByteSize, IggyDuration, IggyError, IggyExpiry, IggyIndexView, IggyMessage,
+    Aes256GcmEncryptor, Args, ArgsOptional, AutoLogin, BinaryRequestKind, CacheMetrics,
+    CacheMetricsKey, ClientError, ClientInfoDetails, ClusterMetadata, ClusterNode, ClusterNodeRole,
+    ClusterNodeStatus, CompressionAlgorithm, Consumer, ConsumerGroup, ConsumerGroupDetails,
+    ConsumerGroupMember, ConsumerKind, EncryptorKind, GlobalPermissions, HeaderKey, HeaderKind,
+    HeaderValue, HttpClientConfig, HttpClientConfigBuilder, HttpMethod, IdKind, Identifier,
+    IdentityInfo, IggyByteSize, IggyDuration, IggyError, IggyExpiry, IggyIndexView, IggyMessage,
     IggyMessageHeader, IggyMessageHeaderView, IggyMessageView, IggyMessageViewIterator,
     IggyTimestamp, MaxTopicSize, Partition, Partitioner, Partitioning, Permissions,
     PersonalAccessTokenExpiry, PollMessages, PolledMessages, PollingKind, PollingStrategy,

--- a/core/sdk/src/quic/quic_client.rs
+++ b/core/sdk/src/quic/quic_client.rs
@@ -15,13 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::binary::validate_binary_request_code;
 use crate::leader_aware::{LeaderRedirectionState, check_and_redirect_to_leader};
 use crate::prelude::AutoLogin;
 #[cfg(feature = "vsr")]
 use crate::session::ConsensusSession;
 #[cfg(feature = "vsr")]
 use iggy_common::VsrSessionControl as _;
-use iggy_common::{BinaryClient, BinaryTransport, Client, PersonalAccessTokenClient, UserClient};
+use iggy_common::{
+    BinaryClient, BinaryRequestKind, BinaryTransport, Client, PersonalAccessTokenClient, UserClient,
+};
 
 use crate::prelude::{IggyDuration, IggyError, IggyTimestamp, QuicClientConfig};
 use crate::quic::skip_server_verification::SkipServerVerification;
@@ -137,59 +140,17 @@ impl BinaryTransport for QuicClient {
     }
 
     async fn send_raw_with_response(&self, code: u32, payload: Bytes) -> Result<Bytes, IggyError> {
-        let result = self.send_raw(code, payload.clone()).await;
-        if result.is_ok() {
-            return result;
-        }
+        self.send_with_reconnect(None, code, payload).await
+    }
 
-        let error = result.unwrap_err();
-        if !matches!(
-            error,
-            IggyError::Disconnected
-                | IggyError::EmptyResponse
-                | IggyError::Unauthenticated
-                | IggyError::StaleClient
-                | IggyError::NotConnected
-                | IggyError::CannotEstablishConnection
-                | IggyError::QuicError
-        ) {
-            return Err(error);
-        }
-
-        if !self.config.reconnection.enabled {
-            return Err(IggyError::Disconnected);
-        }
-
-        #[cfg(feature = "vsr")]
-        if matches!(self.config.auto_login, AutoLogin::Disabled) && !is_login_register_code(code) {
-            // Without auto-login a reconnect cannot re-establish the session, so
-            // non-login requests are not recovered here - their transient replay
-            // happens on the live connection inside `send_raw`. Login/register
-            // is the exception: the server stays deliberately silent on a
-            // transient register failure and relies on the client replaying via
-            // a reconnect with a fresh session.
-            return Err(error);
-        }
-
-        self.disconnect().await?;
-        #[cfg(feature = "vsr")]
-        let skip_auto_login = is_login_register_code(code);
-        #[cfg(feature = "vsr")]
-        if skip_auto_login {
-            *self.skip_auto_login_once.lock().await = true;
-        }
-        let server_address = self.current_server_address.lock().await.to_string();
-        info!(
-            "Reconnecting to the server: {}, by client: {}",
-            server_address, self.config.client_address
-        );
-        let reconnect = self.connect().await;
-        #[cfg(feature = "vsr")]
-        if skip_auto_login && reconnect.is_err() {
-            *self.skip_auto_login_once.lock().await = false;
-        }
-        reconnect?;
-        self.send_raw(code, payload).await
+    async fn send_binary_request(
+        &self,
+        kind: BinaryRequestKind,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
+        validate_binary_request_code(code)?;
+        self.send_with_reconnect(Some(kind), code, payload).await
     }
 
     fn get_heartbeat_interval(&self) -> IggyDuration {
@@ -679,7 +640,76 @@ impl QuicClient {
         Ok(())
     }
 
-    async fn send_raw(&self, code: u32, payload: Bytes) -> Result<Bytes, IggyError> {
+    /// Single reconnect-and-replay path shared by the typed and the raw entry
+    /// points, so `kind` survives the retry attempt unchanged.
+    async fn send_with_reconnect(
+        &self,
+        kind: Option<BinaryRequestKind>,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
+        let result = self.send_raw(kind, code, payload.clone()).await;
+        if result.is_ok() {
+            return result;
+        }
+
+        let error = result.unwrap_err();
+        if !matches!(
+            error,
+            IggyError::Disconnected
+                | IggyError::EmptyResponse
+                | IggyError::Unauthenticated
+                | IggyError::StaleClient
+                | IggyError::NotConnected
+                | IggyError::CannotEstablishConnection
+                | IggyError::QuicError
+        ) {
+            return Err(error);
+        }
+
+        if !self.config.reconnection.enabled {
+            return Err(IggyError::Disconnected);
+        }
+
+        #[cfg(feature = "vsr")]
+        if matches!(self.config.auto_login, AutoLogin::Disabled) && !is_login_register_code(code) {
+            // Without auto-login a reconnect cannot re-establish the session, so
+            // non-login requests are not recovered here - their transient replay
+            // happens on the live connection inside `send_raw`. Login/register
+            // is the exception: the server stays deliberately silent on a
+            // transient register failure and relies on the client replaying via
+            // a reconnect with a fresh session.
+            return Err(error);
+        }
+
+        self.disconnect().await?;
+        #[cfg(feature = "vsr")]
+        let skip_auto_login = is_login_register_code(code);
+        #[cfg(feature = "vsr")]
+        if skip_auto_login {
+            *self.skip_auto_login_once.lock().await = true;
+        }
+        let server_address = self.current_server_address.lock().await.to_string();
+        info!(
+            "Reconnecting to the server: {}, by client: {}",
+            server_address, self.config.client_address
+        );
+        let reconnect = self.connect().await;
+        #[cfg(feature = "vsr")]
+        if skip_auto_login && reconnect.is_err() {
+            *self.skip_auto_login_once.lock().await = false;
+        }
+        reconnect?;
+        self.send_raw(kind, code, payload).await
+    }
+
+    #[cfg_attr(not(feature = "vsr"), expect(unused_variables))]
+    async fn send_raw(
+        &self,
+        kind: Option<BinaryRequestKind>,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
         match self.get_state().await {
             ClientState::Shutdown => {
                 trace!("Cannot send data. Client is shutdown.");
@@ -720,7 +750,12 @@ impl QuicClient {
                     let mut consensus_session = consensus_session
                         .lock()
                         .expect("consensus session mutex poisoned");
-                    crate::vsr::encode_request_header(&mut consensus_session, code, &payload)?
+                    crate::vsr::encode_request_header(
+                        &mut consensus_session,
+                        kind,
+                        code,
+                        &payload,
+                    )?
                 };
                 trace!("Sending a QUIC VSR request of size {request_size} with code: {code}");
                 // Same-connection transient resend, gated on the EXPLICIT
@@ -923,6 +958,27 @@ mod tests {
         let value = "";
         let quic_client = QuicClient::from_connection_string(value);
         assert!(quic_client.is_err());
+    }
+
+    #[tokio::test]
+    async fn raw_binary_transport_rejects_session_control_before_io() {
+        let client =
+            QuicClient::from_connection_string("iggy+quic://iggy:iggy@127.0.0.1:8080").unwrap();
+
+        for kind in [
+            BinaryRequestKind::NonReplicated,
+            BinaryRequestKind::Replicated,
+        ] {
+            let error = client
+                .send_binary_request(
+                    kind,
+                    iggy_binary_protocol::codes::LOGIN_USER_CODE,
+                    Bytes::new(),
+                )
+                .await
+                .unwrap_err();
+            assert!(matches!(error, IggyError::InvalidCommand));
+        }
     }
 
     #[tokio::test]

--- a/core/sdk/src/tcp/tcp_client.rs
+++ b/core/sdk/src/tcp/tcp_client.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::binary::validate_binary_request_code;
 use crate::leader_aware::{LeaderRedirectionState, check_and_redirect_to_leader};
 use crate::prelude::Client;
 use crate::prelude::TcpClientConfig;
@@ -38,7 +39,9 @@ use iggy_common::{
     AutoLogin, ClientState, ConnectionString, ConnectionStringUtils, Credentials, DiagnosticEvent,
     IggyDuration, IggyError, IggyTimestamp, TcpConnectionStringOptions, TransportProtocol,
 };
-use iggy_common::{BinaryClient, BinaryTransport, PersonalAccessTokenClient, UserClient};
+use iggy_common::{
+    BinaryClient, BinaryRequestKind, BinaryTransport, PersonalAccessTokenClient, UserClient,
+};
 use rustls::pki_types::{CertificateDer, ServerName, pem::PemObject};
 use secrecy::ExposeSecret;
 use std::net::SocketAddr;
@@ -148,64 +151,17 @@ impl BinaryTransport for TcpClient {
     }
 
     async fn send_raw_with_response(&self, code: u32, payload: Bytes) -> Result<Bytes, IggyError> {
-        let result = self.send_raw(code, payload.clone()).await;
-        if result.is_ok() {
-            return result;
-        }
+        self.send_with_reconnect(None, code, payload).await
+    }
 
-        let error = result.unwrap_err();
-        if !matches!(
-            error,
-            IggyError::Disconnected
-                | IggyError::EmptyResponse
-                | IggyError::Unauthenticated
-                | IggyError::StaleClient
-                | IggyError::NotConnected
-                | IggyError::CannotEstablishConnection
-                | IggyError::TcpError
-        ) {
-            return Err(error);
-        }
-
-        if !self.config.reconnection.enabled {
-            return Err(IggyError::Disconnected);
-        }
-
-        #[cfg(feature = "vsr")]
-        if matches!(self.config.auto_login, AutoLogin::Disabled) && !is_login_register_code(code) {
-            // Without auto-login a reconnect cannot re-establish the session,
-            // so non-login requests fail fast. Login/register itself is the
-            // exception: the server stays deliberately silent on transient
-            // register failures (server-ng `surface_login_failure`) and
-            // relies on the client timing out and replaying the request.
-            return Err(error);
-        }
-
-        self.disconnect().await?;
-
-        #[cfg(feature = "vsr")]
-        let skip_auto_login = is_login_register_code(code);
-        #[cfg(feature = "vsr")]
-        if skip_auto_login {
-            *self.skip_auto_login_once.lock().await = true;
-        }
-
-        {
-            let client_address = self.get_client_address_value().await;
-            let server_address = self.current_server_address.lock().await.clone();
-            info!(
-                "Reconnecting to the server: {} by client: {client_address}...",
-                server_address
-            );
-        }
-
-        let reconnect = self.connect().await;
-        #[cfg(feature = "vsr")]
-        if skip_auto_login && reconnect.is_err() {
-            *self.skip_auto_login_once.lock().await = false;
-        }
-        reconnect?;
-        self.send_raw(code, payload).await
+    async fn send_binary_request(
+        &self,
+        kind: BinaryRequestKind,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
+        validate_binary_request_code(code)?;
+        self.send_with_reconnect(Some(kind), code, payload).await
     }
 
     fn get_heartbeat_interval(&self) -> IggyDuration {
@@ -708,7 +664,81 @@ impl TcpClient {
         Ok(())
     }
 
-    async fn send_raw(&self, code: u32, payload: Bytes) -> Result<Bytes, IggyError> {
+    /// Single reconnect-and-replay path shared by the typed and the raw entry
+    /// points, so `kind` survives the retry attempt unchanged.
+    async fn send_with_reconnect(
+        &self,
+        kind: Option<BinaryRequestKind>,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
+        let result = self.send_raw(kind, code, payload.clone()).await;
+        if result.is_ok() {
+            return result;
+        }
+
+        let error = result.unwrap_err();
+        if !matches!(
+            error,
+            IggyError::Disconnected
+                | IggyError::EmptyResponse
+                | IggyError::Unauthenticated
+                | IggyError::StaleClient
+                | IggyError::NotConnected
+                | IggyError::CannotEstablishConnection
+                | IggyError::TcpError
+        ) {
+            return Err(error);
+        }
+
+        if !self.config.reconnection.enabled {
+            return Err(IggyError::Disconnected);
+        }
+
+        #[cfg(feature = "vsr")]
+        if matches!(self.config.auto_login, AutoLogin::Disabled) && !is_login_register_code(code) {
+            // Without auto-login a reconnect cannot re-establish the session,
+            // so non-login requests fail fast. Login/register itself is the
+            // exception: the server stays deliberately silent on transient
+            // register failures (server-ng `surface_login_failure`) and
+            // relies on the client timing out and replaying the request.
+            return Err(error);
+        }
+
+        self.disconnect().await?;
+
+        #[cfg(feature = "vsr")]
+        let skip_auto_login = is_login_register_code(code);
+        #[cfg(feature = "vsr")]
+        if skip_auto_login {
+            *self.skip_auto_login_once.lock().await = true;
+        }
+
+        {
+            let client_address = self.get_client_address_value().await;
+            let server_address = self.current_server_address.lock().await.clone();
+            info!(
+                "Reconnecting to the server: {} by client: {client_address}...",
+                server_address
+            );
+        }
+
+        let reconnect = self.connect().await;
+        #[cfg(feature = "vsr")]
+        if skip_auto_login && reconnect.is_err() {
+            *self.skip_auto_login_once.lock().await = false;
+        }
+        reconnect?;
+        self.send_raw(kind, code, payload).await
+    }
+
+    #[cfg_attr(not(feature = "vsr"), expect(unused_variables))]
+    async fn send_raw(
+        &self,
+        kind: Option<BinaryRequestKind>,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
         match self.get_state().await {
             ClientState::Shutdown => {
                 trace!("Cannot send data. Client is shutdown.");
@@ -744,6 +774,7 @@ impl TcpClient {
                 };
                 let (header, result) = self
                     .send_raw_vsr_attempt(
+                        kind,
                         code,
                         payload.clone(),
                         preencoded,
@@ -858,6 +889,7 @@ impl TcpClient {
     #[cfg(feature = "vsr")]
     async fn send_raw_vsr_attempt(
         &self,
+        kind: Option<BinaryRequestKind>,
         code: u32,
         payload: Bytes,
         preencoded: Option<iggy_binary_protocol::consensus::RequestHeader>,
@@ -892,7 +924,12 @@ impl TcpClient {
                         let mut consensus_session = consensus_session
                             .lock()
                             .expect("consensus session mutex poisoned");
-                        crate::vsr::encode_request_header(&mut consensus_session, code, &payload)
+                        crate::vsr::encode_request_header(
+                            &mut consensus_session,
+                            kind,
+                            code,
+                            &payload,
+                        )
                     };
                     match encoded {
                         Ok((header, request_size)) => {
@@ -1063,6 +1100,27 @@ mod tests {
         let value = "";
         let tcp_client = TcpClient::from_connection_string(value);
         assert!(tcp_client.is_err());
+    }
+
+    #[tokio::test]
+    async fn raw_binary_transport_rejects_session_control_before_io() {
+        let client =
+            TcpClient::from_connection_string("iggy+tcp://iggy:iggy@127.0.0.1:8090").unwrap();
+
+        for kind in [
+            BinaryRequestKind::NonReplicated,
+            BinaryRequestKind::Replicated,
+        ] {
+            let error = client
+                .send_binary_request(
+                    kind,
+                    iggy_binary_protocol::codes::LOGIN_USER_CODE,
+                    Bytes::new(),
+                )
+                .await
+                .unwrap_err();
+            assert!(matches!(error, IggyError::InvalidCommand));
+        }
     }
 
     #[test]

--- a/core/sdk/src/vsr.rs
+++ b/core/sdk/src/vsr.rs
@@ -38,7 +38,7 @@ use iggy_binary_protocol::requests::consumer_offsets::{
 use iggy_binary_protocol::requests::messages::SendMessagesHeader;
 use iggy_binary_protocol::requests::segments::DeleteSegmentsRequest;
 use iggy_binary_protocol::{WireIdentifier, WirePartitioning};
-use iggy_common::{IggyError, eviction_reason_to_error};
+use iggy_common::{BinaryRequestKind, IggyError, eviction_reason_to_error};
 
 const NON_REPLICATED_CODE_RANGE: std::ops::Range<usize> = 0..4;
 
@@ -54,18 +54,23 @@ const NON_REPLICATED_CODE_RANGE: std::ops::Range<usize> = 0..4;
 // independent of (client_id, request_id).
 pub(crate) fn encode_contiguous_request(
     session: &mut ConsensusSession,
+    kind: Option<BinaryRequestKind>,
     code: u32,
     payload: &Bytes,
 ) -> Result<Bytes, IggyError> {
-    let (header, total_size) = encode_request_header(session, code, payload)?;
+    let (header, total_size) = encode_request_header(session, kind, code, payload)?;
     let mut request = BytesMut::with_capacity(total_size);
     request.put_slice(bytemuck::bytes_of(&header));
     request.put_slice(payload);
     Ok(request.freeze())
 }
 
+/// `kind` is the caller's replication declaration for a raw request. `None`
+/// marks a standard typed command, which the protocol tables classify on their
+/// own.
 pub(crate) fn encode_request_header(
     session: &mut ConsensusSession,
+    kind: Option<BinaryRequestKind>,
     code: u32,
     payload: &Bytes,
 ) -> Result<(RequestHeader, usize), IggyError> {
@@ -79,7 +84,7 @@ pub(crate) fn encode_request_header(
             (Operation::Register, session.begin_register(), 0)
         }
         _ => {
-            let operation = operation_for_code(code)?;
+            let operation = operation_for_code(code, kind)?;
             // NonReplicated ops (ping, reads) bypass server-side dedup --
             // `ClientTable` only tracks request_ids for replicated ops. If
             // they consumed the monotonic counter, the next replicated
@@ -144,19 +149,57 @@ pub(crate) fn encode_request_header(
     Ok((header, total_size))
 }
 
-fn operation_for_code(code: u32) -> Result<Operation, IggyError> {
+/// Pick the header operation for `code`, honoring the caller's declaration
+/// only where the protocol tables have nothing to say.
+///
+/// Standard codes resolve first so a caller cannot redirect a shipped command
+/// into the other execution model, then an unknown code falls back to the
+/// declaration. Without a declaration an unknown code is a bug in a typed SDK
+/// method rather than a vendor extension, so it stays `InvalidCommand`.
+fn operation_for_code(code: u32, kind: Option<BinaryRequestKind>) -> Result<Operation, IggyError> {
     if code == LOGOUT_USER_CODE {
-        return Ok(Operation::Logout);
+        return accept_declaration(Operation::Logout, kind);
     }
 
     if let Some(operation) = Operation::from_command_code(code) {
-        return Ok(operation);
+        return accept_declaration(operation, kind);
     }
 
     match iggy_binary_protocol::dispatch::lookup_command(code) {
-        Some(meta) if !meta.is_replicated() => Ok(Operation::NonReplicated),
+        Some(meta) if !meta.is_replicated() => accept_declaration(Operation::NonReplicated, kind),
         Some(_) => Err(IggyError::UnknownReplicatedCommand(code)),
-        None => Err(IggyError::InvalidCommand),
+        None => match kind {
+            Some(BinaryRequestKind::NonReplicated) => Ok(Operation::NonReplicated),
+            // A replicated vendor command needs a deterministic server-side
+            // handler registry, replicated state ownership, and a snapshot
+            // contract. None of that exists, and a half-supported frame would
+            // be worse than no frame.
+            Some(BinaryRequestKind::Replicated) => Err(IggyError::FeatureUnavailable),
+            None => Err(IggyError::InvalidCommand),
+        },
+    }
+}
+
+/// Reject a declaration that disagrees with the class `operation` already
+/// carries. Partition operations decode their namespace from a payload the SDK
+/// must understand, so they are replicated but never reachable from a raw
+/// request: `namespace_for_request` refuses an unrecognised code.
+fn accept_declaration(
+    operation: Operation,
+    kind: Option<BinaryRequestKind>,
+) -> Result<Operation, IggyError> {
+    let Some(declared) = kind else {
+        return Ok(operation);
+    };
+    let standard = if operation == Operation::NonReplicated {
+        BinaryRequestKind::NonReplicated
+    } else {
+        BinaryRequestKind::Replicated
+    };
+    if declared == standard {
+        Ok(operation)
+    } else {
+        Err(IggyError::InvalidCommand)
     }
 }
 
@@ -460,6 +503,7 @@ mod tests {
     use iggy_binary_protocol::codes::{
         CREATE_STREAM_CODE, GET_STREAM_CODE, LOGOUT_USER_CODE, PING_CODE,
     };
+    use iggy_binary_protocol::dispatch::COMMAND_TABLE;
     use iggy_binary_protocol::requests::messages::SendMessagesHeader;
     use iggy_binary_protocol::requests::streams::CreateStreamRequest;
     use iggy_binary_protocol::requests::users::LoginRegisterRequest;
@@ -467,8 +511,27 @@ mod tests {
     use iggy_binary_protocol::{ClientVersionInfo, WireEncode, WireName};
     use secrecy::SecretString;
 
+    /// Outside every range the protocol assigns, so it stays unknown as the
+    /// command table grows.
+    const VENDOR_CODE: u32 = 60_001;
+
     fn decode_request_header(bytes: &Bytes) -> RequestHeader {
         *bytemuck::checked::try_from_bytes::<RequestHeader>(&bytes[..HEADER_SIZE]).unwrap()
+    }
+
+    fn read_non_replicated_code(header: &RequestHeader) -> u32 {
+        u32::from_le_bytes(
+            header.reserved[NON_REPLICATED_CODE_RANGE]
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    fn bound_session() -> ConsensusSession {
+        let mut session = ConsensusSession::with_client_id(42);
+        let _ = session.register_request_id();
+        session.bind(99);
+        session
     }
 
     #[test]
@@ -486,7 +549,7 @@ mod tests {
         };
 
         let bytes =
-            encode_contiguous_request(&mut session, LOGIN_REGISTER_CODE, &request.to_bytes())
+            encode_contiguous_request(&mut session, None, LOGIN_REGISTER_CODE, &request.to_bytes())
                 .unwrap();
         let header = decode_request_header(&bytes);
 
@@ -513,13 +576,14 @@ mod tests {
         };
 
         let mut session = ConsensusSession::with_client_id(7);
-        encode_contiguous_request(&mut session, LOGIN_REGISTER_CODE, &request.to_bytes()).unwrap();
+        encode_contiguous_request(&mut session, None, LOGIN_REGISTER_CODE, &request.to_bytes())
+            .unwrap();
         session.bind(42);
 
         // A second login on the same bound session must encode a fresh Register
         // (request 0, session 0), not panic in the one-shot register guard.
         let bytes =
-            encode_contiguous_request(&mut session, LOGIN_REGISTER_CODE, &request.to_bytes())
+            encode_contiguous_request(&mut session, None, LOGIN_REGISTER_CODE, &request.to_bytes())
                 .unwrap();
         let header = decode_request_header(&bytes);
         assert_eq!(header.operation, Operation::Register);
@@ -618,8 +682,10 @@ mod tests {
         }
         .to_bytes();
 
-        let first = encode_contiguous_request(&mut session, CREATE_STREAM_CODE, &payload).unwrap();
-        let second = encode_contiguous_request(&mut session, CREATE_STREAM_CODE, &payload).unwrap();
+        let first =
+            encode_contiguous_request(&mut session, None, CREATE_STREAM_CODE, &payload).unwrap();
+        let second =
+            encode_contiguous_request(&mut session, None, CREATE_STREAM_CODE, &payload).unwrap();
 
         assert_eq!(decode_request_header(&first).request, 1);
         assert_eq!(decode_request_header(&second).request, 2);
@@ -631,18 +697,12 @@ mod tests {
     fn ping_uses_non_replicated_operation() {
         let mut session = ConsensusSession::with_client_id(42);
         session.bind(99);
-        let bytes = encode_contiguous_request(&mut session, PING_CODE, &Bytes::new()).unwrap();
+        let bytes =
+            encode_contiguous_request(&mut session, None, PING_CODE, &Bytes::new()).unwrap();
         let header = decode_request_header(&bytes);
 
         assert_eq!(header.operation, Operation::NonReplicated);
-        assert_eq!(
-            u32::from_le_bytes(
-                header.reserved[NON_REPLICATED_CODE_RANGE]
-                    .try_into()
-                    .unwrap()
-            ),
-            PING_CODE
-        );
+        assert_eq!(read_non_replicated_code(&header), PING_CODE);
         assert_eq!(header.session, 99);
         assert_eq!(header.namespace, 0);
     }
@@ -652,7 +712,7 @@ mod tests {
         let mut session = ConsensusSession::with_client_id(42);
         session.bind(99);
         let bytes =
-            encode_contiguous_request(&mut session, LOGOUT_USER_CODE, &Bytes::new()).unwrap();
+            encode_contiguous_request(&mut session, None, LOGOUT_USER_CODE, &Bytes::new()).unwrap();
         let header = decode_request_header(&bytes);
 
         assert_eq!(header.operation, Operation::Logout);
@@ -668,18 +728,11 @@ mod tests {
         let mut session = ConsensusSession::with_client_id(42);
         session.bind(99);
         let bytes =
-            encode_contiguous_request(&mut session, GET_STREAM_CODE, &Bytes::new()).unwrap();
+            encode_contiguous_request(&mut session, None, GET_STREAM_CODE, &Bytes::new()).unwrap();
         let header = decode_request_header(&bytes);
 
         assert_eq!(header.operation, Operation::NonReplicated);
-        assert_eq!(
-            u32::from_le_bytes(
-                header.reserved[NON_REPLICATED_CODE_RANGE]
-                    .try_into()
-                    .unwrap()
-            ),
-            GET_STREAM_CODE
-        );
+        assert_eq!(read_non_replicated_code(&header), GET_STREAM_CODE);
         assert_eq!(header.session, 99);
     }
 
@@ -835,5 +888,151 @@ mod tests {
         let body = rejection_body(IggyError::InvalidOffset(1).as_code());
         let out = split_metadata_result(Operation::SendMessages, body.clone()).unwrap();
         assert_eq!(out, body);
+    }
+
+    #[test]
+    fn vendor_non_replicated_code_encodes_with_the_code_in_reserved() {
+        let mut session = bound_session();
+        let payload = Bytes::from_static(b"vendor-body");
+
+        let bytes = encode_contiguous_request(
+            &mut session,
+            Some(BinaryRequestKind::NonReplicated),
+            VENDOR_CODE,
+            &payload,
+        )
+        .unwrap();
+        let header = decode_request_header(&bytes);
+
+        assert_eq!(header.operation, Operation::NonReplicated);
+        assert_eq!(read_non_replicated_code(&header), VENDOR_CODE);
+        assert_eq!(header.namespace, 0);
+        assert_eq!(header.session, 99);
+        assert_eq!(&bytes[HEADER_SIZE..], &payload[..]);
+        assert_eq!(header.size as usize, HEADER_SIZE + payload.len());
+    }
+
+    #[test]
+    fn vendor_non_replicated_code_does_not_advance_the_request_identifier() {
+        let mut session = bound_session();
+        let payload = CreateStreamRequest {
+            name: WireName::new("stream").unwrap(),
+        }
+        .to_bytes();
+
+        for _ in 0..3 {
+            encode_contiguous_request(
+                &mut session,
+                Some(BinaryRequestKind::NonReplicated),
+                VENDOR_CODE,
+                &Bytes::new(),
+            )
+            .unwrap();
+        }
+        // The next replicated request must still claim id 1: a gap makes the
+        // primary's `request_preflight` drop it as a `RequestGap`.
+        let replicated =
+            encode_contiguous_request(&mut session, None, CREATE_STREAM_CODE, &payload).unwrap();
+
+        assert_eq!(decode_request_header(&replicated).request, 1);
+    }
+
+    #[test]
+    fn vendor_replicated_code_is_unavailable_until_the_registry_exists() {
+        let mut session = bound_session();
+        let error = encode_contiguous_request(
+            &mut session,
+            Some(BinaryRequestKind::Replicated),
+            VENDOR_CODE,
+            &Bytes::new(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, IggyError::FeatureUnavailable));
+    }
+
+    #[test]
+    fn vendor_code_without_a_declaration_stays_closed_world() {
+        let mut session = bound_session();
+        let error =
+            encode_contiguous_request(&mut session, None, VENDOR_CODE, &Bytes::new()).unwrap_err();
+
+        assert!(matches!(error, IggyError::InvalidCommand));
+    }
+
+    #[test]
+    fn every_standard_code_accepts_its_own_class_and_rejects_the_other() {
+        for meta in COMMAND_TABLE {
+            let Ok(operation) = operation_for_code(meta.code, None) else {
+                // A replicated table entry with no `Operation` mapping stays
+                // unknown, and no declaration may rescue it.
+                for kind in [
+                    BinaryRequestKind::NonReplicated,
+                    BinaryRequestKind::Replicated,
+                ] {
+                    assert!(
+                        matches!(
+                            operation_for_code(meta.code, Some(kind)),
+                            Err(IggyError::UnknownReplicatedCommand(_))
+                        ),
+                        "{} must stay unknown when declared {kind}",
+                        meta.name
+                    );
+                }
+                continue;
+            };
+            let (matching, conflicting) = if operation == Operation::NonReplicated {
+                (
+                    BinaryRequestKind::NonReplicated,
+                    BinaryRequestKind::Replicated,
+                )
+            } else {
+                (
+                    BinaryRequestKind::Replicated,
+                    BinaryRequestKind::NonReplicated,
+                )
+            };
+
+            assert_eq!(
+                operation_for_code(meta.code, Some(matching)).unwrap(),
+                operation,
+                "{} must keep {operation:?} when declared {matching}",
+                meta.name
+            );
+            assert!(
+                matches!(
+                    operation_for_code(meta.code, Some(conflicting)),
+                    Err(IggyError::InvalidCommand)
+                ),
+                "{} must not be redirected by a {conflicting} declaration",
+                meta.name
+            );
+        }
+    }
+
+    #[test]
+    fn logout_keeps_its_replicated_class_despite_the_table_entry() {
+        // The command table lists logout as non-replicated because classic
+        // framing runs it locally, but VSR commits it through `Operation::Logout`.
+        assert!(
+            matches!(
+                operation_for_code(LOGOUT_USER_CODE, Some(BinaryRequestKind::NonReplicated)),
+                Err(IggyError::InvalidCommand)
+            ),
+            "logout must not be reachable as a non-replicated raw request"
+        );
+        assert_eq!(
+            operation_for_code(LOGOUT_USER_CODE, Some(BinaryRequestKind::Replicated)).unwrap(),
+            Operation::Logout
+        );
+    }
+
+    #[test]
+    fn vendor_replicated_code_cannot_reach_partition_routing() {
+        // Partition namespaces are decoded from a payload the SDK must
+        // understand, so no raw request can select one.
+        let error =
+            namespace_for_request(VENDOR_CODE, &Bytes::new(), Operation::SendMessages).unwrap_err();
+        assert!(matches!(error, IggyError::FeatureUnavailable));
     }
 }

--- a/core/sdk/src/websocket/websocket_client.rs
+++ b/core/sdk/src/websocket/websocket_client.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::binary::validate_binary_request_code;
 use crate::leader_aware::{LeaderRedirectionState, check_and_redirect_to_leader};
 #[cfg(feature = "vsr")]
 use crate::session::ConsensusSession;
@@ -39,7 +40,9 @@ use iggy_common::{
     AutoLogin, ClientState, ConnectionString, Credentials, DiagnosticEvent, IggyDuration,
     IggyError, IggyTimestamp, WebSocketClientConfig, WebSocketConnectionStringOptions,
 };
-use iggy_common::{BinaryClient, BinaryTransport, PersonalAccessTokenClient, UserClient};
+use iggy_common::{
+    BinaryClient, BinaryRequestKind, BinaryTransport, PersonalAccessTokenClient, UserClient,
+};
 use secrecy::ExposeSecret;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -136,61 +139,17 @@ impl BinaryTransport for WebSocketClient {
     }
 
     async fn send_raw_with_response(&self, code: u32, payload: Bytes) -> Result<Bytes, IggyError> {
-        let result = self.send_raw(code, payload.clone()).await;
-        if result.is_ok() {
-            return result;
-        }
+        self.send_with_reconnect(None, code, payload).await
+    }
 
-        let error = result.unwrap_err();
-        if !matches!(
-            error,
-            IggyError::Disconnected
-                | IggyError::EmptyResponse
-                | IggyError::Unauthenticated
-                | IggyError::StaleClient
-                | IggyError::NotConnected
-                | IggyError::CannotEstablishConnection
-                | IggyError::TcpError
-                | IggyError::ConnectionClosed
-                | IggyError::WebSocketSendError
-                | IggyError::WebSocketReceiveError
-        ) {
-            return Err(error);
-        }
-
-        if !self.config.reconnection.enabled {
-            return Err(IggyError::Disconnected);
-        }
-
-        #[cfg(feature = "vsr")]
-        if matches!(self.config.auto_login, AutoLogin::Disabled) {
-            return Err(error);
-        }
-
-        self.disconnect().await?;
-
-        #[cfg(feature = "vsr")]
-        let skip_auto_login = is_login_register_code(code);
-        #[cfg(feature = "vsr")]
-        if skip_auto_login {
-            *self.skip_auto_login_once.lock().await = true;
-        }
-
-        {
-            let client_address = self.get_client_address_value().await;
-            info!(
-                "Reconnecting to the server: {} by client: {client_address}...",
-                self.config.server_address
-            );
-        }
-
-        let reconnect = self.connect().await;
-        #[cfg(feature = "vsr")]
-        if skip_auto_login && reconnect.is_err() {
-            *self.skip_auto_login_once.lock().await = false;
-        }
-        reconnect?;
-        self.send_raw(code, payload).await
+    async fn send_binary_request(
+        &self,
+        kind: BinaryRequestKind,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
+        validate_binary_request_code(code)?;
+        self.send_with_reconnect(Some(kind), code, payload).await
     }
 
     fn get_heartbeat_interval(&self) -> IggyDuration {
@@ -683,7 +642,78 @@ impl WebSocketClient {
         Ok(())
     }
 
-    async fn send_raw(&self, code: u32, payload: Bytes) -> Result<Bytes, IggyError> {
+    /// Single reconnect-and-replay path shared by the typed and the raw entry
+    /// points, so `kind` survives the retry attempt unchanged.
+    async fn send_with_reconnect(
+        &self,
+        kind: Option<BinaryRequestKind>,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
+        let result = self.send_raw(kind, code, payload.clone()).await;
+        if result.is_ok() {
+            return result;
+        }
+
+        let error = result.unwrap_err();
+        if !matches!(
+            error,
+            IggyError::Disconnected
+                | IggyError::EmptyResponse
+                | IggyError::Unauthenticated
+                | IggyError::StaleClient
+                | IggyError::NotConnected
+                | IggyError::CannotEstablishConnection
+                | IggyError::TcpError
+                | IggyError::ConnectionClosed
+                | IggyError::WebSocketSendError
+                | IggyError::WebSocketReceiveError
+        ) {
+            return Err(error);
+        }
+
+        if !self.config.reconnection.enabled {
+            return Err(IggyError::Disconnected);
+        }
+
+        #[cfg(feature = "vsr")]
+        if matches!(self.config.auto_login, AutoLogin::Disabled) {
+            return Err(error);
+        }
+
+        self.disconnect().await?;
+
+        #[cfg(feature = "vsr")]
+        let skip_auto_login = is_login_register_code(code);
+        #[cfg(feature = "vsr")]
+        if skip_auto_login {
+            *self.skip_auto_login_once.lock().await = true;
+        }
+
+        {
+            let client_address = self.get_client_address_value().await;
+            info!(
+                "Reconnecting to the server: {} by client: {client_address}...",
+                self.config.server_address
+            );
+        }
+
+        let reconnect = self.connect().await;
+        #[cfg(feature = "vsr")]
+        if skip_auto_login && reconnect.is_err() {
+            *self.skip_auto_login_once.lock().await = false;
+        }
+        reconnect?;
+        self.send_raw(kind, code, payload).await
+    }
+
+    #[cfg_attr(not(feature = "vsr"), expect(unused_variables))]
+    async fn send_raw(
+        &self,
+        kind: Option<BinaryRequestKind>,
+        code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError> {
         match self.get_state().await {
             ClientState::Shutdown => {
                 trace!("Cannot send data. Client is shutdown.");
@@ -720,7 +750,7 @@ impl WebSocketClient {
                     .consensus_session
                     .lock()
                     .expect("consensus session mutex poisoned");
-                crate::vsr::encode_contiguous_request(&mut consensus_session, code, &payload)?
+                crate::vsr::encode_contiguous_request(&mut consensus_session, kind, code, &payload)?
             };
             trace!(
                 "Sending {NAME} VSR request of size {} with code: {code}",
@@ -874,6 +904,27 @@ const fn is_login_register_code(code: u32) -> bool {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[tokio::test]
+    async fn raw_binary_transport_rejects_session_control_before_io() {
+        let client =
+            WebSocketClient::from_connection_string("iggy+ws://iggy:iggy@127.0.0.1:8092").unwrap();
+
+        for kind in [
+            BinaryRequestKind::NonReplicated,
+            BinaryRequestKind::Replicated,
+        ] {
+            let error = client
+                .send_binary_request(
+                    kind,
+                    iggy_binary_protocol::codes::LOGIN_USER_CODE,
+                    Bytes::new(),
+                )
+                .await
+                .unwrap_err();
+            assert!(matches!(error, IggyError::InvalidCommand));
+        }
+    }
 
     #[test]
     fn should_be_created_with_default_config() {

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -8,7 +8,7 @@ exclude-newer-span = "P7D"
 
 [[package]]
 name = "apache-iggy"
-version = "0.8.1.dev3"
+version = "0.8.1.dev4"
 source = { directory = "../../foreign/python" }
 
 [package.metadata]

--- a/foreign/cpp/.bazelrc
+++ b/foreign/cpp/.bazelrc
@@ -35,6 +35,9 @@ build:release --copt=-O2
 build:release --copt=-DNDEBUG
 build:release --strip=always
 
+# VSR framing
+build:vsr --define=iggy_cpp_vsr=true
+
 # CI configuration
 common:ci --color=no
 common:ci --curses=no

--- a/foreign/cpp/BUILD.bazel
+++ b/foreign/cpp/BUILD.bazel
@@ -17,6 +17,11 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library", "cc_test")
 
+config_setting(
+    name = "vsr_enabled",
+    define_values = {"iggy_cpp_vsr": "true"},
+)
+
 genrule(
     name = "cargo_build",
     srcs = glob(["src/**/*.rs"]) + [
@@ -30,6 +35,13 @@ genrule(
         "cxxbridge/sources/lib.rs.cc",
     ],
     cmd = """
+        CARGO_FEATURE_FLAGS=""
+    """ + select({
+        ":vsr_enabled": """
+        CARGO_FEATURE_FLAGS="--features vsr"
+        """,
+        "//conditions:default": "",
+    }) + """
         set -euo pipefail
 
         EXECROOT="$$(pwd)"
@@ -55,7 +67,7 @@ genrule(
         env -u PWD \
             CARGO_TARGET_DIR="$$CARGO_TARGET_DIR" \
             RUSTC="$$RUSTC" \
-            "$$CARGO" build $$FLAGS
+            "$$CARGO" build $$FLAGS $$CARGO_FEATURE_FLAGS
 
         cp "$$CARGO_TARGET_DIR/$$PROFILE/libiggy_cpp.a" "$$OUT_LIB"
 

--- a/foreign/cpp/Cargo.toml
+++ b/foreign/cpp/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy-cpp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [package.metadata.cargo-machete]
@@ -25,6 +25,12 @@ ignored = ["cxx-build"]
 
 [lib]
 crate-type = ["staticlib"]
+
+# Framing is a compile-time choice, so the static library is locked to whatever it
+# was built with. Opt in with `--features vsr` to build against the consensus
+# protocol; the default build stays on the classic protocol.
+[features]
+vsr = ["iggy/vsr", "iggy_common/vsr"]
 
 [dependencies]
 bytes = "1.12.1"

--- a/foreign/cpp/MODULE.bazel
+++ b/foreign/cpp/MODULE.bazel
@@ -17,7 +17,7 @@
 
 module(
     name = "iggy_cpp",
-    version = "0.1.1",
+    version = "0.1.2",
 )
 
 bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/foreign/cpp/README.md
+++ b/foreign/cpp/README.md
@@ -24,6 +24,9 @@ Build commands
 // Build binary
 bazel build //:iggy-cpp
 
+// Build binary with VSR framing
+bazel build --config=vsr //:iggy-cpp
+
 // Unit tests
 bazel test //:unit
 

--- a/foreign/cpp/src/client.rs
+++ b/foreign/cpp/src/client.rs
@@ -37,18 +37,6 @@ use std::sync::Arc;
 /// reserve `u32::MAX` as the sentinel for `partition_id`.
 const ANY_PARTITION_ID: u32 = u32::MAX;
 
-/// A C++ `enum class` can hold any value of its underlying type, so cxx models
-/// a shared enum as an open repr and the catch-all arm is reachable.
-fn resolve_binary_request_kind(
-    kind: ffi::BinaryRequestKind,
-) -> Result<RustBinaryRequestKind, String> {
-    match kind {
-        ffi::BinaryRequestKind::NonReplicated => Ok(RustBinaryRequestKind::NonReplicated),
-        ffi::BinaryRequestKind::Replicated => Ok(RustBinaryRequestKind::Replicated),
-        _ => Err(format!("invalid binary request kind: {}", kind.repr)),
-    }
-}
-
 fn resolve_consumer(consumer_kind: &str, consumer_id: RustIdentifier) -> Result<Consumer, String> {
     match consumer_kind {
         "consumer" => Ok(Consumer::new(consumer_id)),
@@ -1151,7 +1139,7 @@ impl Client {
         code: u32,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, String> {
-        let kind = resolve_binary_request_kind(kind)?;
+        let kind = RustBinaryRequestKind::try_from(kind)?;
         RUNTIME.block_on(async {
             let response = self
                 .inner

--- a/foreign/cpp/src/client.rs
+++ b/foreign/cpp/src/client.rs
@@ -18,7 +18,7 @@
 use crate::{RUNTIME, ffi};
 use bytes::Bytes;
 use iggy::prelude::{
-    Client as IggyConnectionClient, ClusterClient,
+    BinaryRequestKind as RustBinaryRequestKind, Client as IggyConnectionClient, ClusterClient,
     CompressionAlgorithm as RustCompressionAlgorithm, Consumer, ConsumerGroupClient,
     ConsumerOffsetClient, Identifier as RustIdentifier, IggyClient as RustIggyClient,
     IggyClientBuilder as RustIggyClientBuilder, IggyExpiry as RustIggyExpiry, IggyMessage,
@@ -36,6 +36,18 @@ use std::sync::Arc;
 /// partition based on the consumer/strategy. Cxx FFI does not support `Option<u32>`, so we
 /// reserve `u32::MAX` as the sentinel for `partition_id`.
 const ANY_PARTITION_ID: u32 = u32::MAX;
+
+/// A C++ `enum class` can hold any value of its underlying type, so cxx models
+/// a shared enum as an open repr and the catch-all arm is reachable.
+fn resolve_binary_request_kind(
+    kind: ffi::BinaryRequestKind,
+) -> Result<RustBinaryRequestKind, String> {
+    match kind {
+        ffi::BinaryRequestKind::NonReplicated => Ok(RustBinaryRequestKind::NonReplicated),
+        ffi::BinaryRequestKind::Replicated => Ok(RustBinaryRequestKind::Replicated),
+        _ => Err(format!("invalid binary request kind: {}", kind.repr)),
+    }
+}
 
 fn resolve_consumer(consumer_kind: &str, consumer_id: RustIdentifier) -> Result<Consumer, String> {
     match consumer_kind {
@@ -1133,11 +1145,17 @@ impl Client {
 
     /// Sends a command code and payload and returns the raw response bytes.
     /// Session-control codes return an invalid-command error.
-    pub fn send_binary_request(&self, code: u32, payload: Vec<u8>) -> Result<Vec<u8>, String> {
+    pub fn send_binary_request(
+        &self,
+        kind: ffi::BinaryRequestKind,
+        code: u32,
+        payload: Vec<u8>,
+    ) -> Result<Vec<u8>, String> {
+        let kind = resolve_binary_request_kind(kind)?;
         RUNTIME.block_on(async {
             let response = self
                 .inner
-                .send_binary_request(code, Bytes::from(payload))
+                .send_binary_request(kind, code, Bytes::from(payload))
                 .await
                 .map_err(|error| format!("Could not send raw command '{code}': {error}"))?;
             Ok(Vec::from(response))

--- a/foreign/cpp/src/lib.rs
+++ b/foreign/cpp/src/lib.rs
@@ -88,6 +88,17 @@ mod ffi {
         topics_count: u32,
     }
 
+    /// How a raw binary request executes on the server. Inert on classic
+    /// framing (both kinds encode identical bytes and the server decides);
+    /// it only selects a wire path when the binding is built with `vsr`.
+    /// Starts at 1 so a value-initialized variable is not silently a valid
+    /// kind, matching the other FFI enums here.
+    #[repr(u8)]
+    enum BinaryRequestKind {
+        NonReplicated = 1,
+        Replicated = 2,
+    }
+
     #[repr(u8)]
     enum HeaderKind {
         Raw = 1,
@@ -480,7 +491,12 @@ mod ffi {
             snapshot_compression: String,
             snapshot_types: Vec<String>,
         ) -> Result<Vec<u8>>;
-        fn send_binary_request(self: &Client, code: u32, payload: Vec<u8>) -> Result<Vec<u8>>;
+        fn send_binary_request(
+            self: &Client,
+            kind: BinaryRequestKind,
+            code: u32,
+            payload: Vec<u8>,
+        ) -> Result<Vec<u8>>;
 
         // Future functions
         fn disconnect(self: &Client) -> Result<()>;

--- a/foreign/cpp/src/type_conversion.rs
+++ b/foreign/cpp/src/type_conversion.rs
@@ -18,10 +18,11 @@
 use crate::ffi;
 use bytes::Bytes;
 use iggy::prelude::{
-    ConsumerGroupDetails as RustConsumerGroupDetails, IdKind, Identifier as RustIdentifier,
-    IggyMessage as RustIggyMessage, Partition as RustPartition,
-    PolledMessages as RustPolledMessages, Stream as RustStream, StreamDetails as RustStreamDetails,
-    Topic as RustTopic, TopicDetails as RustTopicDetails, Validatable,
+    BinaryRequestKind as RustBinaryRequestKind, ConsumerGroupDetails as RustConsumerGroupDetails,
+    IdKind, Identifier as RustIdentifier, IggyMessage as RustIggyMessage,
+    Partition as RustPartition, PolledMessages as RustPolledMessages, Stream as RustStream,
+    StreamDetails as RustStreamDetails, Topic as RustTopic, TopicDetails as RustTopicDetails,
+    Validatable,
 };
 use iggy_binary_protocol::WireUserHeaders;
 use iggy_common::{
@@ -36,6 +37,19 @@ use iggy_common::{
     TopicPermissions as RustTopicPermissions, TransportEndpoints as RustTransportEndpoints,
 };
 use std::collections::BTreeMap;
+
+/// Cxx models shared C++ enums as open representations, so the catch-all arm is reachable.
+impl TryFrom<ffi::BinaryRequestKind> for RustBinaryRequestKind {
+    type Error = String;
+
+    fn try_from(kind: ffi::BinaryRequestKind) -> Result<Self, Self::Error> {
+        match kind {
+            ffi::BinaryRequestKind::NonReplicated => Ok(Self::NonReplicated),
+            ffi::BinaryRequestKind::Replicated => Ok(Self::Replicated),
+            _ => Err(format!("invalid binary request kind: {}", kind.repr)),
+        }
+    }
+}
 
 impl From<RustIdentifier> for ffi::Identifier {
     fn from(identifier: RustIdentifier) -> Self {

--- a/foreign/cpp/tests/e2e/client.cpp
+++ b/foreign/cpp/tests/e2e/client.cpp
@@ -1718,7 +1718,10 @@ TEST_F(LowLevelE2E_Client, SendBinaryRequestPingReturnsEmptyBytes) {
 
     rust::Vec<std::uint8_t> empty_payload;
     rust::Vec<std::uint8_t> response;
-    ASSERT_NO_THROW({ response = client->send_binary_request(ping_command_code, empty_payload); });
+    ASSERT_NO_THROW({
+        response =
+            client->send_binary_request(iggy::ffi::BinaryRequestKind::NonReplicated, ping_command_code, empty_payload);
+    });
     EXPECT_TRUE(response.empty());
 }
 
@@ -1730,8 +1733,37 @@ TEST_F(LowLevelE2E_Client, SendBinaryRequestGetStatsReturnsNonEmptyBytes) {
 
     rust::Vec<std::uint8_t> empty_payload;
     rust::Vec<std::uint8_t> response;
-    ASSERT_NO_THROW({ response = client->send_binary_request(get_stats_command_code, empty_payload); });
+    ASSERT_NO_THROW({
+        response = client->send_binary_request(iggy::ffi::BinaryRequestKind::NonReplicated, get_stats_command_code,
+                                               empty_payload);
+    });
     EXPECT_FALSE(response.empty());
+}
+
+TEST_F(LowLevelE2E_Client, SendBinaryRequestReplicatedDeclarationIsIgnoredOnClassicFraming) {
+    RecordProperty("description",
+                   "The kind is inert on classic framing: a replicated declaration on a standard command succeeds.");
+    constexpr std::uint32_t get_stats_command_code = 10;
+    iggy::ffi::Client *client                      = GetLoggedInClient();
+
+    rust::Vec<std::uint8_t> empty_payload;
+    rust::Vec<std::uint8_t> response;
+    ASSERT_NO_THROW({
+        response = client->send_binary_request(iggy::ffi::BinaryRequestKind::Replicated, get_stats_command_code,
+                                               empty_payload);
+    });
+    EXPECT_FALSE(response.empty());
+}
+
+TEST_F(LowLevelE2E_Client, SendBinaryRequestUndefinedKindThrows) {
+    RecordProperty("description", "Rejects a kind value outside the defined enum before any bytes are sent.");
+    constexpr std::uint32_t ping_command_code = 1;
+    iggy::ffi::Client *client                 = GetLoggedInClient();
+
+    rust::Vec<std::uint8_t> empty_payload;
+    ASSERT_THROW(
+        client->send_binary_request(static_cast<iggy::ffi::BinaryRequestKind>(7), ping_command_code, empty_payload),
+        std::exception);
 }
 
 TEST_F(LowLevelE2E_Client, SendBinaryRequestLoginUserCodeThrows) {
@@ -1741,14 +1773,34 @@ TEST_F(LowLevelE2E_Client, SendBinaryRequestLoginUserCodeThrows) {
     iggy::ffi::Client *client                       = GetLoggedInClient();
 
     rust::Vec<std::uint8_t> empty_payload;
-    ASSERT_THROW(client->send_binary_request(login_user_command_code, empty_payload), std::exception);
+    for (auto kind : {iggy::ffi::BinaryRequestKind::NonReplicated, iggy::ffi::BinaryRequestKind::Replicated}) {
+        ASSERT_THROW(client->send_binary_request(kind, login_user_command_code, empty_payload), std::exception);
+    }
 }
 
-TEST_F(LowLevelE2E_Client, SendBinaryRequestUnknownCommandCodeThrows) {
-    RecordProperty("description", "Rejects an unknown command code with an invalid-command error from the server.");
-    constexpr std::uint32_t unknown_command_code = 60000;
-    iggy::ffi::Client *client                    = GetLoggedInClient();
+TEST_F(LowLevelE2E_Client, SendBinaryRequestVendorCommandCodeThrows) {
+    RecordProperty("description", "Rejects a vendor command code no server registers a handler for.");
+    constexpr std::uint32_t vendor_command_code = 60001;
+    iggy::ffi::Client *client                   = GetLoggedInClient();
 
     rust::Vec<std::uint8_t> empty_payload;
-    ASSERT_THROW(client->send_binary_request(unknown_command_code, empty_payload), std::exception);
+    ASSERT_THROW(
+        client->send_binary_request(iggy::ffi::BinaryRequestKind::NonReplicated, vendor_command_code, empty_payload),
+        std::exception);
+
+    // The rejection is request-level, so the connection stays usable.
+    constexpr std::uint32_t ping_command_code = 1;
+    ASSERT_NO_THROW(
+        client->send_binary_request(iggy::ffi::BinaryRequestKind::NonReplicated, ping_command_code, empty_payload));
+}
+
+TEST_F(LowLevelE2E_Client, SendBinaryRequestReplicatedVendorCommandCodeThrows) {
+    RecordProperty("description", "Rejects a replicated vendor command code: there is no extension registry yet.");
+    constexpr std::uint32_t vendor_command_code = 60001;
+    iggy::ffi::Client *client                   = GetLoggedInClient();
+
+    rust::Vec<std::uint8_t> empty_payload;
+    ASSERT_THROW(
+        client->send_binary_request(iggy::ffi::BinaryRequestKind::Replicated, vendor_command_code, empty_payload),
+        std::exception);
 }

--- a/foreign/csharp/Iggy_SDK.Tests.BDD/StepDefinitions/RawCommandSteps.cs
+++ b/foreign/csharp/Iggy_SDK.Tests.BDD/StepDefinitions/RawCommandSteps.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using Apache.Iggy.Enums;
 using Apache.Iggy.Exceptions;
 using Reqnroll;
 using Shouldly;
@@ -32,12 +33,19 @@ public class RawCommandSteps
         _context = context;
     }
 
-    [When(@"I send a raw command with code (\d+) and an empty payload")]
-    public async Task WhenISendARawCommand(uint code)
+    [When(@"I send a raw (\w+) command with code (\d+) and an empty payload")]
+    public async Task WhenISendARawCommand(string kind, uint code)
     {
+        var requestKind = kind switch
+        {
+            "non_replicated" => BinaryRequestKind.NonReplicated,
+            "replicated" => BinaryRequestKind.Replicated,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "unknown binary request kind")
+        };
+
         try
         {
-            _context.LastRawResponse = await _context.IggyClient.SendBinaryRequestAsync(code, []);
+            _context.LastRawResponse = await _context.IggyClient.SendBinaryRequestAsync(requestKind, code, []);
             _context.LastRawError = null;
         }
         catch (Exception error)
@@ -67,5 +75,12 @@ public class RawCommandSteps
         _context.LastRawResponse.ShouldBeNull();
         var error = _context.LastRawError.ShouldBeOfType<IggyInvalidStatusCodeException>();
         error.StatusCode.ShouldBe(3);
+    }
+
+    [Then(@"the raw command should fail")]
+    public void ThenTheRawCommandShouldFail()
+    {
+        _context.LastRawResponse.ShouldBeNull();
+        _context.LastRawError.ShouldNotBeNull();
     }
 }

--- a/foreign/csharp/Iggy_SDK.Tests.Integration/RawCommandTests.cs
+++ b/foreign/csharp/Iggy_SDK.Tests.Integration/RawCommandTests.cs
@@ -35,11 +35,38 @@ public class RawCommandTests
     {
         var client = await Fixture.CreateAuthenticatedClient(protocol);
 
-        var pingResponse = await client.SendBinaryRequestAsync(1, []);
-        var statsResponse = await client.SendBinaryRequestAsync(10, []);
+        var pingResponse = await client.SendBinaryRequestAsync(BinaryRequestKind.NonReplicated, 1, []);
+        var statsResponse = await client.SendBinaryRequestAsync(BinaryRequestKind.NonReplicated, 10, []);
 
         pingResponse.ShouldBeEmpty();
         statsResponse.ShouldNotBeEmpty();
+    }
+
+    [Test]
+    [SkipHttp]
+    [MethodDataSource<IggyServerFixture>(nameof(IggyServerFixture.ProtocolData))]
+    public async Task SendBinaryRequest_Tcp_ShouldIgnoreTheDeclaration(Protocol protocol)
+    {
+        var client = await Fixture.CreateAuthenticatedClient(protocol);
+
+        // Classic framing has no operation field, so a replicated declaration encodes the same
+        // bytes and the read still succeeds.
+        var statsResponse = await client.SendBinaryRequestAsync(BinaryRequestKind.Replicated, 10, []);
+
+        statsResponse.ShouldNotBeEmpty();
+    }
+
+    [Test]
+    [SkipHttp]
+    [MethodDataSource<IggyServerFixture>(nameof(IggyServerFixture.ProtocolData))]
+    public async Task SendBinaryRequest_Tcp_ShouldRejectUndefinedKind(Protocol protocol)
+    {
+        var client = await Fixture.CreateAuthenticatedClient(protocol);
+
+        var exception = await Should.ThrowAsync<IggyInvalidStatusCodeException>(
+            () => client.SendBinaryRequestAsync((BinaryRequestKind)0, 1, []));
+
+        exception.StatusCode.ShouldBe(3);
     }
 
     [Test]
@@ -49,11 +76,14 @@ public class RawCommandTests
     {
         var client = await Fixture.CreateAuthenticatedClient(protocol);
 
-        foreach (var code in new uint[] { 38, 39, 40, 44, 45 })
+        foreach (var kind in new[] { BinaryRequestKind.NonReplicated, BinaryRequestKind.Replicated })
         {
-            var exception = await Should.ThrowAsync<IggyInvalidStatusCodeException>(
-                () => client.SendBinaryRequestAsync(code, []));
-            exception.StatusCode.ShouldBe(3);
+            foreach (var code in new uint[] { 38, 39, 40, 44, 45 })
+            {
+                var exception = await Should.ThrowAsync<IggyInvalidStatusCodeException>(
+                    () => client.SendBinaryRequestAsync(kind, code, []));
+                exception.StatusCode.ShouldBe(3);
+            }
         }
     }
 
@@ -65,9 +95,13 @@ public class RawCommandTests
         var client = await Fixture.CreateAuthenticatedClient(protocol);
 
         var exception = await Should.ThrowAsync<IggyInvalidStatusCodeException>(
-            () => client.SendBinaryRequestAsync(60_000, []));
+            () => client.SendBinaryRequestAsync(BinaryRequestKind.NonReplicated, 60_001, []));
 
         exception.StatusCode.ShouldBe(3);
+
+        // The rejection is request-level, so the connection stays usable.
+        var pingResponse = await client.SendBinaryRequestAsync(BinaryRequestKind.NonReplicated, 1, []);
+        pingResponse.ShouldBeEmpty();
     }
 
     [Test]
@@ -77,7 +111,10 @@ public class RawCommandTests
     {
         var client = await Fixture.CreateAuthenticatedClient(protocol);
 
-        await Should.ThrowAsync<FeatureUnavailableException>(
-            () => client.SendBinaryRequestAsync(1, []));
+        foreach (var kind in new[] { BinaryRequestKind.NonReplicated, BinaryRequestKind.Replicated })
+        {
+            await Should.ThrowAsync<FeatureUnavailableException>(
+                () => client.SendBinaryRequestAsync(kind, 1, []));
+        }
     }
 }

--- a/foreign/csharp/Iggy_SDK/Enums/BinaryRequestKind.cs
+++ b/foreign/csharp/Iggy_SDK/Enums/BinaryRequestKind.cs
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace Apache.Iggy.Enums;
+
+/// <summary>
+///     Declares how a raw binary request executes on the server.
+/// </summary>
+/// <remarks>
+///     Classic framing carries the length, the command code, then the payload, with no operation
+///     field, so this SDK encodes both kinds identically and the server decides how a command runs.
+///     The declaration exists so the API matches every other Iggy SDK and is already in place when
+///     the C# client gains VSR framing.
+/// </remarks>
+public enum BinaryRequestKind
+{
+    /// <summary>
+    ///     Runs on the receiving node only, outside consensus.
+    /// </summary>
+    NonReplicated = 1,
+
+    /// <summary>
+    ///     Replicated through consensus before it takes effect.
+    /// </summary>
+    Replicated = 2
+}

--- a/foreign/csharp/Iggy_SDK/IggyClient/IIggyClient.cs
+++ b/foreign/csharp/Iggy_SDK/IggyClient/IIggyClient.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using Apache.Iggy.Encryption;
+using Apache.Iggy.Enums;
 
 namespace Apache.Iggy.IggyClient;
 
@@ -63,12 +64,14 @@ public interface IIggyClient : IIggyPublisher, IIggyStream, IIggyTopic, IIggyCon
     ///     Sends a command code with a payload and returns the raw response bytes.
     /// </summary>
     /// <remarks>
-    ///     Session-control codes are rejected with an invalid-command error.
-    ///     HTTP clients report that this operation is unavailable.
+    ///     Session-control codes are rejected with an invalid-command error, as is an undefined
+    ///     <paramref name="kind" />. HTTP clients report that this operation is unavailable.
     /// </remarks>
+    /// <param name="kind">How the command executes. Classic framing has no operation field, so both kinds encode identical bytes and the server decides.</param>
     /// <param name="code">The numeric command code to send.</param>
     /// <param name="payload">The request payload.</param>
     /// <param name="token">The cancellation token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation and returns the raw response payload bytes.</returns>
-    Task<byte[]> SendBinaryRequestAsync(uint code, byte[] payload, CancellationToken token = default);
+    Task<byte[]> SendBinaryRequestAsync(BinaryRequestKind kind, uint code, byte[] payload,
+        CancellationToken token = default);
 }

--- a/foreign/csharp/Iggy_SDK/IggyClient/Implementations/HttpMessageStream.cs
+++ b/foreign/csharp/Iggy_SDK/IggyClient/Implementations/HttpMessageStream.cs
@@ -528,12 +528,14 @@ public class HttpMessageStream : IIggyClient
     /// <summary>
     ///     This method is only supported in TCP protocol
     /// </summary>
+    /// <param name="kind">How the command executes.</param>
     /// <param name="code">The numeric command code to send.</param>
     /// <param name="payload">The opaque request payload.</param>
     /// <param name="token">The cancellation token to cancel the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <exception cref="FeatureUnavailableException"></exception>
-    public Task<byte[]> SendBinaryRequestAsync(uint code, byte[] payload, CancellationToken token = default)
+    public Task<byte[]> SendBinaryRequestAsync(BinaryRequestKind kind, uint code, byte[] payload,
+        CancellationToken token = default)
     {
         throw new FeatureUnavailableException();
     }

--- a/foreign/csharp/Iggy_SDK/IggyClient/Implementations/TcpMessageStream.cs
+++ b/foreign/csharp/Iggy_SDK/IggyClient/Implementations/TcpMessageStream.cs
@@ -594,9 +594,16 @@ public sealed class TcpMessageStream : IIggyClient
     }
 
     /// <inheritdoc />
-    public async Task<byte[]> SendBinaryRequestAsync(uint code, byte[] payload, CancellationToken token = default)
+    /// <remarks>
+    ///     <paramref name="kind" /> is not encoded: classic framing has no operation field, so both
+    ///     kinds produce the same bytes and the server owns the command's execution model. It is
+    ///     validated so a caller learns about an undefined value here rather than once the C# client
+    ///     gains VSR framing.
+    /// </remarks>
+    public async Task<byte[]> SendBinaryRequestAsync(BinaryRequestKind kind, uint code, byte[] payload,
+        CancellationToken token = default)
     {
-        if (SessionControlCodes.Contains(code))
+        if (!Enum.IsDefined(kind) || SessionControlCodes.Contains(code))
         {
             throw new IggyInvalidStatusCodeException(InvalidCommandStatus,
                 $"Invalid response status code: {InvalidCommandStatus}");

--- a/foreign/csharp/Iggy_SDK/Iggy_SDK.csproj
+++ b/foreign/csharp/Iggy_SDK/Iggy_SDK.csproj
@@ -27,7 +27,7 @@
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <AssemblyName>Apache.Iggy</AssemblyName>
         <RootNamespace>Apache.Iggy</RootNamespace>
-        <Version>0.8.1-edge.4</Version>
+        <Version>0.8.1-edge.5</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 

--- a/foreign/go/client/tcp/tcp_core.go
+++ b/foreign/go/client/tcp/tcp_core.go
@@ -307,8 +307,17 @@ func (c *IggyTcpClient) do(ctx context.Context, cmd command.Command) ([]byte, er
 
 // SendBinaryRequest sends a command code and payload and returns the raw response body.
 // Session-control codes return ierror.ErrInvalidCommand without writing to the connection.
-func (c *IggyTcpClient) SendBinaryRequest(ctx context.Context, code uint32, payload []byte) ([]byte, error) {
-	if isSessionControlCode(code) {
+//
+// kind is not encoded: classic framing has no operation field, so both kinds produce the same
+// bytes and the server owns the command's execution model. It is validated so a caller learns
+// about an undefined value here rather than once the Go client gains VSR framing.
+func (c *IggyTcpClient) SendBinaryRequest(
+	ctx context.Context,
+	kind iggcon.BinaryRequestKind,
+	code uint32,
+	payload []byte,
+) ([]byte, error) {
+	if !kind.IsValid() || isSessionControlCode(code) {
 		return nil, ierror.ErrInvalidCommand
 	}
 

--- a/foreign/go/client/tcp/tcp_core_test.go
+++ b/foreign/go/client/tcp/tcp_core_test.go
@@ -386,8 +386,22 @@ func TestDisconnect_ShutdownClientIsNotResurrected(t *testing.T) {
 }
 
 func TestSendBinaryRequest_FrameLayoutAndSuccess(t *testing.T) {
+	for _, kind := range []iggcon.BinaryRequestKind{
+		iggcon.BinaryRequestKindNonReplicated,
+		iggcon.BinaryRequestKindReplicated,
+	} {
+		t.Run(kind.String(), func(t *testing.T) {
+			assertRawFrameLayout(t, kind)
+		})
+	}
+}
+
+// assertRawFrameLayout proves the declaration never reaches the wire: classic
+// framing has no operation field, so both kinds emit the same bytes.
+func assertRawFrameLayout(t *testing.T, kind iggcon.BinaryRequestKind) {
+	t.Helper()
 	c, serverConn := newTestClient(t)
-	const code = uint32(60_000)
+	const code = uint32(60_001)
 	payload := []byte{0xAA, 0xBB, 0xCC}
 	body := []byte("opaque response")
 
@@ -424,7 +438,7 @@ func TestSendBinaryRequest_FrameLayoutAndSuccess(t *testing.T) {
 		}
 	}()
 
-	result, err := c.SendBinaryRequest(context.Background(), code, payload)
+	result, err := c.SendBinaryRequest(context.Background(), kind, code, payload)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -450,9 +464,32 @@ func TestSendBinaryRequest_ErrorStatus(t *testing.T) {
 
 	go serverRespond(t, serverConn, uint32(ierror.InvalidCommandCode), nil)
 
-	_, err := c.SendBinaryRequest(context.Background(), 60_000, nil)
+	_, err := c.SendBinaryRequest(context.Background(), iggcon.BinaryRequestKindNonReplicated, 60_001, nil)
 	if !errors.Is(err, ierror.ErrInvalidCommand) {
 		t.Errorf("got %v, want %v", err, ierror.ErrInvalidCommand)
+	}
+}
+
+func TestSendBinaryRequest_UndefinedKindGuard(t *testing.T) {
+	c, serverConn := newTestClient(t)
+
+	wrote := make(chan struct{})
+	go func() {
+		buf := make([]byte, 1)
+		if _, err := serverConn.Read(buf); err == nil {
+			close(wrote)
+		}
+	}()
+
+	_, err := c.SendBinaryRequest(context.Background(), iggcon.BinaryRequestKind(0), 60_001, nil)
+	if !errors.Is(err, ierror.ErrInvalidCommand) {
+		t.Errorf("got %v, want %v", err, ierror.ErrInvalidCommand)
+	}
+
+	select {
+	case <-wrote:
+		t.Fatal("expected no bytes to be written to the wire for an undefined kind")
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 
@@ -474,10 +511,15 @@ func TestSendBinaryRequest_SessionControlGuard(t *testing.T) {
 		uint32(command.LoginWithAccessTokenCode),
 		uint32(command.LoginRegisterWithPATCode),
 	}
-	for _, guardedCode := range guardedCodes {
-		_, err := c.SendBinaryRequest(context.Background(), guardedCode, nil)
-		if !errors.Is(err, ierror.ErrInvalidCommand) {
-			t.Errorf("code %d: got %v, want %v", guardedCode, err, ierror.ErrInvalidCommand)
+	for _, kind := range []iggcon.BinaryRequestKind{
+		iggcon.BinaryRequestKindNonReplicated,
+		iggcon.BinaryRequestKindReplicated,
+	} {
+		for _, guardedCode := range guardedCodes {
+			_, err := c.SendBinaryRequest(context.Background(), kind, guardedCode, nil)
+			if !errors.Is(err, ierror.ErrInvalidCommand) {
+				t.Errorf("kind %s, code %d: got %v, want %v", kind, guardedCode, err, ierror.ErrInvalidCommand)
+			}
 		}
 	}
 

--- a/foreign/go/contracts/binary_request_kind.go
+++ b/foreign/go/contracts/binary_request_kind.go
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iggcon
+
+// BinaryRequestKind declares how a raw binary request executes on the server.
+//
+// Classic framing carries [length][code][payload] with no operation field, so
+// this SDK encodes both kinds identically and the server decides how a command
+// runs. The declaration exists so the API matches every other Iggy SDK and is
+// already in place when the Go client gains VSR framing.
+type BinaryRequestKind uint8
+
+const (
+	// BinaryRequestKindNonReplicated runs on the receiving node only, outside
+	// consensus.
+	BinaryRequestKindNonReplicated BinaryRequestKind = 1
+	// BinaryRequestKindReplicated is replicated through consensus before it
+	// takes effect.
+	BinaryRequestKindReplicated BinaryRequestKind = 2
+)
+
+// String returns the cross-SDK name of the kind.
+func (kind BinaryRequestKind) String() string {
+	switch kind {
+	case BinaryRequestKindNonReplicated:
+		return "non_replicated"
+	case BinaryRequestKindReplicated:
+		return "replicated"
+	default:
+		return "unknown"
+	}
+}
+
+// IsValid reports whether the kind is one the API defines. Go has no exhaustive
+// enums, so a caller can hand over any byte.
+func (kind BinaryRequestKind) IsValid() bool {
+	return kind == BinaryRequestKindNonReplicated || kind == BinaryRequestKindReplicated
+}

--- a/foreign/go/contracts/binary_request_kind_test.go
+++ b/foreign/go/contracts/binary_request_kind_test.go
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iggcon
+
+import "testing"
+
+func TestBinaryRequestKind_String(t *testing.T) {
+	cases := []struct {
+		kind BinaryRequestKind
+		want string
+	}{
+		{BinaryRequestKindNonReplicated, "non_replicated"},
+		{BinaryRequestKindReplicated, "replicated"},
+		{BinaryRequestKind(0), "unknown"},
+		{BinaryRequestKind(7), "unknown"},
+	}
+	for _, testCase := range cases {
+		if got := testCase.kind.String(); got != testCase.want {
+			t.Errorf("BinaryRequestKind(%d).String() = %q, want %q", testCase.kind, got, testCase.want)
+		}
+	}
+}
+
+func TestBinaryRequestKind_IsValid(t *testing.T) {
+	cases := []struct {
+		kind BinaryRequestKind
+		want bool
+	}{
+		{BinaryRequestKindNonReplicated, true},
+		{BinaryRequestKindReplicated, true},
+		{BinaryRequestKind(0), false},
+		{BinaryRequestKind(7), false},
+	}
+	for _, testCase := range cases {
+		if got := testCase.kind.IsValid(); got != testCase.want {
+			t.Errorf("BinaryRequestKind(%d).IsValid() = %v, want %v", testCase.kind, got, testCase.want)
+		}
+	}
+}

--- a/foreign/go/contracts/client.go
+++ b/foreign/go/contracts/client.go
@@ -303,5 +303,8 @@ type Client interface {
 
 	// SendBinaryRequest sends a command code and payload and returns the raw response body.
 	// Session-control codes return ierror.ErrInvalidCommand without writing to the connection.
-	SendBinaryRequest(ctx context.Context, code uint32, payload []byte) ([]byte, error)
+	//
+	// kind declares how the command executes. Classic framing has no operation field, so both
+	// kinds encode identical bytes and the server decides; an undefined kind is rejected.
+	SendBinaryRequest(ctx context.Context, kind BinaryRequestKind, code uint32, payload []byte) ([]byte, error)
 }

--- a/foreign/go/contracts/version.go
+++ b/foreign/go/contracts/version.go
@@ -17,4 +17,4 @@
 
 package iggcon
 
-const Version = "0.8.1-edge.2"
+const Version = "0.8.1-edge.3"

--- a/foreign/java/gradle.properties
+++ b/foreign/java/gradle.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version=0.8.2-SNAPSHOT
+version=0.8.3-SNAPSHOT
 group=org.apache.iggy

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/BinaryRequestKind.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/BinaryRequestKind.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iggy.client;
+
+import org.apache.iggy.exception.IggyInvalidArgumentException;
+
+/**
+ * Declares how a raw binary request executes on the server.
+ *
+ * <p>Classic framing carries the length, the command code, then the payload, with no operation
+ * field, so this SDK encodes both kinds identically and the server decides how a command runs. The
+ * declaration exists so the API matches every other Iggy SDK and is already in place when the Java
+ * client gains VSR framing.
+ */
+public enum BinaryRequestKind {
+    /**
+     * Runs on the receiving node only, outside consensus.
+     */
+    NonReplicated("non_replicated"),
+    /**
+     * Replicated through consensus before it takes effect.
+     */
+    Replicated("replicated");
+
+    private final String name;
+
+    BinaryRequestKind(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Resolves the kind from its cross-SDK name.
+     *
+     * @param name the cross-SDK name, as used by the shared BDD scenarios
+     * @return the matching kind
+     */
+    public static BinaryRequestKind fromName(String name) {
+        for (BinaryRequestKind kind : BinaryRequestKind.values()) {
+            if (kind.name.equals(name)) {
+                return kind;
+            }
+        }
+        throw new IggyInvalidArgumentException("Invalid binary request kind: " + name);
+    }
+
+    /**
+     * Returns the cross-SDK name of the kind.
+     *
+     * @return the cross-SDK name
+     */
+    public String asName() {
+        return name;
+    }
+}

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/async/tcp/AsyncIggyTcpClient.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/async/tcp/AsyncIggyTcpClient.java
@@ -21,6 +21,7 @@ package org.apache.iggy.client.async.tcp;
 
 import io.netty.buffer.Unpooled;
 import org.apache.iggy.IggyVersion;
+import org.apache.iggy.client.BinaryRequestKind;
 import org.apache.iggy.client.async.ConsumerGroupsClient;
 import org.apache.iggy.client.async.ConsumerOffsetsClient;
 import org.apache.iggy.client.async.MessagesClient;
@@ -227,12 +228,18 @@ public class AsyncIggyTcpClient {
      *
      * <p>Session-control codes complete the returned future with an invalid-command error.
      *
+     * <p>{@code kind} is not encoded: classic framing has no operation field, so both kinds produce
+     * the same bytes and the server owns the command's execution model. It is required so the API
+     * matches every other Iggy SDK and is already in place when this client gains VSR framing.
+     *
+     * @param kind how the command executes
      * @param code the command code
      * @param payload the command payload
      * @return a future containing the raw response payload
      * @throws IggyNotConnectedException if {@link #connect()} has not been called
      */
-    public CompletableFuture<byte[]> sendBinaryRequest(int code, byte[] payload) {
+    public CompletableFuture<byte[]> sendBinaryRequest(BinaryRequestKind kind, int code, byte[] payload) {
+        Objects.requireNonNull(kind, "kind cannot be null");
         Objects.requireNonNull(payload, "payload cannot be null");
         if (isSessionControlCode(code)) {
             return CompletableFuture.failedFuture(

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/blocking/IggyBaseClient.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/blocking/IggyBaseClient.java
@@ -19,6 +19,8 @@
 
 package org.apache.iggy.client.blocking;
 
+import org.apache.iggy.client.BinaryRequestKind;
+
 public interface IggyBaseClient {
 
     /**
@@ -27,11 +29,13 @@ public interface IggyBaseClient {
      * <p>Session-control codes are rejected with an invalid-command error. HTTP clients report
      * that this operation is unsupported.
      *
+     * @param kind how the command executes; classic framing has no operation field, so both kinds
+     *     encode identical bytes and the server decides
      * @param code the command code
      * @param payload the command payload
      * @return the raw response payload
      */
-    byte[] sendBinaryRequest(int code, byte[] payload);
+    byte[] sendBinaryRequest(BinaryRequestKind kind, int code, byte[] payload);
 
     SystemClient system();
 

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/blocking/http/IggyHttpClient.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/blocking/http/IggyHttpClient.java
@@ -20,6 +20,7 @@
 package org.apache.iggy.client.blocking.http;
 
 import org.apache.iggy.IggyVersion;
+import org.apache.iggy.client.BinaryRequestKind;
 import org.apache.iggy.client.blocking.ConsumerGroupsClient;
 import org.apache.iggy.client.blocking.ConsumerOffsetsClient;
 import org.apache.iggy.client.blocking.IggyBaseClient;
@@ -113,7 +114,7 @@ public class IggyHttpClient implements IggyBaseClient, Closeable {
 
     /** {@inheritDoc} */
     @Override
-    public byte[] sendBinaryRequest(int code, byte[] payload) {
+    public byte[] sendBinaryRequest(BinaryRequestKind kind, int code, byte[] payload) {
         throw new IggyOperationNotSupportedException("sendBinaryRequest", "HTTP");
     }
 

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/blocking/tcp/IggyTcpClient.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/blocking/tcp/IggyTcpClient.java
@@ -19,6 +19,7 @@
 
 package org.apache.iggy.client.blocking.tcp;
 
+import org.apache.iggy.client.BinaryRequestKind;
 import org.apache.iggy.client.async.tcp.AsyncIggyTcpClient;
 import org.apache.iggy.client.blocking.ConsumerGroupsClient;
 import org.apache.iggy.client.blocking.ConsumerOffsetsClient;
@@ -95,8 +96,8 @@ public class IggyTcpClient implements IggyBaseClient, Closeable {
 
     /** {@inheritDoc} */
     @Override
-    public byte[] sendBinaryRequest(int code, byte[] payload) {
-        return FutureUtil.resolve(asyncClient.sendBinaryRequest(code, payload));
+    public byte[] sendBinaryRequest(BinaryRequestKind kind, int code, byte[] payload) {
+        return FutureUtil.resolve(asyncClient.sendBinaryRequest(kind, code, payload));
     }
 
     @Override

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/BinaryRequestKindTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/BinaryRequestKindTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iggy.client;
+
+import org.apache.iggy.exception.IggyInvalidArgumentException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BinaryRequestKindTest {
+
+    @Test
+    void fromNameResolvesEveryCrossSdkName() {
+        assertThat(BinaryRequestKind.fromName("non_replicated")).isEqualTo(BinaryRequestKind.NonReplicated);
+        assertThat(BinaryRequestKind.fromName("replicated")).isEqualTo(BinaryRequestKind.Replicated);
+    }
+
+    @Test
+    void asNameRoundTripsThroughFromName() {
+        for (BinaryRequestKind kind : BinaryRequestKind.values()) {
+            assertThat(BinaryRequestKind.fromName(kind.asName())).isEqualTo(kind);
+        }
+    }
+
+    @Test
+    void fromNameRejectsAnUnknownName() {
+        assertThatThrownBy(() -> BinaryRequestKind.fromName("auto"))
+                .isInstanceOf(IggyInvalidArgumentException.class)
+                .hasMessageContaining("auto");
+    }
+}

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/http/RawCommandHttpClientTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/http/RawCommandHttpClientTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.iggy.client.blocking.http;
 
+import org.apache.iggy.client.BinaryRequestKind;
 import org.apache.iggy.exception.IggyOperationNotSupportedException;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,9 @@ class RawCommandHttpClientTest {
     void shouldRejectRawCommands() {
         var client = new IggyHttpClient("http://127.0.0.1:3000");
 
-        assertThatThrownBy(() -> client.sendBinaryRequest(1, new byte[0]))
-                .isInstanceOf(IggyOperationNotSupportedException.class);
+        for (BinaryRequestKind kind : BinaryRequestKind.values()) {
+            assertThatThrownBy(() -> client.sendBinaryRequest(kind, 1, new byte[0]))
+                    .isInstanceOf(IggyOperationNotSupportedException.class);
+        }
     }
 }

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/tcp/RawCommandTcpClientTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/tcp/RawCommandTcpClientTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.iggy.client.blocking.tcp;
 
+import org.apache.iggy.client.BinaryRequestKind;
 import org.apache.iggy.client.blocking.IggyBaseClient;
 import org.apache.iggy.client.blocking.IntegrationTest;
 import org.apache.iggy.exception.IggyErrorCode;
@@ -30,6 +31,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RawCommandTcpClientTest extends IntegrationTest {
+
+    /** No server registers a handler for this code. */
+    private static final int VENDOR_CODE = 60_001;
 
     @Override
     protected IggyBaseClient getClient() {
@@ -43,32 +47,55 @@ class RawCommandTcpClientTest extends IntegrationTest {
 
     @Test
     void shouldReturnRawResponsePayloads() {
-        assertThat(client.sendBinaryRequest(1, new byte[0])).isEmpty();
-        assertThat(client.sendBinaryRequest(10, new byte[0])).isNotEmpty();
+        assertThat(client.sendBinaryRequest(BinaryRequestKind.NonReplicated, 1, new byte[0]))
+                .isEmpty();
+        assertThat(client.sendBinaryRequest(BinaryRequestKind.NonReplicated, 10, new byte[0]))
+                .isNotEmpty();
+    }
+
+    @Test
+    void shouldIgnoreTheDeclarationOnClassicFraming() {
+        // Classic framing has no operation field, so a replicated declaration encodes the same
+        // bytes and the read still succeeds.
+        assertThat(client.sendBinaryRequest(BinaryRequestKind.Replicated, 10, new byte[0]))
+                .isNotEmpty();
+    }
+
+    @Test
+    void shouldRejectNullKind() {
+        assertThatThrownBy(() -> client.sendBinaryRequest(null, 1, new byte[0]))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("kind cannot be null");
     }
 
     @Test
     void shouldRejectNullPayload() {
-        assertThatThrownBy(() -> client.sendBinaryRequest(1, null))
+        assertThatThrownBy(() -> client.sendBinaryRequest(BinaryRequestKind.NonReplicated, 1, null))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("payload cannot be null");
     }
 
     @Test
     void shouldRejectAllSessionControlCodes() {
-        for (int code : new int[] {38, 39, 40, 44, 45}) {
-            assertThatThrownBy(() -> client.sendBinaryRequest(code, new byte[0]))
-                    .isInstanceOf(IggyServerException.class)
-                    .extracting(exception -> ((IggyServerException) exception).getErrorCode())
-                    .isEqualTo(IggyErrorCode.INVALID_COMMAND);
+        for (BinaryRequestKind kind : BinaryRequestKind.values()) {
+            for (int code : new int[] {38, 39, 40, 44, 45}) {
+                assertThatThrownBy(() -> client.sendBinaryRequest(kind, code, new byte[0]))
+                        .isInstanceOf(IggyServerException.class)
+                        .extracting(exception -> ((IggyServerException) exception).getErrorCode())
+                        .isEqualTo(IggyErrorCode.INVALID_COMMAND);
+            }
         }
     }
 
     @Test
-    void shouldPropagateUnknownCommandError() {
-        assertThatThrownBy(() -> client.sendBinaryRequest(60_000, new byte[0]))
+    void shouldPropagateVendorCommandError() {
+        assertThatThrownBy(() -> client.sendBinaryRequest(BinaryRequestKind.NonReplicated, VENDOR_CODE, new byte[0]))
                 .isInstanceOf(IggyServerException.class)
                 .extracting(exception -> ((IggyServerException) exception).getErrorCode())
                 .isEqualTo(IggyErrorCode.INVALID_COMMAND);
+
+        // The rejection is request-level, so the connection stays usable.
+        assertThat(client.sendBinaryRequest(BinaryRequestKind.NonReplicated, 1, new byte[0]))
+                .isEmpty();
     }
 }

--- a/foreign/node/README.md
+++ b/foreign/node/README.md
@@ -30,6 +30,35 @@ npm i --save apache-iggy
 
 ## basic usage
 
+### VSR framing
+
+Select VSR at runtime when connecting to `iggy-server-ng`:
+
+```typescript
+import {
+  BinaryRequestKind,
+  SimpleClient,
+  getRawClient,
+} from "apache-iggy";
+
+const config = {
+  protocol: "vsr" as const,
+  transport: "TCP" as const,
+  options: { host: "127.0.0.1", port: 8090 },
+  credentials: { username: "iggy", password: "iggy" },
+};
+const client = new SimpleClient(getRawClient(config));
+const response = await client.sendBinaryRequest(
+  BinaryRequestKind.NonReplicated,
+  60_000,
+  Buffer.from("opaque mutation"),
+);
+```
+
+VSR is a runtime protocol choice in Node.js, not a build feature. Custom
+non-replicated codes use `Operation::NonReplicated`; custom replicated codes
+are rejected until a server-side replicated extension registry exists.
+
 ```ts
 import { Client } from "apache-iggy";
 

--- a/foreign/node/package-lock.json
+++ b/foreign/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apache-iggy",
-  "version": "0.8.1-edge.2",
+  "version": "0.8.1-edge.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apache-iggy",
-      "version": "0.8.1-edge.2",
+      "version": "0.8.1-edge.3",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.4.3",

--- a/foreign/node/package.json
+++ b/foreign/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apache-iggy",
   "type": "module",
-  "version": "0.8.1-edge.2",
+  "version": "0.8.1-edge.3",
   "description": "Official Apache Iggy NodeJS SDK",
   "keywords": [
     "iggy",

--- a/foreign/node/src/bdd/raw.ts
+++ b/foreign/node/src/bdd/raw.ts
@@ -17,13 +17,21 @@
 
 import assert from 'node:assert/strict';
 import { Then, When } from '@cucumber/cucumber';
+import { BINARY_REQUEST_KIND, type BinaryRequestKind } from '../wire/command-set.js';
 import type { TestWorld } from './world.js';
 
+const REQUEST_KINDS: Record<string, BinaryRequestKind> = {
+  non_replicated: BINARY_REQUEST_KIND.NonReplicated,
+  replicated: BINARY_REQUEST_KIND.Replicated
+};
+
 When(
-  'I send a raw command with code {int} and an empty payload',
-  async function (this: TestWorld, code: number) {
+  'I send a raw {word} command with code {int} and an empty payload',
+  async function (this: TestWorld, kind: string, code: number) {
+    const requestKind = REQUEST_KINDS[kind];
+    assert.ok(requestKind, `unknown binary request kind: ${kind}`);
     try {
-      this.rawResponse = await this.client.sendBinaryRequest(code, Buffer.alloc(0));
+      this.rawResponse = await this.client.sendBinaryRequest(requestKind, code, Buffer.alloc(0));
       this.rawError = undefined;
     } catch (error) {
       this.rawResponse = undefined;
@@ -45,4 +53,9 @@ Then('the raw command should succeed with a non-empty response', function (this:
 Then('the raw command should fail with an invalid command error', function (this: TestWorld) {
   assert.equal(this.rawResponse, undefined);
   assert.match(this.rawError?.message ?? '', /code: 3, message: Invalid command/);
+});
+
+Then('the raw command should fail', function (this: TestWorld) {
+  assert.equal(this.rawResponse, undefined);
+  assert.ok(this.rawError);
 });

--- a/foreign/node/src/client/client.connection.ts
+++ b/foreign/node/src/client/client.connection.ts
@@ -23,6 +23,7 @@ import { connect as TLSConnect } from 'node:tls';
 import type { ClientConfig, TlsOption, TcpOption, ReconnectOption } from "./client.type.js"
 import { serializeCommand } from './client.utils.js';
 import { debug } from './client.debug.js';
+import { HEADER_SIZE as VSR_HEADER_SIZE, readSize as readVsrSize } from '../wire/vsr/header.js';
 
 
 /**
@@ -208,6 +209,23 @@ export class IggyConnection extends EventEmitter {
     this.connect();
   }
 
+  async redirect(host: string, port: number) {
+    this.socket.removeAllListeners();
+    this.socket.destroy();
+    this.connected = false;
+    this.connecting = false;
+    this._endResponseWait();
+    this.config.options = { ...this.config.options, host, port };
+    this.socket = getTransport(this.config);
+    await this.connect();
+  }
+
+  isConnectedTo(host: string, port: number): boolean {
+    if (this.socket.remotePort !== port)
+      return false;
+    return normalizeHost(this.socket.remoteAddress) === normalizeHost(host);
+  }
+
   /**
    * Destroys the connection and marks it as ending.
    */
@@ -250,17 +268,17 @@ export class IggyConnection extends EventEmitter {
     while (offset < data.length) {
       const remaining = data.length - offset;
 
-      // Need at least 8 bytes for the header (4 bytes status + 4 bytes length)
-      if (remaining < 8) {
+      const headerSize = this.config.protocol === 'vsr' ? VSR_HEADER_SIZE : 8;
+      if (remaining < headerSize) {
         // Buffer the incomplete header and wait for more data
         this.waitingResponseEnd = true;
         this.readBuffers = data.subarray(offset);
         return;
       }
 
-      // Read the header
-      const responseSize = data.readUInt32LE(offset + 4);
-      const totalSize = 8 + responseSize;
+      const totalSize = this.config.protocol === 'vsr'
+        ? readVsrSize(data.subarray(offset))
+        : 8 + data.readUInt32LE(offset + 4);
 
       // Check if we have the complete response (header + payload)
       if (remaining < totalSize) {
@@ -293,4 +311,14 @@ export class IggyConnection extends EventEmitter {
     const cmd = serializeCommand(command, payload);
     return this.socket.write(cmd);
   }
+
+  writeFrame(frame: Buffer): boolean {
+    return this.socket.write(frame);
+  }
 }
+
+const normalizeHost = (host?: string): string =>
+  (host ?? '').toLowerCase()
+    .replace(/^::ffff:/, '')
+    .replace('localhost', '127.0.0.1')
+    .replace('::1', '127.0.0.1');

--- a/foreign/node/src/client/client.socket.ts
+++ b/foreign/node/src/client/client.socket.ts
@@ -22,12 +22,25 @@ import type {
   ClientCredentials, CommandResponse,
   PasswordCredentials, RawClient, TokenCredentials
 } from '../client/client.type.js';
+import type { BinaryRequestKind } from '../wire/command-set.js';
 import { handleResponse } from './client.utils.js';
-import { responseError } from '../wire/error.utils.js';
+import { ResponseError, responseError } from '../wire/error.utils.js';
 import { debug } from './client.debug.js';
 import { IggyConnection } from './client.connection.js';
-import { LOGIN, LOGIN_WITH_TOKEN, PING } from '../wire/index.js';
+import { LOGIN, LOGIN_WITH_TOKEN, LOGOUT, PING } from '../wire/index.js';
+import { GET_CLUSTER_METADATA } from '../wire/cluster/get-cluster-metadata.command.js';
+import { COMMAND_CODE } from '../wire/command.code.js';
+import {
+  decodeVsrResponse,
+  prepareVsrCommand,
+  readRegisteredSession,
+  VsrSession,
+} from '../wire/vsr/index.js';
 
+const VSR_RESPONSE_TIMEOUT_MS = 30_000;
+const VSR_RETRY_INTERVAL_MS = 50;
+const TRANSIENT_NOT_COMMITTED = 57;
+const TRANSIENT_NOT_ACCEPTED = 58;
 
 /**
  * Command codes that can be executed without authentication.
@@ -46,6 +59,10 @@ type Job = {
   command: number,
   /** Command payload */
   payload: Buffer,
+  /** Whether to parse the response */
+  handleResponse: boolean,
+  /** Execution model declared by a raw request */
+  kind?: BinaryRequestKind,
   /** Promise resolve function */
   resolve: (v: CommandResponse | PromiseLike<CommandResponse>) => void,
   /** Promise reject function */
@@ -58,12 +75,16 @@ type Job = {
  * Implements command queuing, authentication, and heartbeat functionality.
  */
 export class CommandResponseStream extends EventEmitter {
+  /** Server wire protocol used by this connection */
+  readonly protocol;
   /** Client configuration */
   private options: ClientConfig;
   /** Underlying connection to the server */
   private connection: IggyConnection;
   /** Queue of pending command jobs */
   private _execQueue: Job[];
+  /** Consensus session used by VSR framing */
+  private vsrSession: VsrSession;
   /** Whether the stream is currently processing a command */
   public busy: boolean;
   /** Whether the client has been authenticated */
@@ -80,11 +101,13 @@ export class CommandResponseStream extends EventEmitter {
    */
   constructor(options: ClientConfig) {
     super();
+    this.protocol = options.protocol ?? 'classic';
     this.options = options;
     this.connection = new IggyConnection(options);
     this.busy = false;
     this.isAuthenticated = false;
     this._execQueue = [];
+    this.vsrSession = new VsrSession();
     this._init();
   };
 
@@ -95,6 +118,8 @@ export class CommandResponseStream extends EventEmitter {
     this.heartbeat(this.options.heartbeatInterval);
     this.connection.on('disconnected', async () => {
       this.isAuthenticated = false;
+      this.userId = undefined;
+      this.vsrSession.reset();
     });
   }
 
@@ -112,21 +137,28 @@ export class CommandResponseStream extends EventEmitter {
     command: number,
     payload: Buffer,
     handleResponse = true,
-    last = true
+    last = true,
+    kind?: BinaryRequestKind
   ): Promise<CommandResponse> {
 
     if (!this.connection.connected)
       await this.connection.connect()
 
-    if (!this.isAuthenticated && !UNLOGGED_COMMAND_CODE.includes(command))
+    if (this.options.protocol === 'vsr' &&
+        isLoginCommand(command) &&
+        this.isAuthenticated)
+      await this.sendCommand(LOGOUT.code, LOGOUT.serialize(), true, false);
+
+    if (!this.isAuthenticated && !this.isUnloggedCommand(command))
       await this.authenticate(this.options.credentials);
 
     return new Promise((resolve, reject) => {
+      const job = { command, payload, handleResponse, kind, resolve, reject };
       if (last)
-        this._execQueue.push({ command, payload, resolve, reject });
+        this._execQueue.push(job);
       else
-        this._execQueue.unshift({ command, payload, resolve, reject });
-      this._processQueue(handleResponse);
+        this._execQueue.unshift(job);
+      this._processQueue();
     });
   }
 
@@ -134,18 +166,17 @@ export class CommandResponseStream extends EventEmitter {
    * Processes queued commands sequentially.
    * Emits 'finishQueue' when all commands are processed.
    *
-   * @param handleResponse - Whether to parse responses
    */
-  async _processQueue(handleResponse = true): Promise<void> {
+  async _processQueue(): Promise<void> {
     if (this.busy)
       return;
     this.busy = true;
     while (this._execQueue.length > 0 && this.connection.socket.writable) {
       const next = this._execQueue.shift();
       if (!next) break;
-      const { command, payload, resolve, reject } = next;
+      const { command, payload, handleResponse, kind, resolve, reject } = next;
       try {
-        resolve(await this._processNext(command, payload, handleResponse));
+        resolve(await this._processNext(command, payload, handleResponse, kind));
       } catch (err) {
         reject(err);
       }
@@ -165,25 +196,152 @@ export class CommandResponseStream extends EventEmitter {
   _processNext(
     command: number,
     payload: Buffer,
-    handleResp = true
+    handleResp = true,
+    kind?: BinaryRequestKind
   ): Promise<CommandResponse> {
-    const lastWrite = this.connection.writeCommand(command, payload);
-    debug('==> writeCommand', lastWrite);
+    if (this.options.protocol !== 'vsr')
+      return this._processClassic(command, payload, handleResp);
+    return this._processVsr(command, payload, handleResp, kind);
+  }
+
+  private async _processClassic(
+    command: number,
+    payload: Buffer,
+    handleResp: boolean
+  ): Promise<CommandResponse> {
+    const response = await this._exchange(
+      () => this.connection.writeCommand(command, payload)
+    );
+    if (!handleResp)
+      return response as unknown as CommandResponse;
+    const parsed = handleResponse(response);
+    if (parsed.status !== 0)
+      throw responseError(command, parsed.status);
+    return parsed;
+  }
+
+  private async _processVsr(
+    command: number,
+    payload: Buffer,
+    handleResp: boolean,
+    kind?: BinaryRequestKind
+  ): Promise<CommandResponse> {
+    const prepared = prepareVsrCommand(command, payload);
+    // Encode once so a transient replay preserves the request ID used by
+    // server-side deduplication.
+    const frame = this.vsrSession.encode(prepared.command, prepared.payload, kind);
+    const deadline = Date.now() + VSR_RESPONSE_TIMEOUT_MS;
+    let parsed: CommandResponse;
+    while (true) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0)
+        throw new Error(
+          `timed out after ${VSR_RESPONSE_TIMEOUT_MS} ms waiting for VSR response`
+        );
+      const response = await this._exchange(
+        () => this.connection.writeFrame(frame),
+        remaining
+      );
+      if (!handleResp)
+        return response as unknown as CommandResponse;
+      try {
+        parsed = decodeVsrResponse(response);
+        break;
+      } catch (error) {
+        if (!(error instanceof ResponseError) ||
+            !isTransientVsrError(error.errorCode))
+          throw error;
+        const retryDelay = Math.min(
+          VSR_RETRY_INTERVAL_MS,
+          Math.max(0, deadline - Date.now())
+        );
+        if (retryDelay === 0)
+          throw error;
+        await delay(retryDelay);
+      }
+    }
+
+    if (prepared.command === COMMAND_CODE.LoginRegister ||
+        prepared.command === COMMAND_CODE.LoginRegisterWithAccessToken) {
+      this.vsrSession.bind(readRegisteredSession(parsed));
+      this.isAuthenticated = true;
+      this.userId = parsed.data.readUInt32LE(0);
+    }
+    if (prepared.command === COMMAND_CODE.LogoutUser) {
+      this.isAuthenticated = false;
+      this.userId = undefined;
+      this.vsrSession.reset();
+    }
+    return parsed;
+  }
+
+  private _exchange(write: () => boolean, timeout?: number): Promise<Buffer> {
     return new Promise((resolve, reject) => {
-      if (!lastWrite)
-        return reject(new Error('failed to write to socket'));
-      const errCb = (err: unknown) => reject(err);
-      this.connection.once('error', errCb);
-      this.connection.once('response', (resp) => {
-        this.connection.removeListener('error', errCb);
-        if (!handleResp) return resolve(resp);
-        const r = handleResponse(resp);
-        if (r.status !== 0) {
-          return reject(responseError(command, r.status));
-        }
-        return resolve(r);
-      });
+      let timeoutHandler: NodeJS.Timeout | undefined;
+      const cleanup = () => {
+        if (timeoutHandler)
+          clearTimeout(timeoutHandler);
+        this.connection.removeListener('error', errorCallback);
+        this.connection.removeListener('disconnected', disconnectedCallback);
+        this.connection.removeListener('response', responseCallback);
+      };
+      const errorCallback = (error: unknown) => {
+        cleanup();
+        reject(error);
+      };
+      const disconnectedCallback = () => {
+        cleanup();
+        reject(new Error('connection closed while waiting for response'));
+      };
+      const responseCallback = (response: Buffer) => {
+        cleanup();
+        resolve(response);
+      };
+      if (timeout !== undefined) {
+        timeoutHandler = setTimeout(() => {
+          cleanup();
+          reject(new Error(`timed out after ${timeout} ms waiting for VSR response`));
+        }, timeout);
+      }
+      this.connection.once('error', errorCallback);
+      this.connection.once('disconnected', disconnectedCallback);
+      this.connection.once('response', responseCallback);
+      if (!write()) {
+        cleanup();
+        reject(new Error('failed to write to socket'));
+      }
     });
+  }
+
+  private isUnloggedCommand(command: number): boolean {
+    return UNLOGGED_COMMAND_CODE.includes(command) ||
+      (this.options.protocol === 'vsr' &&
+        command === COMMAND_CODE.GetClusterMetadata);
+  }
+
+  private async _ensureVsrLeader(): Promise<void> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const response = await this._processNext(
+        GET_CLUSTER_METADATA.code,
+        GET_CLUSTER_METADATA.serialize()
+      );
+      const metadata = GET_CLUSTER_METADATA.deserialize(response);
+      if (metadata.nodes.length <= 1)
+        return;
+      const leader = metadata.nodes.find(
+        (node) => node.role === 'Leader' && node.status === 'Healthy'
+      );
+      if (!leader) {
+        await delay(100);
+        continue;
+      }
+      if (!this.connection.isConnectedTo(leader.ip, leader.endpoints.tcp)) {
+        await this.connection.redirect(leader.ip, leader.endpoints.tcp);
+        this.vsrSession.reset();
+      }
+      return;
+    }
+    throw new Error('VSR cluster has no healthy leader');
   }
 
   /**
@@ -203,6 +361,8 @@ export class CommandResponseStream extends EventEmitter {
    * @returns True if authentication succeeded
    */
   async authenticate(creds: ClientCredentials) {
+    if (this.options.protocol === 'vsr')
+      await this._ensureVsrLeader();
     const r = ('token' in creds) ?
       await this._authWithToken(creds) :
       await this._authWithPassword(creds);
@@ -293,3 +453,14 @@ export class CommandResponseStream extends EventEmitter {
 export function getRawClient(options: ClientConfig): RawClient {
   return new CommandResponseStream(options);
 }
+
+const isLoginCommand = (command: number): boolean =>
+  command === COMMAND_CODE.LoginUser ||
+  command === COMMAND_CODE.LoginWithAccessToken;
+
+const delay = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const isTransientVsrError = (errorCode: number): boolean =>
+  errorCode === TRANSIENT_NOT_COMMITTED ||
+  errorCode === TRANSIENT_NOT_ACCEPTED;

--- a/foreign/node/src/client/client.type.ts
+++ b/foreign/node/src/client/client.type.ts
@@ -19,6 +19,7 @@
 import type { Readable } from 'stream';
 import { type TcpSocketConnectOpts } from 'node:net';
 import { type ConnectionOptions } from 'node:tls';
+import type { BinaryRequestKind } from '../wire/command-set.js';
 
 /**
  * TCP socket connection options.
@@ -49,9 +50,15 @@ export type CommandResponse = {
  * Provides direct access to command sending and event handling.
  */
 export type RawClient = {
+  /** Server wire protocol used by this connection */
+  readonly protocol?: Protocol,
   /** Sends a command to the server and returns the response */
   sendCommand: (
-    code: number, payload: Buffer, handleResponse?: boolean
+    code: number,
+    payload: Buffer,
+    handleResponse?: boolean,
+    last?: boolean,
+    kind?: BinaryRequestKind
   ) => Promise<CommandResponse>,
   /** Whether the client has been authenticated */
   isAuthenticated: boolean
@@ -101,6 +108,9 @@ export type ReconnectOption = {
  */
 export type TransportOption = TcpOption | TlsOption;
 
+/** Server wire protocol. */
+export type Protocol = 'classic' | 'vsr';
+
 /**
  * Token-based authentication credentials.
  */
@@ -139,6 +149,8 @@ export type PoolSizeOption = {
  * Complete client configuration for connecting to the Iggy server.
  */
 export type ClientConfig = {
+  /** Server wire protocol (default: classic) */
+  protocol?: Protocol,
   /** Transport protocol to use (TCP or TLS) */
   transport: TransportType,
   /** Transport-specific connection options */

--- a/foreign/node/src/e2e/tcp.raw.e2e.ts
+++ b/foreign/node/src/e2e/tcp.raw.e2e.ts
@@ -19,32 +19,63 @@
 import { after, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { getTestClient } from './test-client.utils.js';
+import { BINARY_REQUEST_KIND } from '../wire/command-set.js';
 import { COMMAND_CODE } from '../wire/command.code.js';
 
 describe('e2e -> raw', async () => {
 
   const c = getTestClient();
 
+  const VENDOR_CODE = 60_001;
+
   it('e2e -> raw::ping', async () => {
-    const response = await c.sendBinaryRequest(COMMAND_CODE.Ping, Buffer.alloc(0));
+    const response = await c.sendBinaryRequest(
+      BINARY_REQUEST_KIND.NonReplicated,
+      COMMAND_CODE.Ping,
+      Buffer.alloc(0)
+    );
     assert.deepEqual(response, Buffer.alloc(0));
   });
 
   it('e2e -> raw::getStats', async () => {
-    const response = await c.sendBinaryRequest(COMMAND_CODE.GetStats, Buffer.alloc(0));
+    const response = await c.sendBinaryRequest(
+      BINARY_REQUEST_KIND.NonReplicated,
+      COMMAND_CODE.GetStats,
+      Buffer.alloc(0)
+    );
+    assert.ok(response.length > 0);
+  });
+
+  it('e2e -> raw::getStatsIgnoresTheDeclaration', async () => {
+    // Classic framing has no operation field, so a replicated declaration
+    // encodes the same bytes and the read still succeeds.
+    const response = await c.sendBinaryRequest(
+      BINARY_REQUEST_KIND.Replicated,
+      COMMAND_CODE.GetStats,
+      Buffer.alloc(0)
+    );
     assert.ok(response.length > 0);
   });
 
   it('e2e -> raw::sessionControlCodeRejectedClientSide', async () => {
-    await assert.rejects(
-      () => c.sendBinaryRequest(COMMAND_CODE.LoginUser, Buffer.alloc(0))
-    );
+    for (const kind of Object.values(BINARY_REQUEST_KIND))
+      await assert.rejects(
+        () => c.sendBinaryRequest(kind, COMMAND_CODE.LoginUser, Buffer.alloc(0))
+      );
   });
 
-  it('e2e -> raw::unknownCodeRejectedByServer', async () => {
+  it('e2e -> raw::vendorCodeRejectedByServer', async () => {
     await assert.rejects(
-      () => c.sendBinaryRequest(60000, Buffer.alloc(0))
+      () => c.sendBinaryRequest(BINARY_REQUEST_KIND.NonReplicated, VENDOR_CODE, Buffer.alloc(0))
     );
+
+    // The rejection is request-level, so the connection stays usable.
+    const response = await c.sendBinaryRequest(
+      BINARY_REQUEST_KIND.NonReplicated,
+      COMMAND_CODE.Ping,
+      Buffer.alloc(0)
+    );
+    assert.deepEqual(response, Buffer.alloc(0));
   });
 
   after(() => {

--- a/foreign/node/src/index.ts
+++ b/foreign/node/src/index.ts
@@ -23,6 +23,8 @@ export {
   Partitioning,
   HeaderValue,
   HeaderKeyFactory,
+  BINARY_REQUEST_KIND,
+  BinaryRequestKind,
 } from "./wire/index.js";
 
 export * from "./client/index.js";

--- a/foreign/node/src/wire/command-set.test.ts
+++ b/foreign/node/src/wire/command-set.test.ts
@@ -21,6 +21,7 @@ import assert from 'node:assert/strict';
 import { SimpleClient } from '../client/client.js';
 import type { RawClient } from '../client/client.type.js';
 import { COMMAND_CODE } from './command.code.js';
+import { BINARY_REQUEST_KIND, type BinaryRequestKind } from './command-set.js';
 
 const mockRawClient = (): RawClient => ({
   sendCommand: async () => {
@@ -42,22 +43,50 @@ describe('CommandAPI.sendBinaryRequest', () => {
 
   describe('session-control guard', () => {
 
-    [
-      COMMAND_CODE.LoginUser,
-      COMMAND_CODE.LogoutUser,
-      COMMAND_CODE.LoginRegister,
-      COMMAND_CODE.LoginWithAccessToken,
-      COMMAND_CODE.LoginRegisterWithAccessToken,
-    ].forEach((code) => {
-      it(`rejects code ${code} before reaching the client provider`, async () => {
-        const client = new SimpleClient(mockRawClient());
-        await assert.rejects(
-          () => client.sendBinaryRequest(code, Buffer.alloc(0)),
-          /code: 3, message: Invalid command/
-        );
+    Object.values(BINARY_REQUEST_KIND).forEach((kind) => {
+      [
+        COMMAND_CODE.LoginUser,
+        COMMAND_CODE.LogoutUser,
+        COMMAND_CODE.LoginRegister,
+        COMMAND_CODE.LoginWithAccessToken,
+        COMMAND_CODE.LoginRegisterWithAccessToken,
+      ].forEach((code) => {
+        it(`rejects ${kind} code ${code} before reaching the client provider`, async () => {
+          const client = new SimpleClient(mockRawClient());
+          await assert.rejects(
+            () => client.sendBinaryRequest(kind, code, Buffer.alloc(0)),
+            /code: 3, message: Invalid command/
+          );
+        });
       });
     });
 
+  });
+
+  it('rejects an undefined request kind before reaching the client provider', async () => {
+    const client = new SimpleClient(mockRawClient());
+    await assert.rejects(
+      () => client.sendBinaryRequest('auto' as BinaryRequestKind, COMMAND_CODE.Ping, Buffer.alloc(0)),
+      /code: 3, message: Invalid command/
+    );
+  });
+
+  it('encodes both kinds identically because classic framing has no operation field', async () => {
+    const customCode = 60_001;
+    const payload = Buffer.from([0xAA, 0xBB, 0xCC]);
+    const frames: { code: number, payload: Buffer }[] = [];
+    const raw = mockRawClient();
+    raw.sendCommand = async (code, sentPayload) => {
+      frames.push({ code, payload: Buffer.from(sentPayload) });
+      return { status: 0, length: 1, data: Buffer.alloc(0) };
+    };
+    const client = new SimpleClient(raw);
+
+    for (const kind of Object.values(BINARY_REQUEST_KIND))
+      await client.sendBinaryRequest(kind, customCode, payload);
+
+    assert.equal(frames.length, 2);
+    assert.deepEqual(frames[0], frames[1]);
   });
 
   it('forwards a custom code and opaque payload to sendCommand', async () => {
@@ -65,9 +94,10 @@ describe('CommandAPI.sendBinaryRequest', () => {
     const payload = Buffer.from([0xAA, 0xBB, 0xCC]);
     const expectedResponse = Buffer.from('opaque response');
     const raw = mockRawClient();
-    raw.sendCommand = async (code, sentPayload) => {
+    raw.sendCommand = async (code, sentPayload, _handleResponse, _last, kind) => {
       assert.equal(code, customCode);
       assert.deepEqual(sentPayload, payload);
+      assert.equal(kind, BINARY_REQUEST_KIND.NonReplicated);
       return {
         status: 0,
         length: expectedResponse.length,
@@ -75,7 +105,11 @@ describe('CommandAPI.sendBinaryRequest', () => {
       };
     };
     const client = new SimpleClient(raw);
-    const response = await client.sendBinaryRequest(customCode, payload);
+    const response = await client.sendBinaryRequest(
+      BINARY_REQUEST_KIND.NonReplicated,
+      customCode,
+      payload
+    );
     assert.deepEqual(response, expectedResponse);
   });
 
@@ -88,7 +122,11 @@ describe('CommandAPI.sendBinaryRequest', () => {
       return { status: 0, length: 1, data: Buffer.alloc(0) };
     };
 
-    const request = new SimpleClient(raw).sendBinaryRequest(60_000, payload);
+    const request = new SimpleClient(raw).sendBinaryRequest(
+      BINARY_REQUEST_KIND.NonReplicated,
+      60_001,
+      payload
+    );
     payload.fill(0);
 
     await request;
@@ -103,6 +141,7 @@ describe('CommandAPI.sendBinaryRequest', () => {
     });
 
     const response = await new SimpleClient(raw).sendBinaryRequest(
+      BINARY_REQUEST_KIND.NonReplicated,
       COMMAND_CODE.Ping,
       Buffer.alloc(0)
     );

--- a/foreign/node/src/wire/command-set.ts
+++ b/foreign/node/src/wire/command-set.ts
@@ -34,6 +34,7 @@ import { joinGroup } from './consumer-group/join-group.command.js';
 import { getGroup } from './consumer-group/get-group.command.js';
 import { getGroups } from './consumer-group/get-groups.command.js';
 import { leaveGroup } from './consumer-group/leave-group.command.js';
+import { syncGroup } from './consumer-group/sync-group.command.js';
 import { deleteGroup } from './consumer-group/delete-group.command.js';
 import {
   ensureConsumerGroup, ensureConsumerGroupAndJoin
@@ -165,6 +166,7 @@ const groupAPI = (c: ClientProvider) => ({
   create: createGroup(c),
   join: joinGroup(c),
   leave: leaveGroup(c),
+  sync: syncGroup(c),
   delete: deleteGroup(c),
   ensure: ensureConsumerGroup(c),
   ensureAndJoin: ensureConsumerGroupAndJoin(c)
@@ -211,6 +213,26 @@ const SESSION_CONTROL_CODES = new Set([
 
 const INVALID_COMMAND_ERROR_CODE = 3;
 
+/**
+ * How a raw binary request executes on the server.
+ *
+ * Classic framing carries no operation field, while VSR framing uses this
+ * declaration to route unknown extension codes.
+ */
+export const BINARY_REQUEST_KIND = {
+  NonReplicated: 'non_replicated',
+  Replicated: 'replicated'
+} as const;
+
+/** PascalCase alias matching the Rust and Python SDKs. */
+export const BinaryRequestKind = BINARY_REQUEST_KIND;
+
+export type BinaryRequestKind =
+  typeof BINARY_REQUEST_KIND[keyof typeof BINARY_REQUEST_KIND];
+
+const BINARY_REQUEST_KINDS: ReadonlySet<string> =
+  new Set(Object.values(BINARY_REQUEST_KIND));
+
 export abstract class AbstractAPI {
   clientProvider: ClientProvider;
 
@@ -242,16 +264,27 @@ export abstract class CommandAPI extends AbstractAPI {
    * Sends a command code with a payload and returns the raw response payload.
    * Session-control codes are rejected with an invalid-command error.
    *
+   * @param kind - How the command executes
    * @param code - Command code to send
    * @param payload - Raw command payload
    * @returns Raw response payload
    */
-  async sendBinaryRequest(code: number, payload: Buffer): Promise<Buffer> {
-    if (SESSION_CONTROL_CODES.has(code))
+  async sendBinaryRequest(
+    kind: BinaryRequestKind,
+    code: number,
+    payload: Buffer
+  ): Promise<Buffer> {
+    if (!BINARY_REQUEST_KINDS.has(kind) || SESSION_CONTROL_CODES.has(code))
       throw responseError(code, INVALID_COMMAND_ERROR_CODE);
 
     const requestPayload = Buffer.from(payload);
-    const response = await (await this.clientProvider()).sendCommand(code, requestPayload);
+    const response = await (await this.clientProvider()).sendCommand(
+      code,
+      requestPayload,
+      true,
+      true,
+      kind
+    );
     return response.length <= 1 ? Buffer.alloc(0) : response.data;
   }
 }

--- a/foreign/node/src/wire/command.code.ts
+++ b/foreign/node/src/wire/command.code.ts
@@ -47,6 +47,8 @@ export const COMMAND_CODE = {
   GetOffset: 120,
   StoreOffset: 121,
   DeleteConsumerOffset: 122,
+  StoreOffset2: 123,
+  DeleteConsumerOffset2: 124,
   GetStream: 200,
   GetStreams: 201,
   CreateStream: 202,
@@ -68,6 +70,7 @@ export const COMMAND_CODE = {
   DeleteGroup: 603,
   JoinGroup: 604,
   LeaveGroup: 605,
+  SyncGroup: 606,
 };
 
 const reverseCommandCodeMap = reverseRecord(COMMAND_CODE);

--- a/foreign/node/src/wire/consumer-group/group.utils.ts
+++ b/foreign/node/src/wire/consumer-group/group.utils.ts
@@ -18,6 +18,13 @@
 
 import { serializeIdentifier, type Id } from '../identifier.utils.js';
 
+/** Stream, topic, and consumer-group identifiers. */
+export type TargetGroup = {
+  streamId: Id,
+  topicId: Id,
+  groupId: Id,
+};
+
 /**
  * Consumer group information.
  */

--- a/foreign/node/src/wire/consumer-group/index.ts
+++ b/foreign/node/src/wire/consumer-group/index.ts
@@ -22,4 +22,5 @@ export * from './get-group.command.js';
 export * from './get-groups.command.js';
 export * from './join-group.command.js';
 export * from './leave-group.command.js';
+export * from './sync-group.command.js';
 export * from './ensure-group.virtual.command.js';

--- a/foreign/node/src/wire/consumer-group/sync-group.command.test.ts
+++ b/foreign/node/src/wire/consumer-group/sync-group.command.test.ts
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { SYNC_GROUP } from './sync-group.command.js';
+
+describe('SyncGroup', () => {
+  it('serializes group identifiers', () => {
+    assert.equal(
+      SYNC_GROUP.serialize({ streamId: 5, topicId: 2, groupId: 1 }).length,
+      18,
+    );
+  });
+
+  it('deserializes an assignment', () => {
+    const data = Buffer.alloc(20);
+    data.writeBigUInt64LE(7n, 0);
+    data.writeUInt32LE(2, 8);
+    data.writeUInt32LE(1, 12);
+    data.writeUInt32LE(4, 16);
+    assert.deepEqual(
+      SYNC_GROUP.deserialize({ status: 0, length: data.length, data }),
+      { generation: 7n, partitions: [1, 4] },
+    );
+  });
+
+  it('maps an empty response to no assignment', () => {
+    assert.equal(
+      SYNC_GROUP.deserialize({ status: 0, length: 0, data: Buffer.alloc(0) }),
+      null,
+    );
+  });
+});

--- a/foreign/node/src/wire/consumer-group/sync-group.command.ts
+++ b/foreign/node/src/wire/consumer-group/sync-group.command.ts
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import type { CommandResponse } from '../../client/client.type.js';
+import { wrapCommand } from '../command.utils.js';
+import { COMMAND_CODE } from '../command.code.js';
+import {
+  serializeTargetGroup,
+  type TargetGroup,
+} from './group.utils.js';
+
+/** Current assignment for a consumer-group member. */
+export type ConsumerGroupAssignment = {
+  /** Monotonic group generation */
+  generation: bigint,
+  /** Partition IDs currently owned by this member */
+  partitions: number[],
+};
+
+export const SYNC_GROUP = {
+  code: COMMAND_CODE.SyncGroup,
+
+  serialize: ({ streamId, topicId, groupId }: TargetGroup) =>
+    serializeTargetGroup(streamId, topicId, groupId),
+
+  deserialize: (response: CommandResponse): ConsumerGroupAssignment | null => {
+    if (response.data.length === 0)
+      return null;
+    const generation = response.data.readBigUInt64LE(0);
+    const partitionsCount = response.data.readUInt32LE(8);
+    const partitions = new Array<number>(partitionsCount);
+    for (let index = 0; index < partitionsCount; index += 1)
+      partitions[index] = response.data.readUInt32LE(12 + index * 4);
+    return { generation, partitions };
+  },
+};
+
+/** Fetches this connection's current consumer-group assignment. */
+export const syncGroup =
+  wrapCommand<TargetGroup, ConsumerGroupAssignment | null>(SYNC_GROUP);

--- a/foreign/node/src/wire/error.utils.ts
+++ b/foreign/node/src/wire/error.utils.ts
@@ -19,10 +19,24 @@
 import { translateCommandCode } from './command.code.js';
 import { translateErrorCode } from './error.code.js';
 
-export const responseError = (cmdCode: number, errCode: number) => new Error(
-  `command: { code: ${cmdCode}, name: ${translateCommandCode(cmdCode)} } ` +
-  `error: {code: ${errCode}, message: ${translateErrorCode(errCode)} }`
-);
+export class ResponseError extends Error {
+  readonly commandCode: number;
+  readonly errorCode: number;
+
+  constructor(commandCode: number, errorCode: number) {
+    super(
+      `command: { code: ${commandCode}, name: ${translateCommandCode(commandCode)} } ` +
+      `error: {code: ${errorCode}, message: ${translateErrorCode(errorCode)} }`
+    );
+    this.name = 'ResponseError';
+    this.commandCode = commandCode;
+    this.errorCode = errorCode;
+    Object.setPrototypeOf(this, ResponseError.prototype);
+  }
+}
+
+export const responseError = (cmdCode: number, errCode: number) =>
+  new ResponseError(cmdCode, errCode);
 
 export class DeserializeError extends Error {
   constructor(message: string, cause?: Record<string , unknown>) {

--- a/foreign/node/src/wire/message/poll-messages.command.ts
+++ b/foreign/node/src/wire/message/poll-messages.command.ts
@@ -17,15 +17,33 @@
 //
 
 import type { Id } from '../identifier.utils.js';
-import type { CommandResponse } from '../../client/client.type.js';
-import type { Consumer } from '../offset/offset.utils.js';
-import { wrapCommand } from '../command.utils.js';
+import type {
+  CommandResponse,
+  ClientProvider,
+  RawClient,
+} from '../../client/client.type.js';
+import {
+  ConsumerKind,
+  type Consumer,
+} from '../offset/offset.utils.js';
 import { COMMAND_CODE } from '../command.code.js';
+import { responseError } from '../error.utils.js';
+import { SYNC_GROUP } from '../consumer-group/sync-group.command.js';
 import {
   serializePollMessages, deserializePollMessages,
   type PollingStrategy, type PollMessagesResponse
 } from './poll.utils.js';
 
+const RESYNC_REQUIRED_PARTITION = 0xFFFF_FFFF;
+const GROUP_POLL_MAX_ATTEMPTS = 2;
+
+type GroupCursor = {
+  generation: bigint,
+  partitions: number[],
+  position: number,
+};
+
+const groupCursors = new WeakMap<RawClient, Map<string, GroupCursor>>();
 
 /**
  * Parameters for the poll messages command.
@@ -67,7 +85,78 @@ export const POLL_MESSAGES = {
   }
 };
 
+const groupKey = ({ streamId, topicId, consumer }: PollMessages): string =>
+  `${String(streamId)}\0${String(topicId)}\0${String(consumer.id)}`;
+
+const syncAssignment = async (
+  client: RawClient,
+  request: PollMessages,
+): Promise<GroupCursor> => {
+  const response = await client.sendCommand(
+    SYNC_GROUP.code,
+    SYNC_GROUP.serialize({
+      streamId: request.streamId,
+      topicId: request.topicId,
+      groupId: request.consumer.id,
+    }),
+  );
+  const assignment = SYNC_GROUP.deserialize(response);
+  if (assignment === null)
+    throw responseError(SYNC_GROUP.code, 5006);
+
+  let cursors = groupCursors.get(client);
+  if (!cursors) {
+    cursors = new Map();
+    groupCursors.set(client, cursors);
+  }
+  const key = groupKey(request);
+  const current = cursors.get(key);
+  if (current && current.generation === assignment.generation) {
+    current.partitions = assignment.partitions;
+    if (current.position >= current.partitions.length)
+      current.position = 0;
+    return current;
+  }
+  const cursor = { ...assignment, position: 0 };
+  cursors.set(key, cursor);
+  return cursor;
+};
+
+const pollConsumerGroup = async (
+  client: RawClient,
+  request: PollMessages,
+): Promise<PollMessagesResponse> => {
+  for (let attempt = 0; attempt < GROUP_POLL_MAX_ATTEMPTS; attempt += 1) {
+    const cursor = await syncAssignment(client, request);
+    if (cursor.partitions.length === 0)
+      return { partitionId: 0, currentOffset: 0n, count: 0, messages: [] };
+
+    const partitionId = cursor.partitions[cursor.position];
+    cursor.position = (cursor.position + 1) % cursor.partitions.length;
+    const response = await client.sendCommand(
+      POLL_MESSAGES.code,
+      POLL_MESSAGES.serialize({ ...request, partitionId }),
+    );
+    const polled = POLL_MESSAGES.deserialize(response);
+    if (polled.count === 0 &&
+        polled.partitionId === RESYNC_REQUIRED_PARTITION)
+      continue;
+    return polled;
+  }
+  return { partitionId: 0, currentOffset: 0n, count: 0, messages: [] };
+};
+
 /**
  * Executable poll messages command function.
  */
-export const pollMessages = wrapCommand<PollMessages, PollMessagesResponse>(POLL_MESSAGES);
+export const pollMessages = (getClient: ClientProvider) =>
+  async (request: PollMessages): Promise<PollMessagesResponse> => {
+    const client = await getClient();
+    if (client.protocol === 'vsr' &&
+        request.consumer.kind === ConsumerKind.Group &&
+        request.partitionId === null)
+      return pollConsumerGroup(client, request);
+    return POLL_MESSAGES.deserialize(
+      await client.sendCommand(POLL_MESSAGES.code, POLL_MESSAGES.serialize(request))
+    );
+  };

--- a/foreign/node/src/wire/topic/topic.utils.test.ts
+++ b/foreign/node/src/wire/topic/topic.utils.test.ts
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { deserializeBaseTopic } from './topic.utils.js';
+
+describe('deserializeBaseTopic', () => {
+  it('uses the current message-expiry then compression wire layout', () => {
+    const data = Buffer.alloc(52);
+    data.writeUInt32LE(7, 0);
+    data.writeBigUInt64LE(1_710_000_000_000n, 4);
+    data.writeUInt32LE(3, 12);
+    data.writeBigUInt64LE(86_400_000_000n, 16);
+    data.writeUInt8(2, 24);
+    data.writeBigUInt64LE(1_000_000n, 25);
+    data.writeUInt8(3, 33);
+    data.writeBigUInt64LE(4096n, 34);
+    data.writeBigUInt64LE(12n, 42);
+    data.writeUInt8(1, 50);
+    data.write('t', 51);
+
+    const { bytesRead, data: topic } = deserializeBaseTopic(data);
+
+    assert.equal(bytesRead, data.length);
+    assert.equal(topic.messageExpiry, 86_400_000_000n);
+    assert.equal(topic.compressionAlgorithm, 2);
+    assert.equal(topic.maxTopicSize, 1_000_000n);
+  });
+});

--- a/foreign/node/src/wire/topic/topic.utils.ts
+++ b/foreign/node/src/wire/topic/topic.utils.ts
@@ -123,8 +123,8 @@ export const deserializeBaseTopic = (p: Buffer, pos = 0): BaseTopicSerialized =>
   const id = p.readUInt32LE(pos);
   const createdAt = toDate(p.readBigUint64LE(pos + 4));
   const partitionsCount = p.readUInt32LE(pos + 12);
-  const compressionAlgorithm = p.readUInt8(pos + 16);
-  const messageExpiry = p.readBigUInt64LE(pos + 17);
+  const messageExpiry = p.readBigUInt64LE(pos + 16);
+  const compressionAlgorithm = p.readUInt8(pos + 24);
   const maxTopicSize = p.readBigUInt64LE(pos + 25);
   const replicationFactor = p.readUInt8(pos + 33);
   const sizeBytes = p.readBigUInt64LE(pos + 34);

--- a/foreign/node/src/wire/vsr/header.ts
+++ b/foreign/node/src/wire/vsr/header.ts
@@ -1,0 +1,165 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+/**
+ * VSR consensus header layout, ported from
+ * `core/binary_protocol/src/consensus/header.rs`. Every consensus frame in
+ * both directions starts with a 256-byte header. Fields are read and written
+ * by byte offset, mirroring the Rust SDK, which avoids struct casts because
+ * the headers lead with unaligned u128 fields.
+ */
+
+/** Size of every consensus header, both directions. */
+export const HEADER_SIZE = 256;
+
+/** `RequestHeader` field offsets the client writes. */
+export const REQUEST_OFFSET = {
+  size: 48,
+  command: 60,
+  client: 128,
+  timestamp: 160,
+  request: 168,
+  operation: 176,
+  namespace: 184,
+  session: 192,
+  reserved: 204
+} as const;
+
+/** `ReplyHeader` field offsets the client reads. */
+export const REPLY_OFFSET = {
+  size: 48,
+  command: 60,
+  operation: 208,
+  namespace: 216,
+  status: 224
+} as const;
+
+/** `EvictionHeader` field offsets the client reads. */
+export const EVICTION_OFFSET = {
+  command: 60,
+  client: 128,
+  serverProtocolVersion: 144,
+  serverProtocolVersionMin: 148,
+  reason: 255
+} as const;
+
+/** `Command2` frame discriminants a client encounters. */
+export const Command2 = {
+  Request: 5,
+  Reply: 8,
+  Eviction: 13
+} as const;
+
+/**
+ * `EvictionReason` values, mirroring
+ * `core/binary_protocol/src/consensus/header.rs`.
+ */
+export const EvictionReason = {
+  Reserved: 0,
+  NoSession: 1,
+  ClientReleaseTooLow: 2,
+  ClientReleaseTooHigh: 3,
+  InvalidRequestOperation: 4,
+  InvalidRequestBody: 5,
+  InvalidRequestBodySize: 6,
+  SessionTooLow: 7,
+  SessionReleaseMismatch: 8,
+  InvalidCredentials: 9,
+  InvalidToken: 10,
+  UserInactive: 11,
+  SessionError: 12,
+  StaleClient: 13,
+  IncompatibleProtocol: 14,
+  MalformedLogin: 15
+} as const;
+
+/** Fields the client writes into a request header. */
+export type RequestHeaderFields = {
+  /** Header + body total, bytes. */
+  size: number,
+  /** Ephemeral client identifier (u128). */
+  client: bigint,
+  /** Request id (u64): 0 for Register, else per session rules. */
+  request: bigint,
+  /** `Operation` discriminant. */
+  operation: number,
+  /** Routing namespace (u64). */
+  namespace: bigint,
+  /** Bound session (u64), or 0n. */
+  session: bigint,
+  /** Command code for `NonReplicated`, placed in `reserved[0..4]`. */
+  nonReplicatedCode?: number
+};
+
+const U64_MASK = 0xFFFFFFFFFFFFFFFFn;
+
+/**
+ * Encodes a 256-byte request header. Only the seven fields the server reads
+ * are written; the checksums stay zero, matching the Rust SDK's contract
+ * with server-ng.
+ */
+export const encodeRequestHeader = (fields: RequestHeaderFields): Buffer => {
+  const header = Buffer.alloc(HEADER_SIZE);
+  header.writeUInt32LE(fields.size, REQUEST_OFFSET.size);
+  header.writeUInt8(Command2.Request, REQUEST_OFFSET.command);
+  // u128 client id: two little-endian u64 halves, low half first.
+  header.writeBigUInt64LE(fields.client & U64_MASK, REQUEST_OFFSET.client);
+  header.writeBigUInt64LE(fields.client >> 64n, REQUEST_OFFSET.client + 8);
+  header.writeBigUInt64LE(fields.request, REQUEST_OFFSET.request);
+  header.writeUInt8(fields.operation, REQUEST_OFFSET.operation);
+  header.writeBigUInt64LE(fields.namespace, REQUEST_OFFSET.namespace);
+  header.writeBigUInt64LE(fields.session, REQUEST_OFFSET.session);
+  if (fields.nonReplicatedCode !== undefined)
+    header.writeUInt32LE(fields.nonReplicatedCode, REQUEST_OFFSET.reserved);
+  return header;
+};
+
+/**
+ * Reads the frame discriminant. `command` sits at the same offset in every
+ * consensus header, so one byte discriminates the frame type.
+ */
+export const peekCommand = (header: Buffer): number =>
+  header.readUInt8(REPLY_OFFSET.command);
+
+/** Reads the total frame size from a reply or eviction header. */
+export const readSize = (header: Buffer): number =>
+  header.readUInt32LE(REPLY_OFFSET.size);
+
+/** Reads the pre-commit denial status; 0 means the reply committed. */
+export const readStatus = (header: Buffer): number =>
+  header.readUInt32LE(REPLY_OFFSET.status);
+
+/** Reads the `Operation` discriminant from a reply header. */
+export const readReplyOperation = (header: Buffer): number =>
+  header.readUInt8(REPLY_OFFSET.operation);
+
+/** Decoded eviction frame. */
+export type Eviction = {
+  reason: number,
+  serverProtocolVersion: number,
+  serverProtocolVersionMin: number
+};
+
+/** Reads the fields of an eviction header the client acts on. */
+export const readEviction = (header: Buffer): Eviction => ({
+  reason: header.readUInt8(EVICTION_OFFSET.reason),
+  serverProtocolVersion:
+    header.readUInt32LE(EVICTION_OFFSET.serverProtocolVersion),
+  serverProtocolVersionMin:
+    header.readUInt32LE(EVICTION_OFFSET.serverProtocolVersionMin)
+});

--- a/foreign/node/src/wire/vsr/index.ts
+++ b/foreign/node/src/wire/vsr/index.ts
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import type { CommandResponse } from '../../client/client.type.js';
+import type { BinaryRequestKind } from '../command-set.js';
+import { COMMAND_CODE } from '../command.code.js';
+import { HEADER_SIZE, encodeRequestHeader } from './header.js';
+import { namespaceForRequest } from './namespace.js';
+import {
+  Operation,
+  isPartition,
+  operationForCode,
+} from './operation.js';
+import {
+  deserializeLoginRegister,
+  serializeLoginRegister,
+  serializeLoginRegisterWithPat,
+} from './register.js';
+import { decodeResponse } from './reply.js';
+import { ConsensusSession } from './session.js';
+
+const SDK_VERSION = '0.8.1-edge.3';
+
+export class VsrSession {
+  private state = new ConsensusSession();
+
+  reset(): void {
+    this.state = new ConsensusSession();
+  }
+
+  bind(session: bigint): void {
+    this.state.bind(session);
+  }
+
+  encode(command: number, payload: Buffer, kind?: BinaryRequestKind): Buffer {
+    const operation = registerCommand(command)
+      ? Operation.Register
+      : operationForCode(command, kind);
+    let request: bigint;
+    let session: bigint;
+
+    if (operation === Operation.Register) {
+      request = this.state.beginRegister();
+      session = 0n;
+    } else if (operation === Operation.NonReplicated) {
+      request = this.state.currentRequestId();
+      session = this.state.session ?? 0n;
+    } else {
+      if (this.state.session === null)
+        throw new Error('VSR session is not registered');
+      request = isPartition(operation)
+        ? this.state.currentRequestId()
+        : this.state.nextRequestId();
+      session = this.state.session;
+    }
+
+    const header = encodeRequestHeader({
+      size: HEADER_SIZE + payload.length,
+      client: this.state.clientId,
+      request,
+      operation,
+      namespace: namespaceForRequest(command, payload, operation),
+      session,
+      ...(operation === Operation.NonReplicated
+        ? { nonReplicatedCode: command }
+        : {}),
+    });
+    return payload.length === 0 ? header : Buffer.concat([header, payload]);
+  }
+}
+
+export const decodeVsrResponse = (frame: Buffer): CommandResponse => {
+  const data = decodeResponse(frame);
+  return { status: 0, length: data.length, data };
+};
+
+export const readRegisteredSession = (response: CommandResponse): bigint =>
+  deserializeLoginRegister(response.data).session;
+
+export const prepareVsrCommand = (
+  command: number,
+  payload: Buffer
+): { command: number, payload: Buffer } => {
+  if (command === COMMAND_CODE.LoginUser) {
+    const username = readWireName(payload, 0);
+    const password = readWireName(payload, username.next);
+    return {
+      command: COMMAND_CODE.LoginRegister,
+      payload: serializeLoginRegister(username.value, password.value, SDK_VERSION),
+    };
+  }
+  if (command === COMMAND_CODE.LoginWithAccessToken) {
+    const token = readWireName(payload, 0);
+    return {
+      command: COMMAND_CODE.LoginRegisterWithAccessToken,
+      payload: serializeLoginRegisterWithPat(token.value, SDK_VERSION),
+    };
+  }
+  return { command, payload };
+};
+
+const registerCommand = (command: number): boolean =>
+  command === COMMAND_CODE.LoginRegister ||
+  command === COMMAND_CODE.LoginRegisterWithAccessToken;
+
+const readWireName = (
+  payload: Buffer,
+  offset: number
+): { value: string, next: number } => {
+  if (payload.length <= offset)
+    throw new Error('wire name length is missing');
+  const length = payload.readUInt8(offset);
+  const next = offset + 1 + length;
+  if (length === 0 || payload.length < next)
+    throw new Error('wire name is incomplete');
+  return { value: payload.subarray(offset + 1, next).toString('utf8'), next };
+};
+
+export { HEADER_SIZE } from './header.js';

--- a/foreign/node/src/wire/vsr/namespace.ts
+++ b/foreign/node/src/wire/vsr/namespace.ts
@@ -1,0 +1,203 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+/**
+ * Namespace packing and the partition-plane payload peeks needed to derive
+ * it, ported from `core/binary_protocol/src/namespace.rs` and
+ * `namespace_for_request` in `core/sdk/src/vsr.rs`.
+ */
+
+import { COMMAND_CODE } from '../command.code.js';
+import { responseError } from '../error.utils.js';
+import { Operation, isMetadata } from './operation.js';
+
+/** `IggyError::InvalidCommand`. */
+const INVALID_COMMAND = 3;
+/** `IggyError::FeatureUnavailable`. */
+const FEATURE_UNAVAILABLE = 5;
+/** `IggyError::InvalidIdentifier`. */
+const INVALID_IDENTIFIER = 6;
+
+const MAX_STREAMS = 4096;
+const MAX_TOPICS = 4096;
+const MAX_PARTITIONS = 1_000_000;
+const STREAM_SHIFT = 32n;
+const TOPIC_SHIFT = 20n;
+
+/**
+ * Control-plane requests target the metadata replica (shard 0), selected by
+ * this exact sentinel. Plain 0 would fall into namespace hashing and land a
+ * Register on a peer shard.
+ */
+export const METADATA_CONSENSUS_NAMESPACE = 1n << 63n;
+
+/** Packs stream / topic / partition ids into a routing namespace. */
+export const packNamespace = (
+  streamId: number,
+  topicId: number,
+  partitionId: number
+): bigint =>
+  (BigInt(streamId & 0xFFF) << STREAM_SHIFT) |
+  (BigInt(topicId & 0xFFF) << TOPIC_SHIFT) |
+  BigInt(partitionId & 0xFFFFF);
+
+/**
+ * Selects the routing namespace for a request. Partition-plane commands
+ * derive it from their own payload; a named stream or topic identifier
+ * yields 0 so the server resolves the name.
+ *
+ * @throws Error mirroring the Rust SDK: invalid-identifier for an
+ *   out-of-range field, invalid-command for an undecodable payload, and
+ *   feature-unavailable for a partition operation this SDK cannot derive.
+ */
+export const namespaceForRequest = (
+  code: number,
+  payload: Buffer,
+  operation: number
+): bigint => {
+  if (operation === Operation.Register || operation === Operation.Logout)
+    return METADATA_CONSENSUS_NAMESPACE;
+  if (operation === Operation.NonReplicated || isMetadata(operation))
+    return 0n;
+
+  switch (code) {
+    case COMMAND_CODE.SendMessages:
+      return namespaceFromSendMessages(payload);
+    case COMMAND_CODE.StoreOffset:
+    case COMMAND_CODE.DeleteConsumerOffset:
+    case COMMAND_CODE.StoreOffset2:
+    case COMMAND_CODE.DeleteConsumerOffset2:
+      return namespaceFromConsumerOffset(payload);
+    case COMMAND_CODE.DeleteSegments:
+      return namespaceFromDeleteSegments(payload);
+    default:
+      // The guard that keeps custom partition operations unreachable.
+      throw responseError(code, FEATURE_UNAVAILABLE);
+  }
+};
+
+/** A decoded identifier: numeric value, or null for a name (server resolves). */
+type PeekedIdentifier = {
+  numeric: number | null,
+  length: number
+};
+
+const IDENTIFIER_KIND_NUMERIC = 1;
+
+const peekIdentifier = (payload: Buffer, offset: number): PeekedIdentifier => {
+  if (payload.length < offset + 2)
+    throw responseError(0, INVALID_COMMAND);
+  const kind = payload.readUInt8(offset);
+  const length = payload.readUInt8(offset + 1);
+  if (payload.length < offset + 2 + length)
+    throw responseError(0, INVALID_COMMAND);
+  if (kind === IDENTIFIER_KIND_NUMERIC) {
+    if (length !== 4)
+      throw responseError(0, INVALID_COMMAND);
+    return { numeric: payload.readUInt32LE(offset + 2), length: 2 + length };
+  }
+  return { numeric: null, length: 2 + length };
+};
+
+const validateField = (value: number, exclusiveMax: number): void => {
+  if (value >= exclusiveMax)
+    throw responseError(0, INVALID_IDENTIFIER);
+};
+
+const namespaceFromIds = (
+  stream: PeekedIdentifier,
+  topic: PeekedIdentifier,
+  partitionId: number
+): bigint => {
+  // Named identifiers defer resolution to the server.
+  if (stream.numeric === null || topic.numeric === null) return 0n;
+  validateField(stream.numeric, MAX_STREAMS);
+  validateField(topic.numeric, MAX_TOPICS);
+  validateField(partitionId, MAX_PARTITIONS);
+  return packNamespace(stream.numeric, topic.numeric, partitionId);
+};
+
+/**
+ * `SendMessages`: `[metadata_len u32][stream ident][topic ident]
+ * [partitioning kind u8, len u8, value]...`. Only explicit `PartitionId`
+ * partitioning is routable under VSR; the broker never picks a partition.
+ */
+const namespaceFromSendMessages = (payload: Buffer): bigint => {
+  if (payload.length < 4)
+    throw responseError(COMMAND_CODE.SendMessages, INVALID_COMMAND);
+  const metadataLength = payload.readUInt32LE(0);
+  if (payload.length < 4 + metadataLength)
+    throw responseError(COMMAND_CODE.SendMessages, INVALID_COMMAND);
+
+  let offset = 4;
+  const stream = peekIdentifier(payload, offset);
+  offset += stream.length;
+  const topic = peekIdentifier(payload, offset);
+  offset += topic.length;
+
+  if (payload.length < offset + 2)
+    throw responseError(COMMAND_CODE.SendMessages, INVALID_COMMAND);
+  const partitioningKind = payload.readUInt8(offset);
+  const partitioningLength = payload.readUInt8(offset + 1);
+  const PARTITIONING_PARTITION_ID = 2;
+  if (partitioningKind !== PARTITIONING_PARTITION_ID)
+    throw responseError(COMMAND_CODE.SendMessages, FEATURE_UNAVAILABLE);
+  if (partitioningLength !== 4 || payload.length < offset + 2 + 4)
+    throw responseError(COMMAND_CODE.SendMessages, INVALID_COMMAND);
+  const partitionId = payload.readUInt32LE(offset + 2);
+
+  return namespaceFromIds(stream, topic, partitionId);
+};
+
+/**
+ * Consumer-offset requests: `[consumer kind u8][consumer ident]
+ * [stream ident][topic ident][partition flag u8][partition u32]...`.
+ */
+const namespaceFromConsumerOffset = (payload: Buffer): bigint => {
+  let offset = 1;
+  const consumer = peekIdentifier(payload, offset);
+  offset += consumer.length;
+  const stream = peekIdentifier(payload, offset);
+  offset += stream.length;
+  const topic = peekIdentifier(payload, offset);
+  offset += topic.length;
+
+  if (payload.length < offset + 5)
+    throw responseError(COMMAND_CODE.StoreOffset, INVALID_COMMAND);
+  const hasPartition = payload.readUInt8(offset) === 1;
+  if (!hasPartition)
+    throw responseError(COMMAND_CODE.StoreOffset, INVALID_IDENTIFIER);
+  const partitionId = payload.readUInt32LE(offset + 1);
+
+  return namespaceFromIds(stream, topic, partitionId);
+};
+
+/** `DeleteSegments`: `[stream ident][topic ident][partition u32]...`. */
+const namespaceFromDeleteSegments = (payload: Buffer): bigint => {
+  let offset = 0;
+  const stream = peekIdentifier(payload, offset);
+  offset += stream.length;
+  const topic = peekIdentifier(payload, offset);
+  offset += topic.length;
+
+  if (payload.length < offset + 4)
+    throw responseError(COMMAND_CODE.DeleteSegments, INVALID_COMMAND);
+  const partitionId = payload.readUInt32LE(offset);
+
+  return namespaceFromIds(stream, topic, partitionId);
+};

--- a/foreign/node/src/wire/vsr/operation.ts
+++ b/foreign/node/src/wire/vsr/operation.ts
@@ -1,0 +1,185 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+/**
+ * `Operation` values and classification, ported from
+ * `core/binary_protocol/src/consensus/operation.rs` and the command table in
+ * `core/binary_protocol/src/dispatch.rs`.
+ */
+
+import { COMMAND_CODE } from '../command.code.js';
+import { BINARY_REQUEST_KIND, type BinaryRequestKind } from '../command-set.js';
+import { responseError } from '../error.utils.js';
+
+/** `Operation` discriminants a client sends or receives. */
+export const Operation = {
+  Reserved: 0,
+  Register: 1,
+  NonReplicated: 2,
+  Logout: 3,
+  CreateStream: 128,
+  UpdateStream: 129,
+  DeleteStream: 130,
+  PurgeStream: 131,
+  CreateTopic: 132,
+  UpdateTopic: 133,
+  DeleteTopic: 134,
+  PurgeTopic: 135,
+  CreatePartitions: 136,
+  DeletePartitions: 137,
+  DeleteSegments: 138,
+  CreateConsumerGroup: 139,
+  DeleteConsumerGroup: 140,
+  CreateUser: 141,
+  UpdateUser: 142,
+  DeleteUser: 143,
+  ChangePassword: 144,
+  UpdatePermissions: 145,
+  CreatePersonalAccessToken: 146,
+  DeletePersonalAccessToken: 147,
+  JoinConsumerGroup: 148,
+  LeaveConsumerGroup: 149,
+  SendMessages: 160,
+  StoreConsumerOffset: 161,
+  DeleteConsumerOffset: 162,
+  StoreConsumerOffset2: 164,
+  DeleteConsumerOffset2: 165
+} as const;
+
+const INTERNAL_START = 64;
+const METADATA_START = 128;
+const PARTITION_START = 160;
+
+/** `IggyError::InvalidCommand` numeric code. */
+export const ERROR_CODE_INVALID_COMMAND = 3;
+/** `IggyError::FeatureUnavailable` numeric code. */
+export const ERROR_CODE_FEATURE_UNAVAILABLE = 5;
+
+/**
+ * Replicated command code to `Operation` mapping, the client half of the
+ * dispatch table. Codes absent here are non-replicated when the classic
+ * command set knows them, unknown otherwise.
+ */
+const REPLICATED_OPERATION: ReadonlyMap<number, number> = new Map([
+  [COMMAND_CODE.CreateUser, Operation.CreateUser],
+  [COMMAND_CODE.DeleteUser, Operation.DeleteUser],
+  [COMMAND_CODE.UpdateUser, Operation.UpdateUser],
+  [COMMAND_CODE.UpdatePermissions, Operation.UpdatePermissions],
+  [COMMAND_CODE.ChangePassword, Operation.ChangePassword],
+  [COMMAND_CODE.CreateAccessToken, Operation.CreatePersonalAccessToken],
+  [COMMAND_CODE.DeleteAccessToken, Operation.DeletePersonalAccessToken],
+  [COMMAND_CODE.SendMessages, Operation.SendMessages],
+  [COMMAND_CODE.StoreOffset, Operation.StoreConsumerOffset],
+  [COMMAND_CODE.DeleteConsumerOffset, Operation.DeleteConsumerOffset],
+  [COMMAND_CODE.StoreOffset2, Operation.StoreConsumerOffset2],
+  [COMMAND_CODE.DeleteConsumerOffset2, Operation.DeleteConsumerOffset2],
+  [COMMAND_CODE.CreateStream, Operation.CreateStream],
+  [COMMAND_CODE.DeleteStream, Operation.DeleteStream],
+  [COMMAND_CODE.UpdateStream, Operation.UpdateStream],
+  [COMMAND_CODE.PurgeStream, Operation.PurgeStream],
+  [COMMAND_CODE.CreateTopic, Operation.CreateTopic],
+  [COMMAND_CODE.DeleteTopic, Operation.DeleteTopic],
+  [COMMAND_CODE.UpdateTopic, Operation.UpdateTopic],
+  [COMMAND_CODE.PurgeTopic, Operation.PurgeTopic],
+  [COMMAND_CODE.CreatePartitions, Operation.CreatePartitions],
+  [COMMAND_CODE.DeletePartitions, Operation.DeletePartitions],
+  [COMMAND_CODE.DeleteSegments, Operation.DeleteSegments],
+  [COMMAND_CODE.CreateGroup, Operation.CreateConsumerGroup],
+  [COMMAND_CODE.DeleteGroup, Operation.DeleteConsumerGroup],
+  [COMMAND_CODE.JoinGroup, Operation.JoinConsumerGroup],
+  [COMMAND_CODE.LeaveGroup, Operation.LeaveConsumerGroup]
+]);
+
+/** Classic command codes known to the SDK. */
+const KNOWN_COMMAND_CODES: ReadonlySet<number> =
+  new Set(Object.values(COMMAND_CODE));
+
+/** Internal band, never client-sent. */
+export const isInternal = (operation: number): boolean =>
+  operation >= INTERNAL_START && operation < METADATA_START;
+
+/**
+ * Metadata classification is an explicit allowlist, not a range:
+ * `DeleteSegments` (138) sits inside the band but resolves to a partition
+ * truncation server-side, so it is deliberately excluded. Port of
+ * `Operation::is_metadata`.
+ */
+export const isMetadata = (operation: number): boolean => {
+  if (isInternal(operation)) return true;
+  if (operation === Operation.DeleteSegments) return false;
+  return operation >= METADATA_START && operation < PARTITION_START;
+};
+
+/** Partition band is a bare range, mirroring `Operation::is_partition`. */
+export const isPartition = (operation: number): boolean =>
+  operation >= PARTITION_START;
+
+/** Whether a reply body leads with a committed result section. */
+export const isResultFramed = (operation: number): boolean =>
+  isMetadata(operation) ||
+  operation === Operation.StoreConsumerOffset ||
+  operation === Operation.StoreConsumerOffset2 ||
+  operation === Operation.DeleteConsumerOffset ||
+  operation === Operation.DeleteConsumerOffset2;
+
+/**
+ * Picks the header operation for a command code, honoring the caller's
+ * declaration only where the protocol tables have nothing to say. Standard
+ * codes resolve first so a caller cannot redirect a shipped command into the
+ * other execution model. Port of `operation_for_code` in
+ * `core/sdk/src/vsr.rs`.
+ *
+ * @throws Error with the invalid-command code for a conflicting declaration
+ *   or an undeclared unknown code, and feature-unavailable for an unknown
+ *   code declared replicated.
+ */
+export const operationForCode = (
+  code: number,
+  kind?: BinaryRequestKind
+): number => {
+  if (code === COMMAND_CODE.LogoutUser)
+    return acceptDeclaration(code, Operation.Logout, kind);
+
+  const replicated = REPLICATED_OPERATION.get(code);
+  if (replicated !== undefined)
+    return acceptDeclaration(code, replicated, kind);
+
+  if (KNOWN_COMMAND_CODES.has(code))
+    return acceptDeclaration(code, Operation.NonReplicated, kind);
+
+  if (kind === BINARY_REQUEST_KIND.NonReplicated)
+    return Operation.NonReplicated;
+  if (kind === BINARY_REQUEST_KIND.Replicated)
+    // A replicated extension needs a server-side handler registry that does
+    // not exist yet; failing closed beats a half-supported frame.
+    throw responseError(code, ERROR_CODE_FEATURE_UNAVAILABLE);
+  throw responseError(code, ERROR_CODE_INVALID_COMMAND);
+};
+
+const acceptDeclaration = (
+  code: number,
+  operation: number,
+  kind?: BinaryRequestKind
+): number => {
+  if (kind === undefined) return operation;
+  const standard = operation === Operation.NonReplicated ?
+    BINARY_REQUEST_KIND.NonReplicated :
+    BINARY_REQUEST_KIND.Replicated;
+  if (kind === standard) return operation;
+  throw responseError(code, ERROR_CODE_INVALID_COMMAND);
+};

--- a/foreign/node/src/wire/vsr/register.ts
+++ b/foreign/node/src/wire/vsr/register.ts
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+/**
+ * The Register (login) handshake bodies and reply, ported from
+ * `core/binary_protocol/src/requests/users/login_register.rs` and
+ * `responses/users/login_register.rs`. server-ng rejects the legacy login
+ * codes with a `MalformedLogin` eviction, so a VSR client must emit
+ * `LoginRegister` / `LoginRegisterWithPat` and nothing else.
+ */
+
+import { DeserializeError } from '../error.utils.js';
+
+/**
+ * Packed protocol semver of the wire contract this port implements,
+ * `pack(0, 10, 3)` per `core/binary_protocol/src/version.rs`. Bump together
+ * with the Rust `IGGY_PROTOCOL_VERSION` on any wire-incompatible change.
+ */
+export const IGGY_PROTOCOL_VERSION = (0 << 20) | (10 << 10) | 3;
+
+const SDK_NAME = 'node-sdk';
+
+const wireName = (value: string): Buffer => {
+  const bytes = Buffer.from(value, 'utf8');
+  if (bytes.length < 1 || bytes.length > 255)
+    throw new Error(`wire name must be 1..255 bytes, got ${bytes.length}`);
+  return Buffer.concat([Buffer.from([bytes.length]), bytes]);
+};
+
+const versionInfo = (sdkVersion: string): Buffer => {
+  const version = Buffer.alloc(4);
+  version.writeUInt32LE(IGGY_PROTOCOL_VERSION);
+  return Buffer.concat([version, wireName(SDK_NAME), wireName(sdkVersion)]);
+};
+
+/**
+ * `LoginRegisterRequest` body:
+ * `[ClientVersionInfo][username len u8 + bytes][password len u8 + bytes]
+ * [context len u32][context]`.
+ */
+export const serializeLoginRegister = (
+  username: string,
+  password: string,
+  sdkVersion: string
+): Buffer => {
+  const passwordBytes = Buffer.from(password, 'utf8');
+  if (passwordBytes.length > 255)
+    throw new Error('password exceeds the u8 length prefix');
+  return Buffer.concat([
+    versionInfo(sdkVersion),
+    wireName(username),
+    Buffer.from([passwordBytes.length]),
+    passwordBytes,
+    Buffer.alloc(4)
+  ]);
+};
+
+/** `LoginRegisterWithPatRequest` body: the PAT takes the credential slot. */
+export const serializeLoginRegisterWithPat = (
+  token: string,
+  sdkVersion: string
+): Buffer => {
+  const tokenBytes = Buffer.from(token, 'utf8');
+  if (tokenBytes.length > 255)
+    throw new Error('token exceeds the u8 length prefix');
+  return Buffer.concat([
+    versionInfo(sdkVersion),
+    Buffer.from([tokenBytes.length]),
+    tokenBytes,
+    Buffer.alloc(4)
+  ]);
+};
+
+/** Decoded `LoginRegisterResponse`. */
+export type LoginRegisterResponse = {
+  userId: number,
+  session: bigint,
+  serverProtocolVersion: number,
+  serverVersion: string
+};
+
+/**
+ * `[user_id u32][session u64][server_protocol_version u32]
+ * [server_version len u8 + bytes]`.
+ */
+export const deserializeLoginRegister = (
+  body: Buffer
+): LoginRegisterResponse => {
+  if (body.length < 17)
+    throw new DeserializeError(
+      `login register response too short: ${body.length} bytes`);
+  const versionLength = body.readUInt8(16);
+  if (body.length < 17 + versionLength)
+    throw new DeserializeError('login register response truncated');
+  return {
+    userId: body.readUInt32LE(0),
+    session: body.readBigUInt64LE(4),
+    serverProtocolVersion: body.readUInt32LE(12),
+    serverVersion: body.subarray(17, 17 + versionLength).toString('utf8')
+  };
+};

--- a/foreign/node/src/wire/vsr/reply.ts
+++ b/foreign/node/src/wire/vsr/reply.ts
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+/**
+ * Reply decode funnel, ported from `decode_response` in
+ * `core/sdk/src/vsr.rs`. Strict order: frame length, frame discriminant
+ * (evictions surface as typed errors, never a read timeout), declared size,
+ * pre-commit denial status before any body decode, then the committed
+ * result section for result-framed operations.
+ */
+
+import { responseError } from '../error.utils.js';
+import {
+  Command2, EvictionReason, HEADER_SIZE,
+  peekCommand, readEviction, readReplyOperation, readSize, readStatus
+} from './header.js';
+import { Operation, isResultFramed } from './operation.js';
+
+/** `IggyError` codes this funnel raises client-side. */
+const INVALID_COMMAND = 3;
+const UNAUTHENTICATED = 40;
+const INVALID_CREDENTIALS = 42;
+const INVALID_PERSONAL_ACCESS_TOKEN = 53;
+const STALE_CLIENT = 30;
+const INVALID_FORMAT = 4;
+const EMPTY_RESPONSE = 304;
+const INCOMPATIBLE_PROTOCOL_VERSION = 14003;
+
+const RESULT_COUNT_LEN = 4;
+const RESULT_ENTRY_LEN = 8;
+
+/**
+ * Decodes one complete consensus frame into the reply body, stripping the
+ * committed result section for result-framed operations and mapping every
+ * denial channel to a thrown error.
+ */
+export const decodeResponse = (frame: Buffer): Buffer => {
+  if (frame.length < HEADER_SIZE)
+    throw responseError(0, EMPTY_RESPONSE);
+
+  switch (peekCommand(frame)) {
+    case Command2.Eviction:
+      throw evictionError(frame);
+    case Command2.Reply:
+      break;
+    default:
+      throw responseError(0, INVALID_COMMAND);
+  }
+
+  const size = readSize(frame);
+  if (size < HEADER_SIZE || frame.length < size)
+    throw responseError(0, INVALID_COMMAND);
+
+  const status = readStatus(frame);
+  // A pre-commit denial always ships an empty body; the status channel and
+  // the committed result section are mutually exclusive.
+  if (status !== 0)
+    throw responseError(0, status);
+
+  const operation = readReplyOperation(frame);
+  const body = frame.subarray(HEADER_SIZE, size);
+  return splitMetadataResult(operation, body);
+};
+
+/**
+ * Strips the committed result section leading a result-framed reply body.
+ * A Register reply is result-framed too, except a terminal register failure
+ * ships an empty body, passed through so the typed decode fails. A metadata
+ * body too short for the entries its count claims is corruption, never a
+ * silent success.
+ */
+export const splitMetadataResult = (
+  operation: number,
+  body: Buffer
+): Buffer => {
+  const resultFramed = isResultFramed(operation) ||
+    (operation === Operation.Register && body.length > 0);
+  if (!resultFramed) return body;
+
+  if (body.length < RESULT_COUNT_LEN)
+    throw responseError(0, INVALID_COMMAND);
+  const count = body.readUInt32LE(0);
+  const sectionLength = RESULT_COUNT_LEN + count * RESULT_ENTRY_LEN;
+  if (body.length < sectionLength)
+    throw responseError(0, INVALID_COMMAND);
+  if (count === 0)
+    return body.subarray(RESULT_COUNT_LEN);
+  // First entry: {index u32, result u32}; result shares the IggyError space.
+  const code = body.readUInt32LE(RESULT_COUNT_LEN + 4);
+  throw responseError(0, code);
+};
+
+/**
+ * Maps a session-terminal eviction frame to a typed error, the same mapping
+ * as `eviction_reason_to_error` in `core/common`. An invalid protocol window
+ * degrades to an authentication error rather than trusting the remote frame.
+ */
+export const evictionError = (frame: Buffer): Error => {
+  const eviction = readEviction(frame);
+  switch (eviction.reason) {
+    case EvictionReason.InvalidCredentials:
+      return responseError(0, INVALID_CREDENTIALS);
+    case EvictionReason.InvalidToken:
+      return responseError(0, INVALID_PERSONAL_ACCESS_TOKEN);
+    case EvictionReason.UserInactive:
+    case EvictionReason.SessionError:
+    case EvictionReason.NoSession:
+    case EvictionReason.SessionTooLow:
+    case EvictionReason.SessionReleaseMismatch:
+      return responseError(0, UNAUTHENTICATED);
+    case EvictionReason.StaleClient:
+      return responseError(0, STALE_CLIENT);
+    case EvictionReason.IncompatibleProtocol:
+      if (eviction.serverProtocolVersionMin === 0 ||
+        eviction.serverProtocolVersion < eviction.serverProtocolVersionMin)
+        return responseError(0, UNAUTHENTICATED);
+      return responseError(0, INCOMPATIBLE_PROTOCOL_VERSION);
+    case EvictionReason.MalformedLogin:
+      return responseError(0, INVALID_FORMAT);
+    default:
+      return responseError(0, INVALID_COMMAND);
+  }
+};

--- a/foreign/node/src/wire/vsr/session.ts
+++ b/foreign/node/src/wire/vsr/session.ts
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Consensus-level session state, ported from `core/sdk/src/session.rs`.
+ *
+ * Each client instance generates an ephemeral random `clientId` (u128).
+ * After a Register commits, the server assigns a `session` number (commit op
+ * number). Replicated metadata requests advance a monotonic request id;
+ * non-replicated and partition-plane requests read the current id without
+ * advancing it, because the server's `ClientTable` only tracks ids for
+ * replicated metadata ops and a consumed id would gap the next one, which the
+ * primary silently drops (`RequestGap`).
+ */
+export class ConsensusSession {
+  private _clientId: bigint;
+  private _session: bigint | null;
+  private requestCounter: bigint;
+  private registerConsumed: boolean;
+
+  constructor(clientId?: bigint) {
+    this._clientId = clientId ?? generateClientId();
+    this._session = null;
+    this.requestCounter = 1n;
+    this.registerConsumed = false;
+  }
+
+  get clientId(): bigint {
+    return this._clientId;
+  }
+
+  /** The bound session number, or null before Register commits. */
+  get session(): bigint | null {
+    return this._session;
+  }
+
+  get isBound(): boolean {
+    return this._session !== null;
+  }
+
+  /** Binds the session after Register commits through consensus. */
+  bind(session: bigint): void {
+    if (this._session !== null)
+      throw new Error(`session already bound (session=${this._session})`);
+    if (session <= 0n)
+      throw new Error('session must be > 0');
+    this._session = session;
+  }
+
+  /**
+   * Begins a registration, re-arming the session for a re-login. A prior
+   * consumed or bound session is replaced wholesale (fresh client id,
+   * unbound), so a repeat login encodes a clean Register instead of tripping
+   * the one-shot guard. Returns the register request id, always 0.
+   */
+  beginRegister(): bigint {
+    if (this.registerConsumed || this.isBound) {
+      this._clientId = generateClientId();
+      this._session = null;
+      this.requestCounter = 1n;
+      this.registerConsumed = false;
+    }
+    this.registerConsumed = true;
+    return 0n;
+  }
+
+  /**
+   * Next application request id, advancing the counter: 1, 2, 3, ...
+   * Request 0 is reserved for Register.
+   */
+  nextRequestId(): bigint {
+    if (!this.isBound)
+      throw new Error('nextRequestId called before bind');
+    const id = this.requestCounter;
+    this.requestCounter += 1n;
+    return id;
+  }
+
+  /** Current counter value without advancing it. */
+  currentRequestId(): bigint {
+    return this.requestCounter;
+  }
+}
+
+/** Ephemeral random u128, non-zero (retry on the astronomically unlikely 0). */
+const generateClientId = (): bigint => {
+  for (;;) {
+    const id = randomBytes(16).reduce(
+      (acc, byte) => (acc << 8n) | BigInt(byte), 0n);
+    if (id !== 0n) return id;
+  }
+};

--- a/foreign/node/src/wire/vsr/vsr.test.ts
+++ b/foreign/node/src/wire/vsr/vsr.test.ts
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { BINARY_REQUEST_KIND } from '../command-set.js';
+import { REQUEST_OFFSET } from './header.js';
+import { VsrSession } from './index.js';
+import { Operation } from './operation.js';
+
+describe('VSR custom request framing', () => {
+  it('encodes a custom non-replicated code and opaque payload', () => {
+    const session = new VsrSession();
+    const payload = Buffer.from([0xAA, 0xBB, 0xCC]);
+    const frame = session.encode(
+      60_000,
+      payload,
+      BINARY_REQUEST_KIND.NonReplicated
+    );
+
+    assert.equal(frame.readUInt8(REQUEST_OFFSET.operation), Operation.NonReplicated);
+    assert.equal(frame.readUInt32LE(REQUEST_OFFSET.reserved), 60_000);
+    assert.deepEqual(frame.subarray(256), payload);
+  });
+
+  it('rejects a custom replicated code without a server registry', () => {
+    const session = new VsrSession();
+    assert.throws(
+      () => session.encode(
+        60_000,
+        Buffer.alloc(0),
+        BINARY_REQUEST_KIND.Replicated
+      ),
+      /Feature is unavailable/
+    );
+  });
+});

--- a/foreign/php/Cargo.toml
+++ b/foreign/php/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "iggy-php"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Iggy Committers <dev@iggy.apache.org>"]
 license = "Apache-2.0"
@@ -27,6 +27,12 @@ repository = "https://github.com/apache/iggy"
 
 [lib]
 crate-type = ["cdylib"]
+
+# Framing is a compile-time choice, so a built extension is locked to whatever it
+# was compiled with. Opt in with `--features vsr` to build against the consensus
+# protocol; the default build stays on the classic protocol.
+[features]
+vsr = ["iggy/vsr"]
 
 [dependencies]
 bytes = "1.11.1"

--- a/foreign/php/README.md
+++ b/foreign/php/README.md
@@ -214,8 +214,13 @@ iggy+tcp://iggy:iggy@127.0.0.1:8090?tls=true&tls_domain=localhost&tls_ca_file=/p
   be read repeatedly.
 - Large unsigned values that can overflow PHP integers, such as message checksums,
   are returned as decimal strings.
-- `Iggy\Client::sendBinaryRequest(int $code, string $payload): string` sends a
-  command code and payload and returns the raw response body.
+- `Iggy\Client::sendBinaryRequest(string $kind, int $code, string $payload): string`
+  sends a command code and payload and returns the raw response body. `$kind` is
+  `'non_replicated'` or `'replicated'`. The kind is inert on classic framing (both
+  kinds encode identical bytes and the server decides); it only selects a wire
+  path when the extension is built with `vsr`.
+- Framing is chosen at compile time. Build the extension with `--features vsr` to
+  speak the consensus protocol; the default build uses the classic protocol.
 - `Iggy\Client` is synchronous and blocks the current PHP thread.
 - The extension owns a lazy global Tokio runtime. Do not call `pcntl_fork()` after
   the first Iggy SDK call; the child process inherits file descriptors but not

--- a/foreign/php/iggy-php.stubs.php
+++ b/foreign/php/iggy-php.stubs.php
@@ -211,11 +211,16 @@ namespace Iggy {
          * Sends a command code with a payload and returns the raw response bytes.
          * Session-control codes return an invalid-command exception.
          *
+         * `kind` is `non_replicated` or `replicated`. Inert on classic framing
+         * (both kinds encode identical bytes and the server decides); it only
+         * selects a wire path when the extension is built with `vsr`.
+         *
+         * @param string $kind
          * @param int $code
          * @param string $payload
          * @return string
          */
-        public function sendBinaryRequest(int $code, string $payload): string {}
+        public function sendBinaryRequest(string $kind, int $code, string $payload): string {}
 
         /**
          * Sends messages to a topic.

--- a/foreign/php/src/client.rs
+++ b/foreign/php/src/client.rs
@@ -380,12 +380,25 @@ impl IggyClient {
 
     /// Sends a command code with a payload and returns the raw response bytes.
     /// Session-control codes return an invalid-command exception.
-    pub fn send_binary_request(&self, code: u32, payload: Binary<u8>) -> PhpResult<Binary<u8>> {
+    ///
+    /// `kind` is `non_replicated` or `replicated`. Inert on classic framing
+    /// (both kinds encode identical bytes and the server decides); it only
+    /// selects a wire path when the extension is built with `vsr`.
+    pub fn send_binary_request(
+        &self,
+        kind: String,
+        code: u32,
+        payload: Binary<u8>,
+    ) -> PhpResult<Binary<u8>> {
+        // A distinct message from the server's "invalid command", so a caller
+        // can tell a mistyped kind from a rejected code.
+        let kind = BinaryRequestKind::from_str(&kind)
+            .map_err(|_| to_php_exception(format!("invalid binary request kind: {kind}")))?;
         let inner = self.inner.clone();
 
         runtime().block_on(async move {
             inner
-                .send_binary_request(code, Bytes::from(Vec::<u8>::from(payload)))
+                .send_binary_request(kind, code, Bytes::from(Vec::<u8>::from(payload)))
                 .await
                 .map(|response| Binary::new(Vec::from(response)))
                 .map_err(to_php_exception)

--- a/foreign/php/tests/RawCommandTest.php
+++ b/foreign/php/tests/RawCommandTest.php
@@ -27,14 +27,18 @@ final class RawCommandTest extends TestCase
 {
     private const PING_CODE = 1;
     private const GET_STATS_CODE = 10;
-    private const UNKNOWN_CODE = 60_000;
+    private const NON_REPLICATED = 'non_replicated';
+    private const REPLICATED = 'replicated';
+
+    /** No server registers a handler for this code. */
+    private const VENDOR_CODE = 60_001;
 
     #[TestDox('A raw ping command returns an empty successful response')]
     public function testRawPingReturnsEmptyResponse(): void
     {
         $client = new_client();
 
-        $response = $client->sendBinaryRequest(self::PING_CODE, '');
+        $response = $client->sendBinaryRequest(self::NON_REPLICATED, self::PING_CODE, '');
 
         assert_same('', $response);
     }
@@ -44,34 +48,82 @@ final class RawCommandTest extends TestCase
     {
         $client = new_client();
 
-        $response = $client->sendBinaryRequest(self::GET_STATS_CODE, '');
+        $response = $client->sendBinaryRequest(self::NON_REPLICATED, self::GET_STATS_CODE, '');
 
         assert_true($response !== '', 'expected a non-empty stats response');
     }
 
     #[TestDox('A session-control code is rejected before reaching the server')]
     #[DataProvider('sessionControlCodes')]
-    public function testRawSessionControlCodeIsRejected(int $code): void
+    public function testRawSessionControlCodeIsRejected(string $kind, int $code): void
     {
         $client = new_client();
 
-        $throwable = assert_throws(static fn () => $client->sendBinaryRequest($code, ''));
+        $throwable = assert_throws(static fn () => $client->sendBinaryRequest($kind, $code, ''));
 
         assert_instance_of(IggyException::class, $throwable);
     }
 
-    #[TestDox('An unknown command code is rejected by the server')]
-    public function testRawUnknownCodeIsRejectedByServer(): void
+    #[TestDox('A vendor command code is rejected and the connection stays usable')]
+    public function testRawVendorCodeIsRejectedByServer(): void
     {
         $client = new_client();
 
-        $throwable = assert_throws(static fn () => $client->sendBinaryRequest(self::UNKNOWN_CODE, ''));
+        $throwable = assert_throws(
+            static fn () => $client->sendBinaryRequest(self::NON_REPLICATED, self::VENDOR_CODE, '')
+        );
 
         assert_instance_of(IggyException::class, $throwable);
+        assert_same('', $client->sendBinaryRequest(self::NON_REPLICATED, self::PING_CODE, ''));
+    }
+
+    #[TestDox('A replicated vendor command code has no handler')]
+    public function testRawReplicatedVendorCodeIsRejected(): void
+    {
+        $client = new_client();
+
+        $throwable = assert_throws(
+            static fn () => $client->sendBinaryRequest(self::REPLICATED, self::VENDOR_CODE, '')
+        );
+
+        assert_instance_of(IggyException::class, $throwable);
+    }
+
+    #[TestDox('A replicated declaration on a standard command is inert on classic framing')]
+    public function testRawReplicatedDeclarationIsIgnoredOnClassicFraming(): void
+    {
+        $client = new_client();
+
+        $response = $client->sendBinaryRequest(self::REPLICATED, self::GET_STATS_CODE, '');
+
+        assert_true($response !== '', 'expected a non-empty stats response');
+    }
+
+    #[TestDox('An unknown request kind is rejected')]
+    public function testRawUnknownKindIsRejected(): void
+    {
+        $client = new_client();
+
+        $throwable = assert_throws(static fn () => $client->sendBinaryRequest('auto', self::PING_CODE, ''));
+
+        assert_instance_of(IggyException::class, $throwable);
+        // Distinct from the server's "invalid command", so a mistyped kind is
+        // never mistaken for a rejected code.
+        assert_true(
+            str_contains($throwable->getMessage(), 'invalid binary request kind'),
+            'expected the kind-specific rejection message'
+        );
     }
 
     public static function sessionControlCodes(): array
     {
-        return [[38], [39], [40], [44], [45]];
+        $cases = [];
+        foreach ([self::NON_REPLICATED, self::REPLICATED] as $kind) {
+            foreach ([38, 39, 40, 44, 45] as $code) {
+                $cases[] = [$kind, $code];
+            }
+        }
+
+        return $cases;
     }
 }

--- a/foreign/python/Cargo.toml
+++ b/foreign/python/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "apache-iggy"
-version = "0.8.1-dev3"
+version = "0.8.1-dev4"
 edition = "2024"
 authors = ["Iggy Committers <dev@iggy.apache.org>"]
 license = "Apache-2.0"
@@ -34,10 +34,16 @@ name = "stub_gen"
 path = "src/bin/stub_gen.rs"
 doc = false
 
+# Framing is a compile-time choice, so a published wheel is locked to whatever it
+# was built with. Opt in with `--features vsr` to build a consensus-protocol wheel;
+# the default build stays on the classic protocol.
+[features]
+vsr = ["iggy/vsr"]
+
 [dependencies]
 bytes = "1.12.1"
 futures = "0.3.33"
-iggy = { path = "../../core/sdk", version = "0.10.3-edge.2" }
+iggy = { path = "../../core/sdk", version = "0.10.3-edge.3" }
 pyo3 = "0.29.0"
 pyo3-async-runtimes = { version = "0.29.0", features = [
     "attributes",

--- a/foreign/python/apache_iggy.pyi
+++ b/foreign/python/apache_iggy.pyi
@@ -29,6 +29,7 @@ __all__ = [
     "AutoCommit",
     "AutoCommitAfter",
     "AutoCommitWhen",
+    "BinaryRequestKind",
     "ConsumerGroup",
     "ConsumerGroupDetails",
     "ConsumerGroupMember",
@@ -726,7 +727,7 @@ class IggyClient:
         Returns the consumer or a PyRuntimeError on failure.
         """
     def send_binary_request(
-        self, code: builtins.int, payload: builtins.bytes
+        self, kind: BinaryRequestKind, code: builtins.int, payload: builtins.bytes
     ) -> collections.abc.Awaitable[bytes]:
         r"""
         Send a command code with a payload and return the raw response bytes.
@@ -735,6 +736,10 @@ class IggyClient:
         support raw binary commands.
 
         Args:
+            kind: How the command executes, as `BinaryRequestKind`. Inert on
+                classic framing (both kinds encode identical bytes and the
+                server decides); it only selects a wire path when the binding
+                is built with `vsr`.
             code: Command code as `int`.
             payload: Request payload as `bytes`.
 
@@ -1017,6 +1022,24 @@ class UserInfoDetails:
         r"""
         The username of the user.
         """
+
+@typing.final
+class BinaryRequestKind(enum.Enum):
+    r"""
+    How a raw binary request executes on the server.
+    """
+
+    NonReplicated = ...
+    r"""
+    Runs on the receiving node only, outside consensus.
+    """
+    Replicated = ...
+    r"""
+    Replicated through consensus before it takes effect. Inert on classic
+    framing, where both kinds encode identical bytes; under `vsr` an
+    unknown code declared this way is rejected until the server grows a
+    replicated extension registry.
+    """
 
 @typing.final
 class UserStatus(enum.Enum):

--- a/foreign/python/pyproject.toml
+++ b/foreign/python/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "maturin"
 [project]
 name = "apache-iggy"
 requires-python = ">=3.10"
-version = "0.8.1.dev3"
+version = "0.8.1.dev4"
 description = "Apache Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/foreign/python/src/binary_request_kind.rs
+++ b/foreign/python/src/binary_request_kind.rs
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use iggy::prelude::BinaryRequestKind as RustBinaryRequestKind;
+use pyo3::prelude::*;
+use pyo3_stub_gen::derive::gen_stub_pyclass_enum;
+
+/// How a raw binary request executes on the server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[gen_stub_pyclass_enum]
+#[pyclass(eq, from_py_object)]
+pub enum BinaryRequestKind {
+    /// Runs on the receiving node only, outside consensus.
+    NonReplicated,
+    /// Replicated through consensus before it takes effect. Inert on classic
+    /// framing, where both kinds encode identical bytes; under `vsr` an
+    /// unknown code declared this way is rejected until the server grows a
+    /// replicated extension registry.
+    Replicated,
+}
+
+impl From<BinaryRequestKind> for RustBinaryRequestKind {
+    fn from(kind: BinaryRequestKind) -> Self {
+        match kind {
+            BinaryRequestKind::NonReplicated => RustBinaryRequestKind::NonReplicated,
+            BinaryRequestKind::Replicated => RustBinaryRequestKind::Replicated,
+        }
+    }
+}
+
+impl From<RustBinaryRequestKind> for BinaryRequestKind {
+    fn from(kind: RustBinaryRequestKind) -> Self {
+        match kind {
+            RustBinaryRequestKind::NonReplicated => BinaryRequestKind::NonReplicated,
+            RustBinaryRequestKind::Replicated => BinaryRequestKind::Replicated,
+        }
+    }
+}

--- a/foreign/python/src/client.rs
+++ b/foreign/python/src/client.rs
@@ -17,7 +17,8 @@
 
 use bytes::Bytes;
 use iggy::prelude::{
-    Consumer as RustConsumer, IggyClient as RustIggyClient, IggyMessage as RustMessage,
+    BinaryRequestKind as RustBinaryRequestKind, Consumer as RustConsumer,
+    IggyClient as RustIggyClient, IggyMessage as RustMessage,
     PollingStrategy as RustPollingStrategy, *,
 };
 use pyo3::PyRef;
@@ -29,6 +30,7 @@ use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::binary_request_kind::BinaryRequestKind;
 use crate::consumer::{
     AutoCommit, ConsumerGroup as PyConsumerGroup, ConsumerGroupDetails as PyConsumerGroupDetails,
     IggyConsumer, py_delta_to_iggy_duration,
@@ -975,6 +977,10 @@ impl IggyClient {
     /// support raw binary commands.
     ///
     /// Args:
+    ///     kind: How the command executes, as `BinaryRequestKind`. Inert on
+    ///         classic framing (both kinds encode identical bytes and the
+    ///         server decides); it only selects a wire path when the binding
+    ///         is built with `vsr`.
     ///     code: Command code as `int`.
     ///     payload: Request payload as `bytes`.
     ///
@@ -987,13 +993,15 @@ impl IggyClient {
     fn send_binary_request<'a>(
         &self,
         py: Python<'a>,
+        kind: BinaryRequestKind,
         code: u32,
         #[gen_stub(override_type(type_repr = "builtins.bytes"))] payload: Vec<u8>,
     ) -> PyResult<Bound<'a, PyAny>> {
         let inner = self.inner.clone();
+        let kind = RustBinaryRequestKind::from(kind);
         future_into_py(py, async move {
             let response = inner
-                .send_binary_request(code, Bytes::from(payload))
+                .send_binary_request(kind, code, Bytes::from(payload))
                 .await
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
             Ok(Python::attach(|py| PyBytes::new(py, &response).unbind()))

--- a/foreign/python/src/lib.rs
+++ b/foreign/python/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+mod binary_request_kind;
 pub mod client;
 mod consumer;
 mod identifier;
@@ -24,6 +25,7 @@ mod stream;
 mod topic;
 mod user;
 
+use binary_request_kind::BinaryRequestKind;
 use client::IggyClient;
 use consumer::{
     AutoCommit, AutoCommitAfter, AutoCommitWhen, ConsumerGroup, ConsumerGroupDetails,
@@ -57,5 +59,6 @@ fn apache_iggy(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<UserStatus>()?;
     m.add_class::<UserInfo>()?;
     m.add_class::<UserInfoDetails>()?;
+    m.add_class::<BinaryRequestKind>()?;
     Ok(())
 }

--- a/foreign/python/tests/test_raw_command.py
+++ b/foreign/python/tests/test_raw_command.py
@@ -15,33 +15,87 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import cast
+
 import pytest
 
-from apache_iggy import IggyClient
+from apache_iggy import BinaryRequestKind, IggyClient
+
+KINDS = [BinaryRequestKind.NonReplicated, BinaryRequestKind.Replicated]
+
+# No server registers a handler for this code, and it sits past every range the
+# protocol assigns.
+VENDOR_CODE = 60_001
 
 
 @pytest.mark.asyncio
 async def test_raw_ping_returns_empty_response(iggy_client: IggyClient):
-    response = await iggy_client.send_binary_request(1, b"")
+    response = await iggy_client.send_binary_request(
+        BinaryRequestKind.NonReplicated, 1, b""
+    )
 
     assert response == b""
 
 
 @pytest.mark.asyncio
 async def test_raw_get_stats_returns_non_empty_response(iggy_client: IggyClient):
-    response = await iggy_client.send_binary_request(10, b"")
+    response = await iggy_client.send_binary_request(
+        BinaryRequestKind.NonReplicated, 10, b""
+    )
 
     assert response
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("code", [38, 39, 40, 44, 45])
-async def test_raw_session_control_code_is_rejected(iggy_client: IggyClient, code: int):
-    with pytest.raises(RuntimeError, match="(?i)invalid command"):
-        await iggy_client.send_binary_request(code, b"")
+async def test_raw_replicated_declaration_is_ignored_on_classic_framing(
+    iggy_client: IggyClient,
+):
+    # The kind is inert on classic framing, so a replicated declaration on a
+    # standard command still succeeds.
+    response = await iggy_client.send_binary_request(
+        BinaryRequestKind.Replicated, 10, b""
+    )
+
+    assert response
 
 
 @pytest.mark.asyncio
-async def test_raw_unknown_code_is_rejected_by_server(iggy_client: IggyClient):
+async def test_raw_undefined_kind_is_rejected_before_sending(
+    iggy_client: IggyClient,
+):
+    # The cast defeats the static signature on purpose: the runtime boundary
+    # itself must reject a value that is not a BinaryRequestKind.
+    with pytest.raises(TypeError):
+        await iggy_client.send_binary_request(cast(BinaryRequestKind, "auto"), 1, b"")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", KINDS)
+@pytest.mark.parametrize("code", [38, 39, 40, 44, 45])
+async def test_raw_session_control_code_is_rejected(
+    iggy_client: IggyClient, kind: BinaryRequestKind, code: int
+):
     with pytest.raises(RuntimeError, match="(?i)invalid command"):
-        await iggy_client.send_binary_request(60_000, b"")
+        await iggy_client.send_binary_request(kind, code, b"")
+
+
+@pytest.mark.asyncio
+async def test_raw_vendor_code_is_rejected_by_server(iggy_client: IggyClient):
+    with pytest.raises(RuntimeError, match="(?i)invalid command"):
+        await iggy_client.send_binary_request(
+            BinaryRequestKind.NonReplicated, VENDOR_CODE, b""
+        )
+
+    # The rejection is request-level, so the connection stays usable.
+    assert (
+        await iggy_client.send_binary_request(BinaryRequestKind.NonReplicated, 1, b"")
+        == b""
+    )
+
+
+@pytest.mark.asyncio
+async def test_raw_replicated_vendor_code_has_no_handler(iggy_client: IggyClient):
+    with pytest.raises(RuntimeError):
+        await iggy_client.send_binary_request(
+            BinaryRequestKind.Replicated, VENDOR_CODE, b""
+        )

--- a/foreign/python/uv.lock
+++ b/foreign/python/uv.lock
@@ -12,7 +12,7 @@ exclude-newer-span = "P7D"
 
 [[package]]
 name = "apache-iggy"
-version = "0.8.1.dev3"
+version = "0.8.1.dev4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
The raw command path only accepted codes the SDK already knew.
Under VSR, its closed operation table rejected unknown codes before
any bytes left the client, so the raw API was not actually open.

Make replication kind explicit across all nine SDKs in one deliberate
API break. Classic transports ignore the declaration and retain
byte-identical framing.

Rust now applies the declaration to VSR framing, and Python inherits
that behavior through its Rust bindings. Add native VSR framing to the
TypeScript SDK, selected at runtime with `protocol: "vsr"`.

The TypeScript client now implements registration, session and request
tracking, operation and namespace routing, committed reply decoding,
evictions, transient retries, leader redirects, and consumer-group
assignment synchronization.

Protocol tables remain authoritative. A shipped code keeps its class,
an unknown non-replicated code is forwarded for the server to judge,
and an unknown replicated code fails until a replicated extension
registry exists. Login and logout remain rejected before any I/O on
every transport.