### PR TITLE
feat(python): run Python SDK tests only against the VSR server

### DIFF
--- a/.github/actions/python-maturin/pre-merge/action.yml
+++ b/.github/actions/python-maturin/pre-merge/action.yml
@@ -120,14 +120,34 @@ runs:
         ls -la dist/
       shell: bash
 
+    - name: Build server Docker image for TLS tests
+      if: inputs.task == 'test'
+      run: |
+        # test_tls.py spawns the server in a container; build it from the
+        # same vsr binaries the plain-TCP tests run against.
+        # TODO(hubcio): change to iggy-server once legacy server is removed
+        # (core/server has VSR support)
+        cargo build --locked --bin iggy-server-ng --bin iggy --features vsr
+        docker build \
+          -f core/server-ng/Dockerfile \
+          --target runtime-prebuilt \
+          --build-arg PREBUILT_IGGY_SERVER_NG=target/debug/iggy-server-ng \
+          --build-arg PREBUILT_IGGY_CLI=target/debug/iggy \
+          -t iggy-server:local .
+      shell: bash
+
     - name: Start Iggy server
       if: inputs.task == 'test'
       id: iggy
       uses: ./.github/actions/utils/server-start
-      continue-on-error: true
+      with:
+        # TODO(hubcio): change to iggy-server once legacy server is removed
+        # (core/server has VSR support)
+        cargo-bin: iggy-server-ng
+        cargo-features: vsr
 
     - name: Run Python integration tests
-      if: inputs.task == 'test' && steps.iggy.outcome == 'success'
+      if: inputs.task == 'test'
       run: |
         cd foreign/python
 
@@ -138,29 +158,13 @@ runs:
         # overwrite the coverage-instrumented .so with a non-instrumented one
         IGGY_SERVER_HOST=127.0.0.1 \
         IGGY_SERVER_TCP_PORT=8090 \
+        IGGY_SERVER_DOCKER_IMAGE=iggy-server:local \
           uv run --no-sync pytest tests/ -v \
             --junitxml=../../reports/python-junit.xml \
             --tb=short \
             --capture=no || TEST_EXIT_CODE=$?
 
         # Exit with test result
-        exit ${TEST_EXIT_CODE:-0}
-      shell: bash
-
-    - name: Run Python unit tests only (fallback)
-      if: inputs.task == 'test' && steps.iggy.outcome != 'success'
-      run: |
-        cd foreign/python
-
-        echo "⚠️ Server failed to start, running unit tests only..."
-
-        # Run unit tests only (exclude integration tests)
-        uv run --no-sync pytest tests/ -v \
-          -m "not integration" \
-          --junitxml=../../reports/python-junit.xml \
-          --tb=short || TEST_EXIT_CODE=$?
-
-        # Exit with test result (allow some failures in unit-only mode)
         exit ${TEST_EXIT_CODE:-0}
       shell: bash
 

--- a/.github/workflows/_test_bdd.yml
+++ b/.github/workflows/_test_bdd.yml
@@ -51,18 +51,23 @@ jobs:
       - name: Build server for BDD tests
         if: startsWith(inputs.component, 'bdd-') && startsWith(inputs.task, 'bdd-')
         run: |
-          if [ "${{ inputs.task }}" = "bdd-rust-vsr" ]; then
-            # server-ng lane: the vsr feature must be enabled on both the
-            # server and the CLI, otherwise the CLI cannot frame requests
-            # for the VSR wire protocol (healthcheck ping would fail).
+          case "${{ inputs.task }}" in bdd-rust-vsr|bdd-python)
+            # vsr lane: the feature must be enabled on both the server
+            # and the CLI, otherwise the CLI cannot frame requests for
+            # the VSR wire protocol (healthcheck ping would fail).
+            # Python wheels are vsr-built, so the whole lane runs vsr.
+            # TODO(hubcio): change to iggy-server once legacy server is
+            # removed (core/server has VSR support)
             SERVER_BIN="iggy-server-ng"
-            echo "Building server-ng binary and CLI (--features vsr) for BDD tests..."
+            echo "Building server binary and CLI (--features vsr) for BDD tests..."
             cargo build --locked --bin iggy-server-ng --bin iggy --features vsr
