### PR TITLE
ci(security): replace package tokens with OIDC

### DIFF
--- a/.github/actions/csharp-dotnet/post-merge/action.yml
+++ b/.github/actions/csharp-dotnet/post-merge/action.yml
@@ -41,6 +41,22 @@ runs:
         dotnet restore
       shell: bash
 
+    - name: Validate package metadata
+      run: |
+        cd foreign/csharp
+        PACKAGE=$(dotnet msbuild ./Iggy_SDK -nologo -getProperty:PackageId)
+        VERSION=$(dotnet msbuild ./Iggy_SDK -nologo -getProperty:Version)
+
+        if [ "$PACKAGE" != "Apache.Iggy" ]; then
+          echo "❌ Iggy_SDK.csproj PackageId must be Apache.Iggy, got: $PACKAGE"
+          exit 1
+        fi
+        if [ "$VERSION" != "${{ inputs.version }}" ]; then
+          echo "❌ Iggy_SDK.csproj version ($VERSION) does not match ${{ inputs.version }}"
+          exit 1
+        fi
+      shell: bash
+
     - name: Build Release
       run: |
         cd foreign/csharp
@@ -73,9 +89,16 @@ runs:
         ls -la ./nupkgs/ || echo "No packages found"
       shell: bash
 
+    - name: Authenticate with NuGet
+      if: inputs.dry_run == 'false'
+      id: nuget-auth
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      with:
+        user: apache.iggy
+
     - name: Publish to NuGet
       env:
-        NUGET_API_KEY: ${{ env.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.nuget-auth.outputs.NUGET_API_KEY }}
       run: |
         cd foreign/csharp
 
@@ -92,7 +115,7 @@ runs:
           done
         else
           if [ -z "$NUGET_API_KEY" ]; then
-            echo "❌ NUGET_API_KEY is not set"
+            echo "❌ NuGet trusted publishing did not return an API key"
             exit 1
           fi
 

--- a/.github/actions/node-npm/post-merge/action.yml
+++ b/.github/actions/node-npm/post-merge/action.yml
@@ -33,13 +33,12 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: "23"
+        node-version: "24"
         registry-url: "https://registry.npmjs.org"
-        cache: "npm"
-        cache-dependency-path: foreign/node/package-lock.json
+        package-manager-cache: false
 
-    - name: Pin npm to 11 to match Dependabot lockfile format
-      run: npm install -g npm@11
+    - name: Install OIDC-compatible npm
+      run: npm install -g npm@12.0.1
       shell: bash
 
     - name: Install dependencies
@@ -109,6 +108,15 @@ runs:
             console.error('❌ Missing required fields:', missing.join(', '));
             process.exit(1);
           }
+          if (pkg.name !== 'apache-iggy') {
+            console.error('❌ package.json name must be apache-iggy, got:', pkg.name);
+            process.exit(1);
+          }
+          const repositoryUrl = typeof pkg.repository === 'string' ? pkg.repository : pkg.repository?.url;
+          if (repositoryUrl !== 'git+https://github.com/apache/iggy.git') {
+            console.error('❌ package.json repository must point to github.com/apache/iggy, got:', repositoryUrl);
+            process.exit(1);
+          }
           console.log('✅ All required fields present');
           console.log('');
           console.log('Package info:');
@@ -128,8 +136,6 @@ runs:
       shell: bash
 
     - name: Publish to npm
-      env:
-        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
       run: |
         cd foreign/node
 
@@ -170,18 +176,11 @@ runs:
           echo "Or add to package.json:"
           echo '  "apache-iggy": "^${{ inputs.version }}"'
         else
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "❌ NPM_TOKEN is not set"
-            exit 1
-          fi
-
           echo "📦 Publishing to npm registry..."
           echo "Version: $VERSION (dist-tag: $DIST_TAG)"
           echo ""
 
-          # Publish with provenance for supply chain security. --tag keeps
-          # prereleases off `latest` (npm's default tag for any version).
-          npm publish --provenance --access public --tag "$DIST_TAG"
+          npm publish --access public --tag "$DIST_TAG"
 
           if [ $? -eq 0 ]; then
             echo ""

