### PR TITLE
fix(ci): stop trailing checks from skipping text files as binary

### DIFF
--- a/foreign/java/external-processors/iggy-connector-flink/iggy-flink-examples/data-population-explanation.md
+++ b/foreign/java/external-processors/iggy-connector-flink/iggy-flink-examples/data-population-explanation.md
@@ -170,7 +170,8 @@ Use the base64 string in your JSON payload.
 
 ### Example 1: Simple text message
 
-Original text: "hello world"  
+Original text: "hello world"
+
 Base64: `aGVsbG8gd29ybGQ=`
 
 ```bash

--- a/foreign/node/src/wire/cluster/get-cluster-metadata.command.ts
+++ b/foreign/node/src/wire/cluster/get-cluster-metadata.command.ts
@@ -24,7 +24,7 @@ import { deserializeMetadata, type ClusterMetadata } from './cluster.utils.js';
 
 export const GET_CLUSTER_METADATA = {
   code: COMMAND_CODE.GetClusterMetadata,
-  
+
   serialize: () => {
     return Buffer.alloc(0);
   },

--- a/foreign/node/tsconfig.json
+++ b/foreign/node/tsconfig.json
@@ -12,7 +12,7 @@
 
     "declaration": true,
     "declarationMap": true,
-    
+
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./dist",

--- a/scripts/ci/trailing-newline.sh
+++ b/scripts/ci/trailing-newline.sh
@@ -118,7 +118,7 @@ for file in "${CHANGED_FILES[@]}"; do
   fi
 
   # Skip binary files
-  if file "$file" | grep -qE "binary|data|executable|compressed"; then
+  if [ "$(file -bL --mime-encoding "$file" 2>/dev/null)" = "binary" ]; then
     continue
   fi
 

--- a/scripts/ci/trailing-whitespace.sh
+++ b/scripts/ci/trailing-whitespace.sh
@@ -118,7 +118,7 @@ for file in "${CHANGED_FILES[@]}"; do
   fi
 
   # Skip binary files
-  if file "$file" | grep -qE "binary|data|executable|compressed|PDF"; then
+  if [ "$(file -bL --mime-encoding "$file" 2>/dev/null)" = "binary" ]; then
     continue
   fi
 


### PR DESCRIPTION
## Which issue does this PR address?

Closes #3777

## Rationale

The binary-file filter in both trailing checks misclassified hundreds of text files as binary, so they were never checked.

## What changed?

The filter keyword-matched the output of `file(1)` without `-b`, so any path containing `binary`, `data` or `executable` was skipped, and the type description matches text files too (`JSON data`, `... text executable`).

Both scripts now test the MIME encoding (`file -bL --mime-encoding`), which reports `binary` only for genuine binaries on BSD and GNU `file`. 

The three pre-existing violations the repaired check surfaces are fixed as well; the Markdown hard line break becomes a paragraph break to preserve rendering.

## Local Execution

- Passed
- Pre-commit hooks ran

## AI Usage

1. Which tools? Claude code
2. Scope of usage? Diagnosis and the fix
3. How did you verify the generated code works correctly? Ran both scripts over all tracked files locally on macOS 
4. Can you explain every line of the code if asked? Yes