### PR TITLE
feat(php): run PHP SDK tests only against the VSR server

### DIFF
--- a/.github/actions/php/pre-merge/action.yml
+++ b/.github/actions/php/pre-merge/action.yml
@@ -154,6 +154,12 @@ runs:
       if: inputs.task == 'test'
       id: iggy
       uses: ./.github/actions/utils/server-start
+      with:
+        # The PHP extension is vsr-built, so its suites need the vsr server.
+        # TODO(hubcio): change to iggy-server once legacy server is removed
+        # (core/server has VSR support)
+        cargo-bin: iggy-server-ng
+        cargo-features: vsr
 
     - name: Run PHP SDK tests
       if: inputs.task == 'test'
@@ -180,6 +186,10 @@ runs:
       id: iggy-tls
       uses: ./.github/actions/utils/server-start
       with:
+        # TODO(hubcio): change to iggy-server once legacy server is removed
+        # (core/server has VSR support)
+        cargo-bin: iggy-server-ng
+        cargo-features: vsr
         pid-file: ${{ runner.temp }}/iggy-server-tls.pid
         log-file: ${{ runner.temp }}/iggy-server-tls.log
       env:

--- a/.github/workflows/_test_bdd.yml
+++ b/.github/workflows/_test_bdd.yml
@@ -53,11 +53,11 @@ jobs:
         run: |
           # The VSR lanes need the vsr feature on both the server and the CLI,
           # otherwise the CLI cannot frame requests for the VSR wire protocol
-          # and the healthcheck ping fails. The Go SDK and the Node SDK speak
-          # only VSR, while the Python wheels, Java SDK, .NET SDK, and C++
-          # bindings are vsr-built, so those suites are always on this branch.
+          # and the healthcheck ping fails. Every foreign SDK speaks only VSR,
+          # so all of their suites are on this branch; only the legacy Rust
+          # lane still builds the legacy server.
           case "${{ inputs.task }}" in
-          bdd-rust-vsr|bdd-go|bdd-go-race|bdd-python|bdd-node|bdd-csharp|bdd-java|bdd-cpp)
+          bdd-rust-vsr|bdd-go|bdd-go-race|bdd-python|bdd-node|bdd-csharp|bdd-java|bdd-cpp|bdd-php)
             # TODO: change to iggy-server once legacy server is removed (core/server has VSR support)
             SERVER_BIN="iggy-server-ng"
             echo "Building the VSR server binary and CLI (--features vsr) for BDD tests..."
@@ -91,12 +91,12 @@ jobs:
         if: startsWith(inputs.component, 'bdd-') && startsWith(inputs.task, 'bdd-')
         run: |
           # Extract SDK name from task (format: bdd-<sdk>, or bdd-<sdk>-vsr
-          # for an explicit vsr lane). Python, Node, C#, Java, and C++ have
-          # no legacy lane, so their plain task names run vsr.
+          # for an explicit vsr lane). Rust is the only SDK with a legacy
+          # lane left; every other plain task name runs vsr.
           SDK_NAME=$(echo "${{ inputs.task }}" | sed 's/^bdd-//; s/-vsr$//')
           EXTRA_FLAGS=()
           case "${{ inputs.task }}" in
-          bdd-rust-vsr|bdd-python|bdd-node|bdd-csharp|bdd-cpp)
+          bdd-rust-vsr|bdd-python|bdd-node|bdd-csharp|bdd-cpp|bdd-php)
             EXTRA_FLAGS+=(--vsr)
             # TODO: change to iggy-server once legacy server is removed (core/server has VSR support)
             export IGGY_SERVER_NG_PATH="target/debug/iggy-server-ng"

--- a/.github/workflows/_test_examples.yml
+++ b/.github/workflows/_test_examples.yml
@@ -113,11 +113,10 @@ jobs:
           echo "Building common binaries for all examples tests..."
           echo "Current directory: $(pwd)"
 
