### PR TITLE
fix(cli): bound ping retries, macOS boot smoke, java PAT expiry

### DIFF
--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -394,6 +394,40 @@ runs:
       run: cargo build --locked
       shell: bash
 
+    # macOS is build-only everywhere else in CI, so runtime regressions in the
+    # non-Linux driver path (kqueue instead of io_uring) would ship unnoticed.
+    # Boot the freshly built server and ping it over TCP; ping is pre-auth so
+    # no credentials are needed. The retry flags keep each attempt bounded
+    # regardless of CLI reconnection defaults, so a dead server fails the
+    # step fast instead of hanging until the job timeout.
+    - name: Smoke test iggy-server boot on macOS
+      if: inputs.task == 'build-macos-aarch64'
+      run: |
+        target/debug/iggy-server --fresh > server-boot.log 2>&1 &
+        SERVER_PID=$!
+        trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+        for _ in $(seq 1 30); do
+          if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "::error::iggy-server exited before answering ping"
+            cat server-boot.log
+            exit 1
+          fi
+          if target/debug/iggy \
+              --tcp-reconnection-max-retries 1 \
+              --tcp-reconnection-interval 500ms \
+              ping; then
+            echo "Server booted and answered ping"
+            exit 0
+          fi
+          sleep 2
+        done
+
+        echo "::error::iggy-server did not answer ping within 60s"
+        cat server-boot.log
+        exit 1
+      shell: bash
+
     # Windows builds (SDK and CLI only - iggy-server does not support Windows)
     - name: Build Windows SDK and CLI
       if: inputs.task == 'build-windows-sdk'

