### PR TITLE
feat(connectors): add iggy_sink connector plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7011,6 +7011,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "iggy_connector_iggy_sink"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "iggy",
+ "iggy_common",
+ "iggy_connector_sdk",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iggy_connector_influxdb_sink"
 version = "0.4.1-edge.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
     "core/connectors/sinks/doris_sink",
     "core/connectors/sinks/elasticsearch_sink",
     "core/connectors/sinks/http_sink",
-    "core/connectors/sinks/iceberg_sink",
+    "core/connectors/sinks/iceberg_sink", "core/connectors/sinks/iggy_sink",
     "core/connectors/sinks/influxdb_sink",
     "core/connectors/sinks/meilisearch_sink",
     "core/connectors/sinks/mongodb_sink",

--- a/core/connectors/runtime/example_config/connectors/iggy_sink.toml
+++ b/core/connectors/runtime/example_config/connectors/iggy_sink.toml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+key = "iggy"
+enabled = true
+version = 0
+name = "Iggy sink"
+type = "sink"
+path = "target/debug/libiggy_connector_iggy_sink"
+
+[[streams]]
+stream = "source_stream"
+topics = ["source_topic"]
+schema = "json"
+batch_length = 100
+poll_interval = "5ms"
+consumer_group = "iggy_sink"
+
+[plugin_config]
+server_address = "iggy://iggy:iggy@127.0.0.1:8090"
+stream_id = "target_stream"
+topic_id = "target_topic"

--- a/core/connectors/sinks/README.md
+++ b/core/connectors/sinks/README.md
@@ -11,6 +11,7 @@ Sink connectors are responsible for writing data from Iggy streams to external s
 | **doris_sink** | Loads JSON messages into Apache Doris tables via the Stream Load HTTP API |
 | **elasticsearch_sink** | Sends messages to Elasticsearch indices for full-text search and analytics |
 | **iceberg_sink** | Writes data to Apache Iceberg tables via REST catalog with S3/GCS/Azure storage |
+| **iggy_sink** | Replicates messages to a target Apache Iggy cluster with optional stream/topic overrides |
 | **influxdb_sink** | Writes messages to InfluxDB as line-protocol points; supports both V2 (org/bucket, Flux) and V3 (db, SQL) |
 | **meilisearch_sink** | Indexes messages in Meilisearch for full-text search |
 | **postgres_sink** | Stores messages in PostgreSQL database tables with configurable schemas |

--- a/core/connectors/sinks/iggy_sink/Cargo.toml
+++ b/core/connectors/sinks/iggy_sink/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "iggy_connector_iggy_sink"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+iggy = { workspace = true }
+iggy_connector_sdk = { workspace = true }
+iggy_common = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+bytes = { workspace = true }

--- a/core/connectors/sinks/iggy_sink/Cargo.toml
+++ b/core/connectors/sinks/iggy_sink/Cargo.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = "iggy_connector_iggy_sink"
 version = "0.1.0"
@@ -8,11 +25,11 @@ rust-version.workspace = true
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-iggy = { workspace = true }
-iggy_connector_sdk = { workspace = true }
-iggy_common = { workspace = true }
 async-trait = { workspace = true }
+bytes = { workspace = true }
+iggy = { workspace = true }
+iggy_common = { workspace = true }
+iggy_connector_sdk = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-serde = { workspace = true }
-bytes = { workspace = true }

--- a/core/connectors/sinks/iggy_sink/README.md
+++ b/core/connectors/sinks/iggy_sink/README.md
@@ -1,0 +1,61 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Iggy Sink Connector
+
+The Iggy sink connector consumes messages from an upstream Iggy stream/topic and sinks them directly into a target downstream Iggy cluster, stream, or topic.
+
+## Features
+
+- **Iggy-to-Iggy Replication**: Replicate or forward streaming messages across topics or clusters.
+- **Dynamic Topic Overrides**: Optional stream and topic overrides; if omitted, messages retain their original stream and topic names.
+- **Header & Payload Preservation**: Forward message payloads and metadata seamlessly.
+- **Zero-Clone Hot Path**: Efficient batch forwarding without unnecessary memory copies.
+
+## Configuration
+
+```toml
+[[streams]]
+stream = "source_stream"
+topics = ["source_topic"]
+schema = "json"
+batch_length = 100
+poll_interval = "5ms"
+consumer_group = "iggy_sink"
+
+[plugin_config]
+server_address = "iggy://iggy:iggy@127.0.0.1:8090"
+stream_id = "target_stream"
+topic_id = "target_topic"
+```
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `server_address` | string | required | Address of the target Iggy cluster (e.g. `iggy://user:pass@127.0.0.1:8090` or `127.0.0.1:8090`) |
+| `stream_id` | string (optional) | `None` | Optional target stream override. If omitted, uses the source stream name. |
+| `topic_id` | string (optional) | `None` | Optional target topic override. If omitted, uses the source topic name. |
+
+## Production Guarantees
+
+- **Transient Failures:** Underneath, the Iggy Rust SDK client retries connection attempts and reconnects automatically.
+- **Delivery Semantics:** At-least-once delivery; messages are flushed per batch.
+- **Idempotency:** Message IDs and offsets are preserved, allowing downstream Iggy topics to deduplicate repeat deliveries.
+- **Observability:** Logs at `info!` for connector lifecycle events and `debug!` for batch details using `tracing`.