-          else
+            ;;
+          *)
             SERVER_BIN="iggy-server"
             echo "Building server binary and CLI for BDD tests..."
             cargo build --locked --bin iggy-server --bin iggy
-          fi
+            ;;
+          esac
 
           echo "Server binary built at: target/debug/${SERVER_BIN}"
           ls -lh "target/debug/${SERVER_BIN}"
@@ -85,17 +90,21 @@ jobs:
         if: startsWith(inputs.component, 'bdd-') && startsWith(inputs.task, 'bdd-')
         run: |
           # Extract SDK name from task (format: bdd-<sdk>, or bdd-<sdk>-vsr
-          # for the server-ng lane)
-          SDK_NAME=$(echo "${{ inputs.task }}" | sed 's/^bdd-//')
+          # for an explicit vsr lane). Python has no legacy lane, so its
+          # plain task name runs vsr.
+          SDK_NAME=$(echo "${{ inputs.task }}" | sed 's/^bdd-//; s/-vsr$//')
           EXTRA_FLAGS=()
-          if [ "$SDK_NAME" = "rust-vsr" ]; then
-            SDK_NAME="rust"
+          case "${{ inputs.task }}" in bdd-rust-vsr|bdd-python)
             EXTRA_FLAGS+=(--vsr)
+            # TODO(hubcio): change to iggy-server once legacy server is
+            # removed (core/server has VSR support)
             export IGGY_SERVER_NG_PATH="target/debug/iggy-server-ng"
             echo "Server binary location: $(ls -lh target/debug/iggy-server-ng)"
-          else
+            ;;
+          *)
             echo "Server binary location: $(ls -lh target/debug/iggy-server)"
-          fi
+            ;;
+          esac
 
           echo "Running BDD tests for SDK: $SDK_NAME"
           echo "Current directory: $(pwd)"

--- a/.github/workflows/_test_examples.yml
+++ b/.github/workflows/_test_examples.yml
@@ -113,9 +113,20 @@ jobs:
           echo "Building common binaries for all examples tests..."
           echo "Current directory: $(pwd)"
 
-          # Build server (needed by both Rust and Go examples)
-          echo "Building iggy-server..."
-          cargo build --locked --bin iggy-server
+          # Python wheels are vsr-built, so the Python examples run
+          # against the vsr server; every other language still runs
+          # against the legacy server.
+          if [[ "${{ inputs.task }}" == "examples-python" ]]; then
+            # TODO(hubcio): change to iggy-server once legacy server is
+            # removed (core/server has VSR support)
+            SERVER_BIN="iggy-server-ng"
+            echo "Building ${SERVER_BIN} (--features vsr)..."
+            cargo build --locked --bin "${SERVER_BIN}" --features vsr
+          else
+            SERVER_BIN="iggy-server"
+            echo "Building ${SERVER_BIN}..."
+            cargo build --locked --bin "${SERVER_BIN}"
+          fi
 
           # For Rust examples, also build CLI and example binaries
           if [[ "${{ inputs.task }}" == "examples-rust" ]]; then
@@ -125,13 +136,13 @@ jobs:
 
           # Verify server binary was built (needed by all examples)
           echo "Verifying server binary:"
-          if [ -f "target/debug/iggy-server" ]; then
-            echo "✅ Server binary found at target/debug/iggy-server"
-            ls -lh target/debug/iggy-server
+          if [ -f "target/debug/${SERVER_BIN}" ]; then
+            echo "✅ Server binary found at target/debug/${SERVER_BIN}"
+            ls -lh "target/debug/${SERVER_BIN}"
           else
-            echo "❌ Server binary NOT found at target/debug/iggy-server"
+            echo "❌ Server binary NOT found at target/debug/${SERVER_BIN}"
             echo "Checking target directory structure:"
-            find target -name "iggy-server" -type f 2>/dev/null || true
+            find target -name "${SERVER_BIN}" -type f 2>/dev/null || true
             exit 1
           fi
 

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -315,15 +315,36 @@ jobs:
           uv run --no-sync maturin develop
         shell: bash
 