--- a/core/common/src/types/args/mod.rs
+++ b/core/common/src/types/args/mod.rs
@@ -78,7 +78,7 @@ pub struct ArgsOptional {
 
     /// The optional number of max reconnect retries for the TCP transport
     ///
-    /// [default: 3]
+    /// [default: 10]
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tcp_reconnection_max_retries: Option<u32>,
@@ -125,7 +125,7 @@ pub struct ArgsOptional {
 
     /// The optional number of max reconnect retries for the QUIC transport
     ///
-    /// [default: 3]
+    /// [default: 10]
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quic_reconnection_max_retries: Option<u32>,
@@ -207,7 +207,7 @@ pub struct ArgsOptional {
 
     /// The optional number of max reconnect retries for the WebSocket transport
     ///
-    /// [default: 3]
+    /// [default: 10]
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub websocket_reconnection_max_retries: Option<u32>,
@@ -381,7 +381,7 @@ impl Default for Args {
             password: DEFAULT_ROOT_PASSWORD.to_string(),
             tcp_server_address: "127.0.0.1:8090".to_string(),
             tcp_reconnection_enabled: true,
-            tcp_reconnection_max_retries: None,
+            tcp_reconnection_max_retries: Some(10),
             tcp_reconnection_interval: "1s".to_string(),
             tcp_reconnection_reestablish_after: "5s".to_string(),
             tcp_heartbeat_interval: "5s".to_string(),
@@ -393,7 +393,7 @@ impl Default for Args {
             quic_server_address: "127.0.0.1:8080".to_string(),
             quic_server_name: "localhost".to_string(),
             quic_reconnection_enabled: true,
-            quic_reconnection_max_retries: None,
+            quic_reconnection_max_retries: Some(10),
             quic_reconnection_interval: "1s".to_string(),
             quic_reconnection_reestablish_after: "5s".to_string(),
             quic_max_concurrent_bidi_streams: 10000,
@@ -408,7 +408,7 @@ impl Default for Args {
             quic_heartbeat_interval: "5s".to_string(),
             websocket_server_address: "127.0.0.1:8092".to_string(),
             websocket_reconnection_enabled: true,
-            websocket_reconnection_max_retries: None,
+            websocket_reconnection_max_retries: Some(10),
             websocket_reconnection_interval: "1s".to_string(),
             websocket_reconnection_reestablish_after: "5s".to_string(),
             websocket_heartbeat_interval: "5s".to_string(),

--- a/core/integration/tests/cli/general/test_help_command.rs
+++ b/core/integration/tests/cli/general/test_help_command.rs
@@ -93,7 +93,7 @@ Options:
       --tcp-reconnection-max-retries <TCP_RECONNECTION_MAX_RETRIES>
           The optional number of max reconnect retries for the TCP transport
 {CLAP_INDENT}
-          [default: 3]
+          [default: 10]
 
       --tcp-reconnection-interval <TCP_RECONNECTION_INTERVAL>
           The optional reconnect interval for the TCP transport
@@ -126,7 +126,7 @@ Options:
       --quic-reconnection-max-retries <QUIC_RECONNECTION_MAX_RETRIES>
           The optional number of max reconnect retries for the QUIC transport
 {CLAP_INDENT}
-          [default: 3]
+          [default: 10]
 
       --quic-reconnection-interval <QUIC_RECONNECTION_INTERVAL>
           The optional reconnect interval for the QUIC transport
@@ -184,7 +184,7 @@ Options:
       --websocket-reconnection-max-retries <WEBSOCKET_RECONNECTION_MAX_RETRIES>
           The optional number of max reconnect retries for the WebSocket transport
 {CLAP_INDENT}
-          [default: 3]
+          [default: 10]
 
       --websocket-reconnection-interval <WEBSOCKET_RECONNECTION_INTERVAL>
           The optional reconnect interval for the WebSocket transport

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/async/PersonalAccessTokensClient.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/async/PersonalAccessTokensClient.java
@@ -24,6 +24,7 @@ import org.apache.iggy.personalaccesstoken.RawPersonalAccessToken;
 import org.apache.iggy.user.IdentityInfo;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -36,10 +37,23 @@ public interface PersonalAccessTokensClient {
      * Creates a new personal access token asynchronously.
      *
      * @param name The name of the token
-     * @param expiry The expiration time in seconds (0 for no expiration)
+     * @param expiry The token lifetime in microseconds, the wire unit
+     *     (0 for the server default, u64 max for no expiration)
      * @return A CompletableFuture containing the created raw personal access token
      */
     CompletableFuture<RawPersonalAccessToken> createPersonalAccessToken(String name, BigInteger expiry);
+
+    /**
+     * Creates a new personal access token asynchronously, converting the
+     * lifetime to the wire's microsecond unit.
+     *
+     * @param name The name of the token
+     * @param expiry The token lifetime
+     * @return A CompletableFuture containing the created raw personal access token
+     */
+    default CompletableFuture<RawPersonalAccessToken> createPersonalAccessToken(String name, Duration expiry) {
+        return createPersonalAccessToken(name, BigInteger.valueOf(expiry.toNanos() / 1_000));
+    }
 
     /**
      * Gets all personal access tokens asynchronously.

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/blocking/PersonalAccessTokensClient.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/client/blocking/PersonalAccessTokensClient.java
@@ -24,11 +24,32 @@ import org.apache.iggy.personalaccesstoken.RawPersonalAccessToken;
 import org.apache.iggy.user.IdentityInfo;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.List;
 
 public interface PersonalAccessTokensClient {
 
+    /**
+     * Creates a new personal access token.
+     *
+     * @param name The name of the token
+     * @param expiry The token lifetime in microseconds, the wire unit
+     *     (0 for the server default, u64 max for no expiration)
+     * @return The created raw personal access token
+     */
     RawPersonalAccessToken createPersonalAccessToken(String name, BigInteger expiry);
+
+    /**
+     * Creates a new personal access token, converting the lifetime to the
+     * wire's microsecond unit.
+     *
+     * @param name The name of the token
+     * @param expiry The token lifetime
+     * @return The created raw personal access token
+     */
+    default RawPersonalAccessToken createPersonalAccessToken(String name, Duration expiry) {
+        return createPersonalAccessToken(name, BigInteger.valueOf(expiry.toNanos() / 1_000));
+    }
 
     List<PersonalAccessTokenInfo> getPersonalAccessTokens();
 

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/PersonalAccessTokensBaseTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/PersonalAccessTokensBaseTest.java
@@ -23,7 +23,7 @@ import org.apache.iggy.user.IdentityInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigInteger;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,8 +51,7 @@ public abstract class PersonalAccessTokensBaseTest extends IntegrationTest {
     @Test
     void shouldManagePersonalAccessTokens() {
         // when
-        var createdToken =
-                personalAccessTokensClient.createPersonalAccessToken("new-token", BigInteger.valueOf(50_000));
+        var createdToken = personalAccessTokensClient.createPersonalAccessToken("new-token", Duration.ofHours(1));
 
         // then
         assertThat(createdToken).isNotNull();
@@ -75,8 +74,7 @@ public abstract class PersonalAccessTokensBaseTest extends IntegrationTest {
     @Test
     void shouldCreateAndLogInWithPersonalAccessToken() {
         // given
-        var createdToken =
-                personalAccessTokensClient.createPersonalAccessToken("new-token", BigInteger.valueOf(50_000));
+        var createdToken = personalAccessTokensClient.createPersonalAccessToken("new-token", Duration.ofHours(1));
         client.users().logout();
 
         // when


### PR DESCRIPTION
The CLI help promised "[default: 3]" reconnect retries for
tcp/quic/websocket, but the resolved default was None, which the
SDK treats as unlimited: a bare `iggy ping` against a dead server
hung forever. Default to 10 retries; explicit flags still override
and SDK programmatic clients keep unlimited reconnect.

The macOS CI job only compiled the workspace, so regressions in
the non-Linux runtime path (kqueue instead of io_uring) could ship
unnoticed. Boot the freshly built server and poll it with a
pre-auth `iggy ping`, with bounded retries so a dead server fails
the step fast instead of eating the job timeout.

Also fixes the flaky Java PAT test: expiry is microseconds on the
wire, and the test sent a raw 50_000 = a 50 ms token that expired
before login on slow runners. The SDK now offers a Duration
overload converting to the wire unit; the test uses 1 hour.