--- a/.github/actions/python-maturin/post-merge/action.yml
+++ b/.github/actions/python-maturin/post-merge/action.yml
@@ -52,6 +52,21 @@ runs:
         echo "✅ Version format valid: $VERSION"
       shell: bash
 
+    - name: Validate package metadata
+      run: |
+        PACKAGE=$(python3 -c 'import tomllib; print(tomllib.load(open("foreign/python/pyproject.toml", "rb"))["project"]["name"])')
+        VERSION=$(python3 -c 'import tomllib; print(tomllib.load(open("foreign/python/pyproject.toml", "rb"))["project"]["version"])')
+
+        if [ "$PACKAGE" != "apache-iggy" ]; then
+          echo "❌ pyproject.toml project name must be apache-iggy, got: $PACKAGE"
+          exit 1
+        fi
+        if [ "$VERSION" != "${{ inputs.version }}" ]; then
+          echo "❌ pyproject.toml version ($VERSION) does not match ${{ inputs.version }}"
+          exit 1
+        fi
+      shell: bash
+
     - name: Download pre-built wheels
       uses: actions/download-artifact@v8
       with:
@@ -151,13 +166,10 @@ runs:
         echo "View on PyPI: https://pypi.org/project/apache-iggy/$VERSION/"
       shell: bash
 
-    - name: Install uv
-      if: inputs.dry_run == 'false'
-      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-
     - name: Publish to PyPI
       if: inputs.dry_run == 'false'
-      run: uv publish --check-url https://pypi.org/simple/ --token "$PYPI_API_TOKEN" ${{ inputs.wheels_path }}/*
-      shell: bash
-      env:
-        PYPI_API_TOKEN: ${{ env.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+      with:
+        packages-dir: ${{ inputs.wheels_path }}
+        skip-existing: true
+        attestations: true

--- a/.github/actions/rust/post-merge/action.yml
+++ b/.github/actions/rust/post-merge/action.yml
@@ -150,7 +150,7 @@ runs:
         initial_sleep_seconds: "1"
 
     # Publish runs WITHOUT continue-on-error so any failure that is NOT the
-    # "already uploaded" class (invalid CARGO_REGISTRY_TOKEN, 401/403, 429
+    # "already uploaded" class (trusted-publisher mismatch, 401/403, 429
     # rate limit, 5xx, Cargo.toml validation error, dependency resolution)
     # surfaces loudly with its actual error instead of getting swallowed
     # into a misleading "not on sparse index" CAS timeout ~3 min later.
@@ -176,7 +176,7 @@ runs:
         set -euo pipefail
 
         if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
-          echo "❌ CARGO_REGISTRY_TOKEN is not set"
+          echo "❌ crates.io trusted publishing did not return a token"
           exit 1
         fi
 
@@ -229,7 +229,7 @@ runs:
         echo ""
         echo "❌ cargo publish failed with rc=${rc} and no 'already uploaded' signature"
         echo "   The actual error is in the stderr above. Common causes:"
-        echo "     - invalid or expired CARGO_REGISTRY_TOKEN (401/403)"
+        echo "     - trusted publisher policy mismatch (401/403)"
         echo "     - crates.io rate limit (429)"
         echo "     - crates.io 5xx (transient, rerun should recover)"
         echo "     - Cargo.toml validation error or dependency resolution failure"

--- a/.github/workflows/_publish_rust_crates.yml
+++ b/.github/workflows/_publish_rust_crates.yml
@@ -46,9 +46,6 @@ on:
         required: false
         default: false
         description: "Skip git tag creation after successful publish (useful for re-publishing)"
-    secrets:
-      CARGO_REGISTRY_TOKEN:
-        required: true
     outputs:
       status:
         description: "Publishing status"
@@ -56,6 +53,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   IGGY_CI_BUILD: true
@@ -77,8 +75,6 @@ jobs:
   publish:
     name: Publish Rust crates
     runs-on: ubuntu-latest
-    env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     outputs:
       status: ${{ steps.final-status.outputs.status }}
     steps:
@@ -257,7 +253,28 @@ jobs:
       # an expected duration. Operators should only intervene after ~60
       # min of sustained CDN 404s on a single crate.
 
+      # crates.io trusted-publishing tokens expire 30 minutes after the
+      # exchange, and the wait-for-crate gates between crates can each run
+      # up to ~28 minutes. A single token minted before the chain would
+      # expire mid-chain on a slow CDN day, so each crate mints its own
+      # token immediately before its publish step. The export goes through
+      # GITHUB_ENV because actions/rust/post-merge reads env.CARGO_REGISTRY_TOKEN,
+      # and job-level env is the only channel that reliably reaches composite
+      # action internals; each per-crate export overwrites the previous value.
+
       # Step 1: Publish iggy_binary_protocol (depends on nothing in-tree)
+      - name: Authenticate with crates.io (iggy_binary_protocol)
+        if: inputs.dry_run == false && contains(inputs.crates, 'rust-binary-protocol')
+        id: auth-protocol
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Export crates.io token (iggy_binary_protocol)
+        if: inputs.dry_run == false && contains(inputs.crates, 'rust-binary-protocol')
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-protocol.outputs.token }}
+        run: echo "CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Publish iggy_binary_protocol
         if: inputs.dry_run == false && contains(inputs.crates, 'rust-binary-protocol')
         uses: ./.github/actions/rust/post-merge