+      - name: Build server Docker image for TLS tests
+        run: |
+          # test_tls.py spawns the server in a container; build it from the
+          # same vsr binaries the plain-TCP tests run against.
+          # TODO(hubcio): change to iggy-server once legacy server is removed
+          # (core/server has VSR support)
+          cargo build --locked --bin iggy-server-ng --bin iggy --features vsr
+          docker build \
+            -f core/server-ng/Dockerfile \
+            --target runtime-prebuilt \
+            --build-arg PREBUILT_IGGY_SERVER_NG=target/debug/iggy-server-ng \
+            --build-arg PREBUILT_IGGY_CLI=target/debug/iggy \
+            -t iggy-server:local .
+        shell: bash
+
       - name: Start Iggy server
         id: iggy
         uses: ./.github/actions/utils/server-start
+        with:
+          # TODO(hubcio): change to iggy-server once legacy server is removed
+          # (core/server has VSR support)
+          cargo-bin: iggy-server-ng
+          cargo-features: vsr
 
       - name: Run tests
         run: |
           cd foreign/python
           IGGY_SERVER_HOST=127.0.0.1 \
           IGGY_SERVER_TCP_PORT=8090 \
+          IGGY_SERVER_DOCKER_IMAGE=iggy-server:local \
             uv run --no-sync pytest tests/ -v \
               --junitxml=../../reports/python-junit.xml \
               --tb=short \

--- a/core/integration/tests/server/topic_admission_vsr.rs
+++ b/core/integration/tests/server/topic_admission_vsr.rs
@@ -23,7 +23,8 @@
 //! `InvalidTopicSize`; `ServerDefault` and `Unlimited` sizes pass. Update
 //! stores `max_topic_size` and `message_expiry` verbatim and gets echo the
 //! stored value (never the node default frozen at update time), matching
-//! legacy wire behavior.
+//! legacy wire behavior. Listing topics of a missing stream replies with an
+//! empty list, as the legacy server does.
 
 use std::str::FromStr;
 
@@ -250,5 +251,22 @@ async fn given_out_of_bounds_partitions_count_when_mutating_should_reject_typed(
     assert_eq!(
         topic.partitions_count, 3,
         "the in-bounds add lands after the oversized denies"
+    );
+}
+
+#[iggy_harness(
+    test_client_transport = [Tcp],
+    server(tcp.socket.override_defaults = true, tcp.socket.nodelay = true)
+)]
+async fn given_missing_stream_when_listing_topics_should_return_empty(harness: &TestHarness) {
+    let client = harness.tcp_root_client().await.expect("tcp root client");
+    let stream_id = Identifier::from_str_value("no-such-stream").expect("stream identifier");
+    let topics = client
+        .get_topics(&stream_id)
+        .await
+        .expect("get_topics on a missing stream");
+    assert!(
+        topics.is_empty(),
+        "a missing stream must list no topics, got {topics:?}"
     );
 }