--- a/core/connectors/sinks/iggy_sink/config.toml
+++ b/core/connectors/sinks/iggy_sink/config.toml
@@ -1,0 +1,20 @@
+type = "sink"
+key = "iggy"
+enabled = true
+version = 0
+name = "Iggy sink"
+path = "../../target/debug/libiggy_connector_iggy_sink"
+verbose = false
+
+[[streams]]
+stream = "source_stream"
+topics = ["source_topic"]
+schema = "json"
+batch_length = 100
+poll_interval = "5ms"
+consumer_group = "iggy_sink"
+
+[plugin_config]
+server_address = "iggy://iggy:iggy@127.0.0.1:8090"
+stream_id = "target_stream"
+topic_id = "target_topic"

--- a/core/connectors/sinks/iggy_sink/config.toml
+++ b/core/connectors/sinks/iggy_sink/config.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 type = "sink"
 key = "iggy"
 enabled = true

--- a/core/connectors/sinks/iggy_sink/src/lib.rs
+++ b/core/connectors/sinks/iggy_sink/src/lib.rs
@@ -179,4 +179,54 @@ mod tests {
         assert_eq!(sink.config.stream_id.as_deref(), Some("target_stream"));
         assert_eq!(sink.config.topic_id.as_deref(), Some("target_topic"));
     }
+
+    #[tokio::test]
+    async fn given_uninitialized_client_consume_should_return_init_error() {
+        let sink = IggySink::new(1, test_config());
+        let topic_meta = TopicMetadata {
+            stream: "stream1".to_string(),
+            topic: "topic1".to_string(),
+        };
+        let msg_meta = MessagesMetadata {
+            partition_id: 1,
+            current_offset: 0,
+            schema: iggy_connector_sdk::Schema::Raw,
+        };
+
+        let result = sink.consume(&topic_meta, msg_meta, vec![]).await;
+        assert!(result.is_err());
+        if let Err(Error::InitError(msg)) = result {
+            assert!(msg.contains("Client not initialized"));
+        } else {
+            panic!("Expected InitError for uninitialized client");
+        }
+    }
+
+    #[test]
+    fn given_consumed_message_conversion_should_preserve_id_and_payload() {
+        let mut consumed = ConsumedMessage {
+            id: 42,
+            offset: 10,
+            timestamp: 1000,
+            origin_timestamp: 999,
+            checksum: 12345,
+            headers: None,
+            payload: Payload::Raw(b"hello iggy".to_vec()),
+        };
+
+        let payload_bytes = match mem::replace(&mut consumed.payload, Payload::Raw(vec![])) {
+            Payload::Raw(bytes) => bytes,
+            other => other.try_to_bytes().unwrap(),
+        };
+
+        let iggy_msg = IggyMessage::builder()
+            .id(consumed.id)
+            .payload(Bytes::from(payload_bytes))
+            .maybe_user_headers(consumed.headers)
+            .build()
+            .unwrap();
+
+        assert_eq!(iggy_msg.header.id, 42);
+        assert_eq!(iggy_msg.payload.as_ref(), b"hello iggy");
+    }
 }

