### PR TITLE
fix(sdk): carry error payloads over binary protocol

### DIFF
--- a/core/common/src/error/iggy_error.rs
+++ b/core/common/src/error/iggy_error.rs
@@ -178,6 +178,8 @@ pub enum IggyError {
     CannotParseHeaderKind(String) = 209,
     #[error("HTTP response error, status: {0}, body: {1}")]
     HttpResponseError(u16, String) = 300,
+    #[error("Server error, status: {0}, message: {1}")]
+    ServerError(u32, String) = 311,
     #[error("Invalid HTTP request")]
     InvalidHttpRequest = 301,
     #[error("Invalid JSON response")]
@@ -545,7 +547,7 @@ impl IggyError {
     }
 
     pub fn from_code(code: u32) -> Self {
-        IggyError::from_repr(code).unwrap_or(IggyError::Error)
+        IggyError::ServerError(code, IggyError::from_code_as_string(code).to_string())
     }
 
     pub fn from_code_as_string(code: u32) -> &'static str {

--- a/core/sdk/src/quic/quic_client.rs
+++ b/core/sdk/src/quic/quic_client.rs
@@ -354,13 +354,29 @@ impl QuicClient {
                     .map_err(|_| IggyError::InvalidNumberEncoding)?,
             );
             if status != 0 {
+                let length = u32::from_le_bytes(
+                    buffer[4..RESPONSE_INITIAL_BYTES_LENGTH]
+                        .try_into()
+                        .map_err(|_| IggyError::InvalidNumberEncoding)?,
+                );
+                let message = if length > 0
+                    && buffer.len() >= RESPONSE_INITIAL_BYTES_LENGTH + length as usize
+                {
+                    String::from_utf8_lossy(
+                        &buffer[RESPONSE_INITIAL_BYTES_LENGTH
+                            ..RESPONSE_INITIAL_BYTES_LENGTH + length as usize],
+                    )
+                    .to_string()
+                } else {
+                    IggyError::from_code_as_string(status).to_string()
+                };
+
                 error!(
                     "Received an invalid response with status: {} ({}).",
-                    status,
-                    IggyError::from_code_as_string(status)
+                    status, message
                 );
 
-                return Err(IggyError::from_code(status));
+                return Err(IggyError::ServerError(status, message));
             }
 
             let length = u32::from_le_bytes(

--- a/core/sdk/src/tcp/tcp_client.rs
+++ b/core/sdk/src/tcp/tcp_client.rs
@@ -327,6 +327,15 @@ impl TcpClient {
         stream: &mut ConnectionStreamKind,
     ) -> Result<Bytes, IggyError> {
         if status != 0 {
+            let mut message = IggyError::from_code_as_string(status).to_string();
+            if length > 0 {
+                let mut response_buffer = BytesMut::with_capacity(length as usize);
+                response_buffer.put_bytes(0, length as usize);
+                if stream.read(&mut response_buffer).await.is_ok() {
+                    message = String::from_utf8_lossy(&response_buffer).to_string();
+                }
+            }
+
             // TEMP: See https://github.com/apache/iggy/pull/604 for context.
             if status == IggyErrorDiscriminants::TopicNameAlreadyExists as u32
                 || status == IggyErrorDiscriminants::StreamNameAlreadyExists as u32
@@ -337,17 +346,16 @@ impl TcpClient {
                 tracing::debug!(
                     "Received a server resource already exists response: {} ({})",
                     status,
-                    IggyError::from_code_as_string(status)
+                    message
                 )
             } else {
                 error!(
                     "Received an invalid response with status: {} ({}).",
-                    status,
-                    IggyError::from_code_as_string(status),
+                    status, message,
                 );
             }
 
-            return Err(IggyError::from_code(status));
+            return Err(IggyError::ServerError(status, message));
         }
 
         trace!("Status: OK. Response length: {}", length);

--- a/core/sdk/src/websocket/websocket_client.rs
+++ b/core/sdk/src/websocket/websocket_client.rs
@@ -829,6 +829,14 @@ impl WebSocketClient {
             );
 
             if status != 0 {
+                let mut message = IggyError::from_code_as_string(status).to_string();
+                if length > 0 {
+                    let mut response_buffer = vec![0u8; length];
+                    if stream.read(&mut response_buffer).await.is_ok() {
+                        message = String::from_utf8_lossy(&response_buffer).to_string();
+                    }
+                }
+
                 // TEMP: See https://github.com/apache/iggy/pull/604 for context.
                 if status == IggyErrorDiscriminants::TopicNameAlreadyExists as u32
                     || status == IggyErrorDiscriminants::StreamNameAlreadyExists as u32
@@ -838,18 +846,16 @@ impl WebSocketClient {
                 {
                     debug!(
                         "Received a server resource already exists response: {} ({})",
-                        status,
-                        IggyError::from_code_as_string(status)
+                        status, message
                     )
                 } else {
                     error!(
                         "Received an invalid response with status: {} ({}).",
-                        status,
-                        IggyError::from_code_as_string(status),
+                        status, message,
                     );
                 }
 
-                return Err(IggyError::from_code(status));
+                return Err(IggyError::ServerError(status, message));
             }
 
             if length == 0 {

--- a/core/server/src/sender/mod.rs
+++ b/core/server/src/sender/mod.rs
@@ -203,7 +203,8 @@ pub(crate) async fn send_error_response<T>(
 where
     T: AsyncReadExt + AsyncWriteExt + Unpin,
 {
-    send_response(stream, &error.as_code().to_le_bytes(), &[]).await
+    let payload = error.to_string().as_bytes().to_vec();
+    send_response(stream, &error.as_code().to_le_bytes(), &payload).await
 }
 
 pub(crate) async fn send_response<T>(


### PR DESCRIPTION
Fixes #3735. The binary protocol previously dropped the error payload and just sent the status code, causing clients to reconstruct errors with zeroed default values. This changes the server to send the full error message in the payload and the clients to parse it, returning a `ServerError` carrying the actual message instead of a fabricated enum.