### PR TITLE
fix(server-ng): make partition reconvergence safe for in-flight sends

### DIFF
--- a/core/consensus/src/plane_helpers.rs
+++ b/core/consensus/src/plane_helpers.rs
@@ -503,6 +503,48 @@ where
     reply
 }
 
+/// [`build_deny_reply_from_request`] for layers that hold no consensus group
+/// for the request's namespace (a shard fencing a frame aimed at a torn-down
+/// or never-materialised partition).
+///
+/// Replica-stamped fields (`cluster`, `view`, `replica`) echo the request
+/// instead, the same convention as [`build_result_rejection_reply`];
+/// `commit` stays 0 because no commit position exists here and deny frames
+/// are never cached in the `ClientTable`.
+///
+/// # Panics
+/// If the constructed message buffer is not a valid reply message.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn build_deny_reply_from_request_header(
+    request_header: &RequestHeader,
+    status: u32,
+) -> Message<ReplyHeader> {
+    let header_size = std::mem::size_of::<ReplyHeader>();
+    let mut buffer = bytes::BytesMut::zeroed(header_size);
+
+    let header = ReplyHeader {
+        cluster: request_header.cluster,
+        size: header_size as u32,
+        view: request_header.view,
+        release: request_header.release,
+        command: Command2::Reply,
+        replica: request_header.replica,
+        request_checksum: request_header.request_checksum,
+        client: request_header.client,
+        status,
+        timestamp: request_header.timestamp,
+        request: request_header.request,
+        operation: request_header.operation,
+        namespace: request_header.namespace,
+        ..Default::default()
+    };
+    buffer[..header_size].copy_from_slice(bytemuck::bytes_of(&header));
+
+    Message::try_from(Owned::<4096>::copy_from_slice(buffer.as_ref()))
+        .expect("deny reply buffer must contain a valid reply message")
+}
+
 /// Verify hash chain would not break if we add this header.
 ///
 /// # Panics

--- a/core/integration/tests/connectors/http/http_sink.rs
+++ b/core/integration/tests/connectors/http/http_sink.rs
@@ -106,8 +106,10 @@
 //!
 //! **Seed Data**:
 //! `seeds::connector_stream` creates the stream (`test_stream`) and first topic
-//! (`test_topic`). The multi-topic test creates a second topic inline to avoid
-//! polluting the shared harness with HTTP-sink-specific constants.
+//! (`test_topic`). The JSON array test uses a local seed that also pre-publishes
+//! its messages (see `connector_stream_with_json_array_messages`). The multi-topic
+//! test creates a second topic inline to avoid polluting the shared harness with
+//! HTTP-sink-specific constants.
 //!
 //! **Configuration** (`tests/connectors/http/sink.toml`):
 //! ```toml
@@ -183,6 +185,7 @@ use crate::connectors::fixtures::{
     HttpSinkNdjsonFixture, HttpSinkNoMetadataFixture, HttpSinkRawFixture,
 };
 use bytes::Bytes;
+use iggy::prelude::IggyClient;
 use iggy_common::{Identifier, IggyMessage, MessageClient, Partitioning};
 use integration::harness::seeds;
 use integration::iggy_harness;
@@ -390,41 +393,36 @@ async fn ndjson_messages_delivered_as_single_request(
 // Test 3: JSON Array Batch Mode
 // ============================================================================
 
-/// Validates `batch_mode=json_array`: all messages as a single JSON array in one request.
-/// Checks single request, array length = message count, per-item envelope, `application/json`.
-#[iggy_harness(
-    server(connectors_runtime(config_path = "tests/connectors/http/sink.toml")),
-    seed = seeds::connector_stream
-)]
-async fn json_array_messages_delivered_as_single_request(
-    harness: &TestHarness,
-    fixture: HttpSinkJsonArrayFixture,
-) {
-    let client = harness.root_client().await.unwrap();
-    let stream_id: Identifier = seeds::names::STREAM.try_into().unwrap();
-    let topic_id: Identifier = seeds::names::TOPIC.try_into().unwrap();
+/// Creates the connector stream/topic and pre-publishes the JSON array test messages.
+///
+/// Publishing after the connector runtime starts races the sink's poll loop against
+/// the server's commit frontier: a poll can observe a partial batch, which the runtime
+/// flushes as its own HTTP request. Messages at rest before the first poll always
+/// arrive as one batch, so single-request delivery is guaranteed.
+async fn connector_stream_with_json_array_messages(
+    client: &IggyClient,
+) -> Result<(), seeds::SeedError> {
+    seeds::connector_stream(client).await?;
 
-    // Step 1: Build 3 JSON messages representing different event types
+    let stream_id: Identifier = seeds::names::STREAM.try_into()?;
+    let topic_id: Identifier = seeds::names::TOPIC.try_into()?;
+
     let json_payloads: Vec<serde_json::Value> = vec![
         serde_json::json!({"id": 1, "type": "order"}),
         serde_json::json!({"id": 2, "type": "payment"}),
         serde_json::json!({"id": 3, "type": "refund"}),
     ];
 
-    let mut messages: Vec<IggyMessage> = json_payloads
-        .iter()
-        .enumerate()
-        .map(|(i, payload)| {
-            let bytes = serde_json::to_vec(payload).expect("Failed to serialize");
+    let mut messages: Vec<IggyMessage> = Vec::with_capacity(json_payloads.len());
+    for (i, payload) in json_payloads.iter().enumerate() {
+        messages.push(
             IggyMessage::builder()
                 .id((i + 1) as u128)
-                .payload(Bytes::from(bytes))
-                .build()
-                .expect("Failed to build message")
-        })
-        .collect();
+                .payload(Bytes::from(serde_json::to_vec(payload)?))
+                .build()?,
+        );
+    }
 
-    // Step 2: Publish messages to Iggy
     client
         .send_messages(
             &stream_id,
@@ -432,10 +430,20 @@ async fn json_array_messages_delivered_as_single_request(
             &Partitioning::partition_id(0),
             &mut messages,
         )
-        .await
-        .expect("Failed to send messages");
+        .await?;
 
-    // Step 3: Wait for single JSON array request (all messages in one body)
+    Ok(())
+}
+
+/// Validates `batch_mode=json_array`: all messages as a single JSON array in one request.
+/// Checks single request, array length = message count, per-item envelope, `application/json`.
+#[iggy_harness(
+    server(connectors_runtime(config_path = "tests/connectors/http/sink.toml")),
+    seed = connector_stream_with_json_array_messages
+)]
+async fn json_array_messages_delivered_as_single_request(fixture: HttpSinkJsonArrayFixture) {
+    // Step 1: Wait for the single JSON array request. The seed pre-published all
+    // messages, so the sink delivers them in one batch (see the seed docs above).
     let requests = fixture
         .container()
         .wait_for_requests(1)
@@ -446,7 +454,7 @@ async fn json_array_messages_delivered_as_single_request(
     assert_eq!(req.method, "POST", "Expected POST method");
     assert_eq!(req.url, "/ingest", "Expected /ingest URL");
 
-    // Step 4: Parse body as JSON array and verify structure
+    // Step 2: Parse body as JSON array and verify structure
     let body = req.body_as_json().expect("Body should be valid JSON");
     assert!(body.is_array(), "Expected JSON array body, got: {body}");
 
@@ -469,7 +477,7 @@ async fn json_array_messages_delivered_as_single_request(
         );
     }
 
-    // Step 5: Verify JSON content type
+    // Step 3: Verify JSON content type
     let ct = req
         .header("Content-Type")
         .expect("Content-Type header must be present");

--- a/core/integration/tests/server/http_vsr.rs
+++ b/core/integration/tests/server/http_vsr.rs
@@ -615,6 +615,17 @@ async fn given_oversized_body_when_producing_should_reject_413(harness: &TestHar
         StatusCode::PAYLOAD_TOO_LARGE,
         "oversized body must be rejected"
     );
+    // The cap rejects the body unread, so the connection cannot be reused: the
+    // reply must say so, or the client pools a socket the server stopped
+    // reading and the next request on it fails on a clean EOF.
+    assert_eq!(
+        response
+            .headers()
+            .get(reqwest::header::CONNECTION)
+            .and_then(|value| value.to_str().ok()),
+        Some("close"),
+        "a 413 must close the connection rather than let the client pool it"
+    );
 
     // The rejection must not poison the listener: a normal produce still commits.
     let normal = text_message(1, "small-after-large".to_string());

--- a/core/integration/tests/server/message_retrieval.rs
+++ b/core/integration/tests/server/message_retrieval.rs
@@ -84,21 +84,28 @@ fn build_server_config(
         "true".to_string(),
     );
     extra_envs.insert("IGGY_TCP_SOCKET_NODELAY".to_string(), "true".to_string());
-    // Under vsr these scenarios exercise retrieval, not failover, yet run
-    // on the default 3-node cluster. Under a parallel nextest run the box
-    // is oversubscribed and scheduling stalls exceed the 5s default
-    // liveness window, so backups elect a new primary mid-scenario and the
-    // client session dies with it (observed stalls reach ~20s; 60s rides
-    // them out). The knob exists only on server-ng: the legacy flavor's
-    // strict env provider aborts boot on unknown IGGY_ vars, so the gate
-    // is load-bearing.
-    #[cfg(feature = "vsr")]
-    extra_envs.insert(
-        "IGGY_CLUSTER_HEARTBEAT_TIMEOUT".to_string(),
-        "60s".to_string(),
-    );
 
     TestServerConfig::builder().extra_envs(extra_envs).build()
+}
+
+/// These matrices exercise retrieval, not replication: a single node keeps
+/// the wide permutation set cheap under a parallel nextest run, where an
+/// oversubscribed multi-node cluster stalls past the liveness window and
+/// elects a new primary mid-scenario, killing the client session.
+fn build_harness(
+    segment_size: &str,
+    cache_indexes: &str,
+    messages_required_to_save: &str,
+) -> TestHarness {
+    TestHarness::builder()
+        .server(build_server_config(
+            segment_size,
+            cache_indexes,
+            messages_required_to_save,
+        ))
+        .cluster_nodes(1)
+        .build()
+        .unwrap()
 }
 
 #[test_matrix(