-          # The Go SDK and the Node SDK speak only the VSR wire protocol,
-          # while the Python wheels, Java SDK, and .NET SDK are vsr-built, so
-          # those lanes need the VSR server. Every other language still runs
-          # against the legacy one until its own migration lands.
-          if [[ "${{ inputs.task }}" == "examples-go" || "${{ inputs.task }}" == "examples-python" || "${{ inputs.task }}" == "examples-csharp" || "${{ inputs.task }}" == "examples-java" || "${{ inputs.task }}" == "examples-node" ]]; then
+          # Every foreign SDK speaks only the VSR wire protocol, so all of
+          # their lanes need the VSR server. Only the Rust examples still run
+          # against the legacy server, until it is replaced by server-ng.
+          if [[ "${{ inputs.task }}" == "examples-go" || "${{ inputs.task }}" == "examples-python" || "${{ inputs.task }}" == "examples-csharp" || "${{ inputs.task }}" == "examples-java" || "${{ inputs.task }}" == "examples-node" || "${{ inputs.task }}" == "examples-php" ]]; then
             # TODO: change to iggy-server once legacy server is removed (core/server has VSR support)
             SERVER_BIN="iggy-server-ng"
             echo "Building ${SERVER_BIN} (--features vsr)..."

--- a/.github/workflows/_test_examples.yml
+++ b/.github/workflows/_test_examples.yml
@@ -113,24 +113,18 @@ jobs:
           echo "Building common binaries for all examples tests..."
           echo "Current directory: $(pwd)"
 
-          # Every foreign SDK speaks only the VSR wire protocol, so all of
-          # their lanes need the VSR server. Only the Rust examples still run
-          # against the legacy server, until it is replaced by server-ng.
-          if [[ "${{ inputs.task }}" == "examples-go" || "${{ inputs.task }}" == "examples-python" || "${{ inputs.task }}" == "examples-csharp" || "${{ inputs.task }}" == "examples-java" || "${{ inputs.task }}" == "examples-node" || "${{ inputs.task }}" == "examples-php" ]]; then
-            # TODO: change to iggy-server once legacy server is removed (core/server has VSR support)
-            SERVER_BIN="iggy-server-ng"
-            echo "Building ${SERVER_BIN} (--features vsr)..."
-            cargo build --locked --bin "${SERVER_BIN}" --features vsr
-          else
-            SERVER_BIN="iggy-server"
-            echo "Building ${SERVER_BIN}..."
-            cargo build --locked --bin "${SERVER_BIN}"
-          fi
+          # Every SDK speaks only the VSR wire protocol, so every lane runs
+          # against the VSR server.
+          # TODO: change to iggy-server once legacy server is removed (core/server has VSR support)
+          SERVER_BIN="iggy-server-ng"
+          echo "Building ${SERVER_BIN} (--features vsr)..."
+          cargo build --locked --bin "${SERVER_BIN}" --features vsr
 
-          # For Rust examples, also build CLI and example binaries
+          # For Rust examples, also build CLI and example binaries; both must
+          # be vsr-built to speak the VSR server's wire protocol.
           if [[ "${{ inputs.task }}" == "examples-rust" ]]; then
             echo "Building additional binaries for Rust examples..."
-            cargo build --locked --bin iggy --examples
+            cargo build --locked --bin iggy --examples --features vsr
           fi
 
           # Verify server binary was built (needed by all examples)

--- a/bdd/README.md
+++ b/bdd/README.md
@@ -71,9 +71,10 @@ bdd/
 # Run only leader_redirection
 ../scripts/run-bdd-tests.sh all leader_redirection
 
-# Run against iggy-server-ng with VSR. Go and Java always use the VSR
-# overlay. Python and C# are vsr-built, so CI supplies --vsr for their
-# plain lanes. Rust and Node opt in with --vsr. Build the binaries first:
+# Run against iggy-server-ng with VSR. Every foreign SDK speaks only VSR:
+# Go and Java always use the VSR overlay, the rest get --vsr from CI for
+# their plain lanes. Only Rust still has a legacy lane and opts in with
+# --vsr. Build the binaries first:
 #   cargo build --bin iggy-server-ng --bin iggy --features vsr
 # NOTE: `target/debug/iggy` is shared between lanes and the vsr flavour
 # speaks a different wire protocol. When switching back to the legacy