--- a/core/server-ng/src/responses.rs
+++ b/core/server-ng/src/responses.rs
@@ -1062,8 +1062,10 @@ where
     SB: SuperblockStore + 'static,
 {
     shard.plane.metadata().mux_stm.streams().read(|streams| {
-        let resolved_stream =
-            resolve_stream_id(streams, stream_id).ok_or_else(|| stream_not_found(stream_id))?;
+        // Legacy parity: a missing stream lists as empty, not StreamNotFound.
+        let Some(resolved_stream) = resolve_stream_id(streams, stream_id) else {
+            return Ok(GetTopicsResponse { topics: Vec::new() });
+        };
         let stream = streams
             .items
             .get(resolved_stream)

--- a/foreign/python/Cargo.toml
+++ b/foreign/python/Cargo.toml
@@ -37,7 +37,9 @@ doc = false
 [dependencies]
 bytes = "1.12.1"
 futures = "0.3.33"
-iggy = { path = "../../core/sdk", version = "0.11.0-edge.1" }
+iggy = { path = "../../core/sdk", version = "0.11.0-edge.1", features = [
+    "vsr",
+] }
 paste = "1"
 pyo3 = "0.29.0"
 pyo3-async-runtimes = { version = "0.29.0", features = [

--- a/foreign/python/tests/test_message_operations.py
+++ b/foreign/python/tests/test_message_operations.py
@@ -69,10 +69,10 @@ class TestMessageOperations:
         )
 
     @pytest.mark.asyncio
-    async def test_send_messages_reports_no_confirmations_from_legacy_server(
+    async def test_send_messages_reports_committed_confirmation(
         self, iggy_client: IggyClient, unique_name
     ):
-        """Test the send response confirms nothing without server-side offsets."""
+        """Test the send response reports the committed partition and offset."""
         stream_name = unique_name()
         topic_name = unique_name()
         partition_id = 0
@@ -101,12 +101,13 @@ class TestMessageOperations:
 
         assert [message.payload().decode() for message in polled_messages] == payloads
 
-        # This suite runs against the legacy server, which sends no confirmation
-        # payload at all. A genuine confirmation for this send would read as all
-        # zeros (partition 0, first batch at offset 0), so an entry here proves
-        # nothing and could only have been invented. Against a server that does
-        # report offsets, compare base_offset with polled_messages[0].offset().
-        assert response.confirmations == []
+        # The server confirms committed sends with the partition and the base
+        # offset of the batch; the whole send targeted one partition, so a
+        # single confirmation covers it.
+        assert len(response.confirmations) == 1
+        confirmation = response.confirmations[0]
+        assert confirmation.partition_id == partition_id
+        assert confirmation.base_offset == polled_messages[0].offset()
 
     @pytest.mark.asyncio
     async def test_send_and_poll_messages_as_bytes(

--- a/foreign/python/tests/test_tls.py
+++ b/foreign/python/tests/test_tls.py
@@ -26,6 +26,13 @@ Requirements:
     - Docker running locally
     - testcontainers[docker] installed (in [testing-docker] extras)
     - CA certificate available at core/certs/iggy_ca_cert.pem
+    - server image built locally (or IGGY_SERVER_DOCKER_IMAGE set):
+      TODO(hubcio): change to iggy-server once legacy server is removed
+      (core/server has VSR support)
+      docker build -f core/server-ng/Dockerfile --target runtime-prebuilt \
+        --build-arg PREBUILT_IGGY_SERVER_NG=target/debug/iggy-server-ng \
+        --build-arg PREBUILT_IGGY_CLI=target/debug/iggy \
+        -t iggy-server:local .
 """
 
 import asyncio
@@ -45,7 +52,7 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", 
 CERTS_DIR = os.path.join(REPO_ROOT, "core", "certs")
 CA_FILE = os.path.join(CERTS_DIR, "iggy_ca_cert.pem")
 
-IGGY_IMAGE = os.environ.get("IGGY_SERVER_DOCKER_IMAGE", "apache/iggy:edge")
+IGGY_IMAGE = os.environ.get("IGGY_SERVER_DOCKER_IMAGE", "iggy-server:local")
 CONTAINER_TCP_PORT = 8090
 
 
@@ -66,7 +73,7 @@ def tls_container():
     )
     container.start()
     # Wait for the server to be ready inside the container
-    wait_for_logs(container, "Iggy server is running", timeout=60)
+    wait_for_logs(container, "server-ng running", timeout=60)
     yield container
     container.stop()
 

--- a/foreign/python/tests/test_topic.py
+++ b/foreign/python/tests/test_topic.py
@@ -21,7 +21,12 @@ import pytest
 
 from apache_iggy import IggyClient, IggyExpiry, MaxTopicSize, SendMessage
 
-from .utils import get_server_config, wait_for_ping, wait_for_server
+from .utils import (
+    get_server_config,
+    wait_for_ping,
+    wait_for_purged_topic,
+    wait_for_server,
+)
 
 
 class TestCreateTopic:
@@ -1379,10 +1384,9 @@ class TestPurgeTopic:
 
         await iggy_client.purge_topic(stream_name, topic_name)
 
-        after = await iggy_client.get_topic(stream_name, topic_name)
-        assert after is not None
-        assert after.messages_count == 0
-        assert after.size == 0
+        # The purge ack precedes the asynchronous partition prune, so poll
+        # until the stats catch up instead of asserting the counts directly.
+        after = await wait_for_purged_topic(iggy_client, stream_name, topic_name)
         # Purging clears messages and size only; topic config is unchanged.
         assert after.id == before.id
         assert after.name == before.name
@@ -1433,9 +1437,7 @@ class TestPurgeTopic:
         await iggy_client.purge_topic(stream_name, topic_name)
         await iggy_client.purge_topic(stream_name, topic_name)
 
-        topic = await iggy_client.get_topic(stream_name, topic_name)
-        assert topic is not None
-        assert topic.messages_count == 0
+        await wait_for_purged_topic(iggy_client, stream_name, topic_name)
 
     @pytest.mark.asyncio
     async def test_purge_nonexistent_topic_fails(

--- a/foreign/python/tests/utils.py
+++ b/foreign/python/tests/utils.py
@@ -24,7 +24,7 @@ import os
 import socket
 import time
 
-from apache_iggy import IggyClient
+from apache_iggy import IggyClient, TopicDetails
 
 # Server-side limits: usernames are 3-50 bytes, passwords 3-100 bytes.
 MIN_USERNAME_BYTES = 3
@@ -113,6 +113,37 @@ async def wait_for_ping(
                     f"Server not responding to ping after {timeout}s"
                 ) from err
             await asyncio.sleep(interval)
+
+
+async def wait_for_purged_topic(
+    client: IggyClient, stream: str, topic: str, timeout: float = 10.0
+) -> TopicDetails:
+    """
+    Poll get_topic until a committed purge is reflected in the stats.
+
+    The VSR server acknowledges a purge once it commits; partition data
+    is pruned asynchronously, so stats can transiently report pre-purge
+    counts.
+
+    Returns:
+        TopicDetails once messages_count and size reach 0
+
+    Raises:
+        TimeoutError: If the purge is not reflected within timeout
+    """
+    deadline = time.time() + timeout
+
+    while True:
+        details = await client.get_topic(stream, topic)
+        assert details is not None, "purged topic must still exist"
+        if details.messages_count == 0 and details.size == 0:
+            return details
+        if time.time() >= deadline:
+            raise TimeoutError(
+                f"purge of {stream}/{topic} not reflected after {timeout}s: "
+                f"messages_count={details.messages_count} size={details.size}"
+            )
+        await asyncio.sleep(0.05)
 
 
 def unique_credentials(unique_name) -> tuple[str, str]:

--- a/scripts/run-bdd-tests.sh
+++ b/scripts/run-bdd-tests.sh
@@ -39,7 +39,9 @@ usage(){
   log ""
   log "  sdk:     rust | python | php | go | go-race | node | csharp | java | cpp | all | clean (default: all)"
   log "  feature: basic_messaging | leader_redirection | raw_command | all  (default: all)"
-  log "  --vsr:   run against iggy-server-ng built with --features vsr (rust only);"
+  # TODO(hubcio): change to iggy-server once legacy server is removed
+  # (core/server has VSR support)
+  log "  --vsr:   run against iggy-server-ng built with --features vsr (rust and python);"
   log "           expects IGGY_SERVER_NG_PATH (default: target/debug/iggy-server-ng)"
   log "           and a vsr-built iggy CLI at IGGY_CLI_PATH"
   log ""
@@ -53,9 +55,9 @@ usage(){
 
 if [ "$VSR" = "1" ]; then
   case "$SDK" in
-    rust|clean) ;;
+    rust|python|clean) ;;
     *)
-      log "❌ --vsr supports only the Rust SDK (server-ng speaks the VSR wire protocol)"
+      log "❌ --vsr supports only the Rust and Python SDKs (server-ng speaks the VSR wire protocol)"
       usage
       exit 2 ;;
   esac

--- a/scripts/run-examples-from-readme.sh
+++ b/scripts/run-examples-from-readme.sh
@@ -251,7 +251,12 @@ run_go_examples() {
 
 # shellcheck disable=SC2329
 run_python_examples() {
-    resolve_server_binary "${TARGET}"
+    # Python wheels are vsr-built, so examples run against the vsr
+    # server. It takes no --fresh flag; cleanup_server_state wiping
+    # local_data is the fresh start.
+    # TODO(hubcio): change to iggy-server once legacy server is removed
+    # (core/server has VSR support)
+    resolve_server_binary "${TARGET}" iggy-server-ng
     unset -f TRANSFORM_COMMAND 2>/dev/null || true
 
     echo ""
@@ -264,7 +269,7 @@ run_python_examples() {
 
     # --- Non-TLS pass ---
     cleanup_server_state
-    start_plain_server --fresh
+    start_plain_server
     wait_for_server_ready "Python"
 
     cd examples/python || exit 1
@@ -284,7 +289,7 @@ run_python_examples() {
             echo "=== Running Python TLS examples ==="
             echo ""
             cleanup_server_state
-            start_tls_server --fresh
+            start_tls_server
             wait_for_server_ready "Python TLS"
 
             cd examples/python || exit 1

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -159,23 +159,26 @@ readonly EXAMPLES_SERVER_TIMEOUT=300
 readonly EXAMPLES_STOP_TIMEOUT=5
 
 # Resolve and validate the server binary path.
-# Usage: resolve_server_binary [target]
-# Sets global SERVER_BIN.
+# Usage: resolve_server_binary [target] [binary-name]
+# Sets global SERVER_BIN. binary-name defaults to iggy-server; vsr lanes
+# pass their server binary (built with --features vsr so the wire
+# protocol matches vsr-built clients).
 function resolve_server_binary() {
     local target="${1:-}"
+    local binary_name="${2:-iggy-server}"
     if [ -n "${target}" ]; then
-        SERVER_BIN="target/${target}/debug/iggy-server"
+        SERVER_BIN="target/${target}/debug/${binary_name}"
     else
-        SERVER_BIN="target/debug/iggy-server"
+        SERVER_BIN="target/debug/${binary_name}"
     fi
 
     if [ ! -f "${SERVER_BIN}" ]; then
         echo "Error: Server binary not found at ${SERVER_BIN}"
         echo "Please build the server binary before running this script:"
         if [ -n "${target}" ]; then
-            echo "  cargo build --target ${target} --bin iggy-server"
+            echo "  cargo build --target ${target} --bin ${binary_name}"
         else
-            echo "  cargo build --bin iggy-server"
+            echo "  cargo build --bin ${binary_name}"
         fi
         exit 1
     fi
@@ -233,12 +236,14 @@ function start_tls_server() {
     echo $! >"${EXAMPLES_PID_FILE}"
 }
 
-# Block until "has started" appears in the server log or timeout.
+# Block until the server logs readiness or timeout. Matches both the
+# legacy line ("has started") and the vsr server line ("client
+# listeners started", logged once the TCP socket is bound).
 # Usage: wait_for_server_ready [label]
 function wait_for_server_ready() {
     local label="${1:-Iggy}"
     local elapsed=0
-    while ! grep -q "has started" "${EXAMPLES_LOG_FILE}"; do
+    while ! grep -qE "has started|client listeners started" "${EXAMPLES_LOG_FILE}"; do
         if [ ${elapsed} -gt ${EXAMPLES_SERVER_TIMEOUT} ]; then
             echo "${label} server did not start within ${EXAMPLES_SERVER_TIMEOUT} seconds."
             ps fx 2>/dev/null || ps aux


### PR DESCRIPTION
The Python wheel wraps the Rust SDK, so its wire protocol is fixed
at compile time. Testing against the legacy server no longer guards
the server we are about to ship, and the legacy-wire wheel blocked
any Python coverage of the VSR server.

Enable the sdk vsr feature unconditionally in the wheel, so every
build (including published wheels) speaks the VSR wire protocol,
and point all four Python lanes (pre-merge, coverage baseline, BDD,
examples) at the VSR server. The pre-merge unit-only fallback is
removed: a server that fails to boot must fail the lane it gates.
TLS tests run against a locally built server image instead of the
published legacy image.

The legacy-only send-confirmation test now asserts the committed
partition and base offset. Purge tests poll for the purged stats:
the VSR server acknowledges a purge when it commits and prunes the
partition data asynchronously.

The one legacy behavior the suite still pinned as a server-ng gap
goes with it: get_topics on a missing stream replied StreamNotFound
while legacy replies with an empty topic list. Resolve the miss to
an empty response so TCP and HTTP match legacy, as the singular
get_topic already does.