@@ -287,6 +304,18 @@ jobs:
             Released by: GitHub Actions (workflow ${{ github.run_id }})
 
       # Step 2: Publish iggy_common (depends on iggy_binary_protocol)
+      - name: Authenticate with crates.io (iggy_common)
+        if: inputs.dry_run == false && contains(inputs.crates, 'rust-common')
+        id: auth-common
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Export crates.io token (iggy_common)
+        if: inputs.dry_run == false && contains(inputs.crates, 'rust-common')
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-common.outputs.token }}
+        run: echo "CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Publish iggy_common
         if: inputs.dry_run == false && contains(inputs.crates, 'rust-common')
         uses: ./.github/actions/rust/post-merge
@@ -316,6 +345,18 @@ jobs:
             Released by: GitHub Actions (workflow ${{ github.run_id }})
 
       # Step 3: Publish iggy SDK (depends on common and protocol)
+      - name: Authenticate with crates.io (iggy)
+        if: inputs.dry_run == false && contains(inputs.crates, 'rust-sdk')
+        id: auth-sdk
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Export crates.io token (iggy)
+        if: inputs.dry_run == false && contains(inputs.crates, 'rust-sdk')
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-sdk.outputs.token }}
+        run: echo "CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Publish iggy SDK
         if: inputs.dry_run == false && contains(inputs.crates, 'rust-sdk')
         uses: ./.github/actions/rust/post-merge
@@ -345,6 +386,18 @@ jobs:
             Released by: GitHub Actions (workflow ${{ github.run_id }})
 
       # Step 4: Publish iggy-cli (depends on SDK and protocol)
+      - name: Authenticate with crates.io (iggy-cli)
+        if: inputs.dry_run == false && contains(inputs.crates, 'rust-cli')
+        id: auth-cli
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Export crates.io token (iggy-cli)
+        if: inputs.dry_run == false && contains(inputs.crates, 'rust-cli')
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-cli.outputs.token }}
+        run: echo "CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Publish iggy-cli
         if: inputs.dry_run == false && contains(inputs.crates, 'rust-cli')
         uses: ./.github/actions/rust/post-merge

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -26,9 +26,8 @@ on:
     branches: [master]
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write
+  actions: write
+  contents: read
 
 concurrency:
   group: post-merge-${{ github.ref }}
@@ -145,22 +144,66 @@ jobs:
           echo "sdks_to_publish=$SDKS_TO_PUBLISH" >> "$GITHUB_OUTPUT"
           echo "SDKs to publish: ${SDKS_TO_PUBLISH:-<none>}"
 
-  call-publish:
-    name: Publish components
+  dispatch-publish:
+    name: Dispatch publisher
     needs: check-auto-publish
     if: >-
       needs.check-auto-publish.outputs.crates_to_publish != '' ||
       needs.check-auto-publish.outputs.docker_components != '' ||
       needs.check-auto-publish.outputs.sdks_to_publish != ''