@@ -113,14 +120,7 @@ async fn get_by_offset_scenario(
     cache_indexes: &str,
     messages_required_to_save: &str,
 ) {
-    let mut harness = TestHarness::builder()
-        .server(build_server_config(
-            segment_size,
-            cache_indexes,
-            messages_required_to_save,
-        ))
-        .build()
-        .unwrap();
+    let mut harness = build_harness(segment_size, cache_indexes, messages_required_to_save);
 
     harness.start().await.unwrap();
 
@@ -139,14 +139,7 @@ async fn get_by_timestamp_scenario(
     cache_indexes: &str,
     messages_required_to_save: &str,
 ) {
-    let mut harness = TestHarness::builder()
-        .server(build_server_config(
-            segment_size,
-            cache_indexes,
-            messages_required_to_save,
-        ))
-        .build()
-        .unwrap();
+    let mut harness = build_harness(segment_size, cache_indexes, messages_required_to_save);
 
     harness.start().await.unwrap();
 

--- a/core/integration/tests/server/scenarios/message_cleanup_scenario.rs
+++ b/core/integration/tests/server/scenarios/message_cleanup_scenario.rs
@@ -582,7 +582,7 @@ pub async fn run_fair_size_based_cleanup_multipartition(client: &IggyClient, dat
 /// Scenario:
 /// 1. Send 300 messages (3 segments at 100KB each)
 /// 2. Consumer reads only 50 messages (stored offset ~49, within segment 0)
-/// 3. Wait for all segments to expire (2s expiry)
+/// 3. Wait for all segments to expire (4s expiry)
 /// 4. Verify consumer can still poll Next() and get contiguous offsets
 ///
 /// On unfixed code: the cleaner deletes segments 0+1 (expired, consumer offset
@@ -594,7 +594,11 @@ pub async fn run_expiry_respects_consumer_offset(client: &IggyClient, data_path:
     let stream = client.create_stream(TEST_STREAM).await.unwrap();
     let stream_id = stream.id;
 
-    let expiry = Duration::from_secs(2);
+    // Expiry must outlast the send + first-poll phase: 300 serial sends with
+    // per-message fsync (and VSR quorum in cluster mode) take ~3s under load.
+    // If segments expire before the consumer commits its first offset, there is
+    // no barrier yet and the cleaner legally deletes them, breaking the premise.
+    let expiry = Duration::from_secs(4);
     let topic = client
         .create_topic(
             &Identifier::named(TEST_STREAM).unwrap(),

--- a/core/integration/tests/server/scenarios/purge_delete_scenario.rs
+++ b/core/integration/tests/server/scenarios/purge_delete_scenario.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use super::{POLL_CONVERGENCE_TIMEOUT, POLL_RETRY_INTERVAL};
 use bytes::Bytes;
 use iggy::prelude::*;
 use iggy_common::Credentials;
@@ -283,7 +284,7 @@ pub async fn run(harness: &mut TestHarness, restart_server: bool) {
         std::slice::from_ref(&active_segment_offset),
     )
     .await;
-    assert_no_orphaned_segment_files(&partition_path, 1);
+    assert_no_orphaned_segment_files(&partition_path, 1).await;
     assert_segment_file_sizes(
         &partition_path,
         std::slice::from_ref(&active_segment_offset),
@@ -422,7 +423,7 @@ pub async fn run_no_consumers(harness: &mut TestHarness, restart_server: bool) {
     // Only the active segment remains — delete is a no-op
     let active = *layout.last().expect("layout is non-empty");
     await_segment_layout(&partition_path, std::slice::from_ref(&active)).await;
-    assert_no_orphaned_segment_files(&partition_path, 1);
+    assert_no_orphaned_segment_files(&partition_path, 1).await;
 
     client
         .delete_segments(&stream_ident, &topic_ident, PARTITION_ID, 1)
@@ -580,7 +581,7 @@ pub async fn run_consumer_group_barrier(client: &IggyClient, data_path: &Path) {
         [*EXPECTED_SEGMENT_OFFSETS.last().unwrap()],
         "Only active segment remains after consuming all messages"
     );
-    assert_no_orphaned_segment_files(&partition_path, 1);
+    assert_no_orphaned_segment_files(&partition_path, 1).await;
 
     // Cleanup: consumer group auto-managed, just delete stream resources
     drop(consumer);
@@ -818,7 +819,7 @@ pub async fn run_multi_consumer_barrier(harness: &mut TestHarness, restart_serve
         .unwrap();
     maybe_restart(harness, restart_server).await;
     await_segment_layout(&partition_path, &active_only).await;
-    assert_no_orphaned_segment_files(&partition_path, 1);
+    assert_no_orphaned_segment_files(&partition_path, 1).await;
 
     // Cleanup: drop high-level consumer, delete stream resources
     drop(fast_consumer);
@@ -956,14 +957,16 @@ pub async fn run_purge_topic(harness: &mut TestHarness, restart_server: bool) {
     // Verify offset files exist on disk
     let consumers_dir = format!("{partition_path}/offsets/consumers");
     let groups_dir = format!("{partition_path}/offsets/groups");
-    assert!(
-        !is_dir_empty(&consumers_dir),
-        "Consumer offset file must exist before purge"
-    );
-    assert!(
-        !is_dir_empty(&groups_dir),
-        "Consumer group offset file must exist before purge"
-    );
+    await_dir_not_empty(
+        &consumers_dir,
+        "Consumer offset file must exist before purge",
+    )
+    .await;
+    await_dir_not_empty(
+        &groups_dir,
+        "Consumer group offset file must exist before purge",
+    )
+    .await;
 
     // --- Purge topic ---
     // Drop high-level consumer before purge to release group membership
@@ -1301,6 +1304,21 @@ fn get_sorted_segment_offsets(partition_path: &str) -> Vec<u64> {
     offsets
 }
 
+/// Wait until `dir` contains at least one entry, panicking with `context`
+/// once [`POLL_CONVERGENCE_TIMEOUT`] expires.
+///
+/// A stored consumer offset is served from memory as soon as the store is
+/// acked, while the offset file is created asynchronously, so a single-shot
+/// existence check can run ahead of the flush. An offset that is never
+/// flushed still fails once the deadline expires.
+async fn await_dir_not_empty(dir: &str, context: &str) {
+    let deadline = std::time::Instant::now() + POLL_CONVERGENCE_TIMEOUT;
+    while is_dir_empty(dir) {
+        assert!(std::time::Instant::now() < deadline, "{context}");
+        tokio::time::sleep(POLL_RETRY_INTERVAL).await;
+    }
+}
+
 fn is_dir_empty(dir: &str) -> bool {
     read_dir(dir)
         .map(|mut entries| entries.next().is_none())
@@ -1335,20 +1353,28 @@ fn assert_fresh_empty_partition(partition_path: &str) {
     );
 }
 
-/// Asserts no orphaned segment files remain after deletion.
-/// `get_sorted_segment_offsets` only checks .log files — this additionally verifies
-/// that the .index file count matches, catching stale .index files left behind.
-fn assert_no_orphaned_segment_files(partition_path: &str, expected_count: usize) {
-    let log_count = count_files_with_ext(partition_path, LOG_EXTENSION);
-    let index_count = count_files_with_ext(partition_path, INDEX_EXTENSION);
-    assert_eq!(
-        log_count, expected_count,
-        "Expected {expected_count} .log files, found {log_count}"
-    );
-    assert_eq!(
-        index_count, expected_count,
-        "Expected {expected_count} .index files, found {index_count}"
-    );
+/// Asserts no orphaned segment files remain after deletion, polling until the
+/// counts converge or [`POLL_CONVERGENCE_TIMEOUT`] expires.
+///
+/// `get_sorted_segment_offsets` only checks .log files -- this additionally
+/// verifies that the .index file count matches, catching stale .index files
+/// left behind. server-ng unlinks a segment's .log and .index files across
+/// separate awaits, so a layout that already converged on .log files can
+/// transiently show one extra .index file.
+async fn assert_no_orphaned_segment_files(partition_path: &str, expected_count: usize) {
+    let deadline = std::time::Instant::now() + POLL_CONVERGENCE_TIMEOUT;
+    loop {
+        let log_count = count_files_with_ext(partition_path, LOG_EXTENSION);
+        let index_count = count_files_with_ext(partition_path, INDEX_EXTENSION);
+        if log_count == expected_count && index_count == expected_count {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "Expected {expected_count} .log and .index files, found {log_count} .log and {index_count} .index"
+        );
+        tokio::time::sleep(POLL_RETRY_INTERVAL).await;
+    }
 }
 
 fn count_files_with_ext(dir: &str, ext: &str) -> usize {

--- a/core/metadata/src/stm/stream.rs
+++ b/core/metadata/src/stm/stream.rs
@@ -30,14 +30,16 @@ use crate::{collect_handlers, define_state, impl_fill_restore};
 use ahash::AHashMap;
 use bytes::{BufMut, Bytes, BytesMut};
 use iggy_binary_protocol::codec::{WireDecode, WireEncode};
-// Only `seed_single_partition` (below, sim/test-gated) uses this at module
-// scope; keep the import under the same gate so a production build does not
-// see it as unused. The test module re-imports it independently.
+// Only `seed_namespace` (below, sim/test-gated) uses these at module scope;
+// keep the imports under the same gate so a production build does not see them
+// as unused. The test module re-imports them independently.
 #[cfg(any(test, feature = "simulator"))]
 use iggy_binary_protocol::primitives::partition_assignment::CreatedPartitionAssignment;
 use iggy_binary_protocol::requests::consumer_groups::{
     CreateConsumerGroupRequest, DeleteConsumerGroupRequest,
 };
+#[cfg(any(test, feature = "simulator"))]
+use iggy_binary_protocol::requests::partitions::CreatePartitionsRequest;
 use iggy_binary_protocol::requests::partitions::{
     CreatePartitionsWithAssignmentsRequest, DeletePartitionsRequest,
 };
@@ -1164,53 +1166,182 @@ impl Streams {
         })
     }
 
-    /// Seed the first stream / topic / partition straight into the STM so a
-    /// simulator or test namespace resolves without driving the metadata
-    /// consensus + reconciler chain (which the simulator does not wire).
+    /// Committed [`Partition::created_revision`] for the exact partition the
+    /// `namespace` tuple denotes, or `None` if any level of the tuple is not
+    /// committed.
     ///
-    /// Creates stream slab 0, topic slab 0, and one partition `partition_id`
-    /// bound to `consensus_group_id`, so `namespace_from_partition(numeric 0,
-    /// numeric 0, partition_id)` resolves to `IggyNamespace::new(0, 0,
-    /// partition_id)`. Mirrors [`Users::ensure_root_user`]: a seed helper
-    /// that bypasses consensus, never a production runtime path. No-op if a
-    /// stream already occupies slab 0.
+    /// Resolves by slab index rather than by name, so a delete + recreate that
+    /// recycled the freed keys reports the NEW incarnation's revision under the
+    /// byte-identical namespace. That difference is the only thing separating
+    /// the two incarnations, so callers can use it to tell a materialised
+    /// partition apart from the committed one it is impersonating.
+    #[must_use]
+    pub fn created_revision_for_namespace(&self, namespace: IggyNamespace) -> Option<u64> {
+        self.inner.read(|inner| {
+            let stream = inner.items.get(namespace.stream_id())?;
+            let topic = stream.topics.get(namespace.topic_id())?;
+            topic
+                .partitions
+                .iter()
+                .find(|partition| partition.id == namespace.partition_id())
+                .map(|partition| partition.created_revision)
+        })
+    }
+
+    /// Create stream slabs `0..=stream_slab`, skipping those already present.
+    #[cfg(any(test, feature = "simulator"))]
+    fn seed_stream_slabs(&self, stream_slab: usize) {
+        for slab in 0..=stream_slab {
+            if self.read(|inner| inner.items.contains(slab)) {
+                continue;
+            }
+            self.inner
+                .try_apply(StreamsCommand::CreateStream(
+                    CreateStreamRequest {
+                        name: WireName::new(format!("sim-stream-{slab}"))
+                            .expect("sim stream name is valid"),
+                    },
+                    IggyTimestamp::from(1),
+                ))
+                .expect("sim stream seed applies on the metadata writer");
+        }
+    }
+
+    /// Create topic slabs `0..=topic_slab` under `stream_slab`, skipping those
+    /// already present. Only the last slab receives `target_partitions`.
+    #[cfg(any(test, feature = "simulator"))]
+    fn seed_topic_slabs(
+        &self,
+        stream_slab: usize,
+        topic_slab: usize,
+        target_partitions: &[CreatedPartitionAssignment],
+    ) {
+        let stream_wire =
+            WireIdentifier::numeric(u32::try_from(stream_slab).expect("sim stream slab fits u32"));
+        for slab in 0..=topic_slab {
+            let present = self.read(|inner| {
+                inner
+                    .items
+                    .get(stream_slab)
+                    .is_some_and(|stream| stream.topics.contains(slab))
+            });
+            if present {
+                continue;
+            }
+            let partitions = if slab == topic_slab {
+                target_partitions.to_vec()
+            } else {
+                Vec::new()
+            };
+            self.inner
+                .try_apply(StreamsCommand::CreateTopicWithAssignments(
+                    CreateTopicWithAssignmentsRequest {
+                        request: CreateTopicRequest {
+                            stream_id: stream_wire.clone(),
+                            partitions_count: u32::try_from(partitions.len())
+                                .expect("sim partition count fits u32"),
+                            compression_algorithm: 0,
+                            message_expiry: 0,
+                            max_topic_size: 0,
+                            replication_factor: 1,
+                            name: WireName::new(format!("sim-topic-{stream_slab}-{slab}"))
+                                .expect("sim topic name is valid"),
+                        },
+                        partitions,
+                    },
+                    IggyTimestamp::from(1),
+                ))
+                .expect("sim topic seed applies on the metadata writer");
+        }
+    }
+
+    /// Seed the stream / topic / partition that `namespace` denotes straight
+    /// into the STM so a simulator or test namespace resolves without driving
+    /// the metadata consensus + reconciler chain (which the simulator does not
+    /// wire).
+    ///
+    /// Slab keys are handed out in creation order, so landing on stream slab
+    /// `s` / topic slab `t` means creating every slab below it too; those
+    /// fillers carry no partitions and are inert. Each level is skipped when
+    /// already present, so seeding sibling partitions of one topic adds only
+    /// the missing partition. Mirrors [`Users::ensure_root_user`]: a seed
+    /// helper that bypasses consensus, never a production runtime path.
     ///
     /// # Panics
     /// Panics if the apply is attempted on a reader handle rather than the
-    /// writer (never for the simulator's writer-backed STM).
+    /// writer (never for the simulator's writer-backed STM), or if a slab id
+    /// exceeds the `u32` wire identifier space.
     #[cfg(any(test, feature = "simulator"))]
-    pub fn seed_single_partition(&self, partition_id: u32, consensus_group_id: u64) {
-        if self.read(|inner| inner.items.contains(0)) {
+    pub fn seed_namespace(&self, namespace: IggyNamespace, consensus_group_id: u64) {
+        let stream_slab = namespace.stream_id();
+        let topic_slab = namespace.topic_id();
+        let partition_id =
+            u32::try_from(namespace.partition_id()).expect("sim partition id fits u32");
+        let stream_wire = || {
+            WireIdentifier::numeric(u32::try_from(stream_slab).expect("sim stream slab fits u32"))
+        };
+        let topic_wire =
+            || WireIdentifier::numeric(u32::try_from(topic_slab).expect("sim topic slab fits u32"));
+        // Filler partitions created to keep the id range dense get the group id
+        // their own namespace would carry, so the addressed one keeps the
+        // caller's value.
+        let sibling_group_id = |id: u32| {
+            if id == partition_id {
+                consensus_group_id
+            } else {
+                IggyNamespace::new(stream_slab, topic_slab, id as usize).inner()
+            }
+        };
+
+        // Only the addressed topic carries partitions; the fillers below it
+        // exist purely to advance the slab counter. Ids are absolute on the
+        // topic-create command, but the additive path below can only append
+        // above the current maximum, so seed the whole dense range up front and
+        // leave no gap for a later sibling to fall into.
+        let target_partitions: Vec<_> = (0..=partition_id)
+            .map(|id| CreatedPartitionAssignment {
+                partition_id: id,
+                consensus_group_id: sibling_group_id(id),
+            })
+            .collect();
+        self.seed_stream_slabs(stream_slab);
+        self.seed_topic_slabs(stream_slab, topic_slab, &target_partitions);
+
+        if self.created_revision_for_namespace(namespace).is_some() {
             return;
         }
+        // Sibling partition of a topic seeded by an earlier call. Ids on this
+        // command are relative to `max(existing) + 1`, so append the whole run
+        // up to the addressed id rather than the single id itself.
+        let base = self.read(|inner| {
+            inner
+                .items
+                .get(stream_slab)
+                .and_then(|stream| stream.topics.get(topic_slab))
+                .and_then(|topic| topic.partitions.iter().map(|partition| partition.id).max())
+                .map_or(0, |highest| highest + 1)
+        });
+        let base = u32::try_from(base).expect("sim partition base fits u32");
+        let partitions = (base..=partition_id)
+            .map(|id| CreatedPartitionAssignment {
+                partition_id: id - base,
+                consensus_group_id: sibling_group_id(id),
+            })
+            .collect::<Vec<_>>();
         self.inner
-            .try_apply(StreamsCommand::CreateStream(
-                CreateStreamRequest {
-                    name: WireName::new("sim-stream").expect("sim stream name is valid"),
-                },
-                IggyTimestamp::from(1),
-            ))
-            .expect("sim stream seed applies on the metadata writer");
-        self.inner
-            .try_apply(StreamsCommand::CreateTopicWithAssignments(
-                CreateTopicWithAssignmentsRequest {
-                    request: CreateTopicRequest {
-                        stream_id: WireIdentifier::numeric(0),
-                        partitions_count: 1,
-                        compression_algorithm: 0,
-                        message_expiry: 0,
-                        max_topic_size: 0,
-                        replication_factor: 1,
-                        name: WireName::new("sim-topic").expect("sim topic name is valid"),
+            .try_apply(StreamsCommand::CreatePartitionsWithAssignments(
+                CreatePartitionsWithAssignmentsRequest {
+                    request: CreatePartitionsRequest {
+                        stream_id: stream_wire(),
+                        topic_id: topic_wire(),
+                        partitions_count: u32::try_from(partitions.len())
+                            .expect("sim partition count fits u32"),
                     },
-                    partitions: vec![CreatedPartitionAssignment {
-                        partition_id,
-                        consensus_group_id,
-                    }],
+                    partitions,
                 },
                 IggyTimestamp::from(1),
             ))
-            .expect("sim topic seed applies on the metadata writer");
+            .expect("sim partition seed applies on the metadata writer");
     }
 
     #[must_use]

--- a/core/server-ng/src/dispatch.rs
+++ b/core/server-ng/src/dispatch.rs
@@ -988,8 +988,9 @@ async fn handle_get_me<B, MJ, S>(
 ///
 /// Callers must have authenticated the transport already: `vsr_client_id` /
 /// `bound_session` come from its bound VSR session. Every failure before
-/// dispatch replies empty so the client fails fast instead of wedging on a
-/// silent drop.
+/// dispatch replies (empty for an unresolvable namespace, a nonzero status
+/// for denials and the exhausted routable wait) so the client fails fast
+/// instead of wedging on a silent drop.
 ///
 /// `vsr_client_id` keys the consumer-group offset fence (the member id),
 /// not the transport id stamped into the partition-op header.
@@ -1069,13 +1070,23 @@ pub(crate) async fn dispatch_partition_request<B, MJ, S>(
     // bounded wait; steady-state sends (row present, partition probed
     // once) skip it entirely.
     if !wait_for_partition_routable(shard, IggyNamespace::from_raw(namespace)).await {
+        // The op never reached the partition plane, so it is safe to re-issue
+        // anywhere -- the same contract the plane itself answers for a
+        // non-primary routing artifact. A status-0 empty reply here would
+        // fabricate a success ack for a write that hit no partition at all.
         warn!(
             transport_client_id,
             namespace,
             operation = ?header.operation,
-            "partition request not routable within budget; replying empty"
+            "partition request not routable within budget; replying transient"
         );
-        send_empty_partition_reply(shard, transport_client_id, &header).await;
+        send_partition_deny_reply(
+            shard,
+            transport_client_id,
+            &header,
+            IggyError::TransientNotAccepted.as_code(),
+        )
+        .await;
         return;
     }
     // A group consumer-offset op carries the group NAME on the wire; the
@@ -1806,8 +1817,8 @@ async fn handle_sync_consumer_group<B, MJ, S>(
     .await;
 }
 
-/// Ack a partition op that cannot be routed (unresolved or never-
-/// materialised namespace) with an empty Reply. The SDK connection
+/// Ack a partition op whose namespace does not resolve (deleted stream /
+/// topic or unknown consumer group) with an empty Reply. The SDK connection
 /// processes replies in lockstep, so a silent drop wedges every
 /// subsequent request on that connection.
 #[allow(clippy::future_not_send)]
@@ -2715,8 +2726,14 @@ where
 mod tests {
     use super::*;
     use consensus::{LocalPipeline, Plane as _, PlaneKind, VsrConsensus};
+    use iggy_binary_protocol::primitives::partition_assignment::CreatedPartitionAssignment;
+    use iggy_binary_protocol::requests::messages::SendMessagesHeader;
     use iggy_binary_protocol::requests::streams::CreateStreamRequest;
-    use iggy_binary_protocol::{PrepareOkHeader, ReplyHeader};
+    use iggy_binary_protocol::requests::topics::{
+        CreateTopicRequest, CreateTopicWithAssignmentsRequest,
+    };
+    use iggy_binary_protocol::{PrepareOkHeader, ReplyHeader, WireName, WirePartitioning};
+    use iggy_common::defaults::DEFAULT_ROOT_USER_ID;
     use iggy_common::variadic;
     use journal::prepare_journal::PrepareJournal;
     use message_bus::client_listener::RequestHandler;
@@ -2729,6 +2746,7 @@ mod tests {
         ReplicaForwardFn, ReplicaHandshakeDoneFn, SendError,
     };
     use metadata::impls::metadata::IggySnapshot;
+    use metadata::stm::StateMachine as _;
     use metadata::stm::stream::Streams;
     use metadata::stm::user::Users;
     use metadata::{IggyMetadata, MuxStateMachine};
@@ -2736,8 +2754,12 @@ mod tests {
     use server_common::iobuf::Frozen;
     use server_common::sharding::ShardId;
     use server_common::{MESSAGE_ALIGN, Message};
+    use shard::metrics::ShardMetrics;
     use shard::shards_table::PapayaShardsTable;
-    use shard::{IggyShard, PartitionConsensusConfig, ReplicaTopology, ShardIdentity};
+    use shard::{
+        IggyShard, LifecycleFrame, PartitionConsensusConfig, ReconcileOp, ReplicaTopology,
+        ShardFrame, ShardIdentity, shard_channel,
+    };
     use std::cell::RefCell;
     use std::future::Future;
     use std::mem::size_of;
@@ -2745,12 +2767,15 @@ mod tests {
 
     type TestMux = MuxStateMachine<variadic!(Users, Streams)>;
     type TestShard = IggyShard<SpyBus, PrepareJournal, IggySnapshot, TestMux, PapayaShardsTable>;
+    /// `(target client id, reply frame bytes)` per `send_to_client` call.
+    type RecordedReplies = Rc<RefCell<Vec<(u128, Vec<u8>)>>>;
 
-    /// Records every client-bound reply instead of writing to a socket;
-    /// everything else is a no-op. The two `ShellBus` halves are stubbed.
+    /// Records every client-bound reply (target id + frame bytes) instead of
+    /// writing to a socket; everything else is a no-op. The two `ShellBus`
+    /// halves are stubbed.
     #[derive(Debug, Clone, Default)]
     struct SpyBus {
-        client_replies: Rc<RefCell<Vec<u128>>>,
+        client_replies: RecordedReplies,
     }
 
     #[allow(clippy::future_not_send)]
@@ -2759,9 +2784,11 @@ mod tests {
         async fn send_to_client(
             &self,
             client_id: u128,
-            _data: Frozen<MESSAGE_ALIGN>,
+            data: Frozen<MESSAGE_ALIGN>,
         ) -> Result<(), SendError> {
-            self.client_replies.borrow_mut().push(client_id);
+            self.client_replies
+                .borrow_mut()
+                .push((client_id, data.as_slice().to_vec()));
             Ok(())
         }
         async fn send_to_replica(
@@ -3041,7 +3068,10 @@ mod tests {
         // left in silence — that silence is what a one-shot CLI reports as
         // "Problem with server logout / Disconnected".
         assert!(
-            bus.client_replies.borrow().contains(&TRANSPORT_A),
+            bus.client_replies
+                .borrow()
+                .iter()
+                .any(|(client, _)| *client == TRANSPORT_A),
             "logout must produce a reply frame to the client even while the \
              catch-up gate is closed (silence = CLI 'Disconnected', exit 1)"
         );
@@ -3050,6 +3080,277 @@ mod tests {
             None,
             "transport session must be unbound by a client-initiated logout; \
              the VSR slot may lapse to the eviction sweep"
+        );
+    }
+
+    /// A partition write whose routable wait exhausts (namespace committed,
+    /// but no reconciler ever seeds this shard's routing row -- the state a
+    /// teardown/rematerialise churn leaves behind) must answer a nonzero
+    /// retriable status. A status-0 empty reply is a fabricated success: the
+    /// SDK grades the send as acknowledged while zero bytes reached any
+    /// partition.
+    #[compio::test]
+    async fn unroutable_partition_send_must_reply_transient_error_not_success() {
+        const VSR_CLIENT: u128 = 1;
+        const SESSION: u64 = 1;
+        const TRANSPORT: u128 = 91;
+        const STATUS_OFFSET: usize = std::mem::offset_of!(ReplyHeader, status);
+
+        let bus = SpyBus::default();
+        let metadata = IggyMetadata::new(None, None, None, TestMux::default(), None);
+        let partitions = IggyPartitions::new(
+            ShardId::new(0),
+            PartitionsConfig {
+                messages_required_to_save: 1,
+                size_of_messages_required_to_save: iggy_common::IggyByteSize::from(1024_u64),
+                enforce_fsync: false,
+                segment_size: iggy_common::IggyByteSize::from(1_048_576_u64),
+                encryptor: None,
+            },
+        );
+        let shard = Rc::new(TestShard::without_inbox(
+            ShardIdentity::new(0, "unroutable-send-test".to_string()),
+            bus.clone(),
+            metadata,
+            partitions,
+            PapayaShardsTable::new(),
+            PartitionConsensusConfig::new(1, ReplicaTopology::new(0, 1), bus.clone()),
+        ));
+        let md = shard.plane.metadata();
+
+        // Committed stream 0 / topic 0 / partition 0, applied straight into
+        // the STM: the namespace resolves and root authorizes, but no
+        // reconciler runs, so the shards table never gains a routing row and
+        // the routable wait exhausts its budget.
+        md.mux_stm.users().ensure_root_user("iggy", "hash");
+        let create_stream = CreateStreamRequest {
+            name: WireName::new("stream").unwrap(),
+        };
+        md.mux_stm
+            .update(prepare_message(
+                Operation::CreateStream,
+                VSR_CLIENT,
+                1,
+                &create_stream.to_bytes(),
+            ))
+            .unwrap();
+        let create_topic = CreateTopicWithAssignmentsRequest {
+            request: CreateTopicRequest {
+                stream_id: WireIdentifier::numeric(0),
+                partitions_count: 1,
+                compression_algorithm: 0,
+                message_expiry: 0,
+                max_topic_size: 0,
+                replication_factor: 1,
+                name: WireName::new("topic").unwrap(),
+            },
+            partitions: vec![CreatedPartitionAssignment {
+                partition_id: 0,
+                consensus_group_id: 1,
+            }],
+        };
+        md.mux_stm
+            .update(prepare_message(
+                Operation::CreateTopicWithAssignments,
+                VSR_CLIENT,
+                2,
+                &create_topic.to_bytes(),
+            ))
+            .unwrap();
+        assert!(
+            md.mux_stm
+                .streams()
+                .namespace_from_partition(
+                    &WireIdentifier::numeric(0),
+                    &WireIdentifier::numeric(0),
+                    0
+                )
+                .is_some(),
+            "seeded namespace must resolve, or the unresolved-namespace path \
+             would reply instead of the exhausted routable wait"
+        );
+
+        let send_header = SendMessagesHeader {
+            stream_id: WireIdentifier::numeric(0),
+            topic_id: WireIdentifier::numeric(0),
+            partitioning: WirePartitioning::PartitionId(0),
+            messages_count: 1,
+        };
+        let send_metadata = send_header.to_bytes();
+        let mut send_body = Vec::with_capacity(4 + send_metadata.len());
+        send_body.extend_from_slice(&u32::try_from(send_metadata.len()).unwrap().to_le_bytes());
+        send_body.extend_from_slice(&send_metadata);
+        let request = request_message(Operation::SendMessages, VSR_CLIENT, SESSION, 1, &send_body);
+
+        dispatch_partition_request(
+            &shard,
+            request,
+            VSR_CLIENT,
+            SESSION,
+            TRANSPORT,
+            Some(DEFAULT_ROOT_USER_ID),
+        )
+        .await;
+
+        let replies = bus.client_replies.borrow();
+        assert_eq!(replies.len(), 1, "one reply frame for the failed send");
+        let (client, frame) = &replies[0];
+        assert_eq!(*client, TRANSPORT, "reply must target the transport id");
+        let status =
+            u32::from_le_bytes(frame[STATUS_OFFSET..STATUS_OFFSET + 4].try_into().unwrap());
+        assert_eq!(
+            status,
+            IggyError::TransientNotAccepted.as_code(),
+            "an unroutable partition write must surface the retriable \
+             transient status; status 0 with an empty body grades as a \
+             successfully acknowledged send"
+        );
+    }
+
+    /// A send that reaches the owning shard while its namespace is
+    /// tombstoned (the teardown fence a delete/recreate churn sets before
+    /// the disk delete) must answer the retriable transient status. The
+    /// partition plane's own tombstone guard drops the frame without any
+    /// reply; the transports decode replies in lockstep, so that silence
+    /// wedges the connection until the SDK's response read-timeout.
+    #[compio::test]
+    async fn tombstoned_partition_send_must_reply_transient_error_not_silence() {
+        const TRANSPORT: u128 = 91;
+        const SESSION: u64 = 1;
+        const STATUS_OFFSET: usize = std::mem::offset_of!(ReplyHeader, status);
+
+        let bus = SpyBus::default();
+        let metadata = IggyMetadata::new(None, None, None, TestMux::default(), None);
+        let partitions = IggyPartitions::new(
+            ShardId::new(0),
+            PartitionsConfig {
+                messages_required_to_save: 1,
+                size_of_messages_required_to_save: iggy_common::IggyByteSize::from(1024_u64),
+                enforce_fsync: false,
+                segment_size: iggy_common::IggyByteSize::from(1_048_576_u64),
+                encryptor: None,
+            },
+        );
+        let shard = Rc::new(TestShard::without_inbox(
+            ShardIdentity::new(0, "tombstoned-send-test".to_string()),
+            bus.clone(),
+            metadata,
+            partitions,
+            PapayaShardsTable::new(),
+            PartitionConsensusConfig::new(1, ReplicaTopology::new(0, 1), bus.clone()),
+        ));
+
+        let namespace = IggyNamespace::new(0, 0, 0);
+        shard.plane.partitions().tombstone(namespace);
+
+        let request = request_message(Operation::SendMessages, TRANSPORT, SESSION, 1, &[])
+            .transmute_header(|header, new_header: &mut RequestHeader| {
+                *new_header = header;
+                new_header.namespace = namespace.inner();
+            });
+        shard.on_message(request.into_generic()).await;
+
+        let replies = bus.client_replies.borrow();
+        assert_eq!(
+            replies.len(),
+            1,
+            "a send into a tombstoned namespace must produce a reply frame; \
+             silence wedges the connection's lockstep decode"
+        );
+        let (client, frame) = &replies[0];
+        assert_eq!(*client, TRANSPORT, "reply must target the request's client");
+        let status =
+            u32::from_le_bytes(frame[STATUS_OFFSET..STATUS_OFFSET + 4].try_into().unwrap());
+        assert_eq!(
+            status,
+            IggyError::TransientNotAccepted.as_code(),
+            "a tombstoned-namespace send must surface the retriable transient \
+             status so the SDK replays it after the partition rematerialises"
+        );
+    }
+
+    /// A send parked for a namespace that is torn down before materialising
+    /// (create -> delete before the reconciler's `InsertOwned`) is discarded
+    /// on `ConfirmRemove`. The discard must stage the same retriable
+    /// transient deny toward the client -- through the shard's own pump as a
+    /// `ForwardClientSend` -- instead of dropping the request without any
+    /// reply.
+    #[compio::test]
+    async fn discarded_parked_partition_send_must_reply_transient_error_not_silence() {
+        const TRANSPORT: u128 = 91;
+        const SESSION: u64 = 1;
+        const STATUS_OFFSET: usize = std::mem::offset_of!(ReplyHeader, status);
+
+        let bus = SpyBus::default();
+        let metadata = IggyMetadata::new(None, None, None, TestMux::default(), None);
+        let partitions = IggyPartitions::new(
+            ShardId::new(0),
+            PartitionsConfig {
+                messages_required_to_save: 1,
+                size_of_messages_required_to_save: iggy_common::IggyByteSize::from(1024_u64),
+                enforce_fsync: false,
+                segment_size: iggy_common::IggyByteSize::from(1_048_576_u64),
+                encryptor: None,
+            },
+        );
+        // Real sender ring so the staged deny is observable: the test holds
+        // the receiving end of this shard's own channel.
+        let (sender, pump_rx) = shard_channel(0, 16);
+        let (_inbox_tx, inbox_rx) = shard_channel(0, 1);
+        let shard = TestShard::new(
+            ShardIdentity::new(0, "discarded-parked-send-test".to_string()),
+            bus.clone(),
+            Rc::new(|_, _| {}),
+            Rc::new(|_, _| {}),
+            Rc::new(|_| {}),
+            Rc::new(|_| {}),
+            Rc::new(|_, _, _| {}),
+            metadata,
+            partitions,
+            vec![sender],
+            inbox_rx,
+            PapayaShardsTable::new(),
+            PartitionConsensusConfig::new(1, ReplicaTopology::new(0, 1), bus.clone()),
+            None,
+            ShardMetrics::for_shard(),
+        )
+        .expect("single-sender ring is canonically ordered");
+
+        let namespace = IggyNamespace::new(0, 0, 0);
+        let request = request_message(Operation::SendMessages, TRANSPORT, SESSION, 1, &[])
+            .transmute_header(|header, new_header: &mut RequestHeader| {
+                *new_header = header;
+                new_header.namespace = namespace.inner();
+            });
+        // Namespace neither materialised nor tombstoned: the frame parks.
+        shard.on_message(request.into_generic()).await;
+
+        shard.enqueue_reconcile_op(ReconcileOp::ConfirmRemove { namespace });
+        shard.apply_reconcile_ops();
+
+        let mut denies = Vec::new();
+        while let Ok(frame) = pump_rx.try_recv() {
+            if let ShardFrame::Lifecycle(LifecycleFrame::ForwardClientSend { client_id, msg }) =
+                frame
+            {
+                denies.push((client_id, msg.as_slice().to_vec()));
+            }
+        }
+        assert_eq!(
+            denies.len(),
+            1,
+            "discarding a parked client request must stage exactly one deny \
+             reply; silence wedges the connection's lockstep decode"
+        );
+        let (client, frame) = &denies[0];
+        assert_eq!(*client, TRANSPORT, "deny must target the request's client");
+        let status =
+            u32::from_le_bytes(frame[STATUS_OFFSET..STATUS_OFFSET + 4].try_into().unwrap());
+        assert_eq!(
+            status,
+            IggyError::TransientNotAccepted.as_code(),
+            "a discarded parked send must surface the retriable transient \
+             status so the SDK replays it instead of timing out"
         );
     }
 }

--- a/core/server-ng/src/dispatch/authz.rs
+++ b/core/server-ng/src/dispatch/authz.rs
@@ -127,11 +127,11 @@ where
     decision.err().map(|error| error.as_code())
 }
 
-/// Reply to a denied partition op with the op's frame: empty body + nonzero
-/// `status`. Distinct from `send_empty_partition_reply` (status 0, the
-/// fail-fast "not routable" ack); here the SDK peeks the status and surfaces
-/// the typed authorization error. Same lockstep reasoning: a silent drop would
-/// wedge every later request on the connection.
+/// Reply to a denied or transiently unroutable partition op with the op's
+/// frame: empty body + nonzero `status`. Distinct from
+/// `send_empty_partition_reply` (status 0, the unresolvable-namespace ack);
+/// here the SDK peeks the status and surfaces the typed error. Same lockstep
+/// reasoning: a silent drop would wedge every later request on the connection.
 #[allow(clippy::future_not_send)]
 pub(super) async fn send_partition_deny_reply<B, MJ, S>(
     shard: &Rc<ShellShard<B, MJ, S>>,

--- a/core/server-ng/src/http.rs
+++ b/core/server-ng/src/http.rs
@@ -48,8 +48,9 @@ use std::sync::atomic::AtomicU64;
 
 use axum::Router;
 use axum::extract::{DefaultBodyLimit, Request};
-use axum::http::{HeaderName, HeaderValue, Method};
+use axum::http::{HeaderName, HeaderValue, Method, StatusCode, Version, header::CONNECTION};
 use axum::middleware::{Next, from_fn, from_fn_with_state};
+use axum::response::Response;
 use axum::routing::{delete, get, post, put};
 use configs::http::{HttpConfig, HttpCorsConfig};
 use configs::ng_cluster::{ClusterConfig, TransportPorts, http_forwarding_key_material};
@@ -200,7 +201,8 @@ const PING_PATH: &str = "/ping";
 /// `max_request_size` becomes the router-wide `DefaultBodyLimit` (413 past
 /// it), exactly like the legacy server: it bounds the per-request term of the
 /// admission math - what one body may cost in bytes and decode CPU - while
-/// the in-flight caps bound the multiplier.
+/// the in-flight caps bound the multiplier. Those 413s reject the body unread,
+/// so they are stamped `Connection: close` (see below).
 ///
 /// `cors`, present only when `[http.cors]` is enabled, is applied as the
 /// outermost layer. This node authenticates per route (the `Authenticated` /
@@ -322,13 +324,35 @@ fn router(
                     insert_view_header(&view_source, response)
                 }
             }
-        }));
+        }))
+        .layer(from_fn(close_on_payload_too_large));
     let router = match cors {
         Some(cors) => router.layer(cors),
         None => router,
     };
 
     merge_web_ui(router, web_ui)
+}
+
+/// Stamp `Connection: close` on a 413, which rejects its request body unread.
+///
+/// hyper decides to close only once it notices the dropped body, and that is
+/// after the response head is already encoded: the reply advertises keep-alive,
+/// the peer pools a connection the server has stopped reading, and the next
+/// request sent on it dies on a clean EOF. A caller-set `Connection` is written
+/// through untouched, so setting it here has the peer retire the connection.
+///
+/// HTTP/2 carries no connection-level headers, so h2 replies are left alone
+/// rather than handed a header hyper would strip and warn about.
+async fn close_on_payload_too_large(request: Request, next: Next) -> Response {
+    let http2 = request.version() == Version::HTTP_2;
+    let mut response = next.run(request).await;
+    if !http2 && response.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        response
+            .headers_mut()
+            .insert(CONNECTION, HeaderValue::from_static("close"));
+    }
+    response
 }
 
 /// Merge the unauthenticated `/ui` static-asset surface when `web_ui` is set.

--- a/core/server-ng/src/partition_reconciler.rs
+++ b/core/server-ng/src/partition_reconciler.rs
@@ -85,6 +85,7 @@ use configs::server_ng::ServerNgConfig;
 use consensus::{MetadataHandle, PartitionsHandle};
 use futures::FutureExt;
 use iggy_common::{ConsumerGroupId, IggyTimestamp};
+use message_bus::MessageBus;
 use metadata::impls::metadata::StreamsFrontend;
 use partitions::delete_persisted_offset;
 use server_common::sharding::{IggyNamespace, ShardId};
@@ -240,7 +241,7 @@ pub async fn run_reconciler(
     reconcile_once(&ctx).await;
 
     loop {
-        let sleep = compio::time::sleep(periodic);
+        let sleep = ctx.shard.bus.sleep(periodic);
         // Biased for the same reason as the shard pump: unbiased `select!`
         // polls arms in process-random order, which a deterministic
         // simulator cannot seed. Listed order is the intended priority.
@@ -279,6 +280,11 @@ struct PassCounters {
     /// blocked by a consumer barrier or by a rejoin whose offsets land via
     /// journal repair, and neither unblocking bumps `Streams::revision`.
     trims_pending: usize,
+    /// Rebuilds deferred until an in-flight `ConfirmRemove` drains. Counted
+    /// so the pass does not arm the fast-skip: the pump's drop clears the
+    /// tombstone and re-wakes us without bumping `Streams::revision`, so an
+    /// armed skip would swallow that wake and strand the rebuild forever.
+    deferred: usize,
 }
 
 impl PassCounters {
@@ -291,6 +297,7 @@ impl PassCounters {
             + self.stale
             + self.cg_offsets_purged
             + self.trims_pending
+            + self.deferred
     }
 }
 
@@ -311,8 +318,10 @@ async fn reconcile_once(ctx: &ReconcilerCtx) -> bool {
     // Fast-skip: committed partition set unchanged since the last
     // fully-converged pass and no backoff retry due, so the O(N) diff is
     // pure waste. Safe because reconcile is level-triggered: the next
-    // partition-shaping commit bumps `revision` and a pending retry keeps
-    // `failure_state` non-empty, either of which forces the next pass.
+    // partition-shaping commit bumps `revision`, a pending retry keeps
+    // `failure_state` non-empty, and a pass that found work it could not
+    // finish (a deferred rebuild, an incomplete trim) leaves
+    // `last_pass_noop` false; any of the three forces the next pass.
     if ctx.last_revision.get() == Some(revision)
         && ctx.last_pass_noop.get()
         && ctx.failure_state.borrow().is_empty()
@@ -356,6 +365,7 @@ async fn reconcile_once(ctx: &ReconcilerCtx) -> bool {
             removed_routed = counters.removed_routed,
             backoff_skipped = counters.backoff_skipped,
             stale = counters.stale,
+            deferred = counters.deferred,
             "partition reconciler pass complete"
         );
     } else {
@@ -399,6 +409,7 @@ async fn reconcile_additions(
             // [`ReconcilerCtx::has_pending_delete_failure`]).
             if partitions.is_tombstoned(&ns) {
                 if !ctx.has_pending_delete_failure(ns) {
+                    counters.deferred += 1;
                     trace!(
                         shard = shard_id,
                         ns_raw = ns.inner(),
@@ -872,7 +883,9 @@ pub fn install_tick_handler(shard: &Rc<ServerNgShard>, wake_tx: WakeTx) {
 
 #[cfg(test)]
 mod tests {
-    use super::{FailureCause, FailureRecord, ReconcilerCtx, reconcile_once};
+    use super::{
+        FailureCause, FailureRecord, ReconcilerCtx, delete_partitions_from_disk, reconcile_once,
+    };
     use configs::server_ng::{NgSystemConfig, ServerNgConfig};
     use consensus::{MetadataHandle, PartitionsHandle};
     use iggy_binary_protocol::codec::WireEncode;
@@ -897,7 +910,7 @@ mod tests {
     use server_common::Message;
     use server_common::sharding::{IggyNamespace, ShardId};
     use shard::shards_table::{PapayaShardsTable, ShardsTable, calculate_shard_assignment};
-    use shard::{IggyShard, PartitionConsensusConfig, ShardIdentity};
+    use shard::{IggyShard, PartitionConsensusConfig, ReconcileOp, ShardIdentity};
     use std::mem::size_of;
     use std::rc::Rc;
     use std::sync::Arc;
@@ -1563,6 +1576,108 @@ mod tests {
         );
     }
 
+    /// The window between the recreate committing and the reconciler
+    /// converging is a data-loss race: the namespace is byte-identical across
+    /// incarnations, so a `SendMessages` arriving inside it would otherwise be
+    /// journaled and acked against the PRIOR partition, which the reconciler
+    /// then deletes. The shard must refuse to serve until the epoch it stored
+    /// on the routing row matches the committed `created_revision` again.
+    #[compio::test]
+    async fn fence_denies_partition_request_until_recreated_incarnation_converges() {
+        let tmp = TempDir::new().expect("tempdir for system path");
+        let config = test_config(&tmp);
+        let mux = TestMux::default();
+        seed_stream(&mux, 1, "stream-fence");
+        seed_topic(&mux, 2, 0, "topic-fence", vec![assignment(0, 1)]);
+
+        let shard = build_test_shard(0, &config, mux);
+        let ctx = make_ctx(Rc::clone(&shard), 1, Rc::new(config));
+        let ns = IggyNamespace::new(0, 0, 0);
+
+        reconcile_pass(&ctx).await;
+        assert!(
+            shard.serves_committed_incarnation(Operation::SendMessages, ns.inner()),
+            "a converged partition must serve normal traffic; the fence must not \
+             deny the steady state"
+        );
+
+        // Delete + recreate the SAME tuple, reusing the freed slab key. No
+        // reconcile pass runs in between, so the prior incarnation is still
+        // materialised under the recycled identity.
+        seed_delete_topic(&shard.plane.metadata().mux_stm, 3, 0, 0);
+        seed_topic(
+            &shard.plane.metadata().mux_stm,
+            4,
+            0,
+            "topic-fence",
+            vec![assignment(0, 1)],
+        );
+        assert!(
+            !shard.serves_committed_incarnation(Operation::SendMessages, ns.inner()),
+            "a send landing before the reconciler tears the prior incarnation down \
+             must be denied; delivering it acks a batch that teardown then erases"
+        );
+
+        // Pass 1 tears the stale incarnation down, pass 2 rebuilds it at the
+        // committed epoch; only then may traffic resume.
+        reconcile_pass(&ctx).await;
+        reconcile_pass(&ctx).await;
+        assert!(
+            shard.plane.partitions().contains(&ns),
+            "fresh partition must materialise after the teardown"
+        );
+        assert!(
+            shard.serves_committed_incarnation(Operation::SendMessages, ns.inner()),
+            "traffic must resume once the rebuilt row carries the committed epoch"
+        );
+    }
+
+    /// The fence proves an incarnation by pairing the committed
+    /// `created_revision` with the epoch on the routing row. Neither side alone
+    /// is a proof, so a missing row (not yet materialised) and a missing commit
+    /// (namespace deleted, teardown pending) both deny. Metadata operations
+    /// address no partition incarnation and must pass regardless.
+    #[compio::test]
+    async fn fence_denies_partition_request_when_incarnation_is_unverifiable() {
+        let tmp = TempDir::new().expect("tempdir for system path");
+        let config = test_config(&tmp);
+        let mux = TestMux::default();
+        seed_stream(&mux, 1, "stream-unverifiable");
+        seed_topic(&mux, 2, 0, "topic-unverifiable", vec![assignment(0, 1)]);
+
+        let shard = build_test_shard(0, &config, mux);
+        let ctx = make_ctx(Rc::clone(&shard), 1, Rc::new(config));
+        let ns = IggyNamespace::new(0, 0, 0);
+
+        // Committed, but no reconcile pass has run: no row to prove against.
+        assert!(
+            shard.shards_table().epoch_for(ns).is_none(),
+            "precondition: the routing row is written by the reconciler"
+        );
+        assert!(
+            !shard.serves_committed_incarnation(Operation::SendMessages, ns.inner()),
+            "a committed namespace with no routing row cannot be proven current"
+        );
+
+        reconcile_pass(&ctx).await;
+
+        // Deleted, teardown not yet applied: the row outlives the commit.
+        seed_delete_topic(&shard.plane.metadata().mux_stm, 3, 0, 0);
+        assert!(
+            shard.shards_table().epoch_for(ns).is_some(),
+            "precondition: the row survives until the reconciler removes it"
+        );
+        assert!(
+            !shard.serves_committed_incarnation(Operation::SendMessages, ns.inner()),
+            "a namespace no longer committed must be denied even while its row lingers"
+        );
+        assert!(
+            shard.serves_committed_incarnation(Operation::CreateStream, ns.inner()),
+            "the fence guards partition operations only; metadata traffic carries \
+             no partition incarnation"
+        );
+    }
+
     /// Once converged, a pass with an unchanged
     /// `Streams::revision` fast-skips the O(N) diff instead of re-scanning
     /// every committed namespace every periodic tick. A fresh
@@ -1736,6 +1851,73 @@ mod tests {
         assert!(
             std::path::Path::new(&partition_root).exists(),
             "defer must not re-drive teardown: the directory must remain"
+        );
+    }
+
+    /// Deferral-arms-the-fast-skip regression: a deferred rebuild is pending
+    /// work, but a pass that found nothing else used to report `did_work =
+    /// false` and arm the fast-skip. The wake the pump fires after draining
+    /// `ConfirmRemove` carries no revision bump (dropping a partition is not a
+    /// metadata commit), so it landed on the armed guard and was swallowed:
+    /// the rebuild never ran, the namespace stayed unroutable, and every
+    /// parked data-plane frame hung until the client timed out.
+    #[compio::test]
+    async fn reconcile_rebuilds_after_deferred_confirm_remove_drains() {
+        let tmp = TempDir::new().expect("tempdir for system path");
+        let config = test_config(&tmp);
+        let mux = TestMux::default();
+        seed_stream(&mux, 1, "stream-defer-skip");
+        seed_topic(&mux, 2, 0, "topic-defer-skip", vec![assignment(0, 1)]);
+
+        let shard = build_test_shard(0, &config, mux);
+        let ctx = make_ctx(Rc::clone(&shard), 1, Rc::new(config));
+
+        reconcile_pass(&ctx).await;
+        let ns = IggyNamespace::new(0, 0, 0);
+        let partitions = shard.plane.partitions();
+        assert!(partitions.contains(&ns));
+
+        // Post-successful-teardown, pre-drain state: fenced, unlinked, and a
+        // `ConfirmRemove` queued but not yet applied. `ns` is still in the
+        // committed target, so the additions pass can only defer the rebuild.
+        partitions.tombstone(ns);
+        shard.shards_table().remove(&ns);
+        delete_partitions_from_disk(
+            ns.stream_id(),
+            ns.topic_id(),
+            ns.partition_id(),
+            ctx.config.as_ref(),
+        )
+        .await
+        .expect("teardown disk delete succeeds");
+        shard.enqueue_reconcile_op(ReconcileOp::ConfirmRemove { namespace: ns });
+
+        reconcile_once(&ctx).await;
+        assert!(
+            partitions.is_tombstoned(&ns),
+            "the pass under test must be the deferring one"
+        );
+
+        // Pump drains: partition dropped, tombstone cleared, reconciler woken.
+        // No commit happened, so `revision` is unchanged and `last_pass_noop`
+        // is the only thing that can keep the woken pass alive.
+        shard.apply_reconcile_ops();
+        assert!(!partitions.contains(&ns));
+
+        assert!(
+            reconcile_once(&ctx).await,
+            "the post-ConfirmRemove wake must run a full pass: a deferring \
+             pass has not converged and must not arm the fast-skip"
+        );
+        shard.apply_reconcile_ops();
+        assert!(
+            partitions.contains(&ns),
+            "the deferred rebuild must materialise once the drop drains"
+        );
+        assert_eq!(
+            shard.shards_table().shard_for(ns),
+            Some(0),
+            "rebuilt partition must be addressable again"
         );
     }
 

--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -29,7 +29,7 @@ pub use router::CONSENSUS_TICK_INTERVAL;
 use consensus::LocalPipeline;
 use consensus::{
     CommitOutcome, Consensus, ConsensusClock, MetadataHandle, MuxPlane, PartitionsHandle, Pipeline,
-    Plane, PlaneKind, Sequencer, VsrAction, VsrConsensus,
+    Plane, PlaneKind, Sequencer, VsrAction, VsrConsensus, build_deny_reply_from_request_header,
 };
 #[cfg(any(test, feature = "simulator"))]
 use crossfire::AsyncRxTrait;
@@ -42,7 +42,7 @@ use iggy_binary_protocol::{
 #[cfg(any(test, feature = "simulator"))]
 use iggy_common::PartitionStats;
 use iggy_common::variadic;
-use iggy_common::{IggyExpiry, IggyTimestamp};
+use iggy_common::{IggyError, IggyExpiry, IggyTimestamp};
 use journal::{Journal, JournalHandle};
 use message_bus::MessageBus;
 use message_bus::client_listener::RequestHandler;
@@ -1162,7 +1162,8 @@ where
     /// Stage a partition mutation for the pump.
     ///
     /// Marker `try_send` is best-effort; the pump's tail drain on every
-    /// frame catches dropped markers, so the queue never strands ops.
+    /// frame and its consensus-tick drain catch dropped markers, so the
+    /// queue never strands ops for longer than one tick.
     pub fn enqueue_reconcile_op(&self, op: ReconcileOp<B>) {
         self.reconcile_queue.borrow_mut().push_back(op);
         let Some(sender) = self.senders.get(self.id as usize) else {
@@ -1349,6 +1350,20 @@ where
     }
 }
 
+/// Routing verdict of [`IggyShard::park_if_unmaterialised`].
+enum ParkOutcome<H> {
+    /// Namespace is materialised (or the frame is not a partition op):
+    /// process normally.
+    Deliver(Message<H>),
+    /// Frame was parked until the namespace materialises (or dropped on
+    /// park overflow).
+    Parked,
+    /// Namespace is mid-teardown. Client requests must be denied with a
+    /// transient status; replicated traffic still flows to the plane, whose
+    /// own tombstone guards drop it.
+    Tombstoned(Message<H>),
+}
+
 /// Local message processing — these methods handle messages that have been
 /// routed to this shard via the message pump.
 impl<B, MJ, S, M, T> IggyShard<B, MJ, S, M, T>
@@ -1383,35 +1398,61 @@ where
                 Output = metadata::stm::result::ApplyReply,
                 Error = iggy_common::IggyError,
             > + StreamsFrontend,
+        T: ShardsTable,
     {
         match MessageBag::try_from(message) {
             Ok(MessageBag::Request(request)) => {
                 let routing = (request.header().operation, request.header().namespace);
-                if let Some(request) = self.park_if_unmaterialised(request, routing.0, routing.1) {
-                    self.on_request(request).await;
+                match self.park_if_unmaterialised(request, routing.0, routing.1) {
+                    // The incarnation fence runs only here, on client traffic.
+                    // A backup denying what the primary admitted would diverge
+                    // the replicas, so replicated frames are never fenced.
+                    ParkOutcome::Deliver(request)
+                        if !self.serves_committed_incarnation(routing.0, routing.1) =>
+                    {
+                        self.deny_partition_request_transient(request.header())
+                            .await;
+                    }
+                    ParkOutcome::Deliver(request) => self.on_request(request).await,
+                    // Deny instead of forwarding into the partition plane's
+                    // tombstone guard: that guard drops the frame without a
+                    // reply, and the transports decode replies in lockstep,
+                    // so silence wedges the connection until the SDK's
+                    // response read-timeout.
+                    ParkOutcome::Tombstoned(request) => {
+                        self.deny_partition_request_transient(request.header())
+                            .await;
+                    }
+                    ParkOutcome::Parked => {}
                 }
             }
             Ok(MessageBag::Prepare(prepare)) => {
                 let routing = (prepare.header().operation, prepare.header().namespace);
-                if let Some(prepare) = self.park_if_unmaterialised(prepare, routing.0, routing.1) {
-                    self.on_replicate(prepare).await;
-                    // A follower learns the cluster commit point from the
-                    // commit_max piggybacked on each prepare; the Commit
-                    // heartbeat carries commit_min and stops advancing
-                    // commit_max once the piggyback has raced ahead, so
-                    // on_commit alone never drains a follower's journal. Drive
-                    // it here off the prepare, as the metadata plane does inside
-                    // its own on_replicate.
-                    if routing.0.is_partition() {
-                        let planes = self.plane.inner();
-                        let config = planes.1.0.config();
-                        let namespace = IggyNamespace::from_raw(routing.1);
-                        if let Some(partition) = planes.1.0.get_mut_by_ns(&namespace)
-                            && partition.consensus().is_follower()
-                        {
-                            partition.commit_journal(config).await;
+                // A tombstoned prepare still flows to the plane: replicated
+                // traffic has no client awaiting a reply on this node, and
+                // the plane's own tombstone guard drops it.
+                match self.park_if_unmaterialised(prepare, routing.0, routing.1) {
+                    ParkOutcome::Deliver(prepare) | ParkOutcome::Tombstoned(prepare) => {
+                        self.on_replicate(prepare).await;
+                        // A follower learns the cluster commit point from the
+                        // commit_max piggybacked on each prepare; the Commit
+                        // heartbeat carries commit_min and stops advancing
+                        // commit_max once the piggyback has raced ahead, so
+                        // on_commit alone never drains a follower's journal. Drive
+                        // it here off the prepare, as the metadata plane does inside
+                        // its own on_replicate.
+                        if routing.0.is_partition() {
+                            let planes = self.plane.inner();
+                            let config = planes.1.0.config();
+                            let namespace = IggyNamespace::from_raw(routing.1);
+                            if let Some(partition) = planes.1.0.get_mut_by_ns(&namespace)
+                                && partition.consensus().is_follower()
+                            {
+                                partition.commit_journal(config).await;
+                            }
                         }
                     }
+                    ParkOutcome::Parked => {}
                 }
             }
             Ok(MessageBag::PrepareOk(prepare_ok)) => self.on_ack(prepare_ok).await,
@@ -1429,9 +1470,58 @@ where
         }
     }
 
+    /// Does the partition materialised under `namespace_raw` belong to the
+    /// incarnation the committed metadata denotes?
+    ///
+    /// A delete + recreate of the same stream / topic / partition tuple recycles
+    /// the freed slab keys, so the namespace is byte-identical across
+    /// incarnations and presence proves nothing: a request admitted against the
+    /// prior incarnation is journaled and acked, then erased when the reconciler
+    /// tears that incarnation down. `created_revision` is the sole
+    /// discriminator - the committed value must equal the epoch this shard
+    /// stored on the routing row when it materialised the partition.
+    ///
+    /// Either side missing is a failed proof, not a pass: the row may lag the
+    /// plane or vanish entirely, but it never runs ahead, so an unverifiable
+    /// pairing means the reconciler has yet to converge. Non-partition
+    /// operations address no incarnation and always pass.
+    #[must_use]
+    pub fn serves_committed_incarnation(&self, operation: Operation, namespace_raw: u64) -> bool
+    where
+        M: StreamsFrontend,
+        T: ShardsTable,
+    {
+        if !operation.is_partition() {
+            return true;
+        }
+        let namespace = IggyNamespace::from_raw(namespace_raw);
+        let committed = self
+            .plane
+            .metadata()
+            .mux_stm
+            .streams()
+            .created_revision_for_namespace(namespace);
+        let row = self.shards_table.epoch_for(namespace);
+        if committed.is_some() && committed == row {
+            return true;
+        }
+        tracing::debug!(
+            shard = self.id,
+            namespace_raw,
+            operation = ?operation,
+            committed_revision = ?committed,
+            row_epoch = ?row,
+            "denying partition request against an unverified incarnation"
+        );
+        false
+    }
+
     /// Drop parked frames for a namespace that will never materialise (it was
     /// removed before its `ReconcileOp::InsertOwned`), so the pending entry is
-    /// reclaimed instead of leaking until process exit.
+    /// reclaimed instead of leaking until process exit. Parked client requests
+    /// are denied with a transient status rather than dropped: the transports
+    /// decode replies in lockstep, so silence wedges the connection until the
+    /// SDK's response read-timeout.
     fn discard_parked_partition_frames(&self, namespace: IggyNamespace) {
         if let Some(frames) = self
             .pending_partition_frames
@@ -1445,6 +1535,16 @@ where
                 count = frames.len(),
                 "discarding parked partition frames for removed namespace"
             );
+            for frame in frames {
+                if frame.header().command == Command2::Request
+                    && let Ok(request) = frame.try_into_typed::<RequestHeader>()
+                {
+                    // Callers are synchronous (`apply_reconcile_ops`), so the
+                    // deny rides the pump's outbound lifecycle path instead of
+                    // an inline bus send.
+                    self.stage_transient_deny(request.header());
+                }
+            }
         }
     }
 
@@ -1452,29 +1552,36 @@ where
     /// materialised (post-`CreateTopic` convergence window: the metadata
     /// commit precedes the reconciler pass that builds the local replica).
     ///
-    /// Returns `Some(message)` when the frame should be processed normally:
-    /// non-partition operation, namespace materialised, or namespace
-    /// tombstoned (the plane's own tombstone guard handles the drop).
-    /// Returns `None` when the frame was parked (or dropped on overflow);
-    /// [`Self::apply_reconcile_ops`] re-dispatches parked frames once the
-    /// matching `ReconcileOp::InsertOwned` lands.
+    /// Tombstoned namespaces (teardown fence set by the reconciler before the
+    /// disk delete) report [`ParkOutcome::Tombstoned`] so the caller can deny
+    /// client requests instead of feeding them to the plane's silent-drop
+    /// guard, while replicated traffic still flows there. Parked frames are
+    /// re-dispatched by [`Self::apply_reconcile_ops`] once the matching
+    /// `ReconcileOp::InsertOwned` lands; overflow drops the frame
+    /// (at-least-once: client/primary retries recover).
     fn park_if_unmaterialised<H>(
         &self,
         message: Message<H>,
         operation: Operation,
         namespace_raw: u64,
-    ) -> Option<Message<H>>
+    ) -> ParkOutcome<H>
     where
         H: iggy_binary_protocol::ConsensusHeader,
     {
         const MAX_PARKED_PER_NAMESPACE: usize = 128;
         if !operation.is_partition() {
-            return Some(message);
+            return ParkOutcome::Deliver(message);
         }
         let namespace = IggyNamespace::from_raw(namespace_raw);
         let partitions = self.plane.partitions();
-        if partitions.contains(&namespace) || partitions.is_tombstoned(&namespace) {
-            return Some(message);
+        // Tombstone outranks presence: the partition value stays in the vec
+        // until `ConfirmRemove` drains, but the fence already forbids serving
+        // it.
+        if partitions.is_tombstoned(&namespace) {
+            return ParkOutcome::Tombstoned(message);
+        }
+        if partitions.contains(&namespace) {
+            return ParkOutcome::Deliver(message);
         }
         let mut pending = self.pending_partition_frames.borrow_mut();
         let parked = pending.entry(namespace).or_default();
@@ -1484,7 +1591,7 @@ where
                 namespace_raw = namespace.inner(),
                 "parked-frame buffer full; dropping partition frame"
             );
-            return None;
+            return ParkOutcome::Parked;
         }
         tracing::debug!(
             shard = self.id,
@@ -1493,7 +1600,58 @@ where
             "parking partition frame until namespace materialises"
         );
         parked.push(message.into_generic());
-        None
+        ParkOutcome::Parked
+    }
+
+    /// Deny a client partition request with `TransientNotAccepted`: the frame
+    /// never reached journal admission, so the SDK can safely replay it
+    /// anywhere, and partition rebuild completes well inside the replay
+    /// budget. Sent directly over the bus; delivery failure is terminal for
+    /// this reply (the client recovers via its own read-timeout).
+    #[allow(clippy::future_not_send)]
+    async fn deny_partition_request_transient(&self, request_header: &RequestHeader) {
+        let reply = build_deny_reply_from_request_header(
+            request_header,
+            IggyError::TransientNotAccepted.as_code(),
+        );
+        if let Err(error) = self
+            .bus
+            .send_to_client(request_header.client, reply.into_generic().into_frozen())
+            .await
+        {
+            tracing::warn!(
+                shard = self.id,
+                client = request_header.client,
+                operation = ?request_header.operation,
+                error = %error,
+                "failed to send transient deny for partition request"
+            );
+        }
+    }
+
+    /// [`Self::deny_partition_request_transient`] for synchronous callers:
+    /// hand the deny to this shard's own pump as a
+    /// [`LifecycleFrame::ForwardClientSend`], whose handler performs the bus
+    /// send (same funnel the parked-frame re-dispatch uses).
+    fn stage_transient_deny(&self, request_header: &RequestHeader) {
+        let reply = build_deny_reply_from_request_header(
+            request_header,
+            IggyError::TransientNotAccepted.as_code(),
+        );
+        let frame = ShardFrame::lifecycle(LifecycleFrame::ForwardClientSend {
+            client_id: request_header.client,
+            msg: reply.into_generic().into_frozen(),
+        });
+        if let Some(sender) = self.senders.get(self.id as usize)
+            && let Err(error) = sender.try_send(frame)
+        {
+            tracing::warn!(
+                shard = self.id,
+                client = request_header.client,
+                operation = ?request_header.operation,
+                "dropping transient deny for discarded partition frame: inbox rejected: {error:?}"
+            );
+        }
     }
 
     #[allow(clippy::future_not_send)]

--- a/core/shard/src/router.rs
+++ b/core/shard/src/router.rs
@@ -339,6 +339,11 @@ where
                     {
                         self.dispatch_metadata_commit_tick();
                     }
+                    // A dropped `ReconcileApply` marker (full inbox at
+                    // `enqueue_reconcile_op`) otherwise strands staged ops on
+                    // a quiet shard until the next inbound frame's tail
+                    // drain; parked partition frames then never re-dispatch.
+                    self.apply_reconcile_ops();
                     consensus_tick.set(rearm_tick());
                 }
                 frame = self.inbox.recv().fuse() => {

--- a/core/simulator/src/lib.rs
+++ b/core/simulator/src/lib.rs
@@ -308,11 +308,11 @@ impl Simulator {
 
     /// Init a partition with its own consensus group on every live replica.
     ///
-    /// Mirrors the reconciler's outcome without running it: the partition
-    /// materialises only on its hash-owning shard, and every shard of the
-    /// replica gets the routing row (production seeds rows through
-    /// `ReconcileOp::{InsertOwned,InsertRouted}`; the epoch is 0 because
-    /// sim partitions have no created revision).
+    /// Mirrors the reconciler's outcome without running it: the namespace is
+    /// committed to metadata, the partition materialises only on its
+    /// hash-owning shard, and every shard of the replica gets the routing row
+    /// stamped with the committed `created_revision` (production seeds rows
+    /// through `ReconcileOp::{InsertOwned,InsertRouted}`).
     ///
     /// # Panics
     /// Panics if a replica's shard count does not fit `u32` (impossible:
@@ -326,10 +326,21 @@ impl Simulator {
             let shard_count = u32::try_from(replica.shards.len()).expect("shard count fits u32");
             let owner = calculate_shard_assignment(&namespace, shard_count);
             replica.shards[usize::from(owner)].init_partition(namespace);
+            // Commit the namespace before stamping the rows: a partition the
+            // metadata plane never heard of is a shape production cannot
+            // produce, and the shard refuses to serve client traffic whose
+            // routing-row epoch it cannot match against a committed
+            // `created_revision`.
+            let streams = replica.shards[0].plane.metadata().mux_stm.streams();
+            streams.seed_namespace(namespace, namespace.inner());
+            let epoch = streams
+                .created_revision_for_namespace(namespace)
+                .expect("namespace committed by the seed above");
             for shard in &replica.shards {
-                shard
-                    .shards_table()
-                    .insert(namespace, PartitionLocation::new(ShardId::new(owner), 0));
+                shard.shards_table().insert(
+                    namespace,
+                    PartitionLocation::new(ShardId::new(owner), epoch),
+                );
             }
         }
     }
@@ -344,17 +355,8 @@ impl Simulator {
     /// way `init_partition` bypasses it for the partition plane. Pair it with
     /// `init_partition` for the same namespace on the dispatch-shell poll path.
     ///
-    /// # Panics
-    /// Panics unless `namespace` addresses stream 0 / topic 0: the STM
-    /// assigns 0-based slab ids and the seed creates the first stream and
-    /// topic.
     #[allow(clippy::cast_possible_truncation)]
     pub fn seed_stream_topic_partition(&self, namespace: IggyNamespace) {
-        assert!(
-            namespace.stream_id() == 0 && namespace.topic_id() == 0,
-            "seed_stream_topic_partition: seeds the first stream/topic (slab 0), \
-             so namespace must address stream 0 / topic 0"
-        );
         for (i, replica) in self.replicas.iter().enumerate() {
             if self.crashed.contains(&(i as u8)) {
                 continue;
@@ -367,7 +369,7 @@ impl Simulator {
                 .metadata()
                 .mux_stm
                 .streams()
-                .seed_single_partition(namespace.partition_id() as u32, namespace.inner());
+                .seed_namespace(namespace, namespace.inner());
         }
     }
 


### PR DESCRIPTION
Deleting and recreating a stream or topic reuses the same internal
partition key. Requests in flight during that window could go wrong
in several ways:

- the server replied with a fake empty success and wrote nothing
- the server never replied at all and the client hung for 30s
- the reconciler could skip the rebuild forever, wedging the
  namespace until an unrelated change woke it up
- a batch could land in the old partition, get acked, and then be
  deleted together with it when the reconciler caught up

The server now answers such requests with TransientNotAccepted, a
retriable error the SDK replays until the partition is ready (HTTP
gets 503 with Retry-After). The reconciler drains staged work on
every consensus tick, so a lost wake-up heals within 10ms, and a
deferred rebuild counts as progress, so the fast-skip can no longer
starve it.

The acked-then-deleted case is closed with an incarnation check: a
recreated partition looks identical to the old one by key, so the
shard compares the created_revision in committed metadata with the
one on its routing table and refuses to serve until they match.
Replicated traffic between nodes is not checked: a backup must
apply whatever the primary admitted. The simulator setup had to be
fixed as well, since it registered partitions with no metadata
behind them, which a real server can never produce.

Separately, an oversized HTTP request (413) left its connection in
a state the client thought was reusable, and the next request on
it failed with IncompleteMessage. 413 responses now carry
Connection: close on HTTP/1 (HTTP/2 forbids that header).

Test-side: message_retrieval pins to a single node (failover was
never intended), purge_delete waits for segment cleanup instead of
racing it, the json_array sink test seeds messages before the
runtime starts, and the 413 test asserts Connection: close.