--- a/core/integration/tests/server/login_credentials_vsr.rs
+++ b/core/integration/tests/server/login_credentials_vsr.rs
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Credential rejections on the register handshake against server-ng (vsr).
+//!
+//! A username/password body that fails verification falls through to the PAT
+//! decode attempt, so the terminal rejection has to carry the credential
+//! failure that actually happened. Reporting the payload shape instead
+//! (`MalformedLogin` -> `InvalidFormat`) tells a client its request was
+//! malformed when the request was fine and the password was not.
+
+#![cfg(feature = "vsr")]
+
+use iggy::prelude::*;
+use integration::iggy_harness;
+
+#[iggy_harness(test_client_transport = [Tcp])]
+async fn given_wrong_password_when_logging_in_should_reject_invalid_credentials(
+    harness: &TestHarness,
+) {
+    let client = harness
+        .new_client_for(TransportProtocol::Tcp)
+        .await
+        .expect("tcp client");
+
+    let result = client
+        .login_user("iggy", "definitely-not-the-password")
+        .await;
+
+    let expected = IggyError::InvalidCredentials.as_code();
+    assert!(
+        matches!(&result, Err(error) if error.as_code() == expected),
+        "a wrong password must surface Err(InvalidCredentials), got {result:?}"
+    );
+}
+
+#[iggy_harness(test_client_transport = [Tcp])]
+async fn given_unknown_username_when_logging_in_should_reject_invalid_credentials(
+    harness: &TestHarness,
+) {
+    let client = harness
+        .new_client_for(TransportProtocol::Tcp)
+        .await
+        .expect("tcp client");
+
+    let result = client.login_user("no-such-user", "irrelevant").await;
+
+    // Same rejection as a wrong password: an unknown username must not be
+    // distinguishable from a bad password.
+    let expected = IggyError::InvalidCredentials.as_code();
+    assert!(
+        matches!(&result, Err(error) if error.as_code() == expected),
+        "an unknown username must surface Err(InvalidCredentials), got {result:?}"
+    );
+}
+
+#[iggy_harness(test_client_transport = [Tcp])]
+async fn given_rejected_login_when_retrying_with_valid_credentials_should_succeed(
+    harness: &TestHarness,
+) {
+    let client = harness
+        .new_client_for(TransportProtocol::Tcp)
+        .await
+        .expect("tcp client");
+
+    let rejected = client.login_user("iggy", "wrong").await;
+    assert!(rejected.is_err(), "the first login must be rejected");
+
+    // The rejection evicts the session, so a usable client has to reconnect;
+    // the point is that a bad password does not poison the account.
+    let retry = harness
+        .new_client_for(TransportProtocol::Tcp)
+        .await
+        .expect("tcp client");
+    retry
+        .login_user("iggy", "iggy")
+        .await
+        .expect("valid credentials must still authenticate after a rejection");
+}

--- a/core/integration/tests/server/mod.rs
+++ b/core/integration/tests/server/mod.rs
@@ -26,6 +26,10 @@ mod flush_vsr;
 // they must evict typed (MalformedLogin), not stall or reply empty-ok.
 #[cfg(feature = "vsr")]
 mod legacy_login_vsr;
+// A failed credential login must report the credential failure, not the
+// payload shape it fell through to.
+#[cfg(feature = "vsr")]
+mod login_credentials_vsr;
 // Poll addressing + timestamp semantics: typed PartitionNotFound on a bad
 // partition id, at-or-after timestamp polls.
 #[cfg(feature = "vsr")]

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -22,6 +22,9 @@ edition = "2024"
 license = "Apache-2.0"
 publish = false
 
