### PR TITLE
test(bdd): add stream CRUD coverage for Rust and Java

### DIFF
--- a/bdd/docker-compose.coverage.yml
+++ b/bdd/docker-compose.coverage.yml
@@ -34,6 +34,7 @@ services:
         && case "$$BDD_FEATURE" in
           basic_messaging)    cargo llvm-cov test -p bdd --features "$$BDD_RUST_FEATURES" --test basic_messaging --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
           leader_redirection) cargo llvm-cov test -p bdd --features "$$BDD_RUST_FEATURES" --test leader_redirection --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
+          stream_crud)        cargo llvm-cov test -p bdd --features "$$BDD_RUST_FEATURES" --test stream_crud --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
           *)                  cargo llvm-cov test -p bdd --features "$$BDD_RUST_FEATURES" --lcov --output-path /reports/rust-bdd-coverage.lcov ;;
         esac
 
@@ -106,6 +107,12 @@ services:
     command:
       - sh
       - -c
-      - >-
+      - |
+        case "$$BDD_FEATURE" in
+          basic_messaging)    export CUCUMBER_FILTER_TAGS='@basic-messaging' ;;
+          leader_redirection) export CUCUMBER_FILTER_TAGS='@requires-leader-awareness' ;;
+          raw_command)        export CUCUMBER_FILTER_TAGS='@raw-command' ;;
+          stream_crud)        export CUCUMBER_FILTER_TAGS='@stream-crud' ;;
+        esac
         gradle --no-daemon test jacocoTestReport
-        && cp build/reports/jacoco/test/jacocoTestReport.xml /reports/java-bdd-coverage.xml
+        cp build/reports/jacoco/test/jacocoTestReport.xml /reports/java-bdd-coverage.xml

--- a/bdd/docker-compose.coverage.yml
+++ b/bdd/docker-compose.coverage.yml
@@ -114,5 +114,4 @@ services:
           raw_command)        export CUCUMBER_FILTER_TAGS='@raw-command' ;;
           stream_crud)        export CUCUMBER_FILTER_TAGS='@stream-crud' ;;
         esac
-        gradle --no-daemon test jacocoTestReport
-        cp build/reports/jacoco/test/jacocoTestReport.xml /reports/java-bdd-coverage.xml
+        gradle --no-daemon test jacocoTestReport && cp build/reports/jacoco/test/jacocoTestReport.xml /reports/java-bdd-coverage.xml

--- a/bdd/docker-compose.yml
+++ b/bdd/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - ./scenarios/basic_messaging.feature:/app/features/basic_messaging.feature
       - ./scenarios/leader_redirection.feature:/app/features/leader_redirection.feature
       - ./scenarios/raw_command.feature:/app/features/raw_command.feature
+      - ./scenarios/stream_crud.feature:/app/features/stream_crud.feature
     command:
       - sh
       - -c
@@ -40,6 +41,7 @@ services:
           basic_messaging)    cargo test -p bdd --features "$$BDD_RUST_FEATURES" --test basic_messaging ;;
           leader_redirection) cargo test -p bdd --features "$$BDD_RUST_FEATURES" --test leader_redirection ;;
           raw_command)        cargo test -p bdd --features "$$BDD_RUST_FEATURES" --test raw_command ;;
+          stream_crud)        cargo test -p bdd --features "$$BDD_RUST_FEATURES" --test stream_crud ;;
           *)                  cargo test -p bdd --features "$$BDD_RUST_FEATURES" ;;
         esac
     networks:
@@ -172,6 +174,7 @@ services:
       - ./scenarios/basic_messaging.feature:/app/features/basic_messaging.feature
       - ./scenarios/leader_redirection.feature:/app/features/leader_redirection.feature
       - ./scenarios/raw_command.feature:/app/features/raw_command.feature
+      - ./scenarios/stream_crud.feature:/app/features/stream_crud.feature
     command:
       - sh
       - -c
@@ -180,6 +183,7 @@ services:
           basic_messaging)    export CUCUMBER_FILTER_TAGS='@basic-messaging' ;;
           leader_redirection) export CUCUMBER_FILTER_TAGS='@requires-leader-awareness' ;;
           raw_command)        export CUCUMBER_FILTER_TAGS='@raw-command' ;;
+          stream_crud)        export CUCUMBER_FILTER_TAGS='@stream-crud' ;;
         esac
         gradle --no-daemon test
     networks:

--- a/bdd/java/src/test/java/org/apache/iggy/bdd/BasicMessagingSteps.java
+++ b/bdd/java/src/test/java/org/apache/iggy/bdd/BasicMessagingSteps.java
@@ -98,6 +98,56 @@ public class BasicMessagingSteps {
         assertEquals(streamName, stream.get().name(), "Stream should have expected name");
     }
 
+    @Given("a stream with name {string} exists")
+    public void streamExists(String streamName) {
+        createStream(streamName);
+    }
+
+    @When("I get the stream by its numeric ID")
+    public void getStreamByNumericId() {
+        Optional<StreamDetails> stream = getClient().streams().getStream(context.lastStreamId);
+        context.lastStreamName = stream.map(StreamDetails::name).orElse(null);
+    }
+
+    @Then("the returned stream should have name {string}")
+    public void returnedStreamHasName(String streamName) {
+        assertEquals(streamName, context.lastStreamName, "Stream should have expected name");
+    }
+
+    @When("I list all streams")
+    public void listAllStreams() {
+        List<StreamBase> streams = getClient().streams().getStreams();
+        context.lastStreamWasFound =
+                streams.stream().anyMatch(stream -> stream.id().equals(context.lastStreamId));
+    }
+
+    @Then("the stream list should contain the created stream")
+    public void streamListContainsCreatedStream() {
+        assertTrue(context.lastStreamWasFound, "Stream list should contain the created stream");
+    }
+
+    @When("I update the stream name to {string}")
+    public void updateStreamName(String streamName) {
+        getClient().streams().updateStream(context.lastStreamId, streamName);
+    }
+
+    @Then("getting the stream by its numeric ID should return name {string}")
+    public void getStreamReturnsName(String streamName) {
+        getStreamByNumericId();
+        returnedStreamHasName(streamName);
+    }
+
+    @When("I delete the stream by its numeric ID")
+    public void deleteStreamByNumericId() {
+        getClient().streams().deleteStream(context.lastStreamId);
+    }
+
+    @Then("getting the stream by its numeric ID should return no stream")
+    public void getStreamReturnsNoStream() {
+        Optional<StreamDetails> stream = getClient().streams().getStream(context.lastStreamId);
+        assertTrue(stream.isEmpty(), "Deleted stream should not be returned");
+    }
+
     @When("I create a topic with name {string} in stream {int} with {int} partitions")
     public void createTopic(String topicName, int streamId, int partitions) {
         TopicDetails topic = getClient()

--- a/bdd/java/src/test/java/org/apache/iggy/bdd/TestContext.java
+++ b/bdd/java/src/test/java/org/apache/iggy/bdd/TestContext.java
@@ -27,6 +27,7 @@ class TestContext {
     String serverAddr;
     Long lastStreamId;
     String lastStreamName;
+    boolean lastStreamWasFound;
     Long lastTopicId;
     String lastTopicName;
     Long lastTopicPartitions;

--- a/bdd/rust/Cargo.toml
+++ b/bdd/rust/Cargo.toml
@@ -49,3 +49,8 @@ required-features = ["bdd"]
 name = "raw_command"
 harness = false
 required-features = ["bdd"]
+
+[[test]]
+name = "stream_crud"
+harness = false
+required-features = ["bdd"]

--- a/bdd/rust/tests/steps/streams.rs
+++ b/bdd/rust/tests/steps/streams.rs
@@ -17,7 +17,7 @@
 
 use crate::common::global_context::GlobalContext;
 use cucumber::{given, then, when};
-use iggy::prelude::StreamClient;
+use iggy::prelude::{Identifier, StreamClient};
 
 #[given("I have no streams in the system")]
 pub async fn given_no_streams(world: &mut GlobalContext) {
@@ -32,7 +32,7 @@ pub async fn given_no_streams(world: &mut GlobalContext) {
     );
 }
 
-#[when(regex = r"^I create a stream with name (.+)$")]
+#[when(regex = r#"^I create a stream with name "(.+)"$"#)]
 pub async fn when_create_stream(world: &mut GlobalContext, stream_name: String) {
     let client = world.client.as_ref().expect("Client should be available");
     let stream = client
@@ -52,7 +52,7 @@ pub async fn then_stream_created_successfully(world: &mut GlobalContext) {
     );
 }
 
-#[then(regex = r"^the stream should have name (.+)$")]
+#[then(regex = r#"^the stream should have name "(.+)"$"#)]
 pub async fn then_stream_has_name(world: &mut GlobalContext, expected_name: String) {
     let stream_name = world
         .last_stream_name
@@ -61,5 +61,93 @@ pub async fn then_stream_has_name(world: &mut GlobalContext, expected_name: Stri
     assert_eq!(
         stream_name, &expected_name,
         "Stream should have expected name"
+    );
+}
+
+#[given(regex = r#"^a stream with name "(.+)" exists$"#)]
+pub async fn given_stream_exists(world: &mut GlobalContext, stream_name: String) {
+    when_create_stream(world, stream_name).await;
+}
+
+#[when("I get the stream by its numeric ID")]
+pub async fn when_get_stream_by_numeric_id(world: &mut GlobalContext) {
+    let client = world.client.as_ref().expect("Client should be available");
+    let stream_id = world
+        .last_stream_id
+        .expect("Stream should have been created");
+    let stream = client
+        .get_stream(&Identifier::numeric(stream_id).expect("Stream ID should be valid"))
+        .await
+        .expect("Should be able to get stream");
+
+    world.last_stream_name = stream.map(|stream| stream.name);
+}
+
+#[then(regex = r#"^the returned stream should have name "(.+)"$"#)]
+pub async fn then_returned_stream_has_name(world: &mut GlobalContext, expected_name: String) {
+    then_stream_has_name(world, expected_name).await;
+}
+
+#[when("I list all streams")]
+pub async fn when_list_all_streams(world: &mut GlobalContext) {
+    let client = world.client.as_ref().expect("Client should be available");
+    let stream_id = world
+        .last_stream_id
+        .expect("Stream should have been created");
+    let streams = client
+        .get_streams()
+        .await
+        .expect("Should be able to get streams");
+
+    world.last_stream_was_found = streams.iter().any(|stream| stream.id == stream_id);
+}
+
+#[then("the stream list should contain the created stream")]
+pub async fn then_stream_list_contains_created_stream(world: &mut GlobalContext) {
+    assert!(
+        world.last_stream_was_found,
+        "Stream list should contain the created stream"
+    );
+}
+
+#[when(regex = r#"^I update the stream name to "(.+)"$"#)]
+pub async fn when_update_stream_name(world: &mut GlobalContext, stream_name: String) {
+    let client = world.client.as_ref().expect("Client should be available");
+    let stream_id = world
+        .last_stream_id
+        .expect("Stream should have been created");
+    client
+        .update_stream(
+            &Identifier::numeric(stream_id).expect("Stream ID should be valid"),
+            &stream_name,
+        )
+        .await
+        .expect("Should be able to update stream");
+}
+
+#[then(regex = r#"^getting the stream by its numeric ID should return name "(.+)"$"#)]
+pub async fn then_get_stream_returns_name(world: &mut GlobalContext, expected_name: String) {
+    when_get_stream_by_numeric_id(world).await;
+    then_returned_stream_has_name(world, expected_name).await;
+}
+
+#[when("I delete the stream by its numeric ID")]
+pub async fn when_delete_stream_by_numeric_id(world: &mut GlobalContext) {
+    let client = world.client.as_ref().expect("Client should be available");
+    let stream_id = world
+        .last_stream_id
+        .expect("Stream should have been created");
+    client
+        .delete_stream(&Identifier::numeric(stream_id).expect("Stream ID should be valid"))
+        .await
+        .expect("Should be able to delete stream");
+}
+
+#[then("getting the stream by its numeric ID should return no stream")]
+pub async fn then_get_stream_returns_no_stream(world: &mut GlobalContext) {
+    when_get_stream_by_numeric_id(world).await;
+    assert!(
+        world.last_stream_name.is_none(),
+        "Deleted stream should not be returned"
     );
 }

--- a/bdd/rust/tests/steps/streams.rs
+++ b/bdd/rust/tests/steps/streams.rs
@@ -17,7 +17,7 @@
 
 use crate::common::global_context::GlobalContext;
 use cucumber::{given, then, when};
-use iggy::prelude::{Identifier, StreamClient};
+use iggy::prelude::{Identifier, StreamClient, StreamUpdateOptions};
 
 #[given("I have no streams in the system")]
 pub async fn given_no_streams(world: &mut GlobalContext) {
@@ -97,6 +97,7 @@ pub async fn when_update_stream_name(world: &mut GlobalContext, stream_name: Str
         .update_stream(
             &Identifier::numeric(stream_id).expect("Stream ID should be valid"),
             &stream_name,
+            &StreamUpdateOptions::default(),
         )
         .await
         .expect("Should be able to update stream");

--- a/bdd/rust/tests/steps/streams.rs
+++ b/bdd/rust/tests/steps/streams.rs
@@ -34,14 +34,7 @@ pub async fn given_no_streams(world: &mut GlobalContext) {
 
 #[when(regex = r#"^I create a stream with name "(.+)"$"#)]
 pub async fn when_create_stream(world: &mut GlobalContext, stream_name: String) {
-    let client = world.client.as_ref().expect("Client should be available");
-    let stream = client
-        .create_stream(&stream_name)
-        .await
-        .expect("Should be able to create stream");
-
-    world.last_stream_id = Some(stream.id);
-    world.last_stream_name = Some(stream.name.clone());
+    create_stream(world, &stream_name).await;
 }
 
 #[then("the stream should be created successfully")]
@@ -54,38 +47,22 @@ pub async fn then_stream_created_successfully(world: &mut GlobalContext) {
 
 #[then(regex = r#"^the stream should have name "(.+)"$"#)]
 pub async fn then_stream_has_name(world: &mut GlobalContext, expected_name: String) {
-    let stream_name = world
-        .last_stream_name
-        .as_ref()
-        .expect("Stream should exist");
-    assert_eq!(
-        stream_name, &expected_name,
-        "Stream should have expected name"
-    );
+    assert_last_stream_name(world, &expected_name);
 }
 
 #[given(regex = r#"^a stream with name "(.+)" exists$"#)]
 pub async fn given_stream_exists(world: &mut GlobalContext, stream_name: String) {
-    when_create_stream(world, stream_name).await;
+    create_stream(world, &stream_name).await;
 }
 
 #[when("I get the stream by its numeric ID")]
 pub async fn when_get_stream_by_numeric_id(world: &mut GlobalContext) {
-    let client = world.client.as_ref().expect("Client should be available");
-    let stream_id = world
-        .last_stream_id
-        .expect("Stream should have been created");
-    let stream = client
-        .get_stream(&Identifier::numeric(stream_id).expect("Stream ID should be valid"))
-        .await
-        .expect("Should be able to get stream");
-
-    world.last_stream_name = stream.map(|stream| stream.name);
+    get_stream_by_numeric_id(world).await;
 }
 
 #[then(regex = r#"^the returned stream should have name "(.+)"$"#)]
 pub async fn then_returned_stream_has_name(world: &mut GlobalContext, expected_name: String) {
-    then_stream_has_name(world, expected_name).await;
+    assert_last_stream_name(world, &expected_name);
 }
 
 #[when("I list all streams")]
@@ -127,8 +104,8 @@ pub async fn when_update_stream_name(world: &mut GlobalContext, stream_name: Str
 
 #[then(regex = r#"^getting the stream by its numeric ID should return name "(.+)"$"#)]
 pub async fn then_get_stream_returns_name(world: &mut GlobalContext, expected_name: String) {
-    when_get_stream_by_numeric_id(world).await;
-    then_returned_stream_has_name(world, expected_name).await;
+    get_stream_by_numeric_id(world).await;
+    assert_last_stream_name(world, &expected_name);
 }
 
 #[when("I delete the stream by its numeric ID")]
@@ -145,9 +122,44 @@ pub async fn when_delete_stream_by_numeric_id(world: &mut GlobalContext) {
 
 #[then("getting the stream by its numeric ID should return no stream")]
 pub async fn then_get_stream_returns_no_stream(world: &mut GlobalContext) {
-    when_get_stream_by_numeric_id(world).await;
+    get_stream_by_numeric_id(world).await;
     assert!(
         world.last_stream_name.is_none(),
         "Deleted stream should not be returned"
+    );
+}
+
+async fn create_stream(world: &mut GlobalContext, stream_name: &str) {
+    let client = world.client.as_ref().expect("Client should be available");
+    let stream = client
+        .create_stream(stream_name)
+        .await
+        .expect("Should be able to create stream");
+
+    world.last_stream_id = Some(stream.id);
+    world.last_stream_name = Some(stream.name);
+}
+
+async fn get_stream_by_numeric_id(world: &mut GlobalContext) {
+    let client = world.client.as_ref().expect("Client should be available");
+    let stream_id = world
+        .last_stream_id
+        .expect("Stream should have been created");
+    let stream = client
+        .get_stream(&Identifier::numeric(stream_id).expect("Stream ID should be valid"))
+        .await
+        .expect("Should be able to get stream");
+
+    world.last_stream_name = stream.map(|stream| stream.name);
+}
+
+fn assert_last_stream_name(world: &GlobalContext, expected_name: &str) {
+    let stream_name = world
+        .last_stream_name
+        .as_ref()
+        .expect("Stream should exist");
+    assert_eq!(
+        stream_name, expected_name,
+        "Stream should have expected name"
     );
 }

--- a/bdd/rust/tests/stream_crud.rs
+++ b/bdd/rust/tests/stream_crud.rs
@@ -15,22 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use bytes::Bytes;
-use cucumber::World;
-use iggy::clients::client::IggyClient;
-use iggy::prelude::{IggyError, IggyMessage, PolledMessages};
+pub(crate) mod common;
+pub(crate) mod helpers;
+pub(crate) mod steps;
 
-#[derive(Debug, World, Default)]
-pub struct GlobalContext {
-    pub client: Option<IggyClient>,
-    pub server_addr: Option<String>,
-    pub last_stream_id: Option<u32>,
-    pub last_stream_name: Option<String>,
-    pub last_stream_was_found: bool,
-    pub last_topic_id: Option<u32>,
-    pub last_topic_name: Option<String>,
-    pub last_topic_partitions: Option<u32>,
-    pub last_polled_messages: Option<PolledMessages>,
-    pub last_sent_message: Option<IggyMessage>,
-    pub last_raw_result: Option<Result<Bytes, IggyError>>,
+use crate::common::global_context::GlobalContext;
+use cucumber::World;
+
+#[tokio::main]
+async fn main() {
+    GlobalContext::cucumber()
+        .fail_on_skipped()
+        .run_and_exit("../../bdd/scenarios/stream_crud.feature")
+        .await;
 }

--- a/bdd/scenarios/stream_crud.feature
+++ b/bdd/scenarios/stream_crud.feature
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+@stream-crud
+Feature: Stream CRUD operations
+  As a developer using Apache Iggy
+  I want to manage streams
+  So that I can organize message data
+
+  Background:
+    Given I have a running Iggy server
+    And I am authenticated as the root user
+
+  Scenario: Create a stream
+    When I create a stream with name "stream-crud-create"
+    Then the stream should be created successfully
+    And the stream should have name "stream-crud-create"
+    And getting the stream by its numeric ID should return name "stream-crud-create"
+
+  Scenario: Get a stream by numeric ID
+    Given a stream with name "stream-crud-get" exists
+    When I get the stream by its numeric ID
+    Then the returned stream should have name "stream-crud-get"
+
+  Scenario: List streams
+    Given a stream with name "stream-crud-list" exists
+    When I list all streams
+    Then the stream list should contain the created stream
+
+  Scenario: Update a stream
+    Given a stream with name "stream-crud-update" exists
+    When I update the stream name to "stream-crud-updated"
+    Then getting the stream by its numeric ID should return name "stream-crud-updated"
+
+  Scenario: Delete a stream
+    Given a stream with name "stream-crud-delete" exists
+    When I delete the stream by its numeric ID
+    Then getting the stream by its numeric ID should return no stream

--- a/scripts/run-bdd-tests.sh
+++ b/scripts/run-bdd-tests.sh
@@ -94,20 +94,25 @@ if [ "$COVERAGE" = "1" ]; then
   log "📊 Coverage collection enabled → reports will be in ./reports/"
 fi
 
+unsupported(){
+  local feature="$1" svc="$2"
+  if [ "$SDK" = "all" ]; then
+    log "⚠️ skipping ${svc%-bdd} (does not support ${feature})"
+    return 0
+  else
+    log "❌ ${SDK} does not support feature '${feature}'"
+    return 1
+  fi
+}
+
 run_suite(){
   local svc="$1" emoji="$2" label="$3"
   if [ "$FEATURE" = "leader_redirection" ]; then
     case "$svc" in
       rust-bdd|go-bdd|csharp-bdd|java-bdd) ;;
       *)
-        if [ "$SDK" = "all" ]; then
-          log "⚠️ skipping ${svc%-bdd} (does not support ${FEATURE})"
-          return 0
-        else
-          log "❌ ${SDK} does not support feature '${FEATURE}'"
-          return 1
-        fi
-        ;;
+        unsupported "$FEATURE" "$svc" || return 1
+        return 0 ;;
     esac
   fi
 
@@ -115,14 +120,8 @@ run_suite(){
     case "$svc" in
       rust-bdd|java-bdd) ;;
       *)
-        if [ "$SDK" = "all" ]; then
-          log "⚠️ skipping ${svc%-bdd} (does not support ${FEATURE})"
-          return 0
-        else
-          log "❌ ${SDK} does not support feature '${FEATURE}'"
-          return 1
-        fi
-        ;;
+        unsupported "$FEATURE" "$svc" || return 1
+        return 0 ;;
     esac
   fi
 

--- a/scripts/run-bdd-tests.sh
+++ b/scripts/run-bdd-tests.sh
@@ -36,7 +36,7 @@ usage(){
   log "Usage: $0 [--coverage] <sdk> [feature]"
   log ""
   log "  sdk:     rust | python | php | go | go-race | node | csharp | java | cpp | all | clean (default: all)"
-  log "  feature: basic_messaging | leader_redirection | raw_command | all  (default: all)"
+  log "  feature: basic_messaging | leader_redirection | raw_command | stream_crud | all  (default: all)"
   log ""
   log "  Every suite runs against iggy-server, taken from IGGY_SERVER_PATH"
   log "  (default: target/debug/iggy-server) with an iggy CLI at IGGY_CLI_PATH."
@@ -49,7 +49,7 @@ usage(){
 }
 
 case "$FEATURE" in
-  basic_messaging|leader_redirection|raw_command|all) ;;
+  basic_messaging|leader_redirection|raw_command|stream_crud|all) ;;
   *)
     log "Unknown feature: ${FEATURE}"
     usage
@@ -69,7 +69,7 @@ ALL_COMPOSE_FILES=(
 
 COMPOSE_FILES=(-f docker-compose.yml)
 case "$FEATURE" in
-  basic_messaging|leader_redirection|raw_command|all)
+  basic_messaging|leader_redirection|raw_command|stream_crud|all)
     COMPOSE_FILES+=(-f docker-compose.server.yml) ;;
 esac
 case "$FEATURE" in
@@ -99,6 +99,21 @@ run_suite(){
   if [ "$FEATURE" = "leader_redirection" ]; then
     case "$svc" in
       rust-bdd|go-bdd|csharp-bdd|java-bdd) ;;
+      *)
+        if [ "$SDK" = "all" ]; then
+          log "⚠️ skipping ${svc%-bdd} (does not support ${FEATURE})"
+          return 0
+        else
+          log "❌ ${SDK} does not support feature '${FEATURE}'"
+          return 1
+        fi
+        ;;
+    esac
+  fi
+
+  if [ "$FEATURE" = "stream_crud" ]; then
+    case "$svc" in
+      rust-bdd|java-bdd) ;;
       *)
         if [ "$SDK" = "all" ]; then
           log "⚠️ skipping ${svc%-bdd} (does not support ${FEATURE})"


### PR DESCRIPTION
## Which issue does this PR address?

Part of #3609

## Rationale

The BDD roadmap tracks client-visible stream CRUD coverage, but there was no shared feature exercising the lifecycle across SDKs.

## What changed?

This adds five independent scenarios for creating a stream, retrieving it by numeric ID, finding it in the stream list, renaming it, and deleting it. Rust and Java step definitions use their existing client abstractions, and focused runner paths cover normal and coverage executions.

The review follow-up extracts shared Rust step helpers and centralizes unsupported-SDK handling in the BDD runner.

## Local Execution

- `cargo fmt --all -- --check`
- `cargo clippy -p bdd --features bdd --all-targets -- -D warnings`
- `cargo test -p bdd --features bdd --no-run`
- `gradle --no-daemon spotlessCheck testClasses` in `bdd/java`
- `git diff --check`

## AI Usage

1. Which tools? OpenAI Codex
2. Scope of usage? Issue and PR analysis, implementation assistance, review feedback handling, and verification.
3. How did you verify the generated code works correctly? Rust formatting, clippy, and test-target compilation; Java Spotless and test-class compilation; and Linux CI for the server-backed Rust and Java BDD scenarios.
4. Can you explain every line of the code if asked? Yes.