-    uses: ./.github/workflows/publish.yml
-    with:
-      commit: ${{ github.sha }}
-      dry_run: false
-      use_latest_ci: false
-      skip_tag_creation: false
-      publish_crates: ${{ needs.check-auto-publish.outputs.crates_to_publish }}
-      publish_dockerhub: ${{ needs.check-auto-publish.outputs.docker_components }}
-      publish_other: ${{ needs.check-auto-publish.outputs.sdks_to_publish }}
-      create_edge_docker_tag: true
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      # Trusted publishers validate the top-level workflow identity. Dispatching
+      # publish.yml keeps automatic and manual releases on the same identity.
+      - name: Dispatch and wait for publish workflow
+        uses: actions/github-script@v9
+        env:
+          COMMIT: ${{ github.sha }}
+          PUBLISH_CRATES: ${{ needs.check-auto-publish.outputs.crates_to_publish }}
+          PUBLISH_DOCKERHUB: ${{ needs.check-auto-publish.outputs.docker_components }}
+          PUBLISH_OTHER: ${{ needs.check-auto-publish.outputs.sdks_to_publish }}
+        with:
+          script: |
+            const dispatch = await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'publish.yml',
+              ref: 'master',
+              inputs: {
+                commit: process.env.COMMIT,
+                dry_run: 'false',
+                use_latest_ci: 'false',
+                skip_tag_creation: 'false',
+                publish_crates: process.env.PUBLISH_CRATES,
+                publish_dockerhub: process.env.PUBLISH_DOCKERHUB,
+                publish_other: process.env.PUBLISH_OTHER,
+                create_edge_docker_tag: 'true'
+              },
+              headers: {
+                'X-GitHub-Api-Version': '2026-03-10'
+              }
+            });
 
+            const runId = dispatch.data.workflow_run_id;
+            if (!runId) {
+              throw new Error('Workflow dispatch did not return a run ID');
+            }
+
+            core.info(`Publish run: ${dispatch.data.html_url}`);
+            while (true) {
+              const { data: run } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId
+              });
+
+              if (run.status === 'completed') {
+                if (run.conclusion !== 'success') {
+                  throw new Error(`Publish workflow concluded with ${run.conclusion}: ${run.html_url}`);
+                }
+                core.info(`Publish workflow succeeded: ${run.html_url}`);
+                break;
+              }
+
+              await new Promise(resolve => setTimeout(resolve, 30000));
+            }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,62 +53,11 @@ on:
         type: string
         required: false
         default: ""
-
-  workflow_call:
-    inputs:
-      dry_run:
-        description: "Dry run (build/test only, no actual publish)"
-        type: boolean
-        default: false
-      commit:
-        description: "Commit SHA (defaults to github.sha)"
-        type: string
-        default: ""
-      publish_crates:
-        description: "Rust crates to publish (comma-separated)"
-        type: string
-        default: ""
-      publish_dockerhub:
-        description: "Docker images to publish (comma-separated)"
-        type: string
-        default: ""
-      publish_other:
-        description: "Other SDKs to publish (comma-separated)"
-        type: string
-        default: ""
-      skip_tag_creation:
-        description: "Skip git tag creation"
-        type: boolean
-        default: false
-      use_latest_ci:
-        description: "Use latest CI from master"
-        type: boolean
-        default: false
       create_edge_docker_tag:
-        description: "Create rolling :edge Docker tag"
+        description: "Create rolling :edge Docker tag (used by post-merge automation)"
         type: boolean
+        required: false
         default: false
-    secrets:
-      CARGO_REGISTRY_TOKEN:
-        required: false
-      DOCKERHUB_USER:
-        required: false
-      DOCKERHUB_TOKEN:
-        required: false
-      PYPI_API_TOKEN:
-        required: false
-      NPM_TOKEN:
-        required: false
-      NEXUS_USER:
-        required: false
-      NEXUS_PW:
-        required: false
-      JAVA_GPG_SIGNING_KEY:
-        required: false
-      JAVA_GPG_PASSWORD:
-        required: false
-      NUGET_API_KEY:
-        required: false
 
 env:
   IGGY_CI_BUILD: true
@@ -116,7 +65,6 @@ env:
 permissions:
   contents: write # For tag creation
   packages: write