+[features]
+vsr = ["iggy/vsr"]
+
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }

--- a/foreign/php/Cargo.toml
+++ b/foreign/php/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["cdylib"]
 bytes = "1.11.1"
 futures = "0.3.32"
 ext-php-rs = "=0.15.14"
-iggy = { path = "../../core/sdk" }
+iggy = { path = "../../core/sdk", features = ["vsr"] }
 tokio = "1.52.3"
 
 [profile.release]

--- a/foreign/php/docker-compose.test.yml
+++ b/foreign/php/docker-compose.test.yml
@@ -16,13 +16,17 @@
 # under the License.
 
 services:
+  # The PHP extension is vsr-built, so it can only talk to server-ng.
+  # TODO(hubcio): change to core/server/Dockerfile once the legacy server is
+  # removed (core/server has VSR support)
   iggy-server:
     build:
       context: ../..
-      dockerfile: core/server/Dockerfile
+      dockerfile: core/server-ng/Dockerfile
       args:
         PROFILE: debug
-    command: ["--fresh", "--with-default-root-credentials"]
+    # server-ng takes only --replica-id; root credentials come from the env.
+    command: []
     container_name: iggy-server-php-test
     security_opt:
       - seccomp:unconfined
@@ -31,6 +35,8 @@ services:
       - IGGY_TCP_ADDRESS=0.0.0.0:8090
       - IGGY_QUIC_ADDRESS=0.0.0.0:8080
       - IGGY_WEBSOCKET_ADDRESS=0.0.0.0:8092
+      - IGGY_ROOT_USERNAME=iggy
+      - IGGY_ROOT_PASSWORD=iggy
     networks:
       - php-test-network
     ports:

