### PR TITLE
fix(ci): example-runner silently skips Python/Go examples when exclude starts with a dash

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -315,7 +315,7 @@ function run_readme_commands() {
     local commands
     commands=$(grep -E "${grep_pattern}" "${readme_file}" || true)
     if [ -n "${grep_exclude}" ]; then
-        commands=$(echo "${commands}" | grep -v "${grep_exclude}" || true)
+        commands=$(echo "${commands}" | grep -v -e "${grep_exclude}" || true)
     fi
     if [ -z "${commands}" ]; then
         return


### PR DESCRIPTION
## Which issue does this PR address?

Closes #3769

## Rationale
`run_readme_commands` in scripts/utils.sh filters excluded example commands with grep -v "${grep_exclude}". Python and Go pass --tls as the exclude, and grep parses a leading-dash argument as an unknown option instead of a pattern, exiting 2. The surrounding || true swallows that error, so the command list silently ends up empty and no examples run — while the job still reports success. This has been broken since #2920 (658eb8910), which removed the per-language scripts that had no exclude and so never hit this path.

## What changed?

The examples CI job reports success for Python and Go without executing a single non-TLS example.

`run_readme_commands` in `scripts/utils.sh` filters out excluded commands with:

```bash
commands=$(echo "${commands}" | grep -v "${grep_exclude}" || true)
```

Python and Go pass --tls as the exclude (scripts/run-examples-from-readme.sh:259, :231). grep parses --tls as an unknown long option and exits 2 with no output. The || true swallows that error, so commands ends up empty and the function returns without running anything — while run_language_examples still reports success.

## Local Execution

- Passed
- Pre-commit hooks not ran (not installed in this environment) 


## AI Usage

1. Which tools? Claude
2. Scope of usage? Analyze this issue
3. How did you verify the generated code works correctly? Manually running this script
4. Can you explain every line of the code if asked? yes

