### PR TITLE
feat(server-ng): harden configuration surface

### DIFF
--- a/core/configs/src/lib.rs
+++ b/core/configs/src/lib.rs
@@ -30,6 +30,7 @@ pub use server_config::{
     tcp, validators, websocket,
 };
 pub use server_ng_config::{
-    COMPONENT_NG, cluster as ng_cluster, message_bus, metadata as ng_metadata, quic as ng_quic,
-    server_ng, sharding as ng_sharding, tcp as ng_tcp, websocket as ng_websocket,
+    COMPONENT_NG, cluster as ng_cluster, message_bus, metadata as ng_metadata,
+    partition as ng_partition, quic as ng_quic, server_ng, sharding as ng_sharding, tcp as ng_tcp,
+    websocket as ng_websocket,
 };

--- a/core/configs/src/server_ng_config/cluster.rs
+++ b/core/configs/src/server_ng_config/cluster.rs
@@ -34,9 +34,47 @@ use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::str::FromStr;
 use std::time::Duration;
 
-/// The primary heartbeats roughly every second (`PING_TICKS`); a window at
-/// or below one ping interval would elect on every scheduling hiccup.
+/// Absolute floor for the backup liveness window, independent of the
+/// commit-broadcast rate. The primary signals liveness through its commit
+/// broadcast (`commit_broadcast_interval`, 500ms by default); 2s spans several
+/// broadcasts, so a single delayed one never elects. The per-config
+/// `MIN_HEARTBEAT_TO_COMMIT_BROADCAST_RATIO` check scales the same headroom
+/// when the broadcast interval is retuned.
 pub const MIN_CLUSTER_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The backup liveness window (`heartbeat_timeout`) must span at least this
+/// many commit broadcasts (`commit_broadcast_interval`), so one dropped or
+/// delayed broadcast never trips a view change on a healthy primary.
+const MIN_HEARTBEAT_TO_COMMIT_BROADCAST_RATIO: u32 = 4;
+
+/// The view-change status backstop (`view_change_status_timeout`) must span at
+/// least this many retransmit intervals (`view_change_retransmit_interval`), so
+/// a few dropped `StartViewChange` / `DoViewChange` messages retransmit rather
+/// than escalating a progressing view change into a fresh cluster-wide election.
+const MIN_STATUS_TO_RETRANSMIT_RATIO: u32 = 4;
+
+/// Default recovering-replica probe-attempt ceiling. Duplicated here rather
+/// than imported so `core/configs` keeps off a build-time edge onto
+/// `core/consensus` (mirroring [`super::partition`]); `core/server-ng`'s
+/// bootstrap static-asserts it equal to `consensus::PROBE_ATTEMPTS_MAX`.
+pub const DEFAULT_VIEW_PROBE_ATTEMPTS_MAX: u32 = 5;
+
+/// Upper bound on `view_probe_attempts_max`. A recovering replica probes once
+/// per `request_start_view_retransmit_interval`, so hundreds of attempts would
+/// stall the election fallback for minutes on a full-cluster restart; this is a
+/// typo guard, not a sizing endorsement.
+const MAX_VIEW_PROBE_ATTEMPTS: u32 = 100;
+
+/// Default per-round repair-serving chunk. Duplicated here rather than imported
+/// so `core/configs` keeps off a build-time edge onto `core/shard` (mirroring
+/// [`DEFAULT_VIEW_PROBE_ATTEMPTS_MAX`]); `core/server-ng`'s bootstrap
+/// static-asserts it equal to `shard::REPAIR_CHUNK_MAX`.
+pub const DEFAULT_REPAIR_CHUNK_MAX: usize = 128;
+
+/// Upper bound on `repair_chunk_max`. A chunk rides the per-peer bus queue, so
+/// the load-bearing rule is `repair_chunk_max < message_bus.peer_queue_capacity`
+/// (enforced at the top level); this standalone ceiling is a typo guard.
+const MAX_REPAIR_CHUNK_MAX: usize = 1024;
 
 /// Length floor for the replica-auth PSK, in raw bytes. The 32-byte MAC key
 /// is KDF-derived from these bytes at use-site, so any encoding clearing this
@@ -56,6 +94,78 @@ fn default_heartbeat_timeout() -> IggyDuration {
     SERVER_NG_CONFIG.cluster.heartbeat_timeout.parse().unwrap()
 }
 
+/// serde fallback for configs written before the field existed; the value
+/// itself lives in `core/server-ng/config.toml` like every other default.
+fn default_commit_broadcast_interval() -> IggyDuration {
+    SERVER_NG_CONFIG
+        .cluster
+        .commit_broadcast_interval
+        .parse()
+        .unwrap()
+}
+
+/// serde fallback for configs written before the field existed; the value
+/// itself lives in `core/server-ng/config.toml` like every other default.
+fn default_prepare_retransmit_interval() -> IggyDuration {
+    SERVER_NG_CONFIG
+        .cluster
+        .prepare_retransmit_interval
+        .parse()
+        .unwrap()
+}
+
+/// serde fallback for configs written before the field existed; the value
+/// itself lives in `core/server-ng/config.toml` like every other default.
+fn default_view_change_retransmit_interval() -> IggyDuration {
+    SERVER_NG_CONFIG
+        .cluster
+        .view_change_retransmit_interval
+        .parse()
+        .unwrap()
+}
+
+/// serde fallback for configs written before the field existed; the value
+/// itself lives in `core/server-ng/config.toml` like every other default.
+fn default_view_change_status_timeout() -> IggyDuration {
+    SERVER_NG_CONFIG
+        .cluster
+        .view_change_status_timeout
+        .parse()
+        .unwrap()
+}
+
+/// serde fallback for configs written before the field existed; the value
+/// itself lives in `core/server-ng/config.toml` like every other default.
+fn default_request_start_view_retransmit_interval() -> IggyDuration {
+    SERVER_NG_CONFIG
+        .cluster
+        .request_start_view_retransmit_interval
+        .parse()
+        .unwrap()
+}
+
+/// serde fallback for configs written before the field existed; the value
+/// itself lives in `core/server-ng/config.toml` like every other default.
+fn default_view_probe_attempts_max() -> u32 {
+    SERVER_NG_CONFIG.cluster.view_probe_attempts_max as u32
+}
+
+/// serde fallback for configs written before the field existed; the value
+/// itself lives in `core/server-ng/config.toml` like every other default.
+fn default_repair_retry_interval() -> IggyDuration {
+    SERVER_NG_CONFIG
+        .cluster
+        .repair_retry_interval
+        .parse()
+        .unwrap()
+}
+
+/// serde fallback for configs written before the field existed; the value
+/// itself lives in `core/server-ng/config.toml` like every other default.
+fn default_repair_chunk_max() -> usize {
+    SERVER_NG_CONFIG.cluster.repair_chunk_max as usize
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize, Clone, ConfigEnv)]
 #[serde(deny_unknown_fields)]
