### PR TITLE
fix(ci): restore Docker and PyPI releases

### DIFF
--- a/.github/actions/python-maturin/post-merge/action.yml
+++ b/.github/actions/python-maturin/post-merge/action.yml
@@ -165,11 +165,3 @@ runs:
         echo ""
         echo "View on PyPI: https://pypi.org/project/apache-iggy/$VERSION/"
       shell: bash
-
-    - name: Publish to PyPI
-      if: inputs.dry_run == 'false'
-      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
-      with:
-        packages-dir: ${{ inputs.wheels_path }}
-        skip-existing: true
-        attestations: true

--- a/.github/actions/utils/docker-buildx/action.yml
+++ b/.github/actions/utils/docker-buildx/action.yml
@@ -130,12 +130,12 @@ runs:
     - name: Set up QEMU
       # Skip QEMU when building single platform on native runner (no emulation needed)
       if: inputs.platform == ''
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       with:
         platforms: all
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       with:
         driver-opts: |
           network=host
@@ -167,7 +167,7 @@ runs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       with:
         images: ${{ steps.config.outputs.image }}
         # Tags are only used for local builds (dry-run). Push mode always uses digest.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -974,10 +974,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.non_docker_targets) }}
     env:
-      NEXUS_USER: ${{ secrets.NEXUS_USER }}
-      NEXUS_PW: ${{ secrets.NEXUS_PW }}
-      JAVA_GPG_SIGNING_KEY: ${{ secrets.JAVA_GPG_SIGNING_KEY }}
-      JAVA_GPG_PASSWORD: ${{ secrets.JAVA_GPG_PASSWORD }}
       DRY_RUN: ${{ inputs.dry_run }}
     outputs:
       status: ${{ steps.status.outputs.status }}
@@ -1083,6 +1079,14 @@ jobs:
           wheels_artifact: python-wheels-all
           wheels_path: dist
 
+      - name: Upload Python SDK to PyPI
+        if: matrix.type == 'python' && inputs.dry_run == false
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true
+          attestations: true
+
       # ─────────────────────────────────────────
       # Node SDK Publishing
       # ─────────────────────────────────────────
@@ -1099,6 +1103,11 @@ jobs:
       - name: Publish Java SDK
         if: matrix.type == 'java'
         uses: ./.github/actions/java-gradle/post-merge
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PW: ${{ secrets.NEXUS_PW }}
+          JAVA_GPG_SIGNING_KEY: ${{ secrets.JAVA_GPG_SIGNING_KEY }}
+          JAVA_GPG_PASSWORD: ${{ secrets.JAVA_GPG_PASSWORD }}
         with:
           version: ${{ steps.ver.outputs.version }}
           dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
Docker jobs were rejected before startup because their pinned action
SHAs were absent from the current ASF allowlist. PyPI publishing
nested its container action inside Iggy's composite action, causing
it to resolve ghcr.io/apache/iggy:master instead of the publisher
image.

Pin Docker actions to approved revisions and invoke the PyPI
publisher directly from publish.yml. Scope Maven credentials to the
Java step so unrelated SDK jobs cannot receive them.