-  id-token: write
 
 # Static group so two concurrent release dispatches cannot race the
 # crates.io / Maven Central / npm / NuGet / DockerHub / PyPI uploads.
@@ -134,34 +82,10 @@ jobs:
     outputs:
       commit: ${{ steps.resolve.outputs.commit }}
       has_targets: ${{ steps.check.outputs.has_targets }}
-      is_workflow_call: ${{ steps.detect.outputs.is_workflow_call }}
     steps:
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-
-      # Detect whether we are invoked via workflow_call (reusable) or
-      # workflow_dispatch (manual). Trust chain: when called via
-      # workflow_call, the caller is responsible for having validated its
-      # own trigger — the only in-tree caller today is
-      # .github/workflows/post-merge.yml, which is branch-filtered to
-      # master, so the SHA passed in is by construction a commit on
-      # master. Direct workflow_dispatch callers have no such guarantee
-      # and must pass through the master-ancestry check in Resolve
-      # commit below. Any future direct workflow_call caller added to
-      # this repo must preserve the master-ancestry property or the
-      # branch gate below will not apply to them.
-      - name: Detect trigger type
-        id: detect
-        run: |
-          # workflow_call sets github.event_name to 'workflow_call'
-          if [ "${{ github.event_name }}" = "workflow_call" ]; then
-            echo "is_workflow_call=true" >> "$GITHUB_OUTPUT"
-            echo "📞 Triggered via workflow_call"
-          else
-            echo "is_workflow_call=false" >> "$GITHUB_OUTPUT"
-            echo "🖱️ Triggered via workflow_dispatch"
-          fi
 
       - name: Check if any targets specified
         id: check
@@ -178,7 +102,6 @@ jobs:
         id: resolve
         env:
           INPUT_COMMIT: ${{ inputs.commit }}
-          IS_WORKFLOW_CALL: ${{ steps.detect.outputs.is_workflow_call }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
@@ -206,10 +129,7 @@ jobs:
           fi
           COMMIT="$FULL_SHA"
 
-          # Skip master branch check for workflow_call (caller already verified on master)
-          if [ "$IS_WORKFLOW_CALL" = "true" ]; then
-            echo "✅ Called from workflow, skipping master check"
-          elif [ "$DRY_RUN" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             echo "🌵 Dry run, skipping master branch check"
           else
             echo "🔍 Verifying commit is on master branch..."
@@ -719,14 +639,15 @@ jobs:
       needs.validate.outputs.has_targets == 'true' &&
       contains(inputs.publish_crates, 'rust-')
     uses: ./.github/workflows/_publish_rust_crates.yml
+    permissions:
+      contents: write
+      id-token: write
     with:
       crates: ${{ inputs.publish_crates }}
       dry_run: ${{ inputs.dry_run }}
       commit: ${{ needs.validate.outputs.commit }}
       use_latest_ci: ${{ inputs.use_latest_ci }}
       skip_tag_creation: ${{ inputs.skip_tag_creation }}
-    secrets:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Docker publishing on native runners (no QEMU emulation)
   publish-docker:
@@ -1046,18 +967,17 @@ jobs:
       (needs.build-python-wheels.result == 'success' || needs.build-python-wheels.result == 'skipped') &&
       (needs.publish-rust-crates.result == 'success' || needs.publish-rust-crates.result == 'skipped')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.non_docker_targets) }}
     env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       NEXUS_USER: ${{ secrets.NEXUS_USER }}
       NEXUS_PW: ${{ secrets.NEXUS_PW }}
       JAVA_GPG_SIGNING_KEY: ${{ secrets.JAVA_GPG_SIGNING_KEY }}
       JAVA_GPG_PASSWORD: ${{ secrets.JAVA_GPG_PASSWORD }}
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       DRY_RUN: ${{ inputs.dry_run }}
     outputs:
       status: ${{ steps.status.outputs.status }}


### PR DESCRIPTION
Cargo, npm, PyPI, and NuGet publishing depended on long-lived
repository secrets that required rotation and expanded credential
exposure.

Authenticate each registry through GitHub OIDC and short-lived
credentials. Route automatic releases through publish.yml so manual
and version-triggered publishes use the same trusted workflow
identity.