@@ -72,6 +182,80 @@ pub struct ClusterConfig {
     #[serde_as(as = "DisplayFromStr")]
     #[config_env(leaf)]
     pub heartbeat_timeout: IggyDuration,
+    /// How often the primary broadcasts its commit point to every backup, the
+    /// cluster's primary-liveness signal. Each broadcast resets the backups'
+    /// `heartbeat_timeout` window, so that window must span several broadcasts:
+    /// boot rejects `heartbeat_timeout < MIN_HEARTBEAT_TO_COMMIT_BROADCAST_RATIO
+    /// * commit_broadcast_interval`. Sizes the consensus `CommitMessage` timer.
+    /// Zero (and the `0` / `disabled` / `unlimited` sentinels, which all parse
+    /// to zero) is rejected at boot.
+    #[serde(default = "default_commit_broadcast_interval")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[config_env(leaf)]
+    pub commit_broadcast_interval: IggyDuration,
+    /// How often the primary retransmits prepares a backup has not yet acked.
+    /// Lower recovers faster from a dropped prepare at the cost of replica
+    /// traffic. Sizes the consensus `Prepare` timer. Zero (and the `0` /
+    /// `disabled` / `unlimited` sentinels, which all parse to zero) is rejected
+    /// at boot.
+    #[serde(default = "default_prepare_retransmit_interval")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[config_env(leaf)]
+    pub prepare_retransmit_interval: IggyDuration,
+    /// How often a plane retransmits its `StartViewChange` / `DoViewChange`
+    /// while a view change is running. Lower converges a healthy election
+    /// faster at the cost of replica traffic. Sizes both consensus view-change
+    /// retransmit timers, which are deliberately equal. Zero (and the `0` /
+    /// `disabled` / `unlimited` sentinels, which all parse to zero) is rejected
+    /// at boot.
+    #[serde(default = "default_view_change_retransmit_interval")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[config_env(leaf)]
+    pub view_change_retransmit_interval: IggyDuration,
+    /// Backstop for a stalled view change: one that does not conclude within
+    /// this window escalates to a fresh cluster-wide election. Must span
+    /// several `view_change_retransmit_interval`s so a few dropped view-change
+    /// messages retransmit rather than escalate: boot rejects
+    /// `view_change_status_timeout < MIN_STATUS_TO_RETRANSMIT_RATIO *
+    /// view_change_retransmit_interval`. Zero (and the `0` / `disabled` /
+    /// `unlimited` sentinels, which all parse to zero) is rejected at boot.
+    #[serde(default = "default_view_change_status_timeout")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[config_env(leaf)]
+    pub view_change_status_timeout: IggyDuration,
+    /// How often a recovering or view-change backup re-requests the current
+    /// view's `StartView` from its primary (`RequestStartView`). Sizes the
+    /// consensus `RequestStartView` timer. Zero (and the `0` / `disabled` /
+    /// `unlimited` sentinels, which all parse to zero) is rejected at boot.
+    #[serde(default = "default_request_start_view_retransmit_interval")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[config_env(leaf)]
+    pub request_start_view_retransmit_interval: IggyDuration,
+    /// How many consecutive unanswered `RequestStartView` probes a recovering
+    /// replica tolerates before it falls back to an election (a full-cluster
+    /// restart leaves nobody settled to answer). Must be >= 1 and <=
+    /// `MAX_VIEW_PROBE_ATTEMPTS`.
+    #[serde(default = "default_view_probe_attempts_max")]
+    pub view_probe_attempts_max: u32,
+    /// How long a stalled journal-repair stream waits before re-requesting its
+    /// remaining window from the serving peer. Repair frames are
+    /// fire-and-forget over the lossy bus, so a session with no retry wedges
+    /// forever on a single dropped frame. Paces both the metadata and
+    /// partition repair loops. Sizes the retry threshold in consensus ticks.
+    /// Zero (and the `0` / `disabled` / `unlimited` sentinels, which all parse
+    /// to zero) is rejected at boot.
+    #[serde(default = "default_repair_retry_interval")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[config_env(leaf)]
+    pub repair_retry_interval: IggyDuration,
+    /// Prepares a peer serves per repair round before the requester walks to
+    /// the next chunk. Each frame rides the per-peer message-bus queue, so this
+    /// must stay below `message_bus.peer_queue_capacity` or a full round
+    /// overruns the queue and silently drops frames (enforced at the top
+    /// level). Applies to both the metadata and partition repair planes. Must
+    /// be > 0 and <= `MAX_REPAIR_CHUNK_MAX`.
+    #[serde(default = "default_repair_chunk_max")]
+    pub repair_chunk_max: usize,
     /// Full roster of cluster members. Intended to be byte-identical across
     /// every node so operators ship one config. The running node's identity
     /// is supplied out-of-band via the `--replica-id` CLI flag, which
@@ -366,6 +550,23 @@ pub fn http_forwarding_key_material(jwt: &HttpJwtConfig, cluster: &ClusterConfig
 
 impl Validatable<ConfigurationError> for ClusterConfig {
     fn validate(&self) -> Result<(), ConfigurationError> {
+        // Ahead of the enabled gate: the top-level rule against
+        // message_bus.peer_queue_capacity holds repair_chunk_max unconditionally,
+        // so a single-node config skipping these would be bound by the
+        // cross-section rule while its own floor and ceiling went unchecked.
+        if self.repair_chunk_max == 0 {
+            eprintln!("Invalid cluster configuration: cluster.repair_chunk_max must be > 0");
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.repair_chunk_max > MAX_REPAIR_CHUNK_MAX {
+            eprintln!(
+                "Invalid cluster configuration: cluster.repair_chunk_max ({}) exceeds the maximum \
+                 ({MAX_REPAIR_CHUNK_MAX})",
+                self.repair_chunk_max
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
         if !self.enabled {
             return Ok(());
         }
@@ -380,9 +581,127 @@ impl Validatable<ConfigurationError> for ClusterConfig {
         if self.heartbeat_timeout.get_duration() < MIN_CLUSTER_HEARTBEAT_TIMEOUT {
             eprintln!(
                 "Invalid cluster configuration: cluster.heartbeat_timeout '{}' must be at least {}s \
-                 (the primary heartbeats every second; a shorter window elects on every hiccup)",
+                 (the primary signals liveness through its commit broadcast; a shorter window \
+                 elects on every scheduling hiccup)",
                 self.heartbeat_timeout,
                 MIN_CLUSTER_HEARTBEAT_TIMEOUT.as_secs()
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
+        // The commit broadcast is the cluster's liveness feed and the prepare
+        // retransmit its recovery timer; both size consensus timers that have
+        // to advance. `0` / `disabled` / `unlimited` all collapse to a zero
+        // duration, which would stall the timer - reject them.
+        if self.commit_broadcast_interval.get_duration().is_zero() {
+            eprintln!(
+                "Invalid cluster configuration: cluster.commit_broadcast_interval must be nonzero \
+                 (it drives the primary's liveness broadcast)"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.prepare_retransmit_interval.get_duration().is_zero() {
+            eprintln!(
+                "Invalid cluster configuration: cluster.prepare_retransmit_interval must be \
+                 nonzero (it drives prepare retransmission)"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
+        // The liveness window must span several commit broadcasts so a single
+        // delayed broadcast never trips a view change on a healthy primary.
+        let min_heartbeat = self
+            .commit_broadcast_interval
+            .get_duration()
+            .saturating_mul(MIN_HEARTBEAT_TO_COMMIT_BROADCAST_RATIO);
+        if self.heartbeat_timeout.get_duration() < min_heartbeat {
+            eprintln!(
+                "Invalid cluster configuration: cluster.heartbeat_timeout '{}' must be at least \
+                 {}x cluster.commit_broadcast_interval '{}' so the liveness window spans several \
+                 broadcasts",
+                self.heartbeat_timeout,
+                MIN_HEARTBEAT_TO_COMMIT_BROADCAST_RATIO,
+                self.commit_broadcast_interval
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
+        // The three view-change timers each size a consensus timer that has to
+        // advance; `0` / `disabled` / `unlimited` all collapse to zero and
+        // would stall it - reject them.
+        if self
+            .view_change_retransmit_interval
+            .get_duration()
+            .is_zero()
+        {
+            eprintln!(
+                "Invalid cluster configuration: cluster.view_change_retransmit_interval must be \
+                 nonzero (it drives StartViewChange / DoViewChange retransmission)"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.view_change_status_timeout.get_duration().is_zero() {
+            eprintln!(
+                "Invalid cluster configuration: cluster.view_change_status_timeout must be nonzero \
+                 (it backstops a stalled view change)"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self
+            .request_start_view_retransmit_interval
+            .get_duration()
+            .is_zero()
+        {
+            eprintln!(
+                "Invalid cluster configuration: cluster.request_start_view_retransmit_interval \
+                 must be nonzero (it drives RequestStartView retransmission)"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
+        // The status backstop must span several retransmits so a few dropped
+        // view-change messages retransmit rather than escalating a progressing
+        // view change into a fresh cluster-wide election.
+        let min_status = self
+            .view_change_retransmit_interval
+            .get_duration()
+            .saturating_mul(MIN_STATUS_TO_RETRANSMIT_RATIO);
+        if self.view_change_status_timeout.get_duration() < min_status {
+            eprintln!(
+                "Invalid cluster configuration: cluster.view_change_status_timeout '{}' must be at \
+                 least {}x cluster.view_change_retransmit_interval '{}' so a stalled view change \
+                 retransmits before it escalates to an election",
+                self.view_change_status_timeout,
+                MIN_STATUS_TO_RETRANSMIT_RATIO,
+                self.view_change_retransmit_interval
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
+        // A recovering replica needs at least one probe before it may give up
+        // and elect; the ceiling is a typo guard (see MAX_VIEW_PROBE_ATTEMPTS).
+        if self.view_probe_attempts_max == 0 {
+            eprintln!(
+                "Invalid cluster configuration: cluster.view_probe_attempts_max must be >= 1"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.view_probe_attempts_max > MAX_VIEW_PROBE_ATTEMPTS {
+            eprintln!(
+                "Invalid cluster configuration: cluster.view_probe_attempts_max ({}) exceeds the \
+                 maximum ({MAX_VIEW_PROBE_ATTEMPTS})",
+                self.view_probe_attempts_max
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
+        // The repair retry interval sizes a tick threshold that has to advance;
+        // `0` / `disabled` / `unlimited` all collapse to zero and would wedge
+        // every stalled repair stream - reject them.
+        if self.repair_retry_interval.get_duration().is_zero() {
+            eprintln!(
+                "Invalid cluster configuration: cluster.repair_retry_interval must be nonzero \
+                 (it paces stalled-repair retries)"
             );
             return Err(ConfigurationError::InvalidConfigurationValue);
         }
@@ -591,6 +910,15 @@ mod tests {
             enabled: true,
             name: "iggy-cluster".to_owned(),
             heartbeat_timeout: default_heartbeat_timeout(),
+            commit_broadcast_interval: default_commit_broadcast_interval(),
+            prepare_retransmit_interval: default_prepare_retransmit_interval(),
+            view_change_retransmit_interval: default_view_change_retransmit_interval(),
+            view_change_status_timeout: default_view_change_status_timeout(),
+            request_start_view_retransmit_interval: default_request_start_view_retransmit_interval(
+            ),
+            view_probe_attempts_max: default_view_probe_attempts_max(),
+            repair_retry_interval: default_repair_retry_interval(),
+            repair_chunk_max: default_repair_chunk_max(),
             nodes: Vec::new(),
             auth: ClusterAuthConfig {
                 enabled: true,
@@ -727,6 +1055,15 @@ mod cluster_validate_tests {
             enabled: true,
             name: "iggy-cluster".to_string(),
             heartbeat_timeout: default_heartbeat_timeout(),
+            commit_broadcast_interval: default_commit_broadcast_interval(),
+            prepare_retransmit_interval: default_prepare_retransmit_interval(),
+            view_change_retransmit_interval: default_view_change_retransmit_interval(),
+            view_change_status_timeout: default_view_change_status_timeout(),
+            request_start_view_retransmit_interval: default_request_start_view_retransmit_interval(
+            ),
+            view_probe_attempts_max: default_view_probe_attempts_max(),
+            repair_retry_interval: default_repair_retry_interval(),
+            repair_chunk_max: default_repair_chunk_max(),
             nodes,
             auth: ClusterAuthConfig::default(),
             tls: ClusterTlsConfig::default(),
@@ -742,6 +1079,136 @@ mod cluster_validate_tests {
         // be rejected the same way.
         c.heartbeat_timeout = IggyDuration::new(Duration::ZERO);
         assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_commit_broadcast_interval() {
+        // `0` / `disabled` / `unlimited` all collapse to zero and stall the
+        // liveness broadcast.
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.commit_broadcast_interval = IggyDuration::new(Duration::ZERO);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_prepare_retransmit_interval() {
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.prepare_retransmit_interval = IggyDuration::new(Duration::ZERO);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_heartbeat_below_commit_broadcast_ratio() {
+        // 3s clears the absolute 2s floor but is still < 4x the 1s broadcast,
+        // so the ratio rule is what rejects here, not the floor.
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.heartbeat_timeout = IggyDuration::new(Duration::from_secs(3));
+        c.commit_broadcast_interval = IggyDuration::new(Duration::from_secs(1));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_heartbeat_at_commit_broadcast_ratio() {
+        // Exactly 4x the broadcast (and above the 2s floor) must pass.
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.heartbeat_timeout = IggyDuration::new(Duration::from_secs(4));
+        c.commit_broadcast_interval = IggyDuration::new(Duration::from_secs(1));
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_view_change_retransmit_interval() {
+        // `0` / `disabled` / `unlimited` all collapse to zero and stall the
+        // view-change retransmit timers.
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.view_change_retransmit_interval = IggyDuration::new(Duration::ZERO);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_view_change_status_timeout() {
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.view_change_status_timeout = IggyDuration::new(Duration::ZERO);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_request_start_view_retransmit_interval() {
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.request_start_view_retransmit_interval = IggyDuration::new(Duration::ZERO);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_view_change_status_below_retransmit_ratio() {
+        // 3s is nonzero but still < 4x the 1s retransmit, so the ratio rule is
+        // what rejects here, not the zero check.
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.view_change_retransmit_interval = IggyDuration::new(Duration::from_secs(1));
+        c.view_change_status_timeout = IggyDuration::new(Duration::from_secs(3));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_view_change_status_at_retransmit_ratio() {
+        // Exactly 4x the retransmit interval must pass.
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.view_change_retransmit_interval = IggyDuration::new(Duration::from_secs(1));
+        c.view_change_status_timeout = IggyDuration::new(Duration::from_secs(4));
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_view_probe_attempts_max() {
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.view_probe_attempts_max = 0;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_view_probe_attempts_above_ceiling() {
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.view_probe_attempts_max = MAX_VIEW_PROBE_ATTEMPTS + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_view_probe_attempts_at_ceiling() {
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.view_probe_attempts_max = MAX_VIEW_PROBE_ATTEMPTS;
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_repair_retry_interval() {
+        // `0` / `disabled` / `unlimited` all collapse to zero and would wedge
+        // stalled repair streams.
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.repair_retry_interval = IggyDuration::new(Duration::ZERO);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_repair_chunk_max() {
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.repair_chunk_max = 0;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_repair_chunk_max_above_ceiling() {
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.repair_chunk_max = MAX_REPAIR_CHUNK_MAX + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_repair_chunk_max_at_ceiling() {
+        // Section-level validate only; the cross-section rule against
+        // message_bus.peer_queue_capacity lives in the top-level validate.
+        let mut c = cfg(vec![node("n1", 0), node("n2", 1)]);
+        c.repair_chunk_max = MAX_REPAIR_CHUNK_MAX;
+        assert!(c.validate().is_ok());
     }
 
     #[test]
@@ -780,6 +1247,25 @@ mod cluster_validate_tests {
         let mut c = cfg(vec![]);
         c.enabled = false;
         assert!(c.validate().is_ok());
+    }
+
+    // repair_chunk_max is also read by the unconditional top-level check
+    // against message_bus.peer_queue_capacity, so its own bounds apply with
+    // the cluster off too.
+    #[test]
+    fn validate_rejects_zero_repair_chunk_max_when_disabled() {
+        let mut c = cfg(vec![]);
+        c.enabled = false;
+        c.repair_chunk_max = 0;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_repair_chunk_max_above_ceiling_when_disabled() {
+        let mut c = cfg(vec![]);
+        c.enabled = false;
+        c.repair_chunk_max = MAX_REPAIR_CHUNK_MAX + 1;
+        assert!(c.validate().is_err());
     }
 
     #[test]

--- a/core/configs/src/server_ng_config/defaults.rs
+++ b/core/configs/src/server_ng_config/defaults.rs
@@ -32,6 +32,7 @@ use super::cluster::{
 };
 use super::message_bus::MessageBusConfig;
 use super::metadata::MetadataConfig;
+use super::partition::PartitionConfig;
 use super::quic::{QuicCertificateConfig, QuicConfig, QuicSocketConfig};
 use super::server_ng::NgSystemConfig;
 use super::server_ng::{ExtraConfig, ServerNgConfig};
@@ -66,6 +67,7 @@ impl Default for ServerNgConfig {
             telemetry: TelemetryConfig::default(),
             cluster: ClusterConfig::default(),
             metadata: MetadataConfig::default(),
+            partition: PartitionConfig::default(),
             message_bus: MessageBusConfig::default(),
         }
     }
@@ -77,6 +79,38 @@ impl Default for ClusterConfig {
             enabled: SERVER_NG_CONFIG.cluster.enabled,
             name: SERVER_NG_CONFIG.cluster.name.parse().unwrap(),
             heartbeat_timeout: SERVER_NG_CONFIG.cluster.heartbeat_timeout.parse().unwrap(),
+            commit_broadcast_interval: SERVER_NG_CONFIG
+                .cluster
+                .commit_broadcast_interval
+                .parse()
+                .unwrap(),
+            prepare_retransmit_interval: SERVER_NG_CONFIG
+                .cluster
+                .prepare_retransmit_interval
+                .parse()
+                .unwrap(),
+            view_change_retransmit_interval: SERVER_NG_CONFIG
+                .cluster
+                .view_change_retransmit_interval
+                .parse()
+                .unwrap(),
+            view_change_status_timeout: SERVER_NG_CONFIG
+                .cluster
+                .view_change_status_timeout
+                .parse()
+                .unwrap(),
+            request_start_view_retransmit_interval: SERVER_NG_CONFIG
+                .cluster
+                .request_start_view_retransmit_interval
+                .parse()
+                .unwrap(),
+            view_probe_attempts_max: SERVER_NG_CONFIG.cluster.view_probe_attempts_max as u32,
+            repair_retry_interval: SERVER_NG_CONFIG
+                .cluster
+                .repair_retry_interval
+                .parse()
+                .unwrap(),
+            repair_chunk_max: SERVER_NG_CONFIG.cluster.repair_chunk_max as usize,
             nodes: SERVER_NG_CONFIG
                 .cluster
                 .nodes
@@ -127,6 +161,20 @@ impl Default for MetadataConfig {
         MetadataConfig {
             prepare_queue_depth: metadata.prepare_queue_depth as usize,
             journal_slots: metadata.journal_slots as usize,
+            clients_table_max: metadata.clients_table_max as usize,
+        }
+    }
+}
+
+impl Default for PartitionConfig {
+    fn default() -> PartitionConfig {
+        // Read from the embedded TOML so the Default impl and the on-disk
+        // schema cannot drift (same pattern as MetadataConfig above).
+        let partition = &SERVER_NG_CONFIG.partition;
+        PartitionConfig {
+            prepare_queue_depth: partition.prepare_queue_depth as usize,
+            evicted_ring_capacity: partition.evicted_ring_capacity as usize,
+            evicted_ring_bytes_max: partition.evicted_ring_bytes_max.parse().unwrap(),
         }
     }
 }
@@ -233,6 +281,10 @@ impl Default for TcpSocketConfig {
 
 impl Default for WebSocketConfig {
     fn default() -> WebSocketConfig {
+        // The size knobs are optional in the schema (commented-out by
+        // default), so they map to `None` here when absent; every other
+        // field comes from the embedded TOML so the Default impl and
+        // the on-disk schema cannot drift.
         WebSocketConfig {
             enabled: SERVER_NG_CONFIG.websocket.enabled,
             address: SERVER_NG_CONFIG.websocket.address.parse().unwrap(),
@@ -241,7 +293,7 @@ impl Default for WebSocketConfig {
             max_write_buffer_size: None,
             max_message_size: None,
             max_frame_size: None,
-            accept_unmasked_frames: false,
+            accept_unmasked_frames: SERVER_NG_CONFIG.websocket.accept_unmasked_frames,
             tls: WebSocketTlsConfig::default(),
         }
     }
@@ -262,9 +314,7 @@ impl Default for MessageBusConfig {
     fn default() -> MessageBusConfig {
         // Read every field from the embedded TOML so the Default impl
         // and the on-disk schema cannot drift. Sibling impls in this
-        // file follow the same pattern. The `ws_*_size` knobs are
-        // optional in the schema (commented-out by default), so they
-        // map to `None` here when absent.
+        // file follow the same pattern.
         let bus = &SERVER_NG_CONFIG.message_bus;
         MessageBusConfig {
             max_batch: bus.max_batch as usize,
@@ -274,10 +324,6 @@ impl Default for MessageBusConfig {
             close_peer_timeout: bus.close_peer_timeout.parse().unwrap(),
             close_grace: bus.close_grace.parse().unwrap(),
             handshake_grace: bus.handshake_grace.parse().unwrap(),
-            ws_max_message_size: None,
-            ws_max_frame_size: None,
-            ws_write_buffer_size: None,
-            ws_accept_unmasked_frames: bus.ws_accept_unmasked_frames,
         }
     }
 }

--- a/core/configs/src/server_ng_config/displays.rs
+++ b/core/configs/src/server_ng_config/displays.rs
@@ -56,8 +56,8 @@ impl Display for MetadataConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{{ prepare_queue_depth: {}, journal_slots: {} }}",
-            self.prepare_queue_depth, self.journal_slots,
+            "{{ prepare_queue_depth: {}, journal_slots: {}, clients_table_max: {} }}",
+            self.prepare_queue_depth, self.journal_slots, self.clients_table_max,
         )
     }
 }
@@ -68,9 +68,7 @@ impl Display for MessageBusConfig {
             f,
             "{{ max_batch: {}, max_message_size: {}, peer_queue_capacity: {}, \
              reconnect_period: {}, close_peer_timeout: {}, close_grace: {}, \
-             handshake_grace: {}, ws_max_message_size: {:?}, \
-             ws_max_frame_size: {:?}, ws_write_buffer_size: {:?}, \
-             ws_accept_unmasked_frames: {} }}",
+             handshake_grace: {} }}",
             self.max_batch,
             self.max_message_size,
             self.peer_queue_capacity,
@@ -78,10 +76,6 @@ impl Display for MessageBusConfig {
             self.close_peer_timeout,
             self.close_grace,
             self.handshake_grace,
-            self.ws_max_message_size,
-            self.ws_max_frame_size,
-            self.ws_write_buffer_size,
-            self.ws_accept_unmasked_frames,
         )
     }
 }

--- a/core/configs/src/server_ng_config/message_bus.rs
+++ b/core/configs/src/server_ng_config/message_bus.rs
@@ -26,23 +26,21 @@
 //! Transport-section concerns the bus does NOT own:
 //!
 //! - TCP-TLS / WSS listen addresses derive from `[tcp]` + `[tcp.tls]`
-//!   and `[websocket]` + `[websocket.tls]` respectively. The future
-//!   wiring PR populates the bus's runtime listen-addr inputs from
-//!   those sections at bootstrap.
+//!   and `[websocket]` + `[websocket.tls]` respectively.
+//! - WebSocket frame-layer tuning (buffer sizes, message / frame
+//!   ceilings, unmasked-frame acceptance) lives in `[websocket]`
+//!   ([`super::websocket::WebSocketConfig`]): the bus IS server-ng's
+//!   WS / WSS install path, so the listener section carries the frame
+//!   tuning and the runtime folds it into a compio-ws
+//!   `WebSocketConfig` once at bus construction. The
+//!   `websocket.max_*` <= `message_bus.max_message_size` chain is
+//!   enforced as a cross-section check in
+//!   [`super::server_ng::ServerNgConfig`]'s validator.
 //!
-//! Tunables the bus owns directly:
-//!
-//! - Bus-internal abstractions the operator does not see anywhere else
-//!   in the schema (batch sizing, per-peer queue depth, close-grace,
-//!   reconnect period, handshake-grace).
-//! - WebSocket frame-layer tunables for the bus's WS / WSS install
-//!   path (`ws_max_message_size`, `ws_max_frame_size`,
-//!   `ws_write_buffer_size`, `ws_accept_unmasked_frames`). The bus
-//!   plane carries SDK-client traffic with cardinality and burst
-//!   characteristics distinct from the legacy `[websocket]` listener,
-//!   so the bus owns its own frame-layer ceiling rather than aliasing
-//!   the listener's. The runtime conversion folds these into a
-//!   `tungstenite::WebSocketConfig` once at bus construction.
+//! Tunables the bus owns directly: bus-internal abstractions the
+//! operator does not see anywhere else in the schema (batch sizing,
+//! per-peer queue depth, close-grace, reconnect period,
+//! handshake-grace).
 //!
 //! Liveness detection is NOT done via TCP keepalive on the bus: SDK
 //! clients manage their own keepalive policy; replica<->replica
@@ -124,46 +122,6 @@ pub struct MessageBusConfig {
     #[config_env(leaf)]
     #[serde_as(as = "DisplayFromStr")]
     pub handshake_grace: IggyDuration,
-
-    /// Hard upper bound on a single inbound WebSocket message
-    /// (post-fragment-reassembly). `None` keeps the tungstenite
-    /// default (currently 64 MiB). Threaded into
-    /// `tungstenite::WebSocketConfig::max_message_size` at bus
-    /// construction. Distinct from [`Self::max_message_size`], which
-    /// caps a single framed bus payload regardless of transport.
-    #[config_env(leaf)]
-    #[serde(default)]
-    #[serde_as(as = "Option<DisplayFromStr>")]
-    pub ws_max_message_size: Option<IggyByteSize>,
-
-    /// Hard upper bound on a single inbound WebSocket frame
-    /// (pre-fragment-reassembly). `None` keeps the tungstenite default
-    /// (currently 16 MiB). Threaded into
-    /// `tungstenite::WebSocketConfig::max_frame_size` at bus
-    /// construction.
-    #[config_env(leaf)]
-    #[serde(default)]
-    #[serde_as(as = "Option<DisplayFromStr>")]
-    pub ws_max_frame_size: Option<IggyByteSize>,
-
-    /// Target buffer size for batched WebSocket writes before tungstenite
-    /// flushes. `None` keeps the tungstenite default. Threaded into
-    /// `tungstenite::WebSocketConfig::write_buffer_size` at bus
-    /// construction.
-    #[config_env(leaf)]
-    #[serde(default)]
-    #[serde_as(as = "Option<DisplayFromStr>")]
-    pub ws_write_buffer_size: Option<IggyByteSize>,
-
-    /// Whether the bus accepts unmasked frames from clients in violation
-    /// of RFC 6455 client-to-server framing rules. Default `false`
-    /// (strict). Set to `true` only for non-browser test clients that
-    /// emit unmasked frames; production deployments leave this at
-    /// `false`. Threaded into
-    /// `tungstenite::WebSocketConfig::accept_unmasked_frames` at bus
-    /// construction.
-    #[serde(default)]
-    pub ws_accept_unmasked_frames: bool,
 }
 
 impl Validatable<ConfigurationError> for MessageBusConfig {
@@ -201,40 +159,6 @@ impl Validatable<ConfigurationError> for MessageBusConfig {
         }
         if self.reconnect_period.as_micros() == 0 {
             eprintln!("{COMPONENT_NG} message_bus.reconnect_period must be > 0");
-            return Err(ConfigurationError::InvalidConfigurationValue);
-        }
-        // WS frame chain: ws_max_frame_size <= ws_max_message_size <=
-        // max_message_size. The `Option<...>` knobs only enforce a ceiling
-        // when present; an absent value defers to tungstenite's default
-        // (which is itself <= 64 MiB and so satisfies the chain in practice).
-        if let (Some(frame), Some(message)) = (self.ws_max_frame_size, self.ws_max_message_size)
-            && frame.as_bytes_u64() > message.as_bytes_u64()
-        {
-            eprintln!(
-                "{COMPONENT_NG} message_bus.ws_max_frame_size ({}) exceeds ws_max_message_size ({})",
-                frame.as_bytes_u64(),
-                message.as_bytes_u64()
-            );
-            return Err(ConfigurationError::InvalidConfigurationValue);
-        }
-        if let Some(message) = self.ws_max_message_size
-            && message.as_bytes_u64() > self.max_message_size.as_bytes_u64()
-        {
-            eprintln!(
-                "{COMPONENT_NG} message_bus.ws_max_message_size ({}) exceeds max_message_size ({})",
-                message.as_bytes_u64(),
-                self.max_message_size.as_bytes_u64()
-            );
-            return Err(ConfigurationError::InvalidConfigurationValue);
-        }
-        if let Some(frame) = self.ws_max_frame_size
-            && frame.as_bytes_u64() > self.max_message_size.as_bytes_u64()
-        {
-            eprintln!(
-                "{COMPONENT_NG} message_bus.ws_max_frame_size ({}) exceeds max_message_size ({})",
-                frame.as_bytes_u64(),
-                self.max_message_size.as_bytes_u64()
-            );
             return Err(ConfigurationError::InvalidConfigurationValue);
         }
         Ok(())
@@ -318,38 +242,5 @@ mod tests {
         let mut c = baseline();
         c.reconnect_period = IggyDuration::from(std::time::Duration::ZERO);
         assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn rejects_ws_frame_size_above_ws_message_size() {
-        let mut c = baseline();
-        c.ws_max_message_size = Some(IggyByteSize::from(1024_u64));
-        c.ws_max_frame_size = Some(IggyByteSize::from(2048_u64));
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn rejects_ws_message_size_above_bus_max_message_size() {
-        let mut c = baseline();
-        c.max_message_size = IggyByteSize::from(1024_u64);
-        c.ws_max_message_size = Some(IggyByteSize::from(2048_u64));
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn rejects_ws_frame_size_above_bus_max_message_size() {
-        let mut c = baseline();
-        c.max_message_size = IggyByteSize::from(1024_u64);
-        c.ws_max_frame_size = Some(IggyByteSize::from(2048_u64));
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn accepts_ws_chain_in_ascending_order() {
-        let mut c = baseline();
-        c.max_message_size = IggyByteSize::from(64_u64 * 1024 * 1024);
-        c.ws_max_message_size = Some(IggyByteSize::from(32_u64 * 1024 * 1024));
-        c.ws_max_frame_size = Some(IggyByteSize::from(16_u64 * 1024 * 1024));
-        assert!(c.validate().is_ok());
     }
 }

--- a/core/configs/src/server_ng_config/metadata.rs
+++ b/core/configs/src/server_ng_config/metadata.rs
@@ -18,7 +18,7 @@
 //! On-disk schema for the metadata consensus plane (shard 0's VSR
 //! replica: users, streams, topics, sessions).
 //!
-//! Two capacity knobs previously hardcoded in the runtime crates:
+//! Three capacity knobs previously hardcoded in the runtime crates:
 //!
 //! - `prepare_queue_depth` -> `consensus::PIPELINE_PREPARE_QUEUE_MAX`
 //!   (the pipeline's in-flight prepare bound; submits beyond it bounce
@@ -26,8 +26,11 @@
 //! - `journal_slots` -> `journal::prepare_journal::DEFAULT_SLOT_COUNT`
 //!   (the WAL's in-memory index; committed-but-unsnapshotted headroom
 //!   between forced checkpoints)
+//! - `clients_table_max` -> `consensus::CLIENTS_TABLE_MAX` (the VSR
+//!   client-table slot count; independent of the two above). The
+//!   server-ng HTTP session cap tracks it at half.
 //!
-//! The two interlock through the forced-checkpoint margin
+//! The first two interlock through the forced-checkpoint margin
 //! (`max(64, prepare_queue_depth)` at bootstrap): while a checkpoint
 //! runs, up to a full prepare queue of already-pipelined ops appends
 //! into that margin, and `validate` keeps `journal_slots` far enough
@@ -37,7 +40,7 @@
 //! `core/configs` does not grow build-time edges onto `core/consensus`
 //! and `core/journal` (the runtime crates are the consumers of this
 //! config, mirroring the `IOV_MAX_LIMIT_NG` precedent in
-//! [`super::message_bus`]). `core/server-ng`'s bootstrap pins both
+//! [`super::message_bus`]). `core/server-ng`'s bootstrap pins these
 //! literals against the runtime constants with static asserts.
 
 use super::COMPONENT_NG;
@@ -67,6 +70,20 @@ pub const MAX_METADATA_PREPARE_QUEUE_DEPTH: usize = 4096;
 /// ceiling, not a tuning target.
 pub const MAX_METADATA_JOURNAL_SLOTS: usize = 1 << 20;
 
+/// Mirrors `consensus::CLIENTS_TABLE_MAX`, the VSR client-table slot count.
+pub const DEFAULT_METADATA_CLIENTS_TABLE_MAX: usize = 8192;
+
+/// Floor on `clients_table_max`. The server-ng HTTP session cap derives as
+/// `clients_table_max / 2`; below two that floors to zero and HTTP could
+/// register no sessions at all.
+pub const MIN_METADATA_CLIENTS_TABLE_MAX: usize = 2;
+
+/// Upper bound on `clients_table_max`. Every slot is preallocated for the
+/// table's whole lifetime whether or not it holds a live client, so this caps
+/// fixed per-shard table memory; 8x the default is far past any real client
+/// population and a likely unit typo.
+pub const MAX_METADATA_CLIENTS_TABLE_MAX: usize = 1 << 16;
+
 /// Capacity tunables for the metadata consensus plane.
 #[derive(Debug, Deserialize, Serialize, Clone, ConfigEnv)]
 pub struct MetadataConfig {
@@ -80,6 +97,13 @@ pub struct MetadataConfig {
     /// checkpoints; more slots = rarer checkpoints, more memory, larger
     /// per-checkpoint WAL rewrites.
     pub journal_slots: usize,
+
+    /// Slot count of the VSR client table: how many distinct clients
+    /// (TCP/QUIC/WS virtual clients and HTTP sessions together) hold live
+    /// session state before the oldest-committed entry is evicted. The
+    /// server-ng HTTP session cap tracks this at half, so raising it lifts
+    /// both.
+    pub clients_table_max: usize,
 }
 
 impl MetadataConfig {
@@ -127,6 +151,20 @@ impl Validatable<ConfigurationError> for MetadataConfig {
             );
             return Err(ConfigurationError::InvalidConfigurationValue);
         }
+        if self.clients_table_max < MIN_METADATA_CLIENTS_TABLE_MAX {
+            eprintln!(
+                "{COMPONENT_NG} metadata.clients_table_max ({}) must be >= {MIN_METADATA_CLIENTS_TABLE_MAX}",
+                self.clients_table_max
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.clients_table_max > MAX_METADATA_CLIENTS_TABLE_MAX {
+            eprintln!(
+                "{COMPONENT_NG} metadata.clients_table_max ({}) exceeds the maximum ({MAX_METADATA_CLIENTS_TABLE_MAX})",
+                self.clients_table_max
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
         Ok(())
     }
 }
@@ -140,6 +178,7 @@ mod tests {
         let config = MetadataConfig {
             prepare_queue_depth: DEFAULT_METADATA_PREPARE_QUEUE_DEPTH,
             journal_slots: DEFAULT_METADATA_JOURNAL_SLOTS,
+            clients_table_max: DEFAULT_METADATA_CLIENTS_TABLE_MAX,
         };
         assert!(config.validate().is_ok());
         assert_eq!(config.checkpoint_margin(), METADATA_CHECKPOINT_MARGIN_FLOOR);
@@ -150,6 +189,7 @@ mod tests {
         let config = MetadataConfig {
             prepare_queue_depth: 256,
             journal_slots: 4096,
+            clients_table_max: DEFAULT_METADATA_CLIENTS_TABLE_MAX,
         };
         assert!(config.validate().is_ok());
         assert_eq!(config.checkpoint_margin(), 256);
@@ -162,12 +202,14 @@ mod tests {
         let boundary = MetadataConfig {
             prepare_queue_depth: 256,
             journal_slots: 1024,
+            clients_table_max: DEFAULT_METADATA_CLIENTS_TABLE_MAX,
         };
         assert!(boundary.validate().is_ok());
         // ...one slot fewer is refused.
         let starved = MetadataConfig {
             prepare_queue_depth: 256,
             journal_slots: 1023,
+            clients_table_max: DEFAULT_METADATA_CLIENTS_TABLE_MAX,
         };
         assert!(starved.validate().is_err());
     }
@@ -177,6 +219,47 @@ mod tests {
         let config = MetadataConfig {
             prepare_queue_depth: 0,
             journal_slots: DEFAULT_METADATA_JOURNAL_SLOTS,
+            clients_table_max: DEFAULT_METADATA_CLIENTS_TABLE_MAX,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    // The shipped config.toml default is the canonical slot count, so a
+    // pristine deployment sizes the table exactly as the consensus constant.
+    #[test]
+    fn embedded_default_matches_canonical_clients_table_max() {
+        assert_eq!(
+            MetadataConfig::default().clients_table_max,
+            DEFAULT_METADATA_CLIENTS_TABLE_MAX
+        );
+    }
+
+    #[test]
+    fn clients_table_max_below_floor_is_refused() {
+        let config = MetadataConfig {
+            prepare_queue_depth: DEFAULT_METADATA_PREPARE_QUEUE_DEPTH,
+            journal_slots: DEFAULT_METADATA_JOURNAL_SLOTS,
+            clients_table_max: MIN_METADATA_CLIENTS_TABLE_MAX - 1,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn clients_table_max_at_floor_is_accepted() {
+        let config = MetadataConfig {
+            prepare_queue_depth: DEFAULT_METADATA_PREPARE_QUEUE_DEPTH,
+            journal_slots: DEFAULT_METADATA_JOURNAL_SLOTS,
+            clients_table_max: MIN_METADATA_CLIENTS_TABLE_MAX,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn clients_table_max_above_ceiling_is_refused() {
+        let config = MetadataConfig {
+            prepare_queue_depth: DEFAULT_METADATA_PREPARE_QUEUE_DEPTH,
+            journal_slots: DEFAULT_METADATA_JOURNAL_SLOTS,
+            clients_table_max: MAX_METADATA_CLIENTS_TABLE_MAX + 1,
         };
         assert!(config.validate().is_err());
     }

--- a/core/configs/src/server_ng_config/mod.rs
+++ b/core/configs/src/server_ng_config/mod.rs
@@ -32,6 +32,7 @@ pub mod defaults;
 pub mod displays;
 pub mod message_bus;
 pub mod metadata;
+pub mod partition;
 pub mod quic;
 pub mod server_ng;
 pub mod sharding;

--- a/core/configs/src/server_ng_config/partition.rs
+++ b/core/configs/src/server_ng_config/partition.rs
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! On-disk schema for the per-partition consensus plane.
+//!
+//! Capacity knobs previously hardcoded in the runtime crates:
+//!
+//! - `prepare_queue_depth` -> `consensus::PIPELINE_PREPARE_QUEUE_MAX`
+//!   (the pipeline's in-flight prepare bound; submits beyond it bounce
+//!   with the transient prepare-queue-full path the SDK retries)
+//! - `evicted_ring_capacity` -> `partitions::EVICTED_RING_CAPACITY` and
+//!   `evicted_ring_bytes_max` -> `partitions::EVICTED_RING_BYTES_MAX`
+//!   (the per-partition journal-repair retention ring's dual ceilings)
+//!
+//! Distinct from `[metadata]` (a single, shard-0-global VSR plane) because
+//! partition pipelines exist PER PARTITION. The default mirrors the runtime
+//! constant so a default deployment is byte-identical; the ceiling is far
+//! below metadata's because the request queue (`depth * 2` slots) pins full
+//! inbound produce batches, so pinned memory scales with the partition count
+//! (see [`MAX_PARTITION_PREPARE_QUEUE_DEPTH`]).
+//!
+//! The default is a duplicated literal rather than an import so
+//! `core/configs` does not grow a build-time edge onto `core/consensus`
+//! (mirroring [`super::metadata`]). `core/server-ng`'s bootstrap pins the
+//! literal against the runtime constant with a static assert.
+
+use super::COMPONENT_NG;
+use crate::ConfigurationError;
+use configs::ConfigEnv;
+use iggy_common::{IggyByteSize, Validatable};
+use serde::{Deserialize, Serialize};
+
+/// Mirrors `consensus::PIPELINE_PREPARE_QUEUE_MAX`.
+pub const DEFAULT_PARTITION_PREPARE_QUEUE_DEPTH: usize = 32;
+
+/// Upper bound on `prepare_queue_depth`. Unlike the single metadata pipeline,
+/// a pipeline exists per partition, and each queued request pins a full
+/// inbound produce batch (a 4 KiB floor up to megabytes). Worst-case pinned
+/// memory therefore scales as `depth * 2 * partition_count * batch_size`, so
+/// this ceiling sits far below metadata's 4096: it is a typo guard, not a
+/// sizing endorsement.
+pub const MAX_PARTITION_PREPARE_QUEUE_DEPTH: usize = 256;
+
+/// Mirrors `partitions::EVICTED_RING_CAPACITY`.
+pub const DEFAULT_EVICTED_RING_CAPACITY: usize = 4096;
+
+/// Upper bound on `evicted_ring_capacity`. The ring exists per multi-replica
+/// partition and each retained entry pins a full committed batch, so
+/// worst-case pinned memory scales with the partition count; a typo guard,
+/// not a sizing endorsement.
+pub const MAX_EVICTED_RING_CAPACITY: usize = 65536;
+
+/// Mirrors `partitions::EVICTED_RING_BYTES_MAX`.
+pub const DEFAULT_EVICTED_RING_BYTES_MAX: u64 = 16 * 1024 * 1024;
+
+/// Upper bound on `evicted_ring_bytes_max`, per partition. Whichever ring cap
+/// trips first evicts; this byte ceiling is the second typo guard.
+pub const MAX_EVICTED_RING_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Capacity tunables for the per-partition consensus plane.
+#[derive(Debug, Deserialize, Serialize, Clone, ConfigEnv)]
+pub struct PartitionConfig {
+    /// Depth of a partition's prepare queue: how many uncommitted produce /
+    /// consumer-offset ops may be in flight at once for that partition.
+    /// Submits beyond it are rejected with the transient prepare-queue-full
+    /// path the SDK retries. Applies to every partition; raising it multiplies
+    /// pinned request-buffer memory by the partition count.
+    pub prepare_queue_depth: usize,
+
+    /// Entries the evicted ring retains per multi-replica partition for
+    /// journal repair after a peer rejoins. Larger widens the window a
+    /// restarting peer can be served from the ring before falling back to
+    /// bulk sync, at the cost of pinned memory per partition. Must be > 0 and
+    /// <= [`MAX_EVICTED_RING_CAPACITY`]. Single-replica partitions retain
+    /// nothing regardless.
+    pub evicted_ring_capacity: usize,
+
+    /// Byte ceiling for the evicted ring per partition; whichever ring cap
+    /// (this or [`Self::evicted_ring_capacity`]) trips first evicts. Bounds
+    /// the ring memory a burst of large batches can pin. Must be > 0 and <=
+    /// [`MAX_EVICTED_RING_BYTES`].
+    #[config_env(leaf)]
+    pub evicted_ring_bytes_max: IggyByteSize,
+}
+
+impl Validatable<ConfigurationError> for PartitionConfig {
+    fn validate(&self) -> Result<(), ConfigurationError> {
+        if self.prepare_queue_depth == 0 {
+            eprintln!("{COMPONENT_NG} partition.prepare_queue_depth must be > 0");
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.prepare_queue_depth > MAX_PARTITION_PREPARE_QUEUE_DEPTH {
+            eprintln!(
+                "{COMPONENT_NG} partition.prepare_queue_depth ({}) exceeds the maximum ({MAX_PARTITION_PREPARE_QUEUE_DEPTH})",
+                self.prepare_queue_depth
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.evicted_ring_capacity == 0 {
+            eprintln!("{COMPONENT_NG} partition.evicted_ring_capacity must be > 0");
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.evicted_ring_capacity > MAX_EVICTED_RING_CAPACITY {
+            eprintln!(
+                "{COMPONENT_NG} partition.evicted_ring_capacity ({}) exceeds the maximum ({MAX_EVICTED_RING_CAPACITY})",
+                self.evicted_ring_capacity
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        let ring_bytes = self.evicted_ring_bytes_max.as_bytes_u64();
+        if ring_bytes == 0 {
+            eprintln!("{COMPONENT_NG} partition.evicted_ring_bytes_max must be > 0");
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if ring_bytes > MAX_EVICTED_RING_BYTES {
+            eprintln!(
+                "{COMPONENT_NG} partition.evicted_ring_bytes_max ({ring_bytes} bytes) exceeds the maximum ({MAX_EVICTED_RING_BYTES} bytes)"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_impl_validates() {
+        // `Default` reads the shipped config.toml; the pristine deployment
+        // must validate.
+        assert!(PartitionConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_zero_prepare_queue_depth() {
+        let config = PartitionConfig {
+            prepare_queue_depth: 0,
+            ..PartitionConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_prepare_queue_depth_above_ceiling() {
+        let config = PartitionConfig {
+            prepare_queue_depth: MAX_PARTITION_PREPARE_QUEUE_DEPTH + 1,
+            ..PartitionConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_prepare_queue_depth_at_ceiling() {
+        let config = PartitionConfig {
+            prepare_queue_depth: MAX_PARTITION_PREPARE_QUEUE_DEPTH,
+            ..PartitionConfig::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_zero_evicted_ring_capacity() {
+        let config = PartitionConfig {
+            evicted_ring_capacity: 0,
+            ..PartitionConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_evicted_ring_capacity_above_ceiling() {
+        let config = PartitionConfig {
+            evicted_ring_capacity: MAX_EVICTED_RING_CAPACITY + 1,
+            ..PartitionConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_zero_evicted_ring_bytes_max() {
+        let config = PartitionConfig {
+            evicted_ring_bytes_max: IggyByteSize::from(0_u64),
+            ..PartitionConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_evicted_ring_bytes_max_above_ceiling() {
+        let config = PartitionConfig {
+            evicted_ring_bytes_max: IggyByteSize::from(MAX_EVICTED_RING_BYTES + 1),
+            ..PartitionConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+}

--- a/core/configs/src/server_ng_config/server_ng.rs
+++ b/core/configs/src/server_ng_config/server_ng.rs
@@ -19,6 +19,7 @@ use super::COMPONENT_NG;
 use super::cluster::ClusterConfig;
 use super::message_bus::MessageBusConfig;
 use super::metadata::MetadataConfig;
+use super::partition::PartitionConfig;
 use super::quic::QuicConfig;
 use super::tcp::TcpConfig;
 use super::websocket::WebSocketConfig;
@@ -78,6 +79,7 @@ pub struct ServerNgConfig {
     pub telemetry: TelemetryConfig,
     pub cluster: ClusterConfig,
     pub metadata: MetadataConfig,
+    pub partition: PartitionConfig,
     pub message_bus: MessageBusConfig,
 }
 

--- a/core/configs/src/server_ng_config/validators.rs
+++ b/core/configs/src/server_ng_config/validators.rs
@@ -33,6 +33,12 @@ use iggy_common::{IggyExpiry, MaxTopicSize, Validatable};
 use server_common::sharding::IggyNamespace;
 use tracing::warn;
 
+/// compio-ws (tungstenite 0.29) `write_buffer_size` default. Used to
+/// evaluate the `max_write_buffer_size > write_buffer_size` invariant
+/// when the operator leaves `write_buffer_size` unset; keep in sync
+/// with the defaults documented in the shipped config.toml.
+const WS_DEFAULT_WRITE_BUFFER_SIZE: u64 = 128 * 1024;
+
 impl Validatable<ConfigurationError> for ServerNgConfig {
     fn validate(&self) -> Result<(), ConfigurationError> {
         self.system
@@ -82,6 +88,9 @@ impl Validatable<ConfigurationError> for ServerNgConfig {
         })?;
         self.metadata.validate().error(|e: &ConfigurationError| {
             format!("{COMPONENT_NG} (error: {e}) - failed to validate metadata config")
+        })?;
+        self.partition.validate().error(|e: &ConfigurationError| {
+            format!("{COMPONENT_NG} (error: {e}) - failed to validate partition config")
         })?;
         self.system
             .logging
@@ -179,9 +188,129 @@ impl Validatable<ConfigurationError> for ServerNgConfig {
                 format!("{COMPONENT_NG} (error: {e}) - failed to validate message_bus config")
             })?;
 
+        // Repair frames ride the bounded per-peer message-bus queue. A repair
+        // round of cluster.repair_chunk_max frames that meets or overruns
+        // message_bus.peer_queue_capacity drops its own tail silently, wedging
+        // the repair loop into slow retries. Keep the chunk strictly below the
+        // queue; this also floors peer_queue_capacity, which is otherwise only
+        // checked for > 0.
+        if self.cluster.repair_chunk_max >= self.message_bus.peer_queue_capacity {
+            eprintln!(
+                "{COMPONENT_NG} cluster.repair_chunk_max ({}) must be < message_bus.peer_queue_capacity ({}): repair frames ride the per-peer bus queue, so a chunk that fills or overruns it drops frames and wedges repair",
+                self.cluster.repair_chunk_max, self.message_bus.peer_queue_capacity
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
+        // WS frame chain: websocket.max_frame_size <= websocket.max_message_size
+        // <= message_bus.max_message_size. The bus's WS / WSS install path takes
+        // its frame tuning from [websocket], so a WS ceiling above the bus's own
+        // frame cap would admit messages the bus read-side validator then tears
+        // the connection down over. An absent knob defers to the compio-ws
+        // default (16 MiB frame / 64 MiB message), which satisfies the chain
+        // against the shipped bus cap in practice.
+        let bus_max_message_size = self.message_bus.max_message_size.as_bytes_u64();
+        if let (Some(frame), Some(message)) = (
+            self.websocket.max_frame_size,
+            self.websocket.max_message_size,
+        ) && frame.as_bytes_u64() > message.as_bytes_u64()
+        {
+            eprintln!(
+                "{COMPONENT_NG} websocket.max_frame_size ({}) exceeds websocket.max_message_size ({})",
+                frame.as_bytes_u64(),
+                message.as_bytes_u64()
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if let Some(message) = self.websocket.max_message_size
+            && message.as_bytes_u64() > bus_max_message_size
+        {
+            eprintln!(
+                "{COMPONENT_NG} websocket.max_message_size ({}) exceeds message_bus.max_message_size ({})",
+                message.as_bytes_u64(),
+                bus_max_message_size
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if let Some(frame) = self.websocket.max_frame_size
+            && frame.as_bytes_u64() > bus_max_message_size
+        {
+            eprintln!(
+                "{COMPONENT_NG} websocket.max_frame_size ({}) exceeds message_bus.max_message_size ({})",
+                frame.as_bytes_u64(),
+                bus_max_message_size
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+
+        // "0", "unlimited" and "none" all parse to a zero IggyByteSize. A
+        // zero WS tunable is never usable: zero message or frame ceilings
+        // reject every inbound frame, and zero buffers starve the
+        // compio-ws pipeline. Reject at boot instead of shipping a
+        // listener that cannot serve a single message.
+        for (key, size) in [
+            ("read_buffer_size", self.websocket.read_buffer_size),
+            ("write_buffer_size", self.websocket.write_buffer_size),
+            (
+                "max_write_buffer_size",
+                self.websocket.max_write_buffer_size,
+            ),
+            ("max_message_size", self.websocket.max_message_size),
+            ("max_frame_size", self.websocket.max_frame_size),
+        ] {
+            if let Some(size) = size
+                && size.as_bytes_u64() == 0
+            {
+                eprintln!(
+                    "{COMPONENT_NG} websocket.{key} must be non-zero (\"0\", \"unlimited\" and \"none\" all parse to zero)"
+                );
+                return Err(ConfigurationError::InvalidConfigurationValue);
+            }
+        }
+
+        // tungstenite asserts `max_write_buffer_size > write_buffer_size`
+        // during connection setup, so a violating pair panics on every
+        // accepted socket. Enforce the invariant at boot; an unset
+        // write_buffer_size runs at the compio-ws default.
+        if let Some(max_write) = self.websocket.max_write_buffer_size {
+            let write_buffer_size = self
+                .websocket
+                .write_buffer_size
+                .map_or(WS_DEFAULT_WRITE_BUFFER_SIZE, |size| size.as_bytes_u64());
+            if max_write.as_bytes_u64() <= write_buffer_size {
+                eprintln!(
+                    "{COMPONENT_NG} websocket.max_write_buffer_size ({}) must exceed websocket.write_buffer_size ({write_buffer_size})",
+                    max_write.as_bytes_u64()
+                );
+                return Err(ConfigurationError::InvalidConfigurationValue);
+            }
+        }
+
         self.quic.validate().error(|e: &ConfigurationError| {
             format!("{COMPONENT_NG} (error: {e}) - failed to validate quic config")
         })?;
+
+        // Both knobs below are live in server-ng but sit on structs the legacy
+        // server shares, so the rejects live here instead of in a `Validatable`
+        // impl that would tighten legacy boots too. `0` / `disabled` /
+        // `unlimited` all parse to the same zero duration.
+        if self
+            .consumer_group
+            .rebalancing_timeout
+            .get_duration()
+            .is_zero()
+        {
+            eprintln!(
+                "{COMPONENT_NG} consumer_group.rebalancing_timeout must be nonzero: it is the deadline after which a pending revocation completes without the source client committing what it was served, so zero force-transfers every partition on the next reconciler tick and reopens the duplicate-delivery window"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
+        if self.heartbeat.enabled && self.heartbeat.interval.get_duration().is_zero() {
+            eprintln!(
+                "{COMPONENT_NG} heartbeat.interval must be nonzero when heartbeat.enabled: it sizes both the verifier's sleep and the staleness window, so zero spins the verifier and reaps every live session on its first pass"
+            );
+            return Err(ConfigurationError::InvalidConfigurationValue);
+        }
 
         reject_unsupported_and_warn_inert(self)?;
 
@@ -229,6 +358,11 @@ fn reject_unsupported_and_warn_inert(config: &ServerNgConfig) -> Result<(), Conf
     }
     if config.tcp.socket_migration != defaults.tcp.socket_migration {
         warn!("tcp.socket_migration is not implemented in server-ng");
+    }
+    if config.system.partition.validate_checksum != defaults.system.partition.validate_checksum {
+        warn!(
+            "system.partition.validate_checksum is not applied in server-ng; nothing verifies checksums on load"
+        );
     }
     if config.system.segment.cache_indexes != defaults.system.segment.cache_indexes {
         warn!("system.segment.cache_indexes is not applied in server-ng");
@@ -359,6 +493,157 @@ mod tests {
         assert!(config.validate().is_err());
     }
 
+    #[test]
+    fn given_peer_queue_capacity_not_above_repair_chunk_max_when_validating_should_reject() {
+        // The default repair_chunk_max (128) must stay strictly below
+        // peer_queue_capacity; shrinking the queue to the chunk size is the
+        // silent wedged-repair footgun this cross-section guard closes.
+        let config = config_with_override("[message_bus]\npeer_queue_capacity = 128\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_repair_chunk_max_at_peer_queue_capacity_when_validating_should_reject() {
+        let config = config_with_override("[cluster]\nrepair_chunk_max = 256\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_repair_chunk_max_below_peer_queue_capacity_when_validating_should_pass() {
+        let config = config_with_override("[cluster]\nrepair_chunk_max = 255\n");
+        config
+            .validate()
+            .expect("a chunk below the peer queue capacity must validate");
+    }
+
+    #[test]
+    fn given_ws_frame_size_above_ws_message_size_when_validating_should_reject() {
+        let config = config_with_override(
+            "[websocket]\nmax_message_size = \"1 MiB\"\nmax_frame_size = \"2 MiB\"\n",
+        );
+        assert!(config.validate().is_err());
+    }
+
+    // The shipped bus cap is 64 MiB, so a 128 MiB WS ceiling breaks the chain.
+    #[test]
+    fn given_ws_message_size_above_bus_max_message_size_when_validating_should_reject() {
+        let config = config_with_override("[websocket]\nmax_message_size = \"128 MiB\"\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_ws_frame_size_above_bus_max_message_size_when_validating_should_reject() {
+        let config = config_with_override("[websocket]\nmax_frame_size = \"128 MiB\"\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_ws_frame_chain_in_ascending_order_when_validating_should_pass() {
+        let config = config_with_override(
+            "[websocket]\nmax_message_size = \"32 MiB\"\nmax_frame_size = \"16 MiB\"\n",
+        );
+        config
+            .validate()
+            .expect("frame <= message <= bus cap must validate");
+    }
+
+    // "unlimited" is not a supported sentinel for the WS size knobs: it
+    // parses to zero, which as a cap would reject every message.
+    #[test]
+    fn given_zero_ws_size_when_validating_should_reject() {
+        let config = config_with_override("[websocket]\nmax_message_size = \"unlimited\"\n");
+        assert!(config.validate().is_err());
+    }
+
+    // tungstenite panics on this pair at connection setup; boot must
+    // reject it first.
+    #[test]
+    fn given_max_write_buffer_at_write_buffer_when_validating_should_reject() {
+        let config = config_with_override(
+            "[websocket]\nwrite_buffer_size = \"256 KiB\"\nmax_write_buffer_size = \"256 KiB\"\n",
+        );
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_max_write_buffer_below_default_write_buffer_when_validating_should_reject() {
+        let config = config_with_override("[websocket]\nmax_write_buffer_size = \"64 KiB\"\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_max_write_buffer_above_write_buffer_when_validating_should_pass() {
+        let config = config_with_override(
+            "[websocket]\nwrite_buffer_size = \"128 KiB\"\nmax_write_buffer_size = \"1 MiB\"\n",
+        );
+        config
+            .validate()
+            .expect("max write buffer above write buffer must validate");
+    }
+
+    // The size knobs are strictly typed; a malformed string must fail
+    // deserialization at load rather than degrade to the compio-ws default.
+    #[test]
+    fn given_malformed_ws_size_string_when_deserializing_should_reject() {
+        let result: Result<ServerNgConfig, _> = Figment::new()
+            .merge(Toml::string(DEFAULT_CONFIG))
+            .merge(Toml::string(
+                "[websocket]\nmax_message_size = \"not-a-size\"\n",
+            ))
+            .extract();
+        assert!(
+            result.is_err(),
+            "malformed websocket.max_message_size must fail config load"
+        );
+    }
+
+    // The shipped config is single-node (cluster.enabled = false), where the
+    // cross-section rule above is the only repair_chunk_max check that used to
+    // run; its structural bounds have to hold there too.
+    #[test]
+    fn given_single_node_zero_repair_chunk_max_when_validating_should_reject() {
+        let config = config_with_override("[cluster]\nrepair_chunk_max = 0\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_single_node_repair_chunk_max_above_ceiling_when_validating_should_reject() {
+        // Queue widened past the chunk so the cross-section rule passes and
+        // only the structural ceiling can reject.
+        let config = config_with_override(
+            "[cluster]\nrepair_chunk_max = 2000\n\n[message_bus]\npeer_queue_capacity = 4096\n",
+        );
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_zero_rebalancing_timeout_when_validating_should_reject() {
+        let config = config_with_override("[consumer_group]\nrebalancing_timeout = \"0\"\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_disabled_rebalancing_timeout_when_validating_should_reject() {
+        // "disabled" reads like an opt-out but parses to the same zero
+        // duration, which force-transfers every revocation instead.
+        let config = config_with_override("[consumer_group]\nrebalancing_timeout = \"disabled\"\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_zero_heartbeat_interval_when_heartbeat_enabled_should_reject() {
+        let config = config_with_override("[heartbeat]\nenabled = true\ninterval = \"0\"\n");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn given_zero_heartbeat_interval_when_heartbeat_disabled_should_pass() {
+        let config = config_with_override("[heartbeat]\nenabled = false\ninterval = \"0\"\n");
+        config
+            .validate()
+            .expect("a disabled heartbeat never reads its interval");
+    }
+
     /// The warn-helper baseline is [`ServerNgConfig::default`], but the reused
     /// legacy sections source that default from the legacy server config.toml,
     /// not this NG file. Pin the knobs the helper compares so any drift between
@@ -372,6 +657,10 @@ mod tests {
         let defaults = ServerNgConfig::default();
 
         assert_eq!(shipped.tcp.socket_migration, defaults.tcp.socket_migration);
+        assert_eq!(
+            shipped.system.partition.validate_checksum,
+            defaults.system.partition.validate_checksum
+        );
         assert_eq!(
             shipped.system.segment.cache_indexes,
             defaults.system.segment.cache_indexes

--- a/core/configs/src/server_ng_config/websocket.rs
+++ b/core/configs/src/server_ng_config/websocket.rs
@@ -17,36 +17,75 @@
 
 //! Server-ng WebSocket listener schema.
 //!
-//! Field shape mirrors the legacy [`crate::websocket::WebSocketConfig`]
-//! verbatim, including the `Option<String>` frame-tunable fields that
-//! the legacy server parses lazily into `IggyByteSize` inside
-//! [`WebSocketConfig::to_tungstenite_config`]. The fork lives in
-//! `server_ng_config` so server-ng can evolve its WS frame surface
-//! (e.g. tighten the type to `Option<IggyByteSize>`) independently of
-//! the legacy server.
+//! Unlike the legacy [`crate::websocket::WebSocketConfig`] it was
+//! forked from, this section is the live frame-tuning source for
+//! server-ng's WS / WSS plane: the message bus folds the
+//! `Option<IggyByteSize>` knobs below into a compio-ws
+//! `WebSocketConfig` once at bus construction. The sizes are strictly
+//! typed, so a malformed size string fails config load instead of
+//! being silently ignored at conversion time. The conversion itself
+//! lives in `core/message_bus` because the standalone `tungstenite`
+//! dependency and the compio-ws re-export are different major versions
+//! with incompatible config types.
 
 use configs::ConfigEnv;
 use iggy_common::IggyByteSize;
 use serde::{Deserialize, Serialize};
+use serde_with::{DisplayFromStr, serde_as};
 use std::fmt::{Display, Formatter};
-use tungstenite::protocol::WebSocketConfig as TungsteniteConfig;
 
+#[serde_as]
 #[derive(Debug, Deserialize, Serialize, Clone, ConfigEnv)]
 pub struct WebSocketConfig {
     pub enabled: bool,
     pub address: String,
+
+    /// Target minimum size of the frame read buffer. `None` keeps the
+    /// compio-ws default (currently 128 KiB).
+    #[config_env(leaf)]
     #[serde(default)]
-    pub read_buffer_size: Option<String>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub read_buffer_size: Option<IggyByteSize>,
+
+    /// Target buffer size for batched writes before compio-ws flushes.
+    /// `None` keeps the compio-ws default (currently 128 KiB).
+    #[config_env(leaf)]
     #[serde(default)]
-    pub write_buffer_size: Option<String>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub write_buffer_size: Option<IggyByteSize>,
+
+    /// Hard ceiling on the write buffer; writes past it error instead
+    /// of buffering. Must exceed [`Self::write_buffer_size`] by at
+    /// least one frame. `None` keeps the compio-ws default
+    /// (unlimited).
+    #[config_env(leaf)]
     #[serde(default)]
-    pub max_write_buffer_size: Option<String>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub max_write_buffer_size: Option<IggyByteSize>,
+
+    /// Hard upper bound on a single inbound WebSocket message
+    /// (post-fragment-reassembly). `None` keeps the compio-ws default
+    /// (currently 64 MiB).
+    #[config_env(leaf)]
     #[serde(default)]
-    pub max_message_size: Option<String>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub max_message_size: Option<IggyByteSize>,
+
+    /// Hard upper bound on a single inbound WebSocket frame
+    /// (pre-fragment-reassembly). `None` keeps the compio-ws default
+    /// (currently 16 MiB).
+    #[config_env(leaf)]
     #[serde(default)]
-    pub max_frame_size: Option<String>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub max_frame_size: Option<IggyByteSize>,
+
+    /// Whether to accept unmasked frames from clients in violation of
+    /// RFC 6455 client-to-server framing rules. Strict (`false`) by
+    /// default; enable only for non-browser test clients that emit
+    /// unmasked frames.
     #[serde(default)]
     pub accept_unmasked_frames: bool,
+
     #[serde(default)]
     pub tls: WebSocketTlsConfig,
 }
@@ -57,46 +96,6 @@ pub struct WebSocketTlsConfig {
     pub self_signed: bool,
     pub cert_file: String,
     pub key_file: String,
-}
-
-impl WebSocketConfig {
-    pub fn to_tungstenite_config(&self) -> TungsteniteConfig {
-        let mut config = TungsteniteConfig::default();
-
-        if let Some(read_buf_size_str) = &self.read_buffer_size
-            && let Ok(byte_size) = read_buf_size_str.parse::<IggyByteSize>()
-        {
-            config = config.read_buffer_size(byte_size.as_bytes_u64() as usize);
-        }
-
-        if let Some(write_buf_size_str) = &self.write_buffer_size
-            && let Ok(byte_size) = write_buf_size_str.parse::<IggyByteSize>()
-        {
-            config = config.write_buffer_size(byte_size.as_bytes_u64() as usize);
-        }
-
-        if let Some(max_write_buf_size_str) = &self.max_write_buffer_size
-            && let Ok(byte_size) = max_write_buf_size_str.parse::<IggyByteSize>()
-        {
-            config = config.max_write_buffer_size(byte_size.as_bytes_u64() as usize);
-        }
-
-        if let Some(msg_size_str) = &self.max_message_size
-            && let Ok(byte_size) = msg_size_str.parse::<IggyByteSize>()
-        {
-            config = config.max_message_size(Some(byte_size.as_bytes_u64() as usize));
-        }
-
-        if let Some(frame_size_str) = &self.max_frame_size
-            && let Ok(byte_size) = frame_size_str.parse::<IggyByteSize>()
-        {
-            config = config.max_frame_size(Some(byte_size.as_bytes_u64() as usize));
-        }
-
-        config = config.accept_unmasked_frames(self.accept_unmasked_frames);
-
-        config
-    }
 }
 
 impl Display for WebSocketConfig {

--- a/core/consensus/src/client_table.rs
+++ b/core/consensus/src/client_table.rs
@@ -236,6 +236,21 @@ impl ClientTable {
         }
     }
 
+    /// Resize the table to `max_clients` slots. Boot-only: reallocating a
+    /// populated table would silently drop live sessions, so this must run
+    /// before any client registers (server-ng bootstrap applies the configured
+    /// `[metadata] clients_table_max` here).
+    ///
+    /// # Panics
+    /// If the table already holds a client.
+    pub fn set_capacity(&mut self, max_clients: usize) {
+        assert!(
+            self.index.is_empty(),
+            "set_capacity must run before any client registers"
+        );
+        *self = Self::new(max_clients);
+    }
+
     /// Check a request against the table. Epoch fence first, then the
     /// watermark. Register does not come through here: every bind proposes
     /// unconditionally so its fence actually moves, see
@@ -1085,6 +1100,30 @@ mod tests {
         );
         assert!(table.get_reply(200).is_some());
         assert!(table.get_reply(300).is_some());
+    }
+
+    // Capacity resize (boot-only)
+
+    // Resizing an empty table swaps its slot count in: a smaller cap then
+    // evicts once the new bound is reached.
+    #[test]
+    fn set_capacity_resizes_empty_table() {
+        let mut table = ClientTable::new(10);
+        table.set_capacity(2);
+        table.commit_register(100, TEST_USER_ID, make_register_reply(100, 10));
+        table.commit_register(200, TEST_USER_ID, make_register_reply(200, 20));
+        table.commit_register(300, TEST_USER_ID, make_register_reply(300, 30));
+        assert_eq!(table.count(), 2, "resized cap of 2 evicts the oldest");
+        assert!(table.get_reply(100).is_none());
+    }
+
+    // The empty-table contract is asserted, not silently honored: resizing a
+    // populated table would drop live sessions, so it must panic.
+    #[test]
+    #[should_panic(expected = "before any client registers")]
+    fn set_capacity_rejects_a_populated_table() {
+        let (mut table, _session) = table_with_client();
+        table.set_capacity(2);
     }
 
     // Evicting a client mid-prepare is safe: the commit reports NoEntry

--- a/core/consensus/src/impls.rs
+++ b/core/consensus/src/impls.rs
@@ -37,6 +37,7 @@ use server_common::sharding::{IggyNamespace, METADATA_CONSENSUS_NAMESPACE};
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::rc::Rc;
+use std::time::Duration;
 
 /// Injected time source for primary-stamped prepare timestamps.
 ///
@@ -122,16 +123,18 @@ impl Sequencer for LocalSequencer {
     }
 }
 
-/// TODO The below numbers need to be added a consensus config
-/// TODO understand how to configure these numbers.
-/// Maximum number of prepares that can be in-flight in the pipeline.
+/// Default in-flight prepare-queue depth.
 ///
-/// Sized to absorb a synchronized client burst (e.g. the 20-way
-/// concurrent-creation race tests across TCP/QUIC/WebSocket) without
-/// `PipelineFull`-rejecting and disconnecting clients that cannot replay in
-/// time. At depth 8 the QUIC burst wedges the metadata consensus even in
-/// release. Stays well under the journal's `SLOT_COUNT` (1024) and the inbox
-/// capacity headroom.
+/// [`LocalPipeline::new`] uses it, and the server-ng config default
+/// (`DEFAULT_METADATA_PREPARE_QUEUE_DEPTH`) is static-asserted equal to it at
+/// bootstrap. Operators raise the running bound via `[metadata]
+/// prepare_queue_depth`; the pipeline then carries its own capacity (see
+/// [`LocalPipeline::with_capacities`]).
+///
+/// Sized to absorb a synchronized client burst (the 20-way concurrent-creation
+/// race tests across TCP/QUIC/WebSocket) without `PipelineFull`-rejecting
+/// clients that cannot replay in time; a depth of 8 wedged the QUIC burst even
+/// in release. Stays well under the journal's slot count and the inbox headroom.
 pub const PIPELINE_PREPARE_QUEUE_MAX: usize = 32;
 
 /// Max accepted-but-not-yet-prepared requests buffered behind a full
@@ -447,7 +450,7 @@ impl LocalPipeline {
     }
 
     /// Find a message by op number and checksum (immutable).
-    // Pipeline bounded at PIPELINE_PREPARE_QUEUE_MAX (8) entries; index always fits in usize.
+    // op - head_op is bounded by the configured prepare-queue depth; index always fits in usize.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn message_by_op_and_checksum(&self, op: u64, checksum: u128) -> Option<&PipelineEntry> {
@@ -478,7 +481,7 @@ impl LocalPipeline {
     }
 
     /// Find a message by op number only.
-    // Pipeline bounded at PIPELINE_PREPARE_QUEUE_MAX (8) entries; index always fits in usize.
+    // op - head_op is bounded by the configured prepare-queue depth; index always fits in usize.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn message_by_op(&self, op: u64) -> Option<&PipelineEntry> {
@@ -494,7 +497,7 @@ impl LocalPipeline {
 
     /// Get mutable reference to a message entry by op number.
     /// Returns None if op is not in the pipeline.
-    // Pipeline bounded at PIPELINE_PREPARE_QUEUE_MAX (8) entries; index always fits in usize.
+    // op - head_op is bounded by the configured prepare-queue depth; index always fits in usize.
     #[allow(clippy::cast_possible_truncation)]
     pub fn message_by_op_mut(&mut self, op: u64) -> Option<&mut PipelineEntry> {
         let head_op = self.prepare_queue.front()?.header.op;
@@ -531,8 +534,8 @@ impl LocalPipeline {
     /// If any invariant is violated.
     pub fn verify(&self) {
         // Check capacity limits
-        assert!(self.prepare_queue.len() <= PIPELINE_PREPARE_QUEUE_MAX);
-        assert!(self.request_queue.len() <= PIPELINE_REQUEST_QUEUE_MAX);
+        assert!(self.prepare_queue.len() <= self.prepare_queue_max);
+        assert!(self.request_queue.len() <= self.request_queue_max);
 
         // Verify prepare queue hash chain
         if let Some(head) = self.prepare_queue.front() {
@@ -620,6 +623,10 @@ impl Pipeline for LocalPipeline {
 
     fn len(&self) -> usize {
         self.prepare_count()
+    }
+
+    fn prepare_queue_max(&self) -> usize {
+        self.prepare_queue_max
     }
 
     fn verify(&self) {
@@ -784,6 +791,10 @@ where
     /// Commit point the recovered WAL suffix must re-reach before admitting
     /// client requests as primary (`0` = no recovered suffix pending).
     recovery_barrier: Cell<u64>,
+    /// Wall-clock budget the recovered suffix has to re-commit before a waiter
+    /// on [`Self::recovery_barrier`] gives up. Armed together with the barrier;
+    /// `ZERO` when no suffix is pending (barrier `0`), which no waiter reads.
+    recovery_deadline: Cell<Duration>,
     /// True while this replica declines the primaryship its (stale) recovered
     /// view assigns it (see `init_as_backup`). `is_primary()` is pure view
     /// math, so without this flag a restarted view-N primary would still pass
@@ -809,14 +820,24 @@ where
     last_prepare_checksum: Cell<u128>,
 
     pipeline: RefCell<P>,
+    /// Snapshot of the pipeline's in-flight prepare capacity, taken at
+    /// construction. Bounds the loopback queue and the view-change rebuild
+    /// range without re-borrowing `pipeline`.
+    prepare_queue_max: usize,
 
     message_bus: B,
     loopback_queue: RefCell<VecDeque<Message<GenericHeader>>>,
     /// Tracks start view change messages received from all replicas (including self)
     start_view_change_from_all_replicas: RefCell<BitSet<u32>>,
     /// Consecutive unanswered `RequestStartView` probes while Recovering;
-    /// at [`PROBE_ATTEMPTS_MAX`] the replica falls back to an election.
+    /// at the `probe_attempts_max` ceiling the replica falls back to an
+    /// election.
     probe_attempts: Cell<u32>,
+    /// Probe-attempt ceiling backing the fall-back-to-election decision,
+    /// seeded from [`PROBE_ATTEMPTS_MAX`] and overridable by the runtime via
+    /// `[cluster] view_probe_attempts_max`. The simulator and tests keep the
+    /// built-in default.
+    probe_attempts_max: Cell<u32>,
 
     /// Tracks DVC messages received (only used by primary candidate)
     /// Stores metadata; actual log comes from message
@@ -896,6 +917,7 @@ impl<B: MessageBus, P: Pipeline<Entry = PipelineEntry>> VsrConsensus<B, P> {
         // across groups. Consider using a proper hash (e.g., Murmur3) of
         // (replica_id, namespace) for production.
         let timeout_seed = u128::from(replica) ^ u128::from(namespace);
+        let prepare_queue_max = pipeline.prepare_queue_max();
         Self {
             cluster,
             replica,
@@ -904,6 +926,7 @@ impl<B: MessageBus, P: Pipeline<Entry = PipelineEntry>> VsrConsensus<B, P> {
             view: Cell::new(0),
             log_view: Cell::new(0),
             recovery_barrier: Cell::new(0),
+            recovery_deadline: Cell::new(Duration::ZERO),
             ceded_primaryship: Cell::new(false),
             status: Cell::new(Status::Recovering),
             sequencer: LocalSequencer::new(0),
@@ -912,10 +935,12 @@ impl<B: MessageBus, P: Pipeline<Entry = PipelineEntry>> VsrConsensus<B, P> {
             last_timestamp: Cell::new(0),
             last_prepare_checksum: Cell::new(0),
             pipeline: RefCell::new(pipeline),
+            prepare_queue_max,
             message_bus,
-            loopback_queue: RefCell::new(VecDeque::with_capacity(PIPELINE_PREPARE_QUEUE_MAX)),
+            loopback_queue: RefCell::new(VecDeque::with_capacity(prepare_queue_max)),
             start_view_change_from_all_replicas: RefCell::new(BitSet::with_capacity(REPLICAS_MAX)),
             probe_attempts: Cell::new(0),
+            probe_attempts_max: Cell::new(PROBE_ATTEMPTS_MAX),
             do_view_change_from_all_replicas: RefCell::new(dvc_quorum_array_empty()),
             do_view_change_quorum: Cell::new(false),
             sent_own_start_view_change: Cell::new(false),
@@ -932,6 +957,61 @@ impl<B: MessageBus, P: Pipeline<Entry = PipelineEntry>> VsrConsensus<B, P> {
     /// countdown already in flight.
     pub fn set_normal_heartbeat_ticks(&self, ticks: u64) {
         self.timeouts.borrow_mut().set_normal_heartbeat_ticks(ticks);
+    }
+
+    /// Override the primary's commit-broadcast interval, in consensus ticks.
+    /// Sized from `[cluster] commit_broadcast_interval` by the runtime. Must
+    /// run before `init` / `init_as_backup`: the override discards any
+    /// countdown already in flight.
+    pub fn set_commit_message_ticks(&self, ticks: u64) {
+        self.timeouts.borrow_mut().set_commit_message_ticks(ticks);
+    }
+
+    /// Override the primary's prepare-retransmit interval, in consensus ticks.
+    /// Sized from `[cluster] prepare_retransmit_interval` by the runtime. Must
+    /// run before `init` / `init_as_backup`: the override discards any
+    /// countdown already in flight.
+    pub fn set_prepare_ticks(&self, ticks: u64) {
+        self.timeouts.borrow_mut().set_prepare_ticks(ticks);
+    }
+
+    /// Override the view-change retransmit interval (`StartViewChange` and
+    /// `DoViewChange`, kept equal), in consensus ticks. Sized from `[cluster]
+    /// view_change_retransmit_interval` by the runtime. Must run before `init`
+    /// / `init_as_backup`: the override discards any countdown already in
+    /// flight.
+    pub fn set_view_change_retransmit_ticks(&self, ticks: u64) {
+        self.timeouts
+            .borrow_mut()
+            .set_view_change_retransmit_ticks(ticks);
+    }
+
+    /// Override the view-change status backstop, in consensus ticks. Sized from
+    /// `[cluster] view_change_status_timeout` by the runtime. Must run before
+    /// `init` / `init_as_backup`: the override discards any countdown already
+    /// in flight.
+    pub fn set_view_change_status_ticks(&self, ticks: u64) {
+        self.timeouts
+            .borrow_mut()
+            .set_view_change_status_ticks(ticks);
+    }
+
+    /// Override the request-start-view retransmit interval, in consensus ticks.
+    /// Sized from `[cluster] request_start_view_retransmit_interval` by the
+    /// runtime. Must run before `init` / `init_as_backup`: the override
+    /// discards any countdown already in flight.
+    pub fn set_request_start_view_ticks(&self, ticks: u64) {
+        self.timeouts
+            .borrow_mut()
+            .set_request_start_view_ticks(ticks);
+    }
+
+    /// Override the recovering-replica probe-attempt ceiling before it falls
+    /// back to an election. Sized from `[cluster] view_probe_attempts_max` by
+    /// the runtime; the simulator and tests keep [`PROBE_ATTEMPTS_MAX`]. Must
+    /// run before `init` / `init_as_backup`.
+    pub fn set_probe_attempts_max(&self, max: u32) {
+        self.probe_attempts_max.set(max);
     }
 
     pub fn init(&self) {
@@ -1105,6 +1185,17 @@ impl<B: MessageBus, P: Pipeline<Entry = PipelineEntry>> VsrConsensus<B, P> {
 
     pub fn set_recovery_barrier(&self, required_commit: u64) {
         self.recovery_barrier.set(required_commit);
+    }
+
+    /// Deadline paired with [`Self::recovery_barrier`]; only meaningful while the
+    /// barrier is armed (non-zero).
+    #[must_use]
+    pub const fn recovery_deadline(&self) -> Duration {
+        self.recovery_deadline.get()
+    }
+
+    pub fn set_recovery_deadline(&self, deadline: Duration) {
+        self.recovery_deadline.set(deadline);
     }
 
     pub fn set_view(&mut self, view: u32) {
@@ -1436,7 +1527,7 @@ impl<B: MessageBus, P: Pipeline<Entry = PipelineEntry>> VsrConsensus<B, P> {
                     // primary answers well before the fallback fires.
                     let attempts = self.probe_attempts.get() + 1;
                     self.probe_attempts.set(attempts);
-                    if attempts >= PROBE_ATTEMPTS_MAX {
+                    if attempts >= self.probe_attempts_max.get() {
                         self.finish_view_probe();
                         actions.extend(
                             self.start_election(plane, ViewChangeReason::ViewProbeUnanswered),
@@ -2436,13 +2527,13 @@ impl<B: MessageBus, P: Pipeline<Entry = PipelineEntry>> VsrConsensus<B, P> {
         // incoming PrepareOk messages can be matched and commits can proceed.
         if max_commit < new_op {
             assert!(
-                (new_op - max_commit) <= PIPELINE_PREPARE_QUEUE_MAX as u64,
+                (new_op - max_commit) <= self.prepare_queue_max as u64,
                 "view change: uncommitted range {}..={} ({} ops) exceeds pipeline capacity ({}); \
                  DVC winner claims more in-flight ops than the pipeline can hold",
                 max_commit + 1,
                 new_op,
                 new_op - max_commit,
-                PIPELINE_PREPARE_QUEUE_MAX,
+                self.prepare_queue_max,
             );
             actions.push(VsrAction::RebuildPipeline {
                 from_op: max_commit + 1,
@@ -2554,7 +2645,7 @@ impl<B: MessageBus, P: Pipeline<Entry = PipelineEntry>> VsrConsensus<B, P> {
     // TODO: Route SVC/DVC self-messages through loopback once VsrAction dispatch is implemented.
     pub(crate) fn push_loopback(&self, message: Message<GenericHeader>) {
         assert!(
-            self.loopback_queue.borrow().len() < PIPELINE_PREPARE_QUEUE_MAX,
+            self.loopback_queue.borrow().len() < self.prepare_queue_max,
             "loopback queue overflow: {} items",
             self.loopback_queue.borrow().len()
         );
@@ -2948,6 +3039,38 @@ mod pipeline_entry_tests {
         let header = PrepareHeader::default();
         let mut entry = PipelineEntry::new(header);
         assert!(entry.take_reply_sender().is_none());
+    }
+
+    /// A pipeline configured deeper than [`PIPELINE_PREPARE_QUEUE_MAX`] must
+    /// verify a full queue instead of tripping the capacity assert: the bound
+    /// tracks the configured depth, not the default const.
+    #[test]
+    #[allow(clippy::cast_possible_truncation)]
+    fn given_prepare_queue_depth_above_default_when_verify_should_not_panic() {
+        let depth = PIPELINE_PREPARE_QUEUE_MAX * 2;
+        let mut pipeline = LocalPipeline::with_capacities(depth, depth * 2);
+
+        let mut parent = 0u128;
+        for op in 1..=depth as u64 {
+            let checksum = u128::from(op);
+            let header = PrepareHeader {
+                command: Command2::Prepare,
+                size: std::mem::size_of::<PrepareHeader>() as u32,
+                op,
+                parent,
+                checksum,
+                ..Default::default()
+            };
+            pipeline.push(PipelineEntry::new(header));
+            parent = checksum;
+        }
+
+        assert!(
+            pipeline.prepare_queue_full(),
+            "queue filled to the configured depth"
+        );
+        // Would panic on the old `len() <= PIPELINE_PREPARE_QUEUE_MAX` assert.
+        pipeline.verify();
     }
 }
 

--- a/core/consensus/src/lib.rs
+++ b/core/consensus/src/lib.rs
@@ -52,6 +52,11 @@ pub trait Pipeline {
 
     fn len(&self) -> usize;
 
+    /// In-flight prepare-queue capacity. `VsrConsensus` snapshots it at
+    /// construction to size the loopback queue and to bound the uncommitted
+    /// range a new primary may rebuild after a view change.
+    fn prepare_queue_max(&self) -> usize;
+
     fn verify(&self);
 
     /// True iff either queue carries `client_id`. Used by metadata-plane

--- a/core/consensus/src/plane_helpers.rs
+++ b/core/consensus/src/plane_helpers.rs
@@ -683,9 +683,9 @@ mod tests {
         consensus.init();
 
         // Diverge the frontiers: applied (commit_min=5) lags known-committed
-        // (commit_max=13) by more than PIPELINE_PREPARE_QUEUE_MAX (8). op is at
-        // 13 (>= commit_max), so the op clamp on the DVC commit is a no-op here
-        // and the carried value is commit_max. The clamp itself is covered by
+        // (commit_max=13). op is at 13 (>= commit_max), so the op clamp on the
+        // DVC commit is a no-op here and the carried value is commit_max. The
+        // clamp itself is covered by
         // `do_view_change_commit_clamped_to_op_when_commit_max_exceeds_op`.
         consensus.advance_commit_max(13);
         consensus.sequencer().set_sequence(13);
@@ -908,6 +908,74 @@ mod tests {
         assert!(
             buf.is_empty(),
             "loopback queue must be empty after view change completion"
+        );
+    }
+
+    /// A DVC winner may claim an uncommitted range up to the *configured*
+    /// prepare depth. With a pipeline deeper than the default const, the new
+    /// primary schedules the rebuild rather than panicking on the old
+    /// `PIPELINE_PREPARE_QUEUE_MAX` bound.
+    #[test]
+    #[allow(clippy::cast_possible_truncation)]
+    fn given_view_change_range_above_default_when_complete_as_primary_should_rebuild() {
+        use iggy_binary_protocol::{DoViewChangeHeader, StartViewChangeHeader};
+
+        let depth = crate::PIPELINE_PREPARE_QUEUE_MAX * 2;
+        // Strictly above the default const, still within the configured depth.
+        let winner_op = (crate::PIPELINE_PREPARE_QUEUE_MAX + 8) as u64;
+
+        // 3 replicas, replica 0 is primary for view 3 (3 % 3 = 0).
+        let consensus = VsrConsensus::new(
+            1,
+            0,
+            3,
+            0,
+            NoopBus,
+            LocalPipeline::with_capacities(depth, depth * 2),
+        );
+        consensus.init();
+
+        // SVC from replica 1 moves replica 0 into view 3 and records its own DVC.
+        let svc = StartViewChangeHeader {
+            checksum: 0,
+            checksum_body: 0,
+            cluster: 0,
+            size: 0,
+            view: 3,
+            release: 0,
+            command: Command2::StartViewChange,
+            replica: 1,
+            reserved_frame: [0; 66],
+            namespace: 0,
+            reserved: [0; 120],
+        };
+        let _ = consensus.handle_start_view_change(PlaneKind::Metadata, &svc);
+
+        // DVC from replica 2 claims a log head far past commit, forming quorum.
+        let dvc = DoViewChangeHeader {
+            checksum: 0,
+            checksum_body: 0,
+            cluster: 0,
+            size: 0,
+            view: 3,
+            release: 0,
+            command: Command2::DoViewChange,
+            replica: 2,
+            reserved_frame: [0; 66],
+            op: winner_op,
+            commit: 0,
+            namespace: 0,
+            log_view: 0,
+            reserved: [0; 100],
+        };
+        let actions = consensus.handle_do_view_change(PlaneKind::Metadata, &dvc);
+
+        assert!(
+            actions.iter().any(|action| matches!(
+                action,
+                VsrAction::RebuildPipeline { from_op: 1, to_op } if *to_op == winner_op
+            )),
+            "expected RebuildPipeline over the full uncommitted range"
         );
     }
 

--- a/core/consensus/src/vsr_timeout.rs
+++ b/core/consensus/src/vsr_timeout.rs
@@ -99,7 +99,6 @@ impl Timeout {
 #[allow(unused)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TimeoutKind {
-    Ping,
     Prepare,
     CommitMessage,
     NormalHeartbeat,
@@ -115,7 +114,6 @@ pub enum TimeoutKind {
 #[allow(unused)]
 #[derive(Debug)]
 pub struct TimeoutManager {
-    ping: Timeout,
     prepare: Timeout,
     commit_message: Timeout,
     normal_heartbeat: Timeout,
@@ -130,21 +128,36 @@ pub struct TimeoutManager {
 impl TimeoutManager {
     // Timeout durations in ticks (10ms per tick).
     // TODO define 10ms per tick in a separate constant.
-    const PING_TICKS: u64 = 100;
-    const PREPARE_TICKS: u64 = 25;
-    const COMMIT_MESSAGE_TICKS: u64 = 50;
+    /// Public so the runtime can pin its `[cluster] prepare_retransmit_interval`
+    /// config default against this built-in.
+    pub const PREPARE_TICKS: u64 = 25;
+    /// Public so the runtime can pin its `[cluster] commit_broadcast_interval`
+    /// config default against this built-in.
+    pub const COMMIT_MESSAGE_TICKS: u64 = 50;
     /// Public so the runtime can pin its config default (`[cluster]
     /// heartbeat_timeout`) against this built-in with a static assert.
     pub const NORMAL_HEARTBEAT_TICKS: u64 = 500;
-    const START_VIEW_CHANGE_MESSAGE_TICKS: u64 = 50;
-    const VIEW_CHANGE_STATUS_TICKS: u64 = 500;
-    const DO_VIEW_CHANGE_MESSAGE_TICKS: u64 = 50;
-    const REQUEST_START_VIEW_MESSAGE_TICKS: u64 = 100;
+    /// Public so the runtime can pin its `[cluster]
+    /// view_change_retransmit_interval` config default against this built-in.
+    /// Deliberately equal to [`Self::DO_VIEW_CHANGE_MESSAGE_TICKS`]: one config
+    /// knob drives both retransmit timers.
+    pub const START_VIEW_CHANGE_MESSAGE_TICKS: u64 = 50;
+    /// Public so the runtime can pin its `[cluster] view_change_status_timeout`
+    /// config default against this built-in.
+    pub const VIEW_CHANGE_STATUS_TICKS: u64 = 500;
+    /// Public so the runtime can pin its `[cluster]
+    /// view_change_retransmit_interval` config default against this built-in.
+    /// Deliberately equal to [`Self::START_VIEW_CHANGE_MESSAGE_TICKS`]: one
+    /// config knob drives both retransmit timers.
+    pub const DO_VIEW_CHANGE_MESSAGE_TICKS: u64 = 50;
+    /// Public so the runtime can pin its `[cluster]
+    /// request_start_view_retransmit_interval` config default against this
+    /// built-in.
+    pub const REQUEST_START_VIEW_MESSAGE_TICKS: u64 = 100;
 
     #[must_use]
     pub fn new(replica_id: u128) -> Self {
         Self {
-            ping: Timeout::new(replica_id, Self::PING_TICKS),
             prepare: Timeout::new(replica_id, Self::PREPARE_TICKS),
             commit_message: Timeout::new(replica_id, Self::COMMIT_MESSAGE_TICKS),
             normal_heartbeat: Timeout::new(replica_id, Self::NORMAL_HEARTBEAT_TICKS),
@@ -172,11 +185,56 @@ impl TimeoutManager {
         self.normal_heartbeat = Timeout::new(self.normal_heartbeat.id, ticks);
     }
 
+    /// Override the primary's commit-broadcast interval (`[cluster]
+    /// commit_broadcast_interval`). Replaces the timeout object, so any
+    /// countdown already in flight is discarded: call before the replica
+    /// starts ticking (i.e. before `init`).
+    pub const fn set_commit_message_ticks(&mut self, ticks: u64) {
+        self.commit_message = Timeout::new(self.commit_message.id, ticks);
+    }
+
+    /// Override the primary's prepare-retransmit interval (`[cluster]
+    /// prepare_retransmit_interval`). Replaces the timeout object, so any
+    /// countdown already in flight is discarded: call before the replica
+    /// starts ticking (i.e. before `init`).
+    pub const fn set_prepare_ticks(&mut self, ticks: u64) {
+        self.prepare = Timeout::new(self.prepare.id, ticks);
+    }
+
+    /// Override the view-change retransmit interval (`[cluster]
+    /// view_change_retransmit_interval`), in consensus ticks. Drives BOTH the
+    /// `StartViewChange` and `DoViewChange` retransmit timers - kept equal by
+    /// design so a view change retransmits both messages at one cadence.
+    /// Replaces the timeout objects, so any countdown already in flight is
+    /// discarded: call before the replica starts ticking (i.e. before `init`).
+    pub const fn set_view_change_retransmit_ticks(&mut self, ticks: u64) {
+        self.start_view_change_message = Timeout::new(self.start_view_change_message.id, ticks);
+        self.do_view_change_message = Timeout::new(self.do_view_change_message.id, ticks);
+    }
+
+    /// Override the view-change status backstop (`[cluster]
+    /// view_change_status_timeout`), in consensus ticks. A view change stalled
+    /// this long escalates to a fresh cluster-wide election. Replaces the
+    /// timeout object, so any countdown already in flight is discarded: call
+    /// before the replica starts ticking (i.e. before `init`).
+    pub const fn set_view_change_status_ticks(&mut self, ticks: u64) {
+        self.view_change_status = Timeout::new(self.view_change_status.id, ticks);
+    }
+
+    /// Override the request-start-view retransmit interval (`[cluster]
+    /// request_start_view_retransmit_interval`), in consensus ticks: how often
+    /// a recovering or view-change backup re-requests the current view's
+    /// `StartView`. Replaces the timeout object, so any countdown already in
+    /// flight is discarded: call before the replica starts ticking (i.e. before
+    /// `init`).
+    pub const fn set_request_start_view_ticks(&mut self, ticks: u64) {
+        self.request_start_view_message = Timeout::new(self.request_start_view_message.id, ticks);
+    }
+
     /// Tick all timeouts
     /// This is the first phase of the two-phase tick-based timeout mechanism.
     /// 2nd phase is checking which timeouts have fired and calling the appropriate handlers.
     pub const fn tick(&mut self) {
-        self.ping.tick();
         self.prepare.tick();
         self.commit_message.tick();
         self.normal_heartbeat.tick();
@@ -194,7 +252,6 @@ impl TimeoutManager {
     #[must_use]
     pub const fn get(&self, kind: TimeoutKind) -> &Timeout {
         match kind {
-            TimeoutKind::Ping => &self.ping,
             TimeoutKind::Prepare => &self.prepare,
             TimeoutKind::CommitMessage => &self.commit_message,
             TimeoutKind::NormalHeartbeat => &self.normal_heartbeat,
@@ -207,7 +264,6 @@ impl TimeoutManager {
 
     pub const fn get_mut(&mut self, kind: TimeoutKind) -> &mut Timeout {
         match kind {
-            TimeoutKind::Ping => &mut self.ping,
             TimeoutKind::Prepare => &mut self.prepare,
             TimeoutKind::CommitMessage => &mut self.commit_message,
             TimeoutKind::NormalHeartbeat => &mut self.normal_heartbeat,
@@ -232,7 +288,6 @@ impl TimeoutManager {
 
     pub fn backoff(&mut self, kind: TimeoutKind) {
         let timeout = match kind {
-            TimeoutKind::Ping => &mut self.ping,
             TimeoutKind::Prepare => &mut self.prepare,
             TimeoutKind::CommitMessage => &mut self.commit_message,
             TimeoutKind::NormalHeartbeat => &mut self.normal_heartbeat,

--- a/core/integration/tests/server/scenarios/reconnect_after_restart_scenario.rs
+++ b/core/integration/tests/server/scenarios/reconnect_after_restart_scenario.rs
@@ -621,6 +621,15 @@ async fn poll_from_zero_until(
 pub async fn run_ring_overflow_rejoin(harness: &mut TestHarness) {
     const RING_OVERFLOW_OPS: u32 = 4300;
     const POST_RESTART_OPS: u32 = 50;
+    // The point of this scenario is overflowing the peers' evicted ring so
+    // RangeEvicted and the commit floor engage. The harness runs the server on
+    // the shipped default ring capacity; if that default ever reaches this op
+    // count the overflow stops happening and the test silently passes without
+    // covering the floor path. Fail loud instead.
+    const _: () = assert!(
+        RING_OVERFLOW_OPS as usize > configs::ng_partition::DEFAULT_EVICTED_RING_CAPACITY,
+        "RING_OVERFLOW_OPS must exceed the default evicted ring capacity, or this scenario no longer exercises RangeEvicted",
+    );
 
     let setup_client = harness
         .root_client()

--- a/core/message_bus/src/cache/connection.rs
+++ b/core/message_bus/src/cache/connection.rs
@@ -22,8 +22,6 @@ use rand::seq::SliceRandom;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 
-pub const DEFAULT_MAX_CONNECTIONS_PER_REPLICA: usize = 8;
-
 pub trait ShardedState {
     type Entry;
     type Delta;

--- a/core/message_bus/src/client_listener/mod.rs
+++ b/core/message_bus/src/client_listener/mod.rs
@@ -130,7 +130,7 @@ pub async fn bind_nodelay_listener(
         .await
         .map_err(|_| IggyError::CannotBindToSocket(addr.to_string()))?;
     let listener = socket
-        .listen(128)
+        .listen(libc::SOMAXCONN)
         .await
         .map_err(|_| IggyError::CannotBindToSocket(addr.to_string()))?;
     let actual = listener

--- a/core/message_bus/src/config.rs
+++ b/core/message_bus/src/config.rs
@@ -26,14 +26,12 @@
 //! fields directly without per-call conversion.
 //!
 //! The WebSocket frame-layer config the bus consumes lives under the
-//! `[message_bus]` block (`ws_max_message_size`, `ws_max_frame_size`,
-//! `ws_write_buffer_size`, `ws_accept_unmasked_frames`). The schema's
-//! separate `[websocket]` block configures the legacy WS listener and
-//! is not read by the bus; the bus owns its own WS ceiling because the
-//! SDK-client plane has different cardinality and burst characteristics
-//! than the legacy listener (see `configs::server_ng_config::message_bus`).
+//! schema's `[websocket]` block (buffer sizes, message / frame
+//! ceilings, unmasked-frame acceptance): the bus IS server-ng's
+//! WS / WSS install path, so the listener section carries the frame
+//! tuning (see `configs::ng_websocket`).
 //! [`From<&ServerNgConfig> for MessageBusConfig`](MessageBusConfig)
-//! builds [`WebSocketConfig`] from those fields once at boot.
+//! folds that section into [`WebSocketConfig`] once at boot.
 //!
 //! Liveness detection is NOT done via TCP keepalive on the bus: SDK
 //! clients manage their own keepalive policy at the application layer,
@@ -180,9 +178,8 @@ pub struct MessageBusConfig {
     /// install path and into `WssTransportConn::ws_handshake` for WSS.
     /// Built once at boot by `build_ws_config` (see the
     /// [`From<&ServerNgConfig> for MessageBusConfig`](MessageBusConfig) impl below)
-    /// from the bus-owned `ws_*` fields under `[message_bus]`. The
-    /// schema's `[websocket]` block is intentionally NOT consulted
-    /// here; see this module's preamble for the rationale.
+    /// from the schema's `[websocket]` section, the live frame-tuning
+    /// source for server-ng's WS plane.
     ///
     /// The [`WebSocketConfig`] type is re-exported from `compio_ws`'s
     /// vendored `tungstenite` so callers do not need a direct dep on
@@ -222,7 +219,7 @@ impl From<&ServerNgConfig> for MessageBusConfig {
             close_peer_timeout: bus.close_peer_timeout.get_duration(),
             close_grace: bus.close_grace.get_duration(),
             handshake_grace: bus.handshake_grace.get_duration(),
-            ws_config: build_ws_config(bus),
+            ws_config: build_ws_config(&cfg.websocket),
             quic: build_quic_tuning(&cfg.quic),
         }
     }
@@ -274,27 +271,36 @@ impl Default for QuicTuning {
     }
 }
 
-/// Fold the bus's `ws_*` schema knobs into a single
+/// Fold the schema's `[websocket]` frame-tuning knobs into a single
 /// [`tungstenite::WebSocketConfig`].
 ///
-/// Each `Some` overrides the tungstenite default; `None` keeps the
-/// crate-wide default. Conversion to `usize` saturates on platforms
-/// where `IggyByteSize` would overflow, but the schema validator
-/// already constrains all sizes to fit in `u64`, and on supported
-/// targets `usize` is at least 32 bits, so saturation is unreachable
-/// in practice.
-fn build_ws_config(bus: &configs::message_bus::MessageBusConfig) -> WebSocketConfig {
+/// The standalone `tungstenite` crate may be a different major version
+/// than the one re-exported by `compio_ws`, so the conversion lives in
+/// this crate (next to the `compio_ws` dependency) and constructs the
+/// config through the re-export to guarantee type compatibility.
+///
+/// Each `Some` overrides the compio-ws default; `None` keeps it.
+/// Conversion to `usize` saturates on platforms where `IggyByteSize`
+/// would overflow, but on supported targets `usize` is at least 32
+/// bits, so saturation is unreachable in practice.
+fn build_ws_config(websocket: &configs::ng_websocket::WebSocketConfig) -> WebSocketConfig {
     let mut ws = WebSocketConfig::default();
-    if let Some(sz) = bus.ws_max_message_size {
-        ws = ws.max_message_size(Some(byte_size_to_usize(sz)));
+    if let Some(sz) = websocket.read_buffer_size {
+        ws = ws.read_buffer_size(byte_size_to_usize(sz));
     }
-    if let Some(sz) = bus.ws_max_frame_size {
-        ws = ws.max_frame_size(Some(byte_size_to_usize(sz)));
-    }
-    if let Some(sz) = bus.ws_write_buffer_size {
+    if let Some(sz) = websocket.write_buffer_size {
         ws = ws.write_buffer_size(byte_size_to_usize(sz));
     }
-    ws.accept_unmasked_frames(bus.ws_accept_unmasked_frames)
+    if let Some(sz) = websocket.max_write_buffer_size {
+        ws = ws.max_write_buffer_size(byte_size_to_usize(sz));
+    }
+    if let Some(sz) = websocket.max_message_size {
+        ws = ws.max_message_size(Some(byte_size_to_usize(sz)));
+    }
+    if let Some(sz) = websocket.max_frame_size {
+        ws = ws.max_frame_size(Some(byte_size_to_usize(sz)));
+    }
+    ws.accept_unmasked_frames(websocket.accept_unmasked_frames)
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/core/metadata/src/impls/metadata.rs
+++ b/core/metadata/src/impls/metadata.rs
@@ -635,6 +635,14 @@ impl<C, J, S, M> IggyMetadata<C, J, S, M> {
         }
     }
 
+    /// Size the VSR client table to `[metadata] clients_table_max`
+    /// (see [`ClientTable::set_capacity`]). Boot-only, before any client
+    /// registers; server-ng bootstrap applies it alongside
+    /// [`Self::set_checkpoint_margin`].
+    pub fn set_clients_table_max(&self, max_clients: usize) {
+        self.client_table.borrow_mut().set_capacity(max_clients);
+    }
+
     /// Resolved byte value for `MaxTopicSize::ServerDefault`.
     #[must_use]
     pub const fn default_max_topic_size(&self) -> u64 {

--- a/core/partitions/src/journal.rs
+++ b/core/partitions/src/journal.rs
@@ -177,6 +177,14 @@ where
     evicted_ring: UnsafeCell<VecDeque<(u64, JournalBuffer)>>,
     /// Running byte total of the buffers held by `evicted_ring`.
     evicted_ring_bytes: Cell<u64>,
+    /// Entry-count ceiling for `evicted_ring`. Defaults to
+    /// [`EVICTED_RING_CAPACITY`]; server-ng overrides it from config at
+    /// partition build.
+    evicted_ring_capacity: Cell<usize>,
+    /// Byte ceiling for `evicted_ring`. Defaults to
+    /// [`EVICTED_RING_BYTES_MAX`]; server-ng overrides it from config at
+    /// partition build.
+    evicted_ring_bytes_max: Cell<u64>,
     /// Single-replica groups have nobody to repair; retaining evicted
     /// entries for them is pure memory waste.
     repair_retention: Cell<bool>,
@@ -207,6 +215,8 @@ where
             }),
             evicted_ring: UnsafeCell::new(VecDeque::new()),
             evicted_ring_bytes: Cell::new(0),
+            evicted_ring_capacity: Cell::new(EVICTED_RING_CAPACITY),
+            evicted_ring_bytes_max: Cell::new(EVICTED_RING_BYTES_MAX),
             repair_retention: Cell::new(true),
         }
     }
@@ -284,6 +294,15 @@ impl PartitionJournal<PartitionJournalMemStorage> {
             ring.clear();
             self.evicted_ring_bytes.set(0);
         }
+    }
+
+    /// Override the evicted-ring ceilings from configuration. Called once at
+    /// partition build, before any eviction, so the caps govern the first
+    /// flush onward. Leaves `repair_retention` untouched: the single-replica
+    /// disable path stands on its own.
+    pub fn set_ring_caps(&self, capacity: usize, bytes_max: u64) {
+        self.evicted_ring_capacity.set(capacity);
+        self.evicted_ring_bytes_max.set(bytes_max);
     }
 
     /// Resident (un-evicted) entry count; diagnostics only.
@@ -466,8 +485,8 @@ impl PartitionJournal<PartitionJournalMemStorage> {
                 };
                 ring_bytes += entry.len() as u64;
                 ring.push_back((op, entry));
-                while ring.len() > EVICTED_RING_CAPACITY
-                    || (ring_bytes > EVICTED_RING_BYTES_MAX && ring.len() > 1)
+                while ring.len() > self.evicted_ring_capacity.get()
+                    || (ring_bytes > self.evicted_ring_bytes_max.get() && ring.len() > 1)
                 {
                     if let Some((_, dropped)) = ring.pop_front() {
                         ring_bytes -= dropped.len() as u64;
@@ -597,6 +616,8 @@ where
             inner: UnsafeCell::new(JournalInner { storage }),
             evicted_ring: UnsafeCell::new(VecDeque::new()),
             evicted_ring_bytes: Cell::new(0),
+            evicted_ring_capacity: Cell::new(EVICTED_RING_CAPACITY),
+            evicted_ring_bytes_max: Cell::new(EVICTED_RING_BYTES_MAX),
             repair_retention: Cell::new(true),
         }
     }

--- a/core/partitions/src/lib.rs
+++ b/core/partitions/src/lib.rs
@@ -37,6 +37,7 @@ pub use iggy_index_reader::IggyIndexReader;
 pub use iggy_index_writer::IggyIndexWriter;
 pub use iggy_partition::IggyPartition;
 pub use iggy_partitions::IggyPartitions;
+pub use journal::{EVICTED_RING_BYTES_MAX, EVICTED_RING_CAPACITY};
 pub use messages_writer::MessagesWriter;
 pub use offset_storage::delete_persisted_offset;
 pub use poll_plan::{AutoCommitApplied, PollPlan};

--- a/core/server-ng/Cargo.toml
+++ b/core/server-ng/Cargo.toml
@@ -88,7 +88,10 @@ default = ["mimalloc", "iggy-web"]
 disable-mimalloc = []
 mimalloc = ["dep:mimalloc"]
 iggy-web = ["dep:rust-embed", "dep:mime_guess"]
-vsr = ["iggy_common/vsr"]
+# forward iggy/vsr: the SDK gates its VsrSessionControl impls on its own
+# feature while the trait surface follows iggy_common/vsr; without the
+# forward a bare `-p server-ng --features vsr` build breaks in the SDK
+vsr = ["iggy_common/vsr", "iggy/vsr"]
 
 [dependencies]
 ahash = { workspace = true }

--- a/core/server-ng/config.toml
+++ b/core/server-ng/config.toml
@@ -20,6 +20,8 @@
 # Maximum time a partition can remain in pending revocation before being force-transferred to the target member.
 rebalancing_timeout = "30s"
 # How often the periodic checker scans for timed-out pending revocations.
+# TODO(hubcio): inert in server-ng, which paces the scan from
+# system.sharding.reconcile_periodic_interval instead. Boot warns when set.
 rebalancing_check_interval = "5s"
 
 [data_maintenance.messages]
@@ -197,9 +199,12 @@ enabled = true
 address = "127.0.0.1:8090"
 
 # Enable TCP socket migration across shards.
+# TODO(hubcio): inert in server-ng, not implemented. Boot warns when set.
 socket_migration = true
 
 # Whether to use ipv4 or ipv6
+# TODO(hubcio): inert in server-ng, which takes the family from the
+# tcp.address string. Boot warns when set.
 ipv6 = false
 
 # TLS configuration for the TCP server.
@@ -221,6 +226,8 @@ cert_file = "core/certs/iggy_cert.pem"
 key_file = "core/certs/iggy_key.pem"
 
 # Configuration for the TCP socket
+# TODO(hubcio): the whole section is inert in server-ng, which leaves the OS
+# defaults in place. Boot warns when override_defaults is set.
 [tcp.socket]
 # Whether to overwrite the OS-default socket parameters
 override_defaults = false
@@ -298,6 +305,8 @@ cert_file = "core/certs/iggy_cert.pem"
 key_file = "core/certs/iggy_key.pem"
 
 # Configuration for the QUIC socket
+# TODO(hubcio): the whole section is inert in server-ng, which leaves the OS
+# defaults in place. Boot warns when override_defaults is set.
 [quic.socket]
 # Whether to override the OS-default socket parameters
 override_defaults = false
@@ -321,9 +330,12 @@ enabled = true
 # Controls whether data saving is synchronous (enforce fsync) or asynchronous.
 # `true` for synchronous saving, ensuring data integrity at the cost of performance.
 # `false` for asynchronous saving, improving performance but with delayed data writing.
+# TODO(hubcio): inert in server-ng, which only flushes on shutdown and has no
+# periodic saver to configure. Boot warns when set.
 enforce_fsync = true
 
 # Interval for running the message saver.
+# TODO(hubcio): inert in server-ng, see enforce_fsync above. Boot warns when set.
 interval = "30 s"
 
 # Personal access token configuration.
@@ -375,6 +387,8 @@ endpoint = "http://localhost:7281/v1/traces"
 path = "local_data"
 
 # Backup configuration
+# TODO(hubcio): backup is not supported in server-ng; both paths below are
+# inert. Boot warns when either is set.
 [system.backup]
 # Path for storing backup.
 path = "backup"
@@ -384,6 +398,9 @@ path = "backup"
 # Subpath of the backup directory where converted segment data is stored after compatibility conversion.
 path = "compatibility"
 
+# TODO(hubcio): the three tunables below are inert in server-ng, whose state
+# writes do not go through the legacy retrying file layer. Boot warns when any
+# is set.
 [system.state]
 # Determines whether to enforce file synchronization on state updates (boolean).
 # `true` ensures immediate writing of data to disk for durability.
@@ -440,6 +457,8 @@ rotation_check_interval = "1 h"
 retention = "7 days"
 
 # Interval for printing system information to the log.
+# TODO(hubcio): inert in server-ng, which has no sysinfo printer. Boot warns
+# when set.
 sysinfo_print_interval = "10 s"
 
 # Encryption configuration
@@ -459,6 +478,8 @@ key = ""
 # Allows overriding the default compression algorithm per data segment (boolean).
 # `true` permits different compression algorithms for individual segments.
 # `false` means all data segments use the default compression algorithm.
+# TODO(hubcio): inert in server-ng, where live compression is already per-topic
+# from the request. Boot warns when set.
 allow_override = false
 
 # The default compression algorithm used for data storage (string).
@@ -506,8 +527,9 @@ path = "partitions"
 enforce_fsync = false
 
 # Enables checksum validation for data integrity (boolean).
-# `true` activates CRC checks when loading data, guarding against corruption.
-# `false` skips these checks for faster loading at the risk of undetected corruption.
+# TODO(hubcio): inert in server-ng, which never verifies checksums on load
+# whatever this says - `true` buys no corruption guard here. Boot warns when
+# set.
 validate_checksum = false
 
 # The count threshold of buffered messages before triggering a save to disk.
@@ -538,6 +560,8 @@ archive_expired = false
 # - "true" or "all": keeps indexes in memory, speeding up data retrieval at the cost of memory
 # - "open_segment": keeps indexes in memory only for the currently open segment
 # - "false" or "none": reads indexes from disk, which can conserve memory at the cost of access speed
+# TODO(hubcio): inert in server-ng, which picks its own index residency. Boot
+# warns when set.
 cache_indexes = "open_segment"
 
 # Message deduplication configuration
@@ -592,9 +616,58 @@ name = "iggy-cluster"
 # Backup-side liveness window for a consensus plane's primary (duration).
 # A replica that sees no primary traffic for this long starts a view change.
 # Raise it on oversubscribed hosts where scheduling stalls fake primary
-# death. Must be at least "2s": the primary heartbeats every second, and a
-# window at or below one ping interval would elect on every hiccup.
+# death. Must be at least "2s" and at least 4x commit_broadcast_interval: the
+# primary signals liveness through its commit broadcast, and the window must
+# span several broadcasts so one delayed broadcast never trips an election.
 heartbeat_timeout = "5s"
+
+# How often the primary broadcasts its commit point to every backup (duration).
+# This is the cluster's liveness signal: each broadcast resets every backup's
+# heartbeat_timeout window and carries the latest commit point forward. Must be
+# nonzero and, with heartbeat_timeout, satisfy heartbeat_timeout >= 4x this
+# value. Drives the consensus CommitMessage timer.
+commit_broadcast_interval = "500ms"
+
+# How often the primary retransmits prepares that backups have not yet acked
+# (duration). Lower values recover faster from a dropped prepare at the cost of
+# more replica traffic; must be nonzero. Drives the consensus Prepare timer.
+prepare_retransmit_interval = "250ms"
+
+# How often a replica retransmits its StartViewChange / DoViewChange while a
+# view change is in progress (duration). Lower values converge a healthy
+# election faster at the cost of more replica traffic; must be nonzero. Drives
+# both consensus view-change retransmit timers.
+view_change_retransmit_interval = "500ms"
+
+# Backstop for a stalled view change (duration): one that does not conclude
+# within this window escalates to a fresh cluster-wide election. Must be nonzero
+# and at least 4x view_change_retransmit_interval, so a few dropped view-change
+# messages retransmit rather than prematurely escalate.
+view_change_status_timeout = "5s"
+
+# How often a recovering or view-change backup re-requests the current view's
+# StartView from its primary (duration); must be nonzero. Drives the consensus
+# RequestStartView timer.
+request_start_view_retransmit_interval = "1s"
+
+# How many consecutive unanswered RequestStartView probes a recovering replica
+# tolerates before falling back to an election (integer). A full-cluster restart
+# leaves nobody settled to answer, so the replica elects on its recovered log.
+# Must be between 1 and 100.
+view_probe_attempts_max = 5
+
+# How long a stalled journal-repair stream waits before re-requesting its
+# remaining window from the serving peer (duration). Repair frames are
+# fire-and-forget over the lossy bus, so a session with no retry wedges forever
+# on a single dropped frame. Paces both the metadata and partition repair loops;
+# must be nonzero.
+repair_retry_interval = "1s"
+
+# Prepares a peer serves per repair round before the requester walks to the next
+# chunk (integer). Each frame rides the per-peer message-bus queue, so this must
+# stay strictly below message_bus.peer_queue_capacity or a full round overruns
+# the queue and drops frames. Must be > 0 and <= 1024.
+repair_chunk_max = 128
 
 # Replica-to-replica authentication (PSK + BLAKE3 keyed-MAC handshake).
 [cluster.auth]
@@ -661,7 +734,7 @@ ca_file = ""
 name = "iggy-node-1"
 ip = "127.0.0.1"
 replica_id = 0
-ports = { tcp = 8090, quic = 8080, http = 3000, websocket = 8070, tcp_replica = 9090 }
+ports = { tcp = 8090, quic = 8080, http = 3000, websocket = 8092, tcp_replica = 9090 }
 
 [[cluster.nodes]]
 name = "iggy-node-2"
@@ -669,13 +742,14 @@ ip = "127.0.0.1"
 replica_id = 1
 ports = { tcp = 8091, quic = 8081, http = 3001, websocket = 8093, tcp_replica = 9091 }
 
-# Example additional node (commented out):
+# Example additional node (commented out). tcp skips 8092-8094: those are the
+# websocket ports of the three nodes, which collide once nodes share a host.
 # [[cluster.nodes]]
 # name = "iggy-node-3"
 # ip = "192.168.1.100"
 # advertised_address = "iggy-node-3.example.com"
 # replica_id = 2
-# ports = { tcp = 8092, quic = 8082, http = 3002, websocket = 8094, tcp_replica = 9092 }
+# ports = { tcp = 8095, quic = 8082, http = 3002, websocket = 8094, tcp_replica = 9092 }
 
 # Sharding configuration
 [system.sharding]
@@ -702,8 +776,10 @@ pin_cores = true
 # Per-shard inter-shard inbox capacity. Bounded by design: consensus-frame
 # drops recover via VSR retransmit, but cross-shard client-reply drops are
 # terminal. Size for the worst-case sum of both: the consensus working set
-# (~ PIPELINE_PREPARE_QUEUE_MAX (32) * replica_count * directions) plus peak
-# client-reply fan-out per shard.
+# (~ the prepare queue depth of the planes the shard hosts - [metadata] on
+# shard 0, [partition] elsewhere - times replica_count times directions) plus
+# peak client-reply fan-out per shard. Both depths are tunable, so raising
+# either raises the capacity needed here.
 inbox_capacity = 1024
 
 # Wall-clock budget for a single shard's bus drain on shutdown. Drives
@@ -725,9 +801,40 @@ shutdown_poll_interval = "50 ms"
 # dropped wake-ups and the initial post-bootstrap convergence window.
 reconcile_periodic_interval = "1 s"
 
+# WebSocket listener configuration. The frame-tuning knobs below are the
+# live source for server-ng's WS / WSS plane; they are folded into a
+# compio-ws WebSocketConfig once at bus construction. Each size knob is
+# optional: commenting it out keeps the compio-ws (tungstenite) default
+# noted next to it. A malformed size string fails config load.
 [websocket]
 enabled = true
 address = "127.0.0.1:8092"
+
+# Target minimum size of the frame read buffer. compio-ws default: "128 KiB".
+# read_buffer_size = "128 KiB"
+
+# Target buffer size for batched writes before flush. compio-ws
+# default: "128 KiB".
+# write_buffer_size = "128 KiB"
+
+# Hard ceiling on the write buffer; writes past it error instead of
+# buffering, so it must exceed write_buffer_size by at least one message.
+# compio-ws default: unlimited.
+# max_write_buffer_size = "128 MiB"
+
+# Hard upper bound on a single inbound WebSocket message
+# (post-fragment-reassembly). Must not exceed message_bus.max_message_size.
+# compio-ws default: "64 MiB".
+# max_message_size = "64 MiB"
+
+# Hard upper bound on a single inbound WebSocket frame
+# (pre-fragment-reassembly). Must not exceed max_message_size.
+# compio-ws default: "16 MiB".
+# max_frame_size = "16 MiB"
+
+# Whether to accept unmasked frames from clients in violation of
+# RFC 6455 client-to-server framing rules. Strict (false) by default.
+accept_unmasked_frames = false
 
 [websocket.tls]
 enabled = false
@@ -753,6 +860,36 @@ prepare_queue_depth = 32
 # between forced checkpoints at the cost of memory and bigger WAL
 # rewrites per checkpoint.
 journal_slots = 1024
+
+# Slot count of the VSR client table: how many distinct clients (TCP/QUIC/WS
+# virtual clients and HTTP sessions together) hold live session state at once.
+# When full, the client whose last commit is oldest is evicted and its next
+# request re-registers. The HTTP session cap tracks this at half, so raising
+# it lifts both. Must be between 2 and 65536.
+clients_table_max = 8192
+
+# Per-partition consensus plane tunables. Unlike [metadata] (one shard-0
+# plane), a pipeline exists per partition, so raising this multiplies pinned
+# request-buffer memory by the partition count. Keep it modest.
+[partition]
+# Depth of a partition's prepare queue: how many uncommitted produce /
+# consumer-offset ops may be in flight at once for that partition. Submits past
+# it spill into a request queue of twice this depth; once both are full the
+# server drops the request without a reply and the client retries on its own
+# request timeout. Must be > 0 and <= 256.
+prepare_queue_depth = 32
+
+# Entries the evicted ring retains per multi-replica partition for journal
+# repair after a peer rejoins. Larger widens the window a restarting peer can be
+# served from the ring before falling back to bulk sync, at the cost of pinned
+# memory per partition. Must be > 0 and <= 65536. Single-replica partitions
+# retain nothing regardless.
+evicted_ring_capacity = 4096
+
+# Byte ceiling for the evicted ring per partition; whichever ring cap (this or
+# evicted_ring_capacity) trips first evicts. Bounds the ring memory a burst of
+# large batches can pin. Must be > 0 and <= "256 MiB".
+evicted_ring_bytes_max = "16 MiB"
 
 # Message bus configuration.
 # Tunables for the inter-shard / inter-replica internal bus that ships
@@ -789,29 +926,6 @@ close_grace = "2 s"
 # connecting.await + accept_bi.await) so a slowloris peer cannot pin
 # per-conn channels + registry slot + spawned task indefinitely.
 handshake_grace = "10 s"
-
-# WebSocket frame-layer tunables for the bus's WS / WSS install path.
-# Distinct from the legacy [websocket] listener tuning: the bus owns
-# its own ceilings because the bus plane carries SDK-client traffic
-# with cardinality and burst characteristics distinct from the legacy
-# listener. Each `ws_*_size` knob is optional; commenting it out keeps
-# the tungstenite default. Folded once into a tungstenite::WebSocketConfig
-# at bus construction.
-#
-# Hard upper bound on a single inbound WebSocket message
-# (post-fragment-reassembly).
-# ws_max_message_size = "64 MiB"
-#
-# Hard upper bound on a single inbound WebSocket frame
-# (pre-fragment-reassembly).
-# ws_max_frame_size = "16 MiB"
-#
-# Target buffer size for batched WebSocket writes before flush.
-# ws_write_buffer_size = "128 KiB"
-#
-# Whether to accept unmasked frames from clients in violation of
-# RFC 6455 client-to-server framing rules. Strict (false) by default.
-ws_accept_unmasked_frames = false
 
 [extra.namespace]
 max_streams = 4096

--- a/core/server-ng/src/bootstrap.rs
+++ b/core/server-ng/src/bootstrap.rs
@@ -962,6 +962,16 @@ async fn shard_main(
                 Rc::clone(&bus),
                 config.metadata.prepare_queue_depth,
                 cluster_heartbeat_ticks(config),
+                commit_broadcast_ticks(config),
+                prepare_retransmit_ticks(config),
+                view_change_retransmit_ticks(config),
+                view_change_status_ticks(config),
+                request_start_view_ticks(config),
+                config.cluster.view_probe_attempts_max,
+                recovery_barrier_deadline(
+                    config.cluster.heartbeat_timeout.get_duration(),
+                    config.cluster.view_change_status_timeout.get_duration(),
+                ),
             );
             (Some(consensus), Some(journal), snapshot, Some(client_table))
         } else {
@@ -990,6 +1000,10 @@ async fn shard_main(
     // depth: ops already pipelined while a checkpoint runs append into that
     // margin (config validation keeps journal_slots >= 4x this).
     metadata.set_checkpoint_margin(config.metadata.checkpoint_margin());
+    // Size the VSR client table before listeners bind and any client registers.
+    // The table is empty here on both fresh boot and restart (its slots are not
+    // restored from snapshot), which the setter's empty-table contract requires.
+    metadata.set_clients_table_max(config.metadata.clients_table_max);
 
     let shard_metrics = ShardMetrics::for_shard();
     // Notifier install deferred until after tick handler wires below.
@@ -1695,6 +1709,10 @@ async fn build_shard_for_thread(
     .map_err(ServerNgError::ShardConstruction)?;
 
     let shard = Rc::new(built.shard);
+    // Repair pacing is shared by both planes' repair loops, so it is a
+    // per-shard tunable set once here rather than per consensus group.
+    shard.set_repair_retry_ticks(repair_retry_ticks(config));
+    shard.set_repair_chunk_max(config.cluster.repair_chunk_max as u64);
     *shard_handle.borrow_mut() = Some(Rc::downgrade(&shard));
     Ok((shard, sessions))
 }
@@ -1711,13 +1729,127 @@ const _: () = assert!(
     configs::ng_metadata::DEFAULT_METADATA_JOURNAL_SLOTS
         == journal::prepare_journal::DEFAULT_SLOT_COUNT
 );
-/// `[cluster] heartbeat_timeout` in consensus ticks, floored at one tick.
-/// Every consensus group (metadata and per-partition planes alike) gets the
-/// same window: the failure it guards against - a primary that stopped
-/// heartbeating - is host-level, not per-plane.
+const _: () = assert!(
+    configs::ng_partition::DEFAULT_PARTITION_PREPARE_QUEUE_DEPTH
+        == consensus::PIPELINE_PREPARE_QUEUE_MAX
+);
+const _: () = assert!(
+    configs::ng_metadata::DEFAULT_METADATA_CLIENTS_TABLE_MAX == consensus::CLIENTS_TABLE_MAX
+);
+const _: () =
+    assert!(configs::ng_cluster::DEFAULT_VIEW_PROBE_ATTEMPTS_MAX == consensus::PROBE_ATTEMPTS_MAX);
+const _: () = assert!(
+    configs::ng_partition::DEFAULT_EVICTED_RING_CAPACITY == partitions::EVICTED_RING_CAPACITY
+);
+const _: () = assert!(
+    configs::ng_partition::DEFAULT_EVICTED_RING_BYTES_MAX == partitions::EVICTED_RING_BYTES_MAX
+);
+const _: () =
+    assert!(configs::ng_cluster::DEFAULT_REPAIR_CHUNK_MAX as u64 == shard::REPAIR_CHUNK_MAX);
+/// Convert a consensus-timer interval to whole ticks, floored at one tick so a
+/// sub-tick value still fires and saturated on overflow.
+fn duration_to_ticks(interval: Duration) -> u64 {
+    let ticks = interval.as_millis() / shard::CONSENSUS_TICK_INTERVAL.as_millis();
+    u64::try_from(ticks.max(1)).unwrap_or(u64::MAX)
+}
+
+/// `[cluster] heartbeat_timeout` in consensus ticks. Every consensus group
+/// (metadata and per-partition planes alike) gets the same window: the failure
+/// it guards against - a primary that stopped heartbeating - is host-level, not
+/// per-plane.
 pub(crate) fn cluster_heartbeat_ticks(config: &ServerNgConfig) -> u64 {
-    let window = config.cluster.heartbeat_timeout.get_duration().as_millis();
-    u64::try_from((window / shard::CONSENSUS_TICK_INTERVAL.as_millis()).max(1)).unwrap_or(u64::MAX)
+    duration_to_ticks(config.cluster.heartbeat_timeout.get_duration())
+}
+
+/// Floor for the post-restart read-recovery deadline (see
+/// [`recovery_barrier_deadline`]). At and below the 5s default heartbeat the
+/// worst-case recovery is dominated by the heartbeat-independent term - the
+/// `ViewChangeStatus` backstop plus election ceremony and suffix recommit,
+/// empirically ~7s - so the scaled value must never fall under this or a
+/// fast-heartbeat cluster would 503 legitimate reads mid-recovery. The backstop
+/// is the configurable `[cluster] view_change_status_timeout`; raising it past
+/// its 5s default is why `recovery_barrier_deadline` scales that knob in too
+/// rather than leaning on this floor to cover it.
+const RECOVERY_BARRIER_DEADLINE_FLOOR: Duration = Duration::from_secs(15);
+
+/// Safety factor applied to each scaled term of the recovery deadline: a slower
+/// heartbeat stretches election and suffix recommit proportionally, and a wider
+/// status backstop stretches the ceremony it bounds. 3x reproduces the
+/// empirically chosen 15s margin at the shared 5s default (3 x 5s = 15s) and
+/// holds that factor as either knob grows.
+const RECOVERY_BARRIER_MULTIPLIER: u32 = 3;
+
+/// How long the post-restart read path waits for the recovered WAL suffix to
+/// re-commit before failing loud (retryable 503): the largest of the fixed
+/// floor, a `[cluster] heartbeat_timeout`-scaled window, and a
+/// `[cluster] view_change_status_timeout`-scaled window. Both knobs feed it
+/// because either, raised far past its default, stretches worst-case recovery
+/// past the fixed floor; see `await_recovery_barrier` for the read-side wait.
+pub(crate) fn recovery_barrier_deadline(
+    heartbeat: Duration,
+    view_change_status: Duration,
+) -> Duration {
+    // saturating: neither timeout has a config ceiling, plain `*` panics
+    heartbeat
+        .saturating_mul(RECOVERY_BARRIER_MULTIPLIER)
+        .max(view_change_status.saturating_mul(RECOVERY_BARRIER_MULTIPLIER))
+        .max(RECOVERY_BARRIER_DEADLINE_FLOOR)
+}
+
+/// `[cluster] commit_broadcast_interval` in consensus ticks: how often the
+/// primary broadcasts its commit point, the cluster's liveness feed. Applied
+/// to every consensus group, matching `cluster_heartbeat_ticks`.
+pub(crate) fn commit_broadcast_ticks(config: &ServerNgConfig) -> u64 {
+    duration_to_ticks(config.cluster.commit_broadcast_interval.get_duration())
+}
+
+/// `[cluster] prepare_retransmit_interval` in consensus ticks: how often the
+/// primary retransmits un-acked prepares. Applied to every consensus group,
+/// matching `cluster_heartbeat_ticks`.
+pub(crate) fn prepare_retransmit_ticks(config: &ServerNgConfig) -> u64 {
+    duration_to_ticks(config.cluster.prepare_retransmit_interval.get_duration())
+}
+
+/// `[cluster] view_change_retransmit_interval` in consensus ticks: how often a
+/// replica retransmits its `StartViewChange` / `DoViewChange` during a view
+/// change. Applied to every consensus group, matching `cluster_heartbeat_ticks`.
+pub(crate) fn view_change_retransmit_ticks(config: &ServerNgConfig) -> u64 {
+    duration_to_ticks(
+        config
+            .cluster
+            .view_change_retransmit_interval
+            .get_duration(),
+    )
+}
+
+/// `[cluster] view_change_status_timeout` in consensus ticks: the stalled
+/// view-change backstop before escalating to a fresh election. Applied to every
+/// consensus group, matching `cluster_heartbeat_ticks`.
+pub(crate) fn view_change_status_ticks(config: &ServerNgConfig) -> u64 {
+    duration_to_ticks(config.cluster.view_change_status_timeout.get_duration())
+}
+
+/// `[cluster] request_start_view_retransmit_interval` in consensus ticks: how
+/// often a recovering or view-change backup re-requests the current `StartView`.
+/// Applied to every consensus group, matching `cluster_heartbeat_ticks`.
+pub(crate) fn request_start_view_ticks(config: &ServerNgConfig) -> u64 {
+    duration_to_ticks(
+        config
+            .cluster
+            .request_start_view_retransmit_interval
+            .get_duration(),
+    )
+}
+
+/// `[cluster] repair_retry_interval` in consensus ticks: how long a stalled
+/// journal-repair stream waits before re-requesting its window. Both planes'
+/// repair loops share it, so it is applied once per shard (not per consensus
+/// group). Clamped to `u32`, the width of the session idle-tick counter.
+pub(crate) fn repair_retry_ticks(config: &ServerNgConfig) -> u32 {
+    u32::try_from(duration_to_ticks(
+        config.cluster.repair_retry_interval.get_duration(),
+    ))
+    .unwrap_or(u32::MAX)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1731,6 +1863,13 @@ fn restore_metadata_consensus(
     bus: Rc<IggyMessageBus>,
     prepare_queue_depth: usize,
     normal_heartbeat_ticks: u64,
+    commit_message_ticks: u64,
+    prepare_ticks: u64,
+    view_change_retransmit_ticks: u64,
+    view_change_status_ticks: u64,
+    request_start_view_ticks: u64,
+    probe_attempts_max: u32,
+    recovery_deadline: Duration,
 ) -> VsrConsensus<Rc<IggyMessageBus>> {
     let mut consensus = VsrConsensus::new(
         cluster_id,
@@ -1744,6 +1883,12 @@ fn restore_metadata_consensus(
         LocalPipeline::with_capacities(prepare_queue_depth, prepare_queue_depth * 2),
     );
     consensus.set_normal_heartbeat_ticks(normal_heartbeat_ticks);
+    consensus.set_commit_message_ticks(commit_message_ticks);
+    consensus.set_prepare_ticks(prepare_ticks);
+    consensus.set_view_change_retransmit_ticks(view_change_retransmit_ticks);
+    consensus.set_view_change_status_ticks(view_change_status_ticks);
+    consensus.set_request_start_view_ticks(request_start_view_ticks);
+    consensus.set_probe_attempts_max(probe_attempts_max);
 
     let last_header = journal
         .last_op()
@@ -1808,10 +1953,11 @@ fn restore_metadata_consensus(
     // primary; via StartView adoption + the local commit walk on a rejoined
     // backup), serving reads would show pre-restart state that clients already
     // saw acked -- gate them on the barrier regardless of role. If the suffix
-    // never committed cluster-wide, the barrier times out on the read path and
-    // serving resumes (`await_recovery_barrier`).
+    // never re-commits cluster-wide, the read path fails loud with a retryable
+    // 503 once the paired deadline expires (`await_recovery_barrier`).
     if commit_watermark < restored_op {
         consensus.set_recovery_barrier(restored_op);
+        consensus.set_recovery_deadline(recovery_deadline);
     }
 
     // Re-pipeline the prepared-but-uncommitted suffix so the primary's
@@ -1859,15 +2005,24 @@ async fn load_partition(
     let stream_id = namespace.stream_id();
     let topic_id = namespace.topic_id();
     let partition_id = namespace.partition_id();
+    // Request queue holds 2x the prepare depth (buffered requests drain as
+    // prepares commit); depth is the per-partition `[partition]` knob.
+    let prepare_queue_depth = config.partition.prepare_queue_depth;
     let consensus = VsrConsensus::new(
         cluster_id,
         self_replica_id,
         replica_count,
         namespace.inner(),
         bus,
-        LocalPipeline::new(),
+        LocalPipeline::with_capacities(prepare_queue_depth, prepare_queue_depth * 2),
     );
     consensus.set_normal_heartbeat_ticks(cluster_heartbeat_ticks(config));
+    consensus.set_commit_message_ticks(commit_broadcast_ticks(config));
+    consensus.set_prepare_ticks(prepare_retransmit_ticks(config));
+    consensus.set_view_change_retransmit_ticks(view_change_retransmit_ticks(config));
+    consensus.set_view_change_status_ticks(view_change_status_ticks(config));
+    consensus.set_request_start_view_ticks(request_start_view_ticks(config));
+    consensus.set_probe_attempts_max(config.cluster.view_probe_attempts_max);
     // A recovered partition lost its consensus state with the process: the
     // partition journal is in-memory and segments carry no op numbers, so
     // this replica cannot know the group's (op, commit). In a cluster it
@@ -1907,6 +2062,13 @@ async fn load_partition(
             })?;
 
     let mut partition = IggyPartition::new(stats.clone(), consensus);
+    // Recovered partitions honor the same config-surfaced ring ceilings as the
+    // fresh-create path (build_partition_fresh). Retention is already off for
+    // single-replica groups, so this only sizes the multi-replica ring.
+    partition.log.journal().inner.set_ring_caps(
+        config.partition.evicted_ring_capacity,
+        config.partition.evicted_ring_bytes_max.as_bytes_u64(),
+    );
     partition.set_partition_dir(config.system.get_partition_path(
         stream_id,
         topic_id,
@@ -2291,6 +2453,7 @@ async fn start_tcp_runtime(
             shard,
             http_addr,
             &config.http,
+            config.metadata.clients_table_max,
             &config.cluster,
             Arc::clone(&config.system),
             self_ports,
@@ -3148,6 +3311,264 @@ mod tests {
             config_default, built_in,
             "[cluster] heartbeat_timeout default drifted from \
              TimeoutManager::NORMAL_HEARTBEAT_TICKS"
+        );
+    }
+
+    #[test]
+    fn recovery_barrier_deadline_holds_the_floor_for_small_heartbeats() {
+        // Below the 5s default the heartbeat-independent recovery term (~7s of
+        // ViewChangeStatus backstop plus ceremony) dominates, so the floor
+        // governs however small the heartbeat is; 3 x 5s lands exactly on it.
+        // A default-sized status backstop stays on the floor, not above it.
+        assert_eq!(
+            recovery_barrier_deadline(Duration::from_secs(1), Duration::from_secs(5)),
+            RECOVERY_BARRIER_DEADLINE_FLOOR
+        );
+        assert_eq!(
+            recovery_barrier_deadline(Duration::from_secs(5), Duration::from_secs(5)),
+            RECOVERY_BARRIER_DEADLINE_FLOOR
+        );
+    }
+
+    #[test]
+    fn recovery_barrier_deadline_scales_past_the_floor_for_large_heartbeats() {
+        // Once 3 x heartbeat clears the floor the scaled window governs, so a
+        // slow-heartbeat cluster is not failed 503 before its longer recovery
+        // can finish. A default-sized status backstop stays under it.
+        assert_eq!(
+            recovery_barrier_deadline(Duration::from_secs(10), Duration::from_secs(5)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            recovery_barrier_deadline(Duration::from_secs(15), Duration::from_secs(5)),
+            Duration::from_secs(45)
+        );
+    }
+
+    #[test]
+    fn recovery_barrier_deadline_scales_with_the_status_backstop() {
+        // A raised view-change status backstop stretches worst-case recovery
+        // even when the heartbeat stays fast, so the deadline must track it or
+        // post-restart reads 503 before a slow election settles.
+        assert_eq!(
+            recovery_barrier_deadline(Duration::from_secs(1), Duration::from_secs(10)),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn recovery_barrier_deadline_at_config_defaults_matches_the_floor() {
+        // Folding the status term in must not move the stock deadline: at the
+        // shared 5s defaults each scaled term lands exactly on the 15s floor,
+        // so an un-tuned cluster keeps its pre-existing recovery window.
+        let cluster = configs::ng_cluster::ClusterConfig::default();
+        assert_eq!(
+            recovery_barrier_deadline(
+                cluster.heartbeat_timeout.get_duration(),
+                cluster.view_change_status_timeout.get_duration(),
+            ),
+            RECOVERY_BARRIER_DEADLINE_FLOOR
+        );
+    }
+
+    #[test]
+    fn recovery_barrier_deadline_saturates_instead_of_panicking() {
+        // Neither timeout has a config ceiling, so both multiplies must
+        // saturate rather than abort boot on an absurd parseable value.
+        assert_eq!(
+            recovery_barrier_deadline(Duration::MAX, Duration::from_secs(5)),
+            Duration::MAX
+        );
+        assert_eq!(
+            recovery_barrier_deadline(Duration::from_secs(5), Duration::MAX),
+            Duration::MAX
+        );
+    }
+
+    #[test]
+    fn default_commit_broadcast_interval_matches_consensus_constant() {
+        // The config default lives in core/server-ng/config.toml (a string,
+        // so no static assert can pin it); keep it in lockstep with the
+        // built-in the simulator and un-configured replicas run on.
+        let config_default = configs::ng_cluster::ClusterConfig::default()
+            .commit_broadcast_interval
+            .get_duration()
+            .as_millis();
+        let built_in = u128::from(consensus::TimeoutManager::COMMIT_MESSAGE_TICKS)
+            * shard::CONSENSUS_TICK_INTERVAL.as_millis();
+        assert_eq!(
+            config_default, built_in,
+            "[cluster] commit_broadcast_interval default drifted from \
+             TimeoutManager::COMMIT_MESSAGE_TICKS"
+        );
+    }
+
+    #[test]
+    fn default_prepare_retransmit_interval_matches_consensus_constant() {
+        // The config default lives in core/server-ng/config.toml (a string,
+        // so no static assert can pin it); keep it in lockstep with the
+        // built-in the simulator and un-configured replicas run on.
+        let config_default = configs::ng_cluster::ClusterConfig::default()
+            .prepare_retransmit_interval
+            .get_duration()
+            .as_millis();
+        let built_in = u128::from(consensus::TimeoutManager::PREPARE_TICKS)
+            * shard::CONSENSUS_TICK_INTERVAL.as_millis();
+        assert_eq!(
+            config_default, built_in,
+            "[cluster] prepare_retransmit_interval default drifted from \
+             TimeoutManager::PREPARE_TICKS"
+        );
+    }
+
+    #[test]
+    fn default_partition_prepare_queue_depth_matches_consensus_constant() {
+        // The config default lives in core/server-ng/config.toml and flows
+        // through PartitionConfig::default(); keep the embedded value in
+        // lockstep with the pipeline depth LocalPipeline::new() (the simulator
+        // and tests) runs on, so a default deployment is byte-identical.
+        let config_default = configs::ng_partition::PartitionConfig::default().prepare_queue_depth;
+        assert_eq!(
+            config_default,
+            consensus::PIPELINE_PREPARE_QUEUE_MAX,
+            "[partition] prepare_queue_depth default drifted from \
+             consensus::PIPELINE_PREPARE_QUEUE_MAX"
+        );
+    }
+
+    #[test]
+    fn default_view_change_retransmit_interval_matches_consensus_constant() {
+        // The config default lives in core/server-ng/config.toml (a string, so
+        // no static assert can pin it). One knob drives both view-change
+        // retransmit timers, which are equal by design, so pin it against both.
+        let config_default = configs::ng_cluster::ClusterConfig::default()
+            .view_change_retransmit_interval
+            .get_duration()
+            .as_millis();
+        let start_view_change =
+            u128::from(consensus::TimeoutManager::START_VIEW_CHANGE_MESSAGE_TICKS)
+                * shard::CONSENSUS_TICK_INTERVAL.as_millis();
+        let do_view_change = u128::from(consensus::TimeoutManager::DO_VIEW_CHANGE_MESSAGE_TICKS)
+            * shard::CONSENSUS_TICK_INTERVAL.as_millis();
+        assert_eq!(
+            config_default, start_view_change,
+            "[cluster] view_change_retransmit_interval default drifted from \
+             TimeoutManager::START_VIEW_CHANGE_MESSAGE_TICKS"
+        );
+        assert_eq!(
+            config_default, do_view_change,
+            "[cluster] view_change_retransmit_interval default drifted from \
+             TimeoutManager::DO_VIEW_CHANGE_MESSAGE_TICKS"
+        );
+    }
+
+    #[test]
+    fn default_view_change_status_timeout_matches_consensus_constant() {
+        // The config default lives in core/server-ng/config.toml (a string, so
+        // no static assert can pin it); keep it in lockstep with the built-in
+        // the simulator and un-configured replicas run on.
+        let config_default = configs::ng_cluster::ClusterConfig::default()
+            .view_change_status_timeout
+            .get_duration()
+            .as_millis();
+        let built_in = u128::from(consensus::TimeoutManager::VIEW_CHANGE_STATUS_TICKS)
+            * shard::CONSENSUS_TICK_INTERVAL.as_millis();
+        assert_eq!(
+            config_default, built_in,
+            "[cluster] view_change_status_timeout default drifted from \
+             TimeoutManager::VIEW_CHANGE_STATUS_TICKS"
+        );
+    }
+
+    #[test]
+    fn default_request_start_view_retransmit_interval_matches_consensus_constant() {
+        // The config default lives in core/server-ng/config.toml (a string, so
+        // no static assert can pin it); keep it in lockstep with the built-in
+        // the simulator and un-configured replicas run on.
+        let config_default = configs::ng_cluster::ClusterConfig::default()
+            .request_start_view_retransmit_interval
+            .get_duration()
+            .as_millis();
+        let built_in = u128::from(consensus::TimeoutManager::REQUEST_START_VIEW_MESSAGE_TICKS)
+            * shard::CONSENSUS_TICK_INTERVAL.as_millis();
+        assert_eq!(
+            config_default, built_in,
+            "[cluster] request_start_view_retransmit_interval default drifted from \
+             TimeoutManager::REQUEST_START_VIEW_MESSAGE_TICKS"
+        );
+    }
+
+    #[test]
+    fn default_view_probe_attempts_max_matches_consensus_constant() {
+        // Belt and suspenders with the static assert above: that pins the
+        // duplicated configs-crate literal, this pins the shipped config.toml
+        // value the simulator and un-configured replicas run on.
+        let config_default = configs::ng_cluster::ClusterConfig::default().view_probe_attempts_max;
+        assert_eq!(
+            config_default,
+            consensus::PROBE_ATTEMPTS_MAX,
+            "[cluster] view_probe_attempts_max default drifted from \
+             consensus::PROBE_ATTEMPTS_MAX"
+        );
+    }
+
+    #[test]
+    fn default_repair_retry_interval_matches_partitions_constant() {
+        // The config default lives in core/server-ng/config.toml (a string, so
+        // no static assert can pin it); keep it in lockstep with the built-in
+        // the simulator and un-configured replicas run on.
+        let config_default = configs::ng_cluster::ClusterConfig::default()
+            .repair_retry_interval
+            .get_duration()
+            .as_millis();
+        let built_in =
+            u128::from(partitions::REPAIR_RETRY_TICKS) * shard::CONSENSUS_TICK_INTERVAL.as_millis();
+        assert_eq!(
+            config_default, built_in,
+            "[cluster] repair_retry_interval default drifted from \
+             partitions::REPAIR_RETRY_TICKS"
+        );
+    }
+
+    #[test]
+    fn default_repair_chunk_max_matches_shard_constant() {
+        // Belt and suspenders with the static assert above: that pins the
+        // duplicated configs-crate literal, this pins the shipped config.toml
+        // value the simulator and un-configured replicas run on.
+        let config_default = configs::ng_cluster::ClusterConfig::default().repair_chunk_max;
+        assert_eq!(
+            config_default as u64,
+            shard::REPAIR_CHUNK_MAX,
+            "[cluster] repair_chunk_max default drifted from shard::REPAIR_CHUNK_MAX"
+        );
+    }
+
+    #[test]
+    fn default_evicted_ring_capacity_matches_partitions_constant() {
+        // Belt and suspenders with the static assert above; this pins the
+        // shipped config.toml value.
+        let config_default =
+            configs::ng_partition::PartitionConfig::default().evicted_ring_capacity;
+        assert_eq!(
+            config_default,
+            partitions::EVICTED_RING_CAPACITY,
+            "[partition] evicted_ring_capacity default drifted from \
+             partitions::EVICTED_RING_CAPACITY"
+        );
+    }
+
+    #[test]
+    fn default_evicted_ring_bytes_max_matches_partitions_constant() {
+        // Belt and suspenders with the static assert above; this pins the
+        // shipped config.toml value.
+        let config_default = configs::ng_partition::PartitionConfig::default()
+            .evicted_ring_bytes_max
+            .as_bytes_u64();
+        assert_eq!(
+            config_default,
+            partitions::EVICTED_RING_BYTES_MAX,
+            "[partition] evicted_ring_bytes_max default drifted from \
+             partitions::EVICTED_RING_BYTES_MAX"
         );
     }
 

--- a/core/server-ng/src/http.rs
+++ b/core/server-ng/src/http.rs
@@ -94,6 +94,7 @@ pub async fn start(
     shard: &Rc<ServerNgShard>,
     addr: SocketAddr,
     http_config: &HttpConfig,
+    clients_table_max: usize,
     cluster: &ClusterConfig,
     system_config: Arc<NgSystemConfig>,
     self_ports: TransportPorts,
@@ -151,6 +152,7 @@ pub async fn start(
             // never consulted here.
             metadata_view: Arc::new(AtomicU64::new(crate::cluster_meta::METADATA_VIEW_UNKNOWN)),
         },
+        max_http_sessions: crate::http::session::max_http_sessions(clients_table_max),
         in_flight_writes: Cell::new(0),
         forward,
     }));
@@ -158,8 +160,12 @@ pub async fn start(
 
     if http_config.tls.enabled {
         let server_config = tls::load_http_tls_server_config(&http_config.tls)?;
-        let (connections, pump) =
-            tls::spawn_accept_pump(listener, server_config, shard.bus.token());
+        let (connections, pump) = tls::spawn_accept_pump(
+            listener,
+            server_config,
+            shard.bus.config().handshake_grace,
+            shard.bus.token(),
+        );
         shard.bus.track_background(pump);
         info!(address = %bound_addr, "server-ng HTTPS listener started");
         let handle = compio::runtime::spawn(tls::serve(connections, router, shard.bus.token()));

--- a/core/server-ng/src/http/error.rs
+++ b/core/server-ng/src/http/error.rs
@@ -198,10 +198,11 @@ impl IntoResponse for AuthError {
             }
             // A fresh session could not be established: the Register was
             // canceled with its commit outcome unknown, or the session table
-            // is at `MAX_HTTP_SESSIONS` and refused the fresh registration.
-            // Transient server condition -> 503, retryable by the CLIENT only
-            // (a forwarder must not re-issue an unknown-outcome Register under
-            // this node's session budget on the caller's behalf).
+            // is at its cap (half `[metadata] clients_table_max`) and refused
+            // the fresh registration. Transient server condition -> 503,
+            // retryable by the CLIENT only (a forwarder must not re-issue an
+            // unknown-outcome Register under this node's session budget on
+            // the caller's behalf).
             // `SessionIdTaken` only escapes the mint retry when every attempt
             // collided, which means the minter is wrong rather than unlucky --
             // same unknown-outcome answer as a canceled Register.
@@ -461,6 +462,12 @@ pub(in crate::http) enum ReadError {
     /// query, so the caller re-issues the read against the leader (see
     /// [`primary_redirect_response`]).
     RedirectToPrimary(String),
+    /// The post-restart read-recovery barrier expired with the recovered WAL
+    /// suffix still uncommitted: serving now could show state that rolls back
+    /// history a client already saw acked. Fail-closed 503 via the shared
+    /// [`service_unavailable`] body, retryable once the cluster re-commits the
+    /// suffix.
+    RecoveryIncomplete,
     /// A partition read (poll / consumer-offset) got no reply from the owning
     /// shard within the mesh budget. 504 like a produce timeout: the outcome is
     /// unknown (the abandoned read may still be running), so the caller retries.
@@ -476,6 +483,7 @@ impl IntoResponse for ReadError {
             Self::NotFound => CustomError::ResourceNotFound.into_response(),
             Self::NotPrimary => not_primary_response(),
             Self::RedirectToPrimary(location) => primary_redirect_response(&location),
+            Self::RecoveryIncomplete => service_unavailable(),
             Self::Timeout => gateway_timeout_response(
                 "partition_read_timeout",
                 "the partition owner did not answer the read in time; retry",
@@ -738,5 +746,25 @@ mod tests {
                 "an unknown commit outcome must stay retryable, got {status}"
             );
         }
+    }
+
+    #[test]
+    fn recovery_incomplete_renders_retryable_503_like_not_primary() {
+        // Barrier expiry must render as the shared retryable 503: the same
+        // status and Retry-After hint as the not-primary 503, so an SDK treats
+        // it as a connection-level retry rather than a terminal error.
+        let recovery = ReadError::RecoveryIncomplete.into_response();
+        assert_eq!(recovery.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            recovery.headers().get(RETRY_AFTER),
+            Some(&HeaderValue::from(RETRY_AFTER_SECONDS))
+        );
+
+        let not_primary = ReadError::NotPrimary.into_response();
+        assert_eq!(recovery.status(), not_primary.status());
+        assert_eq!(
+            recovery.headers().get(RETRY_AFTER),
+            not_primary.headers().get(RETRY_AFTER)
+        );
     }
 }

--- a/core/server-ng/src/http/handlers.rs
+++ b/core/server-ng/src/http/handlers.rs
@@ -176,8 +176,13 @@ pub(in crate::http) async fn login_user(
 ) -> Result<Json<IdentityInfo>, CustomError> {
     // Credential verification is a consensus-free STM read; hold it while a
     // recovered WAL suffix (which may carry the user's create/password ops)
-    // re-commits, like every other local read.
-    SendWrapper::new(crate::http::reads::await_recovery_barrier(&state.shard)).await;
+    // re-commits, like every other local read. On barrier expiry, fail with a
+    // retryable 503 rather than validating against rolled-back credentials:
+    // this route's error currency is `IggyError -> CustomError`, and
+    // `TransientNotCommitted` is the variant `CustomError` renders 503.
+    SendWrapper::new(crate::http::reads::await_recovery_barrier(&state.shard))
+        .await
+        .map_err(|_| IggyError::TransientNotCommitted)?;
     let user_id = verify_login_credentials(
         &state.shard,
         &command.username,
@@ -191,7 +196,11 @@ pub(in crate::http) async fn login_with_personal_access_token(
     State(state): State<HttpState>,
     Json(command): Json<LoginWithPersonalAccessToken>,
 ) -> Result<Json<IdentityInfo>, CustomError> {
-    SendWrapper::new(crate::http::reads::await_recovery_barrier(&state.shard)).await;
+    // Same recovery-barrier wait and retryable-503-on-expiry mapping as
+    // `login_user`.
+    SendWrapper::new(crate::http::reads::await_recovery_barrier(&state.shard))
+        .await
+        .map_err(|_| IggyError::TransientNotCommitted)?;
     let user_id = verify_pat_credentials(&state.shard, command.token.expose_secret())
         .map_err(|error| login_error_to_iggy(&error))?;
     issue_identity(&state, user_id)

--- a/core/server-ng/src/http/reads.rs
+++ b/core/server-ng/src/http/reads.rs
@@ -90,7 +90,7 @@ pub(in crate::http) async fn read_local(
     body: &[u8],
     rule: impl FnOnce(&Permissioner, u32) -> Result<(), IggyError>,
 ) -> Result<Bytes, ReadError> {
-    await_recovery_barrier(&state.shard).await;
+    await_recovery_barrier(&state.shard).await?;
     authorize_read(state, identity, consistency, rule)?;
     match build_non_replicated_response(
         &state.shard,
@@ -106,25 +106,54 @@ pub(in crate::http) async fn read_local(
     }
 }
 
+/// One recovery-barrier check's outcome, factored out of [`await_recovery_barrier`]
+/// so the expiry decision is unit-testable without a runtime: the loop reads the
+/// clock and injects whether the deadline has passed.
+#[derive(Debug, PartialEq, Eq)]
+enum BarrierWait {
+    /// Barrier met, or none armed: serve the read.
+    Ready,
+    /// Barrier unmet and the deadline has passed: fail loud.
+    Expired,
+    /// Barrier unmet, deadline still ahead: keep polling.
+    Pending,
+}
+
+/// Decide the barrier outcome from the armed barrier, the locally applied commit
+/// point, and whether the deadline has passed. A met barrier wins over an
+/// expired deadline, so recovery that completes as the deadline lands still
+/// serves rather than 503-ing.
+const fn barrier_state(barrier: u64, commit_min: u64, expired: bool) -> BarrierWait {
+    if barrier == 0 || commit_min >= barrier {
+        BarrierWait::Ready
+    } else if expired {
+        BarrierWait::Expired
+    } else {
+        BarrierWait::Pending
+    }
+}
+
 /// Hold a local read while the recovered WAL suffix re-commits.
 ///
 /// Recovery re-pipelines prepared-but-uncommitted ops that clients saw
 /// committed before the restart; JWT-authenticated HTTP reads skip consensus
 /// entirely, so without this wait they can observe state that rolls back
 /// committed history in the first few hundred milliseconds after a restart.
-/// No-op (`recovery_barrier() == 0`) outside that window. Bounded: the
-/// suffix needs a backup quorum to re-commit, so serve anyway after the
-/// deadline rather than wedging reads on a partitioned cluster.
-pub(in crate::http) async fn await_recovery_barrier(shard: &Rc<ServerNgShard>) {
-    // Must outlast a full post-restart convergence: the peers' election
-    // (several heartbeat timeouts in the worst case) plus the new primary
-    // re-committing the journaled suffix. A shorter deadline expires mid
-    // view-change and serves pre-restart state that clients saw acked.
-    const DEADLINE: std::time::Duration = std::time::Duration::from_secs(15);
+/// `Ok(())` immediately when no suffix is pending (`recovery_barrier() == 0`).
+///
+/// Bounded by the barrier's paired deadline (scaled from the configured
+/// cluster timeouts; see `recovery_barrier_deadline`). If the suffix has not
+/// re-committed by then the read fails loud with a retryable 503
+/// ([`ReadError::RecoveryIncomplete`]) instead of silently serving pre-restart
+/// state a client already saw acked; the caller retries against a converged
+/// cluster.
+pub(in crate::http) async fn await_recovery_barrier(
+    shard: &Rc<ServerNgShard>,
+) -> Result<(), ReadError> {
     const POLL: std::time::Duration = std::time::Duration::from_millis(10);
 
     let Some(consensus) = shard.plane.metadata().consensus.as_ref() else {
-        return;
+        return Ok(());
     };
     let barrier = consensus.recovery_barrier();
     // Gate on commit_MIN (locally applied), not commit_max (known committed):
@@ -132,20 +161,24 @@ pub(in crate::http) async fn await_recovery_barrier(shard: &Rc<ServerNgShard>) {
     // journal applying ops, and this task interleaves with that walk at its
     // await points -- a commit_max gate would serve state from before the
     // suffix applied (e.g. a pre-restart password change not yet visible).
-    if barrier == 0 || consensus.commit_min() >= barrier {
-        return;
+    if barrier_state(barrier, consensus.commit_min(), false) == BarrierWait::Ready {
+        return Ok(());
     }
-    let deadline = std::time::Instant::now() + DEADLINE;
-    while consensus.commit_min() < barrier {
-        if std::time::Instant::now() >= deadline {
-            tracing::warn!(
-                barrier,
-                commit_min = consensus.commit_min(),
-                "recovered suffix still unapplied past deadline; serving read anyway"
-            );
-            return;
+    let deadline = std::time::Instant::now() + consensus.recovery_deadline();
+    loop {
+        let expired = std::time::Instant::now() >= deadline;
+        match barrier_state(barrier, consensus.commit_min(), expired) {
+            BarrierWait::Ready => return Ok(()),
+            BarrierWait::Expired => {
+                tracing::warn!(
+                    barrier,
+                    commit_min = consensus.commit_min(),
+                    "recovered suffix still unapplied past deadline; failing read with retryable 503"
+                );
+                return Err(ReadError::RecoveryIncomplete);
+            }
+            BarrierWait::Pending => compio::time::sleep(POLL).await,
         }
-        compio::time::sleep(POLL).await;
     }
 }
 
@@ -227,4 +260,39 @@ pub(in crate::http) fn authorize_data_plane(
         .mux_stm
         .users()
         .authorize(|permissioner| rule(permissioner, user_id, stream_id, topic_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BarrierWait, barrier_state};
+
+    #[test]
+    fn barrier_state_ready_when_no_barrier_armed() {
+        assert_eq!(barrier_state(0, 0, false), BarrierWait::Ready);
+        assert_eq!(barrier_state(0, 0, true), BarrierWait::Ready);
+    }
+
+    #[test]
+    fn barrier_state_ready_when_commit_reached_barrier() {
+        assert_eq!(barrier_state(5, 5, false), BarrierWait::Ready);
+        assert_eq!(barrier_state(5, 6, false), BarrierWait::Ready);
+    }
+
+    #[test]
+    fn barrier_state_pending_while_unmet_before_deadline() {
+        assert_eq!(barrier_state(5, 3, false), BarrierWait::Pending);
+    }
+
+    #[test]
+    fn barrier_state_expires_when_unmet_past_deadline() {
+        // Red before the fail-loud change: an expired barrier used to serve the
+        // read (a bare `()`), now an unmet barrier past its deadline is a
+        // distinct terminal outcome the wait maps to a retryable 503.
+        assert_eq!(barrier_state(5, 3, true), BarrierWait::Expired);
+    }
+
+    #[test]
+    fn barrier_state_met_wins_over_expired_deadline() {
+        assert_eq!(barrier_state(5, 5, true), BarrierWait::Ready);
+    }
 }

--- a/core/server-ng/src/http/session.rs
+++ b/core/server-ng/src/http/session.rs
@@ -29,24 +29,41 @@ use futures::channel::oneshot;
 use message_bus::InstanceToken;
 use tokio::sync::Mutex;
 
-/// Hard cap on live per-credential sessions. A leak-guard, not a tuning knob:
-/// reaching it means this many distinct live tokens are in flight at once. New
-/// sessions past the cap are refused with a transient 503 rather than evicting
-/// a live one; the client retries. Expired entries are dropped first, so the
-/// cap only bites on live oversubscription.
+/// HTTP's slice of the shared VSR client table: half the configured
+/// `[metadata] clients_table_max`. A leak-guard, not a tuning knob: reaching
+/// the cap means that many distinct live tokens are in flight at once. New
+/// sessions past it are refused with a transient 503 rather than evicting a
+/// live one; the client retries. Expired entries are dropped first, so the cap
+/// only bites on live oversubscription.
 ///
 /// Bounded by the shared VSR client table: HTTP sessions and the TCP/QUIC/WS
-/// virtual clients all Register into the one [`CLIENTS_TABLE_MAX`]-slot table,
-/// which evicts the oldest-committed client when full. Capping HTTP at half
-/// that bound keeps this plane from crowding the others out and keeps the
-/// combined steady state under the shared bound, so a live idle HTTP session
-/// is not routinely evicted consensus-side. The non-HTTP half tracks live
-/// connections because every transport disconnect logs its session out
-/// (`submit_disconnect_logout`), so occupancy there is concurrent, not
-/// cumulative. The residual eviction race (both planes busy) degrades
-/// gracefully: an evicted session's next control write is classified as an
-/// eviction and re-registers (see [`HttpInner::forget_session`]).
-pub(in crate::http) const MAX_HTTP_SESSIONS: usize = CLIENTS_TABLE_MAX / 2;
+/// virtual clients all Register into the one client table, which evicts the
+/// oldest-committed client when full. Capping HTTP at half that bound keeps
+/// this plane from crowding the others out and keeps the combined steady state
+/// under the shared bound, so a live idle HTTP session is not routinely evicted
+/// consensus-side. The non-HTTP half tracks live connections because every
+/// transport disconnect logs its session out (`submit_disconnect_logout`), so
+/// occupancy there is concurrent, not cumulative. The residual eviction race
+/// (both planes busy) degrades gracefully: an evicted session's next control
+/// write is classified as an eviction and re-registers (see
+/// [`HttpInner::forget_session`]).
+///
+/// The half rule lives here so a change to the ratio flows to both the runtime
+/// value (threaded through `HttpInner` at boot) and the pinned default.
+pub(in crate::http) const fn max_http_sessions(clients_table_max: usize) -> usize {
+    clients_table_max / 2
+}
+
+/// HTTP session cap at the shipped-default client table ([`CLIENTS_TABLE_MAX`]).
+/// The runtime value ([`max_http_sessions`] of the configured
+/// `clients_table_max`) equals this on a default deployment; the tests pin it.
+pub(in crate::http) const DEFAULT_MAX_HTTP_SESSIONS: usize = max_http_sessions(CLIENTS_TABLE_MAX);
+
+// HTTP must never claim the whole shared VSR client table, or a login storm
+// could evict every TCP/QUIC/WS virtual client. Compile-time pin of the
+// headroom the half-cap guarantees (config validation floors the table at 2, so
+// the runtime cap keeps the same headroom).
+const _: () = assert!(DEFAULT_MAX_HTTP_SESSIONS < CLIENTS_TABLE_MAX);
 
 /// Watermark a brand-new client-table entry carries: no application request
 /// has committed under it yet. A fresh mint that comes back with anything else
@@ -354,15 +371,21 @@ mod tests {
         assert_eq!(table.len(), 8, "no live session is evicted to make room");
     }
 
+    // Pins the specific half ratio (not just headroom, which the module-level
+    // compile assert covers): narrowing the split would silently starve HTTP.
     #[test]
-    fn http_session_cap_leaves_headroom_below_the_shared_client_table_bound() {
-        const {
-            assert!(
-                MAX_HTTP_SESSIONS < CLIENTS_TABLE_MAX,
-                "HTTP must not claim the whole shared VSR client table"
-            );
-        }
-        assert_eq!(MAX_HTTP_SESSIONS, CLIENTS_TABLE_MAX / 2);
+    fn http_session_cap_is_half_the_shared_client_table_bound() {
+        assert_eq!(DEFAULT_MAX_HTTP_SESSIONS, CLIENTS_TABLE_MAX / 2);
+    }
+
+    // Zero behavior change at defaults: the cap computed at boot from the
+    // shipped `[metadata] clients_table_max` equals the historical compile-time
+    // default, so surfacing the table size as config leaves a default
+    // deployment untouched.
+    #[test]
+    fn runtime_cap_at_default_config_equals_pinned_default() {
+        let configured = configs::ng_metadata::MetadataConfig::default().clients_table_max;
+        assert_eq!(max_http_sessions(configured), DEFAULT_MAX_HTTP_SESSIONS);
     }
 
     // Eviction recovery: forgetting the evicted session drops exactly its

--- a/core/server-ng/src/http/state.rs
+++ b/core/server-ng/src/http/state.rs
@@ -43,8 +43,8 @@ use crate::http::error::{AuthError, ReadError, primary_redirect_location};
 use crate::http::forward::ForwardState;
 use crate::http::jwt::JwtManager;
 use crate::http::session::{
-    BarrierEntry, FIRST_REQUEST_ID, FRESH_ENTRY_WATERMARK, HttpSession, MAX_HTTP_SESSIONS,
-    RegistrationBarrier, forget_if_same, live_entry, sweep_expired,
+    BarrierEntry, FIRST_REQUEST_ID, FRESH_ENTRY_WATERMARK, HttpSession, RegistrationBarrier,
+    forget_if_same, live_entry, sweep_expired,
 };
 
 /// Response header carrying the current VSR view number. Stamped by
@@ -82,6 +82,11 @@ pub(in crate::http) struct HttpInner {
     /// requests for one credential from each running its own `Register`.
     pub(in crate::http) registrations: RegistrationBarrier,
     pub(in crate::http) roster: ClusterRoster,
+    /// Cap on live per-credential sessions: half the configured `[metadata]
+    /// clients_table_max`, so HTTP sessions cannot crowd the TCP/QUIC/WS virtual
+    /// clients out of the shared VSR client table. Read by `resolve_session`
+    /// when admitting a fresh session.
+    pub(in crate::http) max_http_sessions: usize,
     /// Awaited partition writes currently in flight across all sessions, gated
     /// by [`MAX_IN_FLIGHT_WRITES_GLOBAL`]. Only [`InFlightWriteGuard`] touches
     /// it, so every admission is paired with exactly one release.
@@ -170,7 +175,7 @@ impl HttpInner {
                     let (admitted, torn) = {
                         let mut table = self.sessions.borrow_mut();
                         let torn = sweep_expired(&mut table, now);
-                        if table.len() >= MAX_HTTP_SESSIONS {
+                        if table.len() >= self.max_http_sessions {
                             // Still full after dropping expired entries: too many
                             // genuinely live sessions. Refuse rather than evict a
                             // live one (its `fresh` client id is orphaned on the

--- a/core/server-ng/src/http/tls.rs
+++ b/core/server-ng/src/http/tls.rs
@@ -65,11 +65,6 @@ use crate::server_error::ServerNgError;
 const ALPN_H2: &[u8] = b"h2";
 const ALPN_HTTP11: &[u8] = b"http/1.1";
 
-/// Handshake wall-clock bound for the accept pump. The HTTP listener has no
-/// `MessageBusConfig` to source it from, so it mirrors the binary
-/// transports' `DEFAULT_HANDSHAKE_GRACE` directly.
-const HTTP_TLS_HANDSHAKE_GRACE: Duration = Duration::from_secs(10);
-
 /// Depth of the handshaken-connection channel between the accept pump and
 /// the serve loop. The serve loop drains one per accept and immediately
 /// spawns a per-connection hyper task, so it rarely fills; the bound keeps
@@ -101,16 +96,26 @@ pub fn load_http_tls_server_config(
 
 /// Bind the accept pump: build the acceptor, spawn the pump task, and hand
 /// back the handshaken-connection receiver for [`serve`] plus the pump's
-/// join handle for the caller to track.
+/// join handle for the caller to track. `handshake_grace` bounds each
+/// connection's TLS handshake; the caller sources it from
+/// `MessageBusConfig::handshake_grace` so the HTTPS listener shares the same
+/// slowloris budget as the binary transports.
 pub fn spawn_accept_pump(
     listener: TcpListener,
     config: Arc<rustls::ServerConfig>,
+    handshake_grace: Duration,
     shutdown: ShutdownToken,
 ) -> (Receiver<Handshaken>, JoinHandle<()>) {
     let (connections_tx, connections_rx) =
         async_channel::bounded::<Handshaken>(ACCEPT_CHANNEL_DEPTH);
     let acceptor = TlsAcceptor::from(config);
-    let pump = compio::runtime::spawn(accept_pump(listener, acceptor, connections_tx, shutdown));
+    let pump = compio::runtime::spawn(accept_pump(
+        listener,
+        acceptor,
+        connections_tx,
+        handshake_grace,
+        shutdown,
+    ));
     (connections_rx, pump)
 }
 
@@ -205,6 +210,7 @@ async fn accept_pump(
     listener: TcpListener,
     acceptor: TlsAcceptor,
     connections: Sender<Handshaken>,
+    handshake_grace: Duration,
     shutdown: ShutdownToken,
 ) {
     loop {
@@ -214,7 +220,9 @@ async fn accept_pump(
                 break;
             }
             result = listener.accept().fuse() => match result {
-                Ok((stream, peer)) => spawn_handshake(&acceptor, &connections, stream, peer),
+                Ok((stream, peer)) => {
+                    spawn_handshake(&acceptor, &connections, handshake_grace, stream, peer);
+                }
                 Err(error) => error!(%error, "server-ng HTTPS accept failed"),
             },
         }
@@ -228,13 +236,14 @@ async fn accept_pump(
 fn spawn_handshake(
     acceptor: &TlsAcceptor,
     connections: &Sender<Handshaken>,
+    handshake_grace: Duration,
     stream: TcpStream,
     peer: SocketAddr,
 ) {
     let acceptor = acceptor.clone();
     let connections = connections.clone();
     compio::runtime::spawn(async move {
-        match compio::time::timeout(HTTP_TLS_HANDSHAKE_GRACE, acceptor.accept(stream)).await {
+        match compio::time::timeout(handshake_grace, acceptor.accept(stream)).await {
             Ok(Ok(tls)) => {
                 // Drop on send error: the channel is closed only at
                 // shutdown, when the serve loop is already tearing down.
@@ -242,7 +251,7 @@ fn spawn_handshake(
             }
             Ok(Err(error)) => debug!(%peer, %error, "server-ng HTTPS handshake failed"),
             Err(_elapsed) => {
-                debug!(%peer, grace = ?HTTP_TLS_HANDSHAKE_GRACE, "server-ng HTTPS handshake timed out");
+                debug!(%peer, grace = ?handshake_grace, "server-ng HTTPS handshake timed out");
             }
         }
     })

--- a/core/server-ng/src/partition_helpers.rs
+++ b/core/server-ng/src/partition_helpers.rs
@@ -487,15 +487,25 @@ pub async fn build_partition_fresh(
             source
         })?;
 
+    // Request queue holds 2x the prepare depth (buffered requests drain as
+    // prepares commit); depth is the per-partition `[partition]` knob.
+    let prepare_queue_depth = config.partition.prepare_queue_depth;
     let consensus = VsrConsensus::new(
         cluster_id,
         self_replica_id,
         replica_count,
         namespace.inner(),
         bus,
-        LocalPipeline::new(),
+        LocalPipeline::with_capacities(prepare_queue_depth, prepare_queue_depth * 2),
     );
     consensus.set_normal_heartbeat_ticks(crate::bootstrap::cluster_heartbeat_ticks(config));
+    consensus.set_commit_message_ticks(crate::bootstrap::commit_broadcast_ticks(config));
+    consensus.set_prepare_ticks(crate::bootstrap::prepare_retransmit_ticks(config));
+    consensus
+        .set_view_change_retransmit_ticks(crate::bootstrap::view_change_retransmit_ticks(config));
+    consensus.set_view_change_status_ticks(crate::bootstrap::view_change_status_ticks(config));
+    consensus.set_request_start_view_ticks(crate::bootstrap::request_start_view_ticks(config));
+    consensus.set_probe_attempts_max(config.cluster.view_probe_attempts_max);
     // A partition directory that already holds segment bytes is a RESTART
     // materialization, not a fresh create: this replica's group state died
     // with the process, so claiming view-0 primaryship would heartbeat
@@ -513,6 +523,14 @@ pub async fn build_partition_fresh(
     }
 
     let mut partition = IggyPartition::new(stats, consensus);
+    // Surface the evicted-ring ceilings from config onto the fresh journal.
+    // IggyPartition::new has already disabled retention for single-replica
+    // groups (nobody to serve), so this only sizes the multi-replica ring; the
+    // caps are inert while retention is off.
+    partition.log.journal().inner.set_ring_caps(
+        config.partition.evicted_ring_capacity,
+        config.partition.evicted_ring_bytes_max.as_bytes_u64(),
+    );
     partition.set_partition_dir(config.system.get_partition_path(
         stream_id,
         topic_id,

--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -57,7 +57,7 @@ use partitions::{IggyPartition, IggyPartitions, PollFragments, PollingArgs, Poll
 use server_common::sharding::{IggyNamespace, PartitionLocation, ShardId};
 use server_common::{MESSAGE_ALIGN, Message, MessageBag, iobuf::Frozen};
 use shards_table::ShardsTable;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::rc::Rc;
@@ -714,12 +714,16 @@ impl ShardFrame {
     }
 }
 
-/// Prepares served per `RequestPrepares` round. The per-peer bus queues
-/// are bounded (`peer_queue_capacity`, 256 by default) and overrun frames
-/// drop silently, so an unbounded burst loses its own tail; the receiver
-/// pulls the window chunk by chunk instead (each walked `RepairDone`
-/// immediately requests the next chunk while progress holds).
-const REPAIR_CHUNK_MAX: u64 = 128;
+/// Prepares served per `RequestPrepares` round.
+///
+/// The per-peer bus queues are bounded (`peer_queue_capacity`, 256 by default)
+/// and overrun frames drop silently, so an unbounded burst loses its own tail;
+/// the receiver pulls the window chunk by chunk instead (each walked
+/// `RepairDone` immediately requests the next chunk while progress holds).
+///
+/// Runtime default; server-ng overrides the live ceiling per shard from
+/// `[cluster] repair_chunk_max` at bootstrap.
+pub const REPAIR_CHUNK_MAX: u64 = 128;
 
 /// One in-flight metadata journal-repair stream (shard 0 only).
 #[derive(Debug, Clone, Copy)]
@@ -830,6 +834,16 @@ where
     /// `ReconcileOp::InsertOwned` lands. Bounded per namespace; overflow
     /// drops the frame (at-least-once: client/primary retries recover).
     pending_partition_frames: RefCell<HashMap<IggyNamespace, Vec<Message<GenericHeader>>>>,
+
+    /// Live ceiling on prepares served per `RequestPrepares` round. Defaults
+    /// to [`REPAIR_CHUNK_MAX`]; server-ng overrides it from
+    /// `[cluster] repair_chunk_max` at bootstrap.
+    repair_chunk_max: Cell<u64>,
+
+    /// Live stalled-repair retry threshold in consensus ticks. Defaults to
+    /// [`partitions::REPAIR_RETRY_TICKS`]; server-ng overrides it from
+    /// `[cluster] repair_retry_interval` at bootstrap.
+    repair_retry_ticks: Cell<u32>,
 }
 
 impl<B, MJ, S, M, T> IggyShard<B, MJ, S, M, T>
@@ -922,7 +936,23 @@ where
             reconcile_queue: RefCell::new(VecDeque::new()),
             pending_partition_frames: RefCell::new(HashMap::new()),
             metadata_repair: RefCell::new(None),
+            repair_chunk_max: Cell::new(REPAIR_CHUNK_MAX),
+            repair_retry_ticks: Cell::new(partitions::REPAIR_RETRY_TICKS),
         })
+    }
+
+    /// Override the stalled-repair retry threshold (consensus ticks) from
+    /// configuration. Called once per shard at bootstrap; the simulator and
+    /// tests keep the compile-time [`partitions::REPAIR_RETRY_TICKS`] default.
+    pub fn set_repair_retry_ticks(&self, ticks: u32) {
+        self.repair_retry_ticks.set(ticks);
+    }
+
+    /// Override the per-round repair-serving chunk ceiling from configuration.
+    /// Called once per shard at bootstrap; the simulator and tests keep the
+    /// compile-time [`REPAIR_CHUNK_MAX`] default.
+    pub fn set_repair_chunk_max(&self, chunk: u64) {
+        self.repair_chunk_max.set(chunk);
     }
 
     /// Hand a metadata consensus submit (login/logout) to shard 0.
@@ -1129,6 +1159,8 @@ where
             reconcile_queue: RefCell::new(VecDeque::new()),
             pending_partition_frames: RefCell::new(HashMap::new()),
             metadata_repair: RefCell::new(None),
+            repair_chunk_max: Cell::new(REPAIR_CHUNK_MAX),
+            repair_retry_ticks: Cell::new(partitions::REPAIR_RETRY_TICKS),
         }
     }
 
@@ -2042,6 +2074,9 @@ where
     {
         let header = *msg.header();
         let target = header.replica;
+        // Snapshot the config-overridable chunk ceiling once; both plane
+        // branches below serve the same per-round window.
+        let repair_chunk_max = self.repair_chunk_max.get();
         let planes = self.plane.inner();
         if let Some(ref consensus) = planes.0.consensus
             && consensus.namespace() == header.namespace
@@ -2103,7 +2138,7 @@ where
                 )
                 .await;
             }
-            let chunk_end = to_op.min(from_op.saturating_add(REPAIR_CHUNK_MAX - 1));
+            let chunk_end = to_op.min(from_op.saturating_add(repair_chunk_max - 1));
             let mut served_through = from_op.saturating_sub(1);
             for op in from_op..=chunk_end {
                 #[allow(clippy::cast_possible_truncation)]
@@ -2163,7 +2198,7 @@ where
             .await;
             from_op = retained_from;
         }
-        let chunk_end = to_op.min(from_op.saturating_add(REPAIR_CHUNK_MAX - 1));
+        let chunk_end = to_op.min(from_op.saturating_add(repair_chunk_max - 1));
         let mut served_through = from_op.saturating_sub(1);
         for op in from_op..=chunk_end {
             let Some(entry) = partition.log.journal().inner.repair_entry(op) else {
@@ -2547,6 +2582,7 @@ where
             >,
     {
         let partitions = self.plane.partitions();
+        let repair_retry_ticks = self.repair_retry_ticks.get();
         // Fan out over every group (each partition's heartbeat/retransmit timer
         // must advance), so the keyed single-namespace lookup the control-frame
         // handlers use does not apply here. The namespaces are snapshotted into
@@ -2585,7 +2621,7 @@ where
                         return None;
                     }
                     session.idle_ticks += 1;
-                    if session.idle_ticks < partitions::REPAIR_RETRY_TICKS {
+                    if session.idle_ticks < repair_retry_ticks {
                         return None;
                     }
                     session.idle_ticks = 0;
@@ -2699,6 +2735,7 @@ where
 
         // Stall retry, mirroring `tick_partitions`: a lost repair frame must
         // not wedge the session forever.
+        let repair_retry_ticks = self.repair_retry_ticks.get();
         let stalled = {
             let mut session = self.metadata_repair.borrow_mut();
             session.as_mut().and_then(|session| {
@@ -2706,7 +2743,7 @@ where
                     return None;
                 }
                 session.idle_ticks += 1;
-                if session.idle_ticks < partitions::REPAIR_RETRY_TICKS {
+                if session.idle_ticks < repair_retry_ticks {
                     return None;
                 }
                 session.idle_ticks = 0;

--- a/justfile
+++ b/justfile
@@ -62,7 +62,7 @@ nextest: build
   #!/usr/bin/env bash
   set -euo pipefail
   trap "{{reap_test_containers}}" EXIT
-  cargo nextest run
+  cargo nextest run --retries 2
 
 # Like `nextest` but with the `vsr` feature; builds vsr first so the
 # harness-spawned iggy-server-ng carries the vsr wire format. `--no-fail-fast`
@@ -73,7 +73,7 @@ nextest-vsr: build-vsr
   #!/usr/bin/env bash
   set -euo pipefail
   trap "{{reap_test_containers}}" EXIT
-  cargo nextest run --features vsr --no-fail-fast
+  cargo nextest run --features vsr --no-fail-fast --retries 2
 
 nextests TEST: build
   #!/usr/bin/env bash


### PR DESCRIPTION
Make VSR timing and capacity tunables configurable and close the
config-audit findings on the configuration plane: reject configs that
cannot work at runtime (zero rebalancing and heartbeat durations, zero
or panic-prone WebSocket size pairs, out-of-bounds repair_chunk_max on
a single node), warn on parsed-but-inert knobs and annotate them in
the shipped config, and move live WebSocket frame tuning to
[websocket].

Old [message_bus] ws_* keys are ignored; cluster roster websocket
ports now bind the actual listener; listener backlog follows SOMAXCONN
and the HTTP TLS handshake budget tracks handshake_grace.
