### PR TITLE
fix(server): restore get_user self-read without read_users permission

### DIFF
--- a/core/integration/tests/server/scenarios/permissions_scenario.rs
+++ b/core/integration/tests/server/scenarios/permissions_scenario.rs
@@ -235,6 +235,24 @@ async fn test_no_permissions(harness: &TestHarness, root_client: &IggyClient) {
         "snapshot must be rejected as unauthorized without read_servers, got {snapshot_result:?}"
     );
 
+    // Self-read skips read_users, matching the legacy server: a user can
+    // always fetch its own account, by name or by numeric id, while any
+    // other target stays gated.
+    let own_details = client
+        .get_user(&Identifier::named(USER).unwrap())
+        .await
+        .expect("get_user: self by name should work without read_users")
+        .expect("self user should exist");
+    client
+        .get_user(&Identifier::numeric(own_details.id).unwrap())
+        .await
+        .expect("get_user: self by id should work without read_users")
+        .expect("self user should exist");
+    assert_unauthorized(
+        client.get_user(&Identifier::numeric(0).unwrap()).await,
+        "get_user: other user",
+    );
+
     delete_test_user(root_client, USER).await;
 }
 

--- a/core/metadata/src/stm/user.rs
+++ b/core/metadata/src/stm/user.rs
@@ -129,7 +129,10 @@ collect_handlers! {
 }
 
 impl UsersInner {
-    pub(crate) fn resolve_user_id(&self, identifier: &WireIdentifier) -> Option<usize> {
+    /// Resolve a wire user identifier to its committed slab id, `None` when
+    /// the user does not exist.
+    #[must_use]
+    pub fn resolve_user_id(&self, identifier: &WireIdentifier) -> Option<usize> {
         match identifier {
             WireIdentifier::Numeric(id) => {
                 let id = *id as usize;

--- a/core/server/src/dispatch/authz.rs
+++ b/core/server/src/dispatch/authz.rs
@@ -38,6 +38,7 @@ use iggy_binary_protocol::requests::consumer_groups::{
 };
 use iggy_binary_protocol::requests::streams::GetStreamRequest;
 use iggy_binary_protocol::requests::topics::{GetTopicRequest, GetTopicsRequest};
+use iggy_binary_protocol::requests::users::GetUserRequest;
 use iggy_binary_protocol::{
     Operation, PrepareHeader, RoutedRequestHeader, WireDecode, WireIdentifier,
 };
@@ -280,7 +281,7 @@ where
     match code {
         GET_STATS_CODE => authorize_uid(shard, user_id, Permissioner::get_stats),
         GET_USERS_CODE => authorize_uid(shard, user_id, Permissioner::get_users),
-        GET_USER_CODE => authorize_uid(shard, user_id, Permissioner::get_user),
+        GET_USER_CODE => gate_user_scoped(shard, user_id, body),
         // Self-scoped: lists only the caller's own tokens, so there is no
         // permissioner rule to run (legacy runs none either).
         GET_PERSONAL_ACCESS_TOKENS_CODE => user_id.map(|_| ()).ok_or(IggyError::Unauthenticated),
@@ -368,6 +369,43 @@ pub(super) async fn send_non_replicated_deny<B, MJ, S, SB>(
             "failed to surface non-replicated authz denial"
         );
     }
+}
+
+/// Gate `GET_USER`: decode the request and resolve its target against the
+/// committed users STM. A target resolving to the caller passes without any
+/// permissioner rule, matching the legacy server, which skipped `read_users`
+/// when a user fetched its own account. A malformed body or a resolution miss
+/// returns `Ok(())` so the builder's own error / not-found reply holds
+/// (decode-and-notfound-before-permission); any other target runs
+/// [`Permissioner::get_user`].
+fn gate_user_scoped<B, MJ, S, SB>(
+    shard: &Rc<ShellShard<B, MJ, S, SB>>,
+    user_id: Option<u32>,
+    body: &[u8],
+) -> Result<(), IggyError>
+where
+    B: ShellBus,
+    MJ: JournalHandle + 'static,
+    MJ::Target: Journal<MJ::Storage, Entry = Message<PrepareHeader>, Header = PrepareHeader>,
+    S: 'static,
+    SB: SuperblockStore + 'static,
+{
+    let Ok(request) = GetUserRequest::decode_from(body) else {
+        return Ok(());
+    };
+    let Some(target_id) = shard
+        .plane
+        .metadata()
+        .mux_stm
+        .users()
+        .read(|users| users.resolve_user_id(&request.user_id))
+    else {
+        return Ok(());
+    };
+    if user_id.is_some_and(|caller_id| caller_id as usize == target_id) {
+        return Ok(());
+    }
+    authorize_uid(shard, user_id, Permissioner::get_user)
 }
 
 /// Gate a stream-scoped read: decode the request, project its wire stream id,

--- a/core/server/src/http/handlers.rs
+++ b/core/server/src/http/handlers.rs
@@ -130,7 +130,7 @@ use crate::http::error::{
 use crate::http::extractor::{Authenticated, Identity};
 use crate::http::reads::{
     authorize_data_plane, authorize_read, read_local, resolve_gate_stream, resolve_gate_topic,
-    resolve_gate_topic_ids,
+    resolve_gate_topic_ids, resolve_gate_user,
 };
 use crate::http::reply::{
     committed_payload, decode_consumer_group_details, decode_raw_pat_token, decode_stream_details,
@@ -456,22 +456,22 @@ pub(in crate::http) async fn get_users(
 
 /// `GET /users/{user_id}`: fetch one user by numeric id or name as the same
 /// `UserInfoDetails` JSON the legacy server returns; 404 when absent. A
-/// consensus-free local STM read via [`read_local`]. [`CURRENT_USER_ALIAS`]
-/// resolves to the caller and skips the `read_users` gate, mirroring the
-/// legacy self-read bypass.
+/// consensus-free local STM read via [`read_local`]. Any target resolving to
+/// the caller - [`CURRENT_USER_ALIAS`], own id, own username - skips the
+/// `read_users` gate, mirroring the legacy self-read bypass.
 pub(in crate::http) async fn get_user(
     State(state): State<HttpState>,
     identity: Identity,
     Path(user_id): Path<String>,
     Query(query): Query<ConsistencyQuery>,
 ) -> Result<Json<UserInfoDetails>, ReadError> {
-    let is_self = user_id == CURRENT_USER_ALIAS;
-    let wire_user_id = if is_self {
+    let wire_user_id = if user_id == CURRENT_USER_ALIAS {
         WireIdentifier::numeric(identity.user_id)
     } else {
         let user_id = Identifier::from_str_value(&user_id).map_err(ReadError::Rejected)?;
         identifier_to_wire(&user_id).map_err(ReadError::Rejected)?
     };
+    let is_self = resolve_gate_user(&state, &wire_user_id) == Some(identity.user_id as usize);
     let request = GetUserRequest {
         user_id: wire_user_id,
     };

--- a/core/server/src/http/reads.rs
+++ b/core/server/src/http/reads.rs
@@ -209,6 +209,21 @@ pub(in crate::http) fn resolve_gate_stream(
         .read(|inner| resolve_stream_id(inner, stream_id))
 }
 
+/// Resolve a wire user identifier to its committed slab id, or `None` on a
+/// miss. Mirrors the TCP dispatch gate's self-read resolution.
+pub(in crate::http) fn resolve_gate_user(
+    state: &HttpInner,
+    user_id: &WireIdentifier,
+) -> Option<usize> {
+    state
+        .shard
+        .plane
+        .metadata()
+        .mux_stm
+        .users()
+        .read(|inner| inner.resolve_user_id(user_id))
+}
+
 /// Resolve a wire (stream, topic) pair to committed slab ids, or `None` if
 /// either misses.
 pub(in crate::http) fn resolve_gate_topic(

--- a/core/server/src/responses.rs
+++ b/core/server/src/responses.rs
@@ -1141,14 +1141,7 @@ where
     SB: SuperblockStore + 'static,
 {
     shard.plane.metadata().mux_stm.users().read(|users| {
-        let resolved = match user_id {
-            WireIdentifier::Numeric(id) => {
-                let id = *id as usize;
-                users.items.contains(id).then_some(id)
-            }
-            WireIdentifier::String(name) => users.index.get(name.as_str()).map(|&id| id as usize),
-        };
-        let Some(id) = resolved else {
+        let Some(id) = users.resolve_user_id(user_id) else {
             return Ok(None);
         };
         let user = users.items.get(id).ok_or(IggyError::InvalidIdentifier)?;


### PR DESCRIPTION
The legacy server skipped the read_users check when a user fetched
its own account. The server-ng promotion (#3856) gated GET_USER
unconditionally on the binary path, and the HTTP route kept the
bypass only for the "me" alias, so a user without read_users could
no longer fetch itself by id or name. Reported under #3733.

Resolve the target against the committed users STM in the dispatch
gate and the HTTP route; a target resolving to the caller passes
without a permissioner rule, any other target still requires
read_users. A resolution miss keeps the notfound-before-permission
ordering, matching legacy and the other identifier-scoped reads.