--- a/foreign/php/iggy-php.stubs.php
+++ b/foreign/php/iggy-php.stubs.php
@@ -218,9 +218,8 @@ namespace Iggy {
         public function sendBinaryRequest(int $code, string $payload): string {}
 
         /**
-         * Sends messages to a topic and returns the commit confirmations.
-         *
-         * The list is empty against the legacy server, which reports no offsets.
+         * Sends messages to a topic and returns the commit confirmations, one per
+         * partition the batch landed in.
          *
          * @param mixed $stream
          * @param mixed $topic
@@ -513,9 +512,6 @@ namespace Iggy {
          * crash-restart can stamp a later batch with an offset a client has already
          * recorded.
          *
-         * The legacy server returns an empty confirmation list, so it reports no offset
-         * at all.
-         *
          * @var int
          */
         public readonly int $base_offset;
@@ -536,9 +532,9 @@ namespace Iggy {
         /**
          * One confirmation per partition the batch landed in.
          *
-         * The list is empty when the server reports no offsets. The legacy server never
-         * reports any, and a server that does can still commit a batch it has no offsets
-         * to describe, so check for an empty array instead of indexing.
+         * The list is empty when the server reports no offsets. A server can commit a
+         * batch it has no offsets to describe, so check for an empty array instead of
+         * indexing.
          *
          * The confirmations are rebuilt on each getter call; cache the result in PHP if
          * they will be read repeatedly.

--- a/foreign/php/src/client.rs
+++ b/foreign/php/src/client.rs
@@ -184,9 +184,8 @@ impl IggyClient {
         })
     }
 
-    /// Sends messages to a topic and returns the commit confirmations.
-    ///
-    /// The list is empty against the legacy server, which reports no offsets.
+    /// Sends messages to a topic and returns the commit confirmations, one per
+    /// partition the batch landed in.
     pub fn send_messages(
         &self,
         stream: PhpIdentifier,

--- a/foreign/php/src/send_message.rs
+++ b/foreign/php/src/send_message.rs
@@ -99,9 +99,9 @@ impl From<RustSendMessagesResponse> for SendMessagesResponse {
 impl SendMessagesResponse {
     /// One confirmation per partition the batch landed in.
     ///
-    /// The list is empty when the server reports no offsets. The legacy server never
-    /// reports any, and a server that does can still commit a batch it has no offsets
-    /// to describe, so check for an empty array instead of indexing.
+    /// The list is empty when the server reports no offsets. A server can commit a
+    /// batch it has no offsets to describe, so check for an empty array instead of
+    /// indexing.
     ///
     /// The confirmations are rebuilt on each getter call; cache the result in PHP if
     /// they will be read repeatedly.
@@ -154,9 +154,6 @@ impl SendMessagesConfirmation {
     /// A batch is confirmed once it is committed in memory, not once it is fsynced. A
     /// crash-restart can stamp a later batch with an offset a client has already
     /// recorded.
-    ///
-    /// The legacy server returns an empty confirmation list, so it reports no offset
-    /// at all.
     #[php(getter)]
     pub fn base_offset(&self) -> u64 {
         self.inner.base_offset

--- a/foreign/php/tests/IggySdkTest.php
+++ b/foreign/php/tests/IggySdkTest.php
@@ -222,8 +222,8 @@ final class IggySdkTest extends TestCase
         }
     }
 
-    #[TestDox('sendMessages against the legacy server reports no commit confirmations')]
-    public function testSendMessagesReportsNoConfirmationFromLegacyServer(): void
+    #[TestDox('sendMessages reports one commit confirmation per written partition')]
+    public function testSendMessagesReportsCommitConfirmation(): void
     {
         $client = new_client();
         $streamName = unique_name('confirm-stream');
@@ -235,7 +235,17 @@ final class IggySdkTest extends TestCase
 
             $response = $client->sendMessages($streamName, $topicName, $partitionId, [new SendMessage('confirm-first')]);
             assert_instance_of(SendMessagesResponse::class, $response);
-            assert_count(0, $response->confirmations, 'the legacy server answers a send with no offsets');
+            assert_count(1, $response->confirmations, 'a single-partition send commits in exactly one partition');
+            assert_same($partitionId, $response->confirmations[0]->partition_id);
+
+            // Offsets are per partition and start at 0, so the second send of
+            // the same size must be confirmed one message later.
+            $second = $client->sendMessages($streamName, $topicName, $partitionId, [new SendMessage('confirm-second')]);
+            assert_same(
+                $response->confirmations[0]->base_offset + 1,
+                $second->confirmations[0]->base_offset,
+                'the confirmed offset must advance by the committed message count'
+            );
         } finally {
             cleanup_stream_with_topics($client, $streamName, [$topicName]);
         }

--- a/scripts/run-bdd-tests.sh
+++ b/scripts/run-bdd-tests.sh
@@ -40,11 +40,12 @@ usage(){
   log "  sdk:     rust | python | php | go | go-race | node | csharp | java | cpp | all | clean (default: all)"
   log "  feature: basic_messaging | leader_redirection | raw_command | all  (default: all)"
   # TODO: change to iggy-server once legacy server is removed (core/server has VSR support)
-  log "  --vsr:   run against iggy-server-ng built with --features vsr (rust, python, go, node, csharp, cpp);"
+  log "  --vsr:   run against iggy-server-ng built with --features vsr (every SDK);"
   log "           expects IGGY_SERVER_NG_PATH (default: target/debug/iggy-server-ng)"
   log "           and a vsr-built iggy CLI at IGGY_CLI_PATH."
-  log "           The go suites imply it: the Go SDK speaks only the VSR protocol."
-  log "           The java suite always applies the VSR overlay."
+  log "           Every foreign SDK speaks only VSR; the go suites imply the"
+  log "           flag and the java suite always applies the VSR overlay."
+  log "           Only rust still has a legacy (no --vsr) lane."
   log ""
   log "Examples:"
   log "  $0 rust                         # run all features for Rust"
@@ -56,12 +57,12 @@ usage(){
 
 if [ "$VSR" = "1" ]; then
   case "$SDK" in
-    rust|python|go|go-race|node|csharp|cpp|clean) ;;
+    rust|python|php|go|go-race|node|csharp|cpp|clean) ;;
     java)
       # Redundant: the Java suite applies the VSR overlay unconditionally.
       VSR=0 ;;
     *)
-      log "❌ --vsr supports only the Rust, Python, Go, Node, C#, Java, and C++ SDKs so far"
+      log "❌ unknown sdk for --vsr: ${SDK}"
       usage
       exit 2 ;;
   esac

--- a/scripts/run-examples-from-readme.sh
+++ b/scripts/run-examples-from-readme.sh
@@ -314,7 +314,12 @@ run_python_examples() {
 
 # shellcheck disable=SC2329
 run_php_examples() {
-    resolve_server_binary "${TARGET}"
+    # The PHP extension is vsr-built, so examples run against the vsr server.
+    # It takes no --fresh flag; cleanup_server_state wiping local_data is the
+    # fresh start.
+    # TODO(hubcio): change to iggy-server once legacy server is removed
+    # (core/server has VSR support)
+    resolve_server_binary "${TARGET}" iggy-server-ng
 
     local php_bin="${PHP:-php}"
     if [ -z "${PHP_IGGY_EXTENSION:-}" ]; then
@@ -350,7 +355,7 @@ run_php_examples() {
         "" \
         "" \
         0 \
-        "--fresh"
+        ""
 }
 
 # shellcheck disable=SC2329

--- a/scripts/run-examples-from-readme.sh
+++ b/scripts/run-examples-from-readme.sh
@@ -179,18 +179,23 @@ run_language_examples() {
 
 # shellcheck disable=SC2329
 run_rust_examples() {
-    resolve_server_binary "${TARGET}"
+    # TODO(hubcio): change to iggy-server once legacy server is removed
+    # (core/server has VSR support)
+    resolve_server_binary "${TARGET}" "iggy-server-ng" "vsr"
     resolve_cli_binary "${TARGET}"
 
     # The README documents credentials as <iggy_username>/<iggy_password>
-    # placeholders; the test server starts with iggy/iggy.
+    # placeholders; the test server starts with iggy/iggy. The README keeps
+    # plain cargo run commands, but the CLI and examples must be vsr-built
+    # to speak the VSR server's wire protocol, so the feature is injected
+    # here.
     if [ -n "${TARGET}" ]; then
         TRANSFORM_COMMAND() {
-            echo "$1" | sed "s|<iggy_username>|iggy|g; s|<iggy_password>|iggy|g; s|cargo run |cargo run --target ${TARGET} |g"
+            echo "$1" | sed "s|<iggy_username>|iggy|g; s|<iggy_password>|iggy|g; s|cargo run |cargo run --target ${TARGET} --features vsr |g"
         }
     else
         TRANSFORM_COMMAND() {
-            echo "$1" | sed "s|<iggy_username>|iggy|g; s|<iggy_password>|iggy|g"
+            echo "$1" | sed "s|<iggy_username>|iggy|g; s|<iggy_password>|iggy|g; s|cargo run |cargo run --features vsr |g"
         }
     fi
 


### PR DESCRIPTION
The PHP extension wraps the Rust SDK without the vsr feature, so its
suites only ever exercised the legacy wire protocol. Building it with
the feature moves the SDK, BDD and examples lanes onto server-ng, and
the dev compose harness with them, since a vsr-built extension cannot
talk to the legacy server at all.

Only one expectation encoded legacy behavior: a send used to assert an
empty confirmation list, where the VSR server reports the written
partition's offsets. It now asserts one confirmation per partition and
that the offset advances by the committed message count.

The migration also surfaced a server bug. A username/password body
that fails verification falls through to the PAT decode attempt so a
credential payload shaped like a token still gets a chance, but when
that decode failed too the terminal rejection reported the payload
shape rather than the credential failure, and clients saw InvalidFormat
for a wrong password. The fall-through now carries the rejection that
actually happened, which is what makes the PHP suite raise
AuthenticationException instead of the untyped base exception.
