### PR TITLE
fix(connectors): use block_in_place for SDK source callbacks

### DIFF
--- a/core/connectors/sdk/src/source.rs
+++ b/core/connectors/sdk/src/source.rs
@@ -195,8 +195,9 @@ async fn handle_messages<T: Source>(
                         continue;
                     }
                 };
-
-                callback(plugin_id, messages.as_ptr(), messages.len());
+                tokio::task::block_in_place(|| {
+                    callback(plugin_id, messages.as_ptr(), messages.len());
+                });
             }
         }
     }


### PR DESCRIPTION
Fixes #3796. Wraps the SDK source callback execution in `tokio::task::block_in_place` to prevent long-running callbacks from starving the tokio worker thread pool.