### PR TITLE
fix(server): remove compio thread pool limit on macOS

### DIFF
--- a/core/server_common/src/executor.rs
+++ b/core/server_common/src/executor.rs
@@ -60,7 +60,7 @@ pub fn create_shard_executor() -> Result<Runtime, std::io::Error> {
     // FIXME(hubcio): Only set thread_pool_limit(0) on non-macOS platforms
     // This causes a freeze on macOS with compio fs operations
     // see https://github.com/compio-rs/compio/issues/446
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(not(target_os = "macos"))]
     proactor.thread_pool_limit(0);
 
     compio::runtime::RuntimeBuilder::new()


### PR DESCRIPTION
Fixes #3788. macOS falls back to the compio thread pool for file system operations. Setting the thread pool limit to 0 causes a panic when launching the server. This change ensures we only limit the thread pool on non-macOS platforms.