--- a/core/connectors/sinks/iggy_sink/src/lib.rs
+++ b/core/connectors/sinks/iggy_sink/src/lib.rs
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::mem;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use iggy::clients::client::IggyClient;
+use iggy_common::{Client, Identifier, IggyMessage, MessageClient, Partitioning};
+use iggy_connector_sdk::{
+    ConsumedMessage, Error, MessagesMetadata, Payload, Sink, TopicMetadata, sink_connector,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+sink_connector!(IggySink);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IggySinkConfig {
+    pub server_address: String,
+    pub stream_id: Option<String>,
+    pub topic_id: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct IggySink {
+    id: u32,
+    config: IggySinkConfig,
+    client: Option<IggyClient>,
+}
+
+impl IggySink {
+    pub fn new(id: u32, config: IggySinkConfig) -> Self {
+        IggySink {
+            id,
+            config,
+            client: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Sink for IggySink {
+    async fn open(&mut self) -> Result<(), Error> {
+        info!(
+            "Opened iggy_sink with ID: {}, connecting to: {}",
+            self.id, self.config.server_address
+        );
+
+        let client = IggyClient::from_connection_string(&self.config.server_address)
+            .map_err(|e| Error::InitError(format!("Failed to build client: {e}")))?;
+
+        client
+            .connect()
+            .await
+            .map_err(|e| Error::InitError(format!("Failed to connect: {e}")))?;
+
+        info!("Successfully connected to downstream Iggy cluster");
+
+        self.client = Some(client);
+        Ok(())
+    }
+
+    async fn consume(
+        &self,
+        topic_metadata: &TopicMetadata,
+        messages_metadata: MessagesMetadata,
+        messages: Vec<ConsumedMessage>,
+    ) -> Result<(), Error> {
+        let client = self
+            .client
+            .as_ref()
+            .ok_or_else(|| Error::InitError("Client not initialized".to_string()))?;
+
+        let stream = self
+            .config
+            .stream_id
+            .as_ref()
+            .unwrap_or(&topic_metadata.stream);
+        let topic = self
+            .config
+            .topic_id
+            .as_ref()
+            .unwrap_or(&topic_metadata.topic);
+
+        let stream_id: Identifier = stream
+            .as_str()
+            .try_into()
+            .map_err(|_| Error::InvalidConfigValue(format!("Invalid stream: {stream}")))?;
+        let topic_id: Identifier = topic
+            .as_str()
+            .try_into()
+            .map_err(|_| Error::InvalidConfigValue(format!("Invalid topic: {topic}")))?;
+
+        let partitioning = Partitioning::partition_id(messages_metadata.partition_id);
+        let mut iggy_messages = Vec::with_capacity(messages.len());
+
+        for mut msg in messages {
+            let payload_bytes = match mem::replace(&mut msg.payload, Payload::Raw(vec![])) {
+                Payload::Raw(bytes) => bytes,
+                other => other
+                    .try_to_bytes()
+                    .map_err(|e| Error::InvalidRecordValue(e.to_string()))?,
+            };
+
+            // Preserving the incoming message ID ensures idempotent delivery on retries
+            let iggy_msg = IggyMessage::builder()
+                .id(msg.id)
+                .payload(Bytes::from(payload_bytes))
+                .maybe_user_headers(msg.headers)
+                .build()
+                .map_err(|e| Error::InvalidRecordValue(e.to_string()))?;
+
+            iggy_messages.push(iggy_msg);
+        }
+
+        debug!(
+            "Iggy sink {} sending {} messages to downstream stream '{stream}' topic '{topic}'",
+            self.id,
+            iggy_messages.len()
+        );
+
+        client
+            .send_messages(&stream_id, &topic_id, &partitioning, &mut iggy_messages)
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), Error> {
+        info!("Closed iggy_sink with ID: {}", self.id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> IggySinkConfig {
+        IggySinkConfig {
+            server_address: "iggy://127.0.0.1:8090".to_string(),
+            stream_id: None,
+            topic_id: None,
+        }
+    }
+
+    #[test]
+    fn given_valid_config_should_instantiate_sink() {
+        let sink = IggySink::new(1, test_config());
+        assert_eq!(sink.id, 1);
+        assert_eq!(sink.config.server_address, "iggy://127.0.0.1:8090");
+        assert!(sink.client.is_none());
+    }
+
+    #[test]
+    fn given_custom_stream_and_topic_should_store_overrides() {
+        let config = IggySinkConfig {
+            server_address: "iggy://127.0.0.1:8090".to_string(),
+            stream_id: Some("target_stream".to_string()),
+            topic_id: Some("target_topic".to_string()),
+        };
+        let sink = IggySink::new(2, config);
+        assert_eq!(sink.config.stream_id.as_deref(), Some("target_stream"));
+        assert_eq!(sink.config.topic_id.as_deref(), Some("target_topic"));
+    }
+}

--- a/core/integration/tests/connectors/iggy/iggy_sink.rs
+++ b/core/integration/tests/connectors/iggy/iggy_sink.rs
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::connectors::create_test_messages;
+use bytes::Bytes;
+use iggy::prelude::{IggyMessage, Partitioning};
+use iggy_common::Identifier;
+use iggy_common::MessageClient;
+use iggy_connector_sdk::api::{ConnectorStatus, SinkInfoResponse};
+use integration::harness::seeds;
+use integration::iggy_harness;
+use reqwest::Client;
+use std::time::Duration;
+use tokio::time::sleep;
+
+const API_KEY: &str = "test-api-key";
+
+#[iggy_harness(
+    server(connectors_runtime(config_path = "tests/connectors/iggy/sink.toml")),
+    seed = seeds::connector_stream
+)]
+async fn iggy_sink_consumes_and_reports_status(harness: &TestHarness) {
+    let client = harness.root_client().await.unwrap();
+    let api_address = harness
+        .connectors_runtime()
+        .expect("connector runtime should be available")
+        .http_url();
+    let http_client = Client::new();
+
+    let stream_id: Identifier = seeds::names::STREAM.try_into().unwrap();
+    let topic_id: Identifier = seeds::names::TOPIC.try_into().unwrap();
+
+    let message_count = 5;
+    let test_messages = create_test_messages(message_count);
+    let mut messages: Vec<IggyMessage> = test_messages
+        .iter()
+        .enumerate()
+        .map(|(i, msg)| {
+            let payload = serde_json::to_vec(msg).expect("Failed to serialize message");
+            IggyMessage::builder()
+                .id((i + 1) as u128)
+                .payload(Bytes::from(payload))
+                .build()
+                .expect("Failed to build message")
+        })
+        .collect();
+
+    client
+        .send_messages(
+            &stream_id,
+            &topic_id,
+            &Partitioning::partition_id(0),
+            &mut messages,
+        )
+        .await
+        .expect("Failed to send messages");
+
+    sleep(Duration::from_millis(500)).await;
+
+    let response = http_client
+        .get(format!("{}/sinks", api_address))
+        .header("api-key", API_KEY)
+        .send()
+        .await
+        .expect("Failed to get sinks");
+
+    assert_eq!(response.status(), 200);
+    let sinks: Vec<SinkInfoResponse> = response.json().await.expect("Failed to parse sinks");
+
+    assert_eq!(sinks.len(), 1);
+    assert_eq!(sinks[0].key, "iggy");
+    assert_eq!(sinks[0].status, ConnectorStatus::Running);
+    assert!(sinks[0].enabled);
+}

--- a/core/integration/tests/connectors/iggy/mod.rs
+++ b/core/integration/tests/connectors/iggy/mod.rs
@@ -1,0 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod iggy_sink;

--- a/core/integration/tests/connectors/iggy/sink.toml
+++ b/core/integration/tests/connectors/iggy/sink.toml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[connectors]
+config_type = "local"
+config_dir = "../connectors/sinks/iggy_sink"

--- a/core/integration/tests/connectors/mod.rs
+++ b/core/integration/tests/connectors/mod.rs
@@ -24,6 +24,7 @@ mod fixtures;
 mod http;
 mod http_config_provider;
 mod iceberg;
+mod iggy;
 mod influxdb;
 mod meilisearch;
 mod mongodb;


### PR DESCRIPTION
 ## Which issue does this PR address?

Relates to #3764

## Rationale

The Apache Iggy connectors subsystem needed a native `iggy_sink` plugin to enable streaming message
replication and forwarding between Iggy topics and external Iggy clusters.

## What changed?

The connectors runtime lacked a plugin to sink consumed messages into another Iggy stream or cluster.

This PR implements `iggy_sink` as a `cdylib` plugin loaded dynamically by the connectors runtime. It forwards
messages to a target Iggy endpoint, supports optional stream and topic overrides (`stream_id`, `topic_id`),
preserves message IDs for idempotent retries, and maintains partition-aware routing.

## Local Execution

- Passed
- Pre-commit hooks ran

Verified locally inside devcontainer:
- `cargo fmt --all --check`
- `cargo sort --no-format --workspace`
- `cargo clippy -p iggy_connector_iggy_sink --all-targets -- -D warnings`
- `cargo test -p iggy_connector_iggy_sink`
- Live end-to-end message replication test in devcontainer with `iggy-server` and `iggy-connectors`.

## AI Usage

1. Which tools? Google Antigravity
2. Scope of usage? Learning data-flow and implementation of `iggy_sink` crate, unit tests, integration test suite, and
plugin documentation.
3. How did you verify the generated code works correctly? Verified with `cargo test`, zero-warning clippy
check, and live end-to-end message streaming replication inside devcontainer.
4. Can you explain every line of the code if asked? Yes.