### PR TITLE
test(integration): add SIGKILL crash-durability cluster tests

### DIFF
--- a/core/consensus/src/client_table.rs
+++ b/core/consensus/src/client_table.rs
@@ -101,7 +101,7 @@ pub const CLIENTS_TABLE_SLOT_MAX: usize = 1 << 16;
 /// original bytes instead of a bare "already applied"; losing one
 /// degrades the answer, never correctness. In-memory only: ring contents are
 /// refcount bumps and are never persisted or transferred.
-const REPLY_RING_CAPACITY: usize = 5;
+pub const REPLY_RING_CAPACITY: usize = 5;
 
 /// Per-session entry: fence epoch + committed-request watermark + replies.
 ///

--- a/core/integration/src/harness/disk.rs
+++ b/core/integration/src/harness/disk.rs
@@ -1,0 +1,478 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! On-disk oracles over a node's data directory: segment walkers, cross-replica
+//! byte comparison, consumer-offset and superblock readers, and cluster-role
+//! lookups. Several older test files still hold local copies of these helpers;
+//! consolidating them onto this module is a follow-up.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use consensus::VsrState;
+use iggy::prelude::{ClusterClient, ClusterNodeRole};
+use journal::superblock::{SLOT_FILE_NAMES, SuperblockContents, decode_slots};
+use tokio::time::sleep;
+
+use super::TestHarness;
+
+// Poll the per-node segment `.log` sizes until they agree and hold steady,
+// instead of a fixed sleep: a fixed wait either flakes under CI load or hides a
+// real replication lag.
+const CONVERGENCE_POLL_INTERVAL: Duration = Duration::from_millis(200);
+const CONVERGENCE_DEADLINE: Duration = Duration::from_secs(20);
+const CONVERGENCE_STABLE_POLLS: u32 = 3;
+
+/// A partition segment `.log`, named for its 20-digit zero-padded base offset
+/// (see `partitions::state_transfer`'s path builders).
+///
+/// Matches the segment file NAME shape, not the `.log` extension alone and not
+/// a `streams/` path prefix: the server's own text log sits under the same data
+/// root, so an extension-only match would count tracing output as segment data.
+pub fn is_segment_log(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "log")
+        && path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| stem.len() == 20 && stem.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+/// Depth-first walk of `root`, skipping the `metadata` plane, returning the
+/// first path for which `matches` is true. Callers wanting a full sweep return
+/// `false` from `matches` and accumulate via its side effects.
+pub fn walk(root: &Path, matches: &mut dyn FnMut(&Path) -> bool) -> Option<PathBuf> {
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        if dir.file_name().is_some_and(|name| name == "metadata") {
+            continue;
+        }
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if matches(&path) {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// `Ok(())` when every payload in `expected` appears in node-local segment
+/// bytes at a non-decreasing position, otherwise the first discrepancy.
+pub fn installed_payloads_complete(data_path: &Path, expected: &[String]) -> Result<(), String> {
+    let mut chain = Vec::new();
+    let mut paths = Vec::new();
+    let _ = walk(data_path, &mut |path| {
+        if is_segment_log(path) {
+            paths.push(path.to_path_buf());
+        }
+        false
+    });
+    // Segment files are named for their zero-padded base offset, so lexical
+    // order is offset order.
+    paths.sort();
+    for path in paths {
+        let Ok(bytes) = fs::read(&path) else {
+            return Err(format!("{} could not be read", path.display()));
+        };
+        chain.extend_from_slice(&bytes);
+    }
+    let mut searched_from = 0;
+    for payload in expected {
+        let found = chain[searched_from..]
+            .windows(payload.len())
+            .enumerate()
+            .filter(|(_, window)| *window == payload.as_bytes())
+            .map(|(offset, _)| searched_from + offset)
+            // A bare find would match `message-1` inside `message-10`; skip
+            // digit-extended matches and take the next occurrence instead of
+            // rejecting the payload outright (the follow byte of a genuine
+            // match can itself be a digit, e.g. inside a following header).
+            .find(|start| {
+                chain
+                    .get(start + payload.len())
+                    .is_none_or(|byte| !byte.is_ascii_digit())
+            });
+        let Some(start) = found else {
+            return Err(format!(
+                "{payload:?} is absent from the {} installed bytes after position {searched_from}",
+                chain.len()
+            ));
+        };
+        searched_from = start;
+    }
+    Ok(())
+}
+
+/// A file (relative to a node's data dir) whose bytes must match across
+/// replicas: the partition segment `.log`, plus the replicated metadata WAL
+/// when `include_wal` is set. Per-node files (logs, runtime, config, stdout)
+/// are excluded by construction.
+///
+/// Callers default `include_wal` to false: WAL byte content legitimately
+/// diverges across replicas once a node crosses its checkpoint margin, so only
+/// runs kept well below that margin may compare it. Two metadata-plane files
+/// are always excluded as local, per-replica artifacts:
+///
+/// - `metadata/snapshot.bin`: a local compaction artifact stamped with
+///   `created_at = now()` and a per-replica `sequence_number`, plus unsorted
+///   hashmap iteration order; it can never match across replicas.
+/// - `state/`: not populated by the VSR plane; excluded for the same
+///   local-artifact reason so it cannot start flaking if that changes.
+///
+/// The segment `.index` is excluded for the same class of reason: a local
+/// sparse index (one entry per persist flush), not replicated and not part of
+/// the VSR hash chain; recovery rebuilds it from the `.log`. Its length tracks
+/// commit cadence, which differs between primary (one flush per op) and backup
+/// (one flush per committed heartbeat range).
+fn is_comparable(rel: &str, include_wal: bool) -> bool {
+    let is_segment = rel.starts_with("streams/") && rel.ends_with(".log");
+    let is_metadata_wal = rel == "metadata/journal.wal";
+    is_segment || (include_wal && is_metadata_wal)
+}
+
+/// Every comparable file under `root`, keyed by its `/`-separated relative path.
+pub fn collect_comparable_files(root: &Path, include_wal: bool) -> BTreeMap<String, Vec<u8>> {
+    let mut files = BTreeMap::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file()
+                && let Ok(rel) = path.strip_prefix(root)
+            {
+                let rel = rel.to_string_lossy().replace('\\', "/");
+                if is_comparable(&rel, include_wal) {
+                    let bytes = fs::read(&path)
+                        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+                    files.insert(rel, bytes);
+                }
+            }
+        }
+    }
+    files
+}
+
+/// Byte-compare every comparable file across the given node data dirs,
+/// panicking with a per-file diff on any divergence.
+///
+/// Guards against a vacuous pass: node 0 must hold at least one produced
+/// segment, otherwise nothing was persisted and the comparison proves nothing.
+pub fn assert_replica_data_identical(data_paths: &[PathBuf], include_wal: bool) {
+    let per_node: Vec<BTreeMap<String, Vec<u8>>> = data_paths
+        .iter()
+        .map(|root| collect_comparable_files(root, include_wal))
+        .collect();
+
+    for (idx, node) in per_node.iter().enumerate() {
+        eprintln!(
+            "node {idx}: {} comparable file(s): {:?}",
+            node.len(),
+            node.iter()
+                .map(|(rel, bytes)| format!("{rel} ({} B)", bytes.len()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    let node0 = &per_node[0];
+    assert!(
+        node0
+            .keys()
+            .any(|k| k.starts_with("streams/") && k.ends_with(".log")),
+        "node 0 holds no segment .log under streams/ - no partition data was persisted, \
+         so the cross-replica comparison would be vacuous. Comparable files: {:?}",
+        node0.keys().collect::<Vec<_>>()
+    );
+
+    let all_keys: BTreeSet<&str> = per_node
+        .iter()
+        .flat_map(|node| node.keys().map(String::as_str))
+        .collect();
+
+    let mut problems = Vec::new();
+    for key in all_keys {
+        let mut reference: Option<(usize, &[u8])> = None;
+        for (idx, node) in per_node.iter().enumerate() {
+            let Some(bytes) = node.get(key) else {
+                problems.push(format!(
+                    "`{key}` present on some replicas but MISSING on node {idx}"
+                ));
+                continue;
+            };
+            let bytes: &[u8] = bytes;
+            match reference {
+                None => reference = Some((idx, bytes)),
+                Some((ref_idx, ref_bytes)) => {
+                    if bytes != ref_bytes {
+                        problems.push(describe_mismatch(key, ref_idx, ref_bytes, idx, bytes));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "cross-replica data divergence ({} issue(s)):\n{}",
+        problems.len(),
+        problems.join("\n")
+    );
+}
+
+/// Human-readable first-difference report for one relative path across two nodes.
+pub fn describe_mismatch(key: &str, a_idx: usize, a: &[u8], b_idx: usize, b: &[u8]) -> String {
+    let window = |buf: &[u8], at: usize| {
+        let start = at.saturating_sub(8);
+        let end = (at + 8).min(buf.len());
+        buf[start..end]
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+    match a.iter().zip(b.iter()).position(|(x, y)| x != y) {
+        Some(at) => format!(
+            "`{key}`: bytes differ between node {a_idx} ({} B) and node {b_idx} ({} B) at offset {at}. \
+             node{a_idx}=[{}] node{b_idx}=[{}]",
+            a.len(),
+            b.len(),
+            window(a, at),
+            window(b, at),
+        ),
+        None => format!(
+            "`{key}`: length differs between node {a_idx} ({} B) and node {b_idx} ({} B)",
+            a.len(),
+            b.len(),
+        ),
+    }
+}
+
+/// Poll each node's total segment `.log` bytes until all nodes agree and the
+/// figure holds steady for a few consecutive polls, or the deadline (20s)
+/// elapses. On timeout, return anyway: the byte-for-byte compare that follows
+/// then fails with a precise diff instead of this masking a real lag.
+pub async fn wait_for_log_convergence(data_paths: &[PathBuf]) {
+    let deadline = tokio::time::Instant::now() + CONVERGENCE_DEADLINE;
+    let mut previous: Option<Vec<u64>> = None;
+    let mut stable_polls = 0u32;
+    loop {
+        let sizes: Vec<u64> = data_paths
+            .iter()
+            .map(|root| total_log_bytes(root))
+            .collect();
+        let all_equal = sizes.iter().all(|size| *size == sizes[0]);
+        if all_equal && previous.as_ref() == Some(&sizes) {
+            stable_polls += 1;
+            if stable_polls >= CONVERGENCE_STABLE_POLLS {
+                return;
+            }
+        } else {
+            stable_polls = 0;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        previous = Some(sizes);
+        sleep(CONVERGENCE_POLL_INTERVAL).await;
+    }
+}
+
+/// Total bytes of every partition segment `.log` under a node's data dir.
+/// Mirrors the `.log` selection in `is_comparable`; sizes only, no contents.
+fn total_log_bytes(root: &Path) -> u64 {
+    let mut total = 0;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file()
+                && let Ok(rel) = path.strip_prefix(root)
+            {
+                let rel = rel.to_string_lossy().replace('\\', "/");
+                if rel.starts_with("streams/") && rel.ends_with(".log") {
+                    total += fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
+                }
+            }
+        }
+    }
+    total
+}
+
+/// The u64 offset persisted under any `offsets/consumers/<id>` file in a node's
+/// data dir, or `None` when no such file has been written yet. Walks the tree
+/// so it is robust to the stream/topic/partition id layout. Reads the leading
+/// u64 of the record: the file is offset + trailing checksum (see
+/// `partitions::offset_storage::encode_offset_record`), and a shorter read
+/// (persist truncates before writing) is treated as not-yet-written.
+pub fn read_replicated_consumer_offset(data_dir: &Path) -> Option<u64> {
+    let mut stack: Vec<PathBuf> = vec![data_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let is_consumer_offset = path
+                .parent()
+                .and_then(Path::file_name)
+                .is_some_and(|name| name == "consumers")
+                && path
+                    .parent()
+                    .and_then(Path::parent)
+                    .and_then(Path::file_name)
+                    .is_some_and(|name| name == "offsets");
+            if is_consumer_offset
+                && let Ok(bytes) = fs::read(&path)
+                && let Some(offset_bytes) = bytes.first_chunk::<8>()
+            {
+                return Some(u64::from_le_bytes(*offset_bytes));
+            }
+        }
+    }
+    None
+}
+
+/// Decode a node's durable metadata `VsrState` from its on-disk superblock,
+/// `None` if no record exists yet. Reads the two slot files with blocking I/O
+/// (callers are tokio tests off any compio runtime) and decodes them through
+/// the journal's own newest-verifying-wins selection, so the caller sees
+/// exactly what `PingPongSuperblock::read_latest` would.
+///
+/// # Panics
+/// If a slot holds bytes that do not verify. For callers that do not corrupt
+/// slots that is a real durability bug; returning `None` would let pollers
+/// read it as "not written yet" and time out on a misleading message.
+pub fn read_metadata_superblock_state(data_path: &Path) -> Option<VsrState> {
+    // `<data_dir>/metadata/` is where shard 0 opens its `PingPongSuperblock`.
+    let dir = data_path.join("metadata");
+    read_superblock_state_in(&dir, "metadata")
+}
+
+/// The single partition directory's superblock record on a node, `None` while
+/// no record exists yet (a partition group that never left view 0 has an empty
+/// superblock, and its slot files may not exist at all). Intended for layouts
+/// with exactly one partition group.
+///
+/// # Panics
+/// Same contract as [`read_metadata_superblock_state`].
+pub fn read_partition_superblock_state(data_path: &Path) -> Option<VsrState> {
+    let dir = find_partition_superblock_dir(data_path)?;
+    read_superblock_state_in(&dir, "partition")
+}
+
+fn read_superblock_state_in(dir: &Path, plane: &str) -> Option<VsrState> {
+    let slot_a = fs::read(dir.join(SLOT_FILE_NAMES[0])).ok();
+    let slot_b = fs::read(dir.join(SLOT_FILE_NAMES[1])).ok();
+    match decode_slots(slot_a.as_deref(), slot_b.as_deref()) {
+        SuperblockContents::Present(payload) => VsrState::try_from(payload.as_slice()).ok(),
+        SuperblockContents::Empty => None,
+        SuperblockContents::Unreadable { version } => panic!(
+            "{plane} superblock at {} is unreadable (version {version:?})",
+            dir.display()
+        ),
+    }
+}
+
+/// First directory under `root` (metadata plane excluded) holding a superblock
+/// slot file; walked so callers do not hard-code the
+/// `streams/<s>/topics/<t>/partitions/<p>` layout.
+pub fn find_partition_superblock_dir(root: &Path) -> Option<PathBuf> {
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        // The metadata plane keeps its own superblock under `<data>/metadata`;
+        // only partition records are of interest here.
+        if dir.file_name().is_some_and(|name| name == "metadata") {
+            continue;
+        }
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path
+                .file_name()
+                .is_some_and(|name| name == SLOT_FILE_NAMES[0])
+            {
+                return Some(dir);
+            }
+        }
+    }
+    None
+}
+
+/// Index of the node the metadata roster marks as leader, resolved by matching
+/// the roster's TCP port against each node's bound address.
+///
+/// # Panics
+/// If no root client connects, the roster query fails, no node is marked
+/// leader, or the leader's port matches no harness node.
+pub async fn leader_node_index(harness: &TestHarness) -> usize {
+    let client = harness
+        .root_client_for_node(0)
+        .await
+        .expect("a root client (redirecting to the leader if node 0 is not it)");
+    let metadata = client
+        .get_cluster_metadata()
+        .await
+        .expect("get cluster metadata");
+    let leader_port = metadata
+        .nodes
+        .iter()
+        .find(|node| node.role == ClusterNodeRole::Leader)
+        .unwrap_or_else(|| panic!("the cluster must have elected a leader, got {metadata}"))
+        .endpoints
+        .tcp;
+    (0..harness.cluster_size())
+        .find(|index| {
+            harness
+                .node(*index)
+                .tcp_addr()
+                .is_some_and(|address| address.port() == leader_port)
+        })
+        .expect("the leader must be one of the roster nodes")
+}

--- a/core/integration/src/harness/handle/server.rs
+++ b/core/integration/src/harness/handle/server.rs
@@ -1020,6 +1020,32 @@ impl ServerHandle {
 
         self.start()
     }
+
+    /// Kill the server with SIGKILL: no shutdown hook runs, nothing buffered
+    /// in process memory is flushed. Models a real crash, unlike
+    /// [`TestBinary::stop`] whose graceful shutdown flushes state before exit.
+    ///
+    /// Restart afterwards with [`TestBinary::start`]. Taking `child_handle`
+    /// makes the eventual `Drop -> stop()` a no-op.
+    pub fn kill(&mut self) -> Result<(), TestBinaryError> {
+        // Watchdog must stop BEFORE the signal lands: it polls liveness every
+        // 100ms and panics on unexpected process death.
+        self.stop_watchdog();
+        if let Some(mut child) = self.child_handle.take() {
+            // SAFETY: plain syscall. The watchdog is already joined, so its
+            // unexpected-death path (a raw waitpid) can no longer reap this
+            // pid, and `Child` has not waited yet; the worst case is a signal
+            // to an already-dead but unreaped zombie, which is harmless. The
+            // result is deliberately discarded for the same reason.
+            unsafe {
+                libc::kill(child.id() as libc::pid_t, libc::SIGKILL);
+            }
+            // Reap via the owned Child, not reap_exit_status: a raw waitpid
+            // would race Child's own bookkeeping.
+            let _ = child.wait();
+        }
+        Ok(())
+    }
 }
 
 impl Drop for ServerHandle {

--- a/core/integration/src/harness/mod.rs
+++ b/core/integration/src/harness/mod.rs
@@ -42,6 +42,7 @@
 
 pub mod config;
 mod context;
+pub mod disk;
 mod error;
 mod fixture;
 pub mod handle;

--- a/core/integration/src/harness/orchestrator/harness.rs
+++ b/core/integration/src/harness/orchestrator/harness.rs
@@ -358,6 +358,34 @@ impl TestHarness {
         server.stop()
     }
 
+    /// SIGKILL node `index` and leave it down: the crash counterpart of
+    /// [`Self::stop_node`]. No shutdown hook runs, so nothing buffered in
+    /// process memory reaches disk. Restart via [`Self::restart_node`] to
+    /// exercise crash recovery.
+    pub fn kill_node(&mut self, index: usize) -> Result<(), TestBinaryError> {
+        let server = self
+            .servers
+            .get_mut(index)
+            .ok_or(TestBinaryError::MissingServer)?;
+        server.kill()
+    }
+
+    /// SIGKILL EVERY node, in ascending index order: the whole-cluster
+    /// power-loss shape, versus [`Self::restart_cluster`]'s graceful
+    /// stop-all-then-start-all. The kills spread over at most a couple hundred
+    /// milliseconds (a watchdog join plus a reap each), far below the 5s
+    /// heartbeat timeout, so no election starts between them. Restart via
+    /// [`Self::restart_cluster`].
+    pub fn kill_cluster(&mut self) -> Result<(), TestBinaryError> {
+        if self.servers.is_empty() {
+            return Err(TestBinaryError::MissingServer);
+        }
+        for server in &mut self.servers {
+            server.kill()?;
+        }
+        Ok(())
+    }
+
     /// Restart EVERY node and reconnect all clients: the full-cluster
     /// restart path, where no settled primary survives to answer the rejoin
     /// probes and the replicas must fall back to an election among their

--- a/core/integration/tests/cluster/client_table_adversarial.rs
+++ b/core/integration/tests/cluster/client_table_adversarial.rs
@@ -41,7 +41,7 @@ use consensus::client_table::REPLY_RING_CAPACITY;
 use iggy::prelude::*;
 use iggy_binary_protocol::codec::{WireDecode, WireEncode};
 use iggy_binary_protocol::consensus::{
-    Command2, Operation, ReplyHeader, RequestHeader, read_size_field, result_code,
+    Command, Operation, ReplyHeader, RequestHeader, read_size_field, result_code,
     result_section_len,
 };
 use iggy_binary_protocol::requests::streams::CreateStreamRequest;
@@ -211,7 +211,7 @@ fn create_stream_payload(name: &str) -> Bytes {
 
 fn request_header(client: u128, session: u64, request: u64, body_len: usize) -> RequestHeader {
     RequestHeader {
-        command: Command2::Request,
+        command: Command::Request,
         operation: Operation::CreateStream,
         size: u32::try_from(HEADER_SIZE + body_len).unwrap(),
         client,
@@ -254,7 +254,7 @@ async fn login_on(stream: &mut TcpStream, client: u128) -> Option<u64> {
     }
     .to_bytes();
     let header = RequestHeader {
-        command: Command2::Request,
+        command: Command::Request,
         operation: Operation::Register,
         size: u32::try_from(HEADER_SIZE + body.len()).unwrap(),
         client,
@@ -424,14 +424,14 @@ async fn exchange(stream: &mut TcpStream, header: &RequestHeader, body: &Bytes) 
     }
 
     let command_offset = offset_of!(RequestHeader, command);
-    if reply_header[command_offset] == Command2::Eviction as u8 {
+    if reply_header[command_offset] == Command::Eviction as u8 {
         return Exchange::Eviction {
             reason: reply_header[HEADER_SIZE - 1],
         };
     }
     assert_eq!(
         reply_header[command_offset],
-        Command2::Reply as u8,
+        Command::Reply as u8,
         "expected a Reply frame"
     );
 

--- a/core/integration/tests/cluster/client_table_adversarial.rs
+++ b/core/integration/tests/cluster/client_table_adversarial.rs
@@ -1,0 +1,461 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Adversarial specs against the VSR client table's at-most-once guarantees.
+//!
+//! Both tests are RED SPECS, expected to FAIL: they assert the dedup contract
+//! a retrying client needs, and the current table cannot honour it at its two
+//! resource edges.
+//!
+//! 1. Capacity: a full table evicts the entry with the oldest commit, and the
+//!    eviction erases that client's request watermark. A client that was
+//!    merely quiet (not gone) re-registers and its retry of an
+//!    already-committed request id re-executes.
+//! 2. Reply ring: each entry retains only its `REPLY_RING_CAPACITY` most
+//!    recent committed replies. A retry of a request whose reply aged out is
+//!    refused with the terminal `RequestAlreadyApplied` and no result payload,
+//!    indistinguishable from a rejection to the caller.
+//!
+//! The frames are hand-crafted on raw TCP sockets, same technique and frame
+//! builders as the clients-table restart tests, because the churn needs
+//! per-connection client identities and byte-level replay the SDK does not
+//! expose. The builders here are parameterized by client id, which is why the
+//! restart tests' fixed-identity helpers are not reused directly.
+
+use bytes::Bytes;
+use consensus::client_table::REPLY_RING_CAPACITY;
+use iggy::prelude::*;
+use iggy_binary_protocol::codec::{WireDecode, WireEncode};
+use iggy_binary_protocol::consensus::{
+    Command2, Operation, ReplyHeader, RequestHeader, read_size_field, result_code,
+    result_section_len,
+};
+use iggy_binary_protocol::requests::streams::CreateStreamRequest;
+use iggy_binary_protocol::requests::users::LoginRegisterRequest;
+use iggy_binary_protocol::responses::users::LoginRegisterResponse;
+use iggy_binary_protocol::{
+    ClientVersionInfo, HEADER_SIZE, IGGY_PROTOCOL_VERSION, WireName, WireOptions,
+};
+use integration::harness::TestHarness;
+use integration::iggy_harness;
+use secrecy::SecretString;
+use std::mem::offset_of;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::{Instant, sleep, timeout};
+
+/// The client whose dedup state each test puts under pressure.
+const CLIENT_A: u128 = 0xA11CE0001;
+
+/// Churn identities that overflow the capacity-2 table and force the
+/// eviction of `CLIENT_A`'s entry.
+const CHURN_CLIENTS: [u128; 3] = [0xB0B0001, 0xB0B0002, 0xB0B0003];
+
+/// Budget for one committed round-trip (covers transient replays while the
+/// single node elects itself after boot).
+const COMMIT_BUDGET: Duration = Duration::from_secs(15);
+
+/// Per-attempt reply wait; an unanswered read is a verdict, not a reason to
+/// wait longer.
+const REPLY_WAIT: Duration = Duration::from_secs(5);
+
+const RETRY_PAUSE: Duration = Duration::from_millis(100);
+
+/// RED SPEC, expected to FAIL: capacity eviction must not erase a live
+/// client's dedup watermark.
+///
+/// With the table floored at two slots, three fresh registrations evict
+/// `CLIENT_A` (its commit is the oldest) while its connection is still open
+/// and its request 1 is committed. The client then does exactly what the
+/// resume contract tells a disconnected client to do: reconnect,
+/// re-authenticate under its own identity, and retry the request it never saw
+/// answered. The register finds no entry to rebind, mints a fresh one at
+/// watermark zero, and the retry of the committed request re-executes.
+///
+/// The proof of re-execution is the committed duplicate-name rejection: a
+/// dedup hit replays the cached success bytes, so any committed rejection
+/// means the state machine ran the operation a second time. At-most-once
+/// holds only for clients the table happened not to evict.
+// TODO(hubcio): fix this test
+#[ignore = "capacity eviction erases a live client's dedup watermark; replay re-executes"]
+#[iggy_harness(cluster_nodes = 1, server(metadata.clients_table_max = "2"))]
+async fn given_a_low_client_table_cap_when_connects_churn_should_erase_a_live_dedup_watermark(
+    harness: &mut TestHarness,
+) {
+    let addr = tcp_addr(harness);
+    let (mut stream_a, session_a) = register(addr, CLIENT_A).await;
+    let payload = create_stream_payload("adv-k-dedup");
+    let committed = commit_request(&mut stream_a, CLIENT_A, session_a, 1, &payload).await;
+
+    // Each register is a commit, so after the first churn client the table
+    // holds [A, churn0]; the second churn register evicts A (oldest commit).
+    // The sockets stay open so no Logout frees a slot and dodges the
+    // capacity pressure.
+    let mut churn_streams = Vec::with_capacity(CHURN_CLIENTS.len());
+    for churn_client in CHURN_CLIENTS {
+        churn_streams.push(register(addr, churn_client).await);
+    }
+
+    // The eviction is observable on the still-open connection: the entry is
+    // gone, so the next request on it draws an eviction, not an answer. This
+    // stages the scenario; the contract violation comes after the resume.
+    let probe = request_header(CLIENT_A, session_a, 2, payload.len());
+    match exchange(&mut stream_a, &probe, &payload).await.verdict() {
+        Verdict::Evicted(reason) => {
+            eprintln!("churn evicted CLIENT_A's entry (wire eviction reason byte {reason})");
+        }
+        Verdict::NoResultSection | Verdict::Ignored => {}
+        other => panic!(
+            "the churn must evict CLIENT_A's entry before the replay is meaningful; \
+             its live connection still got {other:?}"
+        ),
+    }
+    drop(stream_a);
+
+    // Resume exactly as the contract prescribes: fresh connection,
+    // credential-bearing re-register under the same client id, then retry
+    // the committed request id under the new epoch.
+    let (mut resumed_stream, resumed_session) = register(addr, CLIENT_A).await;
+    let replay = replay_request(&mut resumed_stream, CLIENT_A, resumed_session, 1, &payload).await;
+
+    match replay {
+        Verdict::Success(replayed) => {
+            assert_replayed_from_cache(&committed, &replayed, 1);
+        }
+        other => panic!(
+            "capacity eviction erased a live client's dedup watermark: request 1 was \
+             committed and its reply delivered, but after the table (capacity 2) evicted \
+             the entry to admit churn registrations, the resume re-registered at watermark \
+             zero and the retry of request 1 was re-executed by the state machine instead \
+             of being answered from the dedup cache (at-most-once broken for any client \
+             the table evicts while it is merely quiet); got {other:?}"
+        ),
+    }
+}
+
+/// RED SPEC, expected to FAIL: a retry that falls off the reply ring must not
+/// be terminally rejected without a result.
+///
+/// Request 1 commits, then later requests on the same session push its reply
+/// out of the ring. The retry of request 1 is then answered with the terminal
+/// `RequestAlreadyApplied` code and no result payload. The
+/// caller cannot distinguish "your operation succeeded, the reply aged out"
+/// from "your operation was rejected", so a slow retrier is forced to treat a
+/// success as a failure.
+// TODO(hubcio): fix this test
+#[ignore = "replay past the reply ring draws terminal RequestAlreadyApplied, no result payload"]
+#[iggy_harness(cluster_nodes = 1)]
+async fn given_replays_past_the_reply_ring_when_a_request_id_falls_off_should_not_terminally_reject(
+    harness: &mut TestHarness,
+) {
+    let addr = tcp_addr(harness);
+    let (mut stream, session) = register(addr, CLIENT_A).await;
+    let aged_payload = create_stream_payload("adv-l-aged");
+    let committed = commit_request(&mut stream, CLIENT_A, session, 1, &aged_payload).await;
+
+    // One more commit than the ring holds, so request 1's reply is evicted
+    // even though the register reply seeded a slot of its own.
+    let later_requests = REPLY_RING_CAPACITY as u64 + 1;
+    for index in 0..later_requests {
+        let payload = create_stream_payload(&format!("adv-l-filler-{index}"));
+        commit_request(&mut stream, CLIENT_A, session, 2 + index, &payload).await;
+    }
+
+    let replay = replay_request(&mut stream, CLIENT_A, session, 1, &aged_payload).await;
+
+    match replay {
+        Verdict::Success(replayed) => {
+            assert_replayed_from_cache(&committed, &replayed, 1);
+        }
+        other => panic!(
+            "a committed request replayed past the reply ring is terminally rejected: \
+             request 1 was applied and confirmed, but after {later_requests} newer commits \
+             its reply aged out of the {REPLY_RING_CAPACITY}-deep ring and the server \
+             answered the terminal RequestAlreadyApplied code with no result payload, which the \
+             client cannot distinguish from a rejection of an operation that in fact \
+             succeeded; got {other:?}"
+        ),
+    }
+}
+
+fn tcp_addr(harness: &TestHarness) -> SocketAddr {
+    harness
+        .server()
+        .tcp_addr()
+        .expect("server must expose a TCP address")
+}
+
+fn create_stream_payload(name: &str) -> Bytes {
+    CreateStreamRequest {
+        name: WireName::new(name).unwrap(),
+        options: WireOptions::empty(),
+    }
+    .to_bytes()
+}
+
+fn request_header(client: u128, session: u64, request: u64, body_len: usize) -> RequestHeader {
+    RequestHeader {
+        command: Command2::Request,
+        operation: Operation::CreateStream,
+        size: u32::try_from(HEADER_SIZE + body_len).unwrap(),
+        client,
+        session,
+        request,
+        ..Default::default()
+    }
+}
+
+/// Connect and register `client` as root, returning the connection with its
+/// bound session id. Replays on transient rejections (right after boot the
+/// single node may not have elected itself yet).
+async fn register(addr: SocketAddr, client: u128) -> (TcpStream, u64) {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let deadline = Instant::now() + COMMIT_BUDGET;
+    loop {
+        if let Some(session) = login_on(&mut stream, client).await {
+            return (stream, session);
+        }
+        assert!(
+            Instant::now() < deadline,
+            "register of client {client:#x} did not commit within {COMMIT_BUDGET:?}"
+        );
+        sleep(RETRY_PAUSE).await;
+    }
+}
+
+/// Root login/register for `client` on an already-connected socket.
+/// `Some(session)` on a committed register, `None` on a transient rejection.
+async fn login_on(stream: &mut TcpStream, client: u128) -> Option<u64> {
+    let body = LoginRegisterRequest {
+        version_info: ClientVersionInfo {
+            protocol_version: IGGY_PROTOCOL_VERSION,
+            sdk_name: WireName::new("adversarial-raw").unwrap(),
+            sdk_version: WireName::new("0.0.1").unwrap(),
+        },
+        username: WireName::new(DEFAULT_ROOT_USERNAME).unwrap(),
+        password: SecretString::from(DEFAULT_ROOT_PASSWORD),
+        client_context: None,
+    }
+    .to_bytes();
+    let header = RequestHeader {
+        command: Command2::Request,
+        operation: Operation::Register,
+        size: u32::try_from(HEADER_SIZE + body.len()).unwrap(),
+        client,
+        session: 0,
+        request: 0,
+        ..Default::default()
+    };
+
+    match exchange(stream, &header, &body).await.verdict() {
+        Verdict::Success(reply) => {
+            let response = LoginRegisterResponse::decode_from(&reply.payload)
+                .expect("register payload must decode");
+            assert_ne!(response.session, 0, "server must bind a nonzero session");
+            Some(response.session)
+        }
+        Verdict::Rejected(code) if is_transient(code) => None,
+        other => panic!("register of client {client:#x} did not commit: {other:?}"),
+    }
+}
+
+/// Send one replicated request on the registered connection and require a
+/// committed success within `COMMIT_BUDGET`. Returns the committed reply so a
+/// later replay can be compared against it byte for byte.
+async fn commit_request(
+    stream: &mut TcpStream,
+    client: u128,
+    session: u64,
+    request: u64,
+    body: &Bytes,
+) -> CommittedReply {
+    let header = request_header(client, session, request, body.len());
+    let deadline = Instant::now() + COMMIT_BUDGET;
+    loop {
+        match exchange(stream, &header, body).await.verdict() {
+            Verdict::Success(reply) => return reply,
+            Verdict::Rejected(code) if is_transient(code) && Instant::now() < deadline => {
+                sleep(RETRY_PAUSE).await;
+            }
+            other => panic!("request {request} did not commit: {other:?}"),
+        }
+    }
+}
+
+/// Replay `request` and return the first non-transient verdict. Unlike
+/// `commit_request` this never panics on a committed rejection: the rejection
+/// IS the observation the red specs are after.
+async fn replay_request(
+    stream: &mut TcpStream,
+    client: u128,
+    session: u64,
+    request: u64,
+    body: &Bytes,
+) -> Verdict {
+    let header = request_header(client, session, request, body.len());
+    let deadline = Instant::now() + COMMIT_BUDGET;
+    loop {
+        let verdict = exchange(stream, &header, body).await.verdict();
+        match verdict {
+            Verdict::Rejected(code) if is_transient(code) && Instant::now() < deadline => {
+                sleep(RETRY_PAUSE).await;
+            }
+            other => return other,
+        }
+    }
+}
+
+/// Prove a retry was answered from the dedup cache rather than re-executed:
+/// a cached replay is byte-identical to the original committed reply, while a
+/// re-apply commits at a fresh op, which changes `op`/`commit` and the frame
+/// checksum.
+fn assert_replayed_from_cache(original: &CommittedReply, replayed: &CommittedReply, request: u64) {
+    let field = |bytes: &[u8; HEADER_SIZE], offset: usize| {
+        u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap())
+    };
+    let op_offset = offset_of!(ReplyHeader, op);
+    let commit_offset = offset_of!(ReplyHeader, commit);
+    assert_eq!(
+        field(&replayed.header, op_offset),
+        field(&original.header, op_offset),
+        "request {request} was re-applied at a new op instead of replayed from cache"
+    );
+    assert_eq!(
+        field(&replayed.header, commit_offset),
+        field(&original.header, commit_offset),
+        "request {request} replay carries a different commit than the original"
+    );
+    assert_eq!(
+        replayed.payload, original.payload,
+        "request {request} replay is not the cached bytes (payloads differ)"
+    );
+}
+
+/// Everything one request/reply exchange can end in, spelled out so the
+/// red-spec panics name the exact failure mode instead of a decode error.
+#[derive(Debug)]
+enum Verdict {
+    /// Committed success; carries the reply header plus the payload after the
+    /// result section.
+    Success(CommittedReply),
+    /// Committed (or pre-consensus transient) rejection code.
+    Rejected(u32),
+    /// A Reply with no result section, i.e. the empty Reply the server emits
+    /// for a replicated request on a transport it has no session for.
+    NoResultSection,
+    /// No frame within `REPLY_WAIT`.
+    Ignored,
+    /// Session-terminal Eviction frame; carries the wire reason byte.
+    Evicted(u8),
+}
+
+/// A committed `Reply`, split into the wire header and the post-result-section
+/// payload. The header is boxed to keep it off the stack in `Verdict`.
+#[derive(Debug)]
+struct CommittedReply {
+    header: Box<[u8; HEADER_SIZE]>,
+    payload: Bytes,
+}
+
+enum Exchange {
+    Reply {
+        status: u32,
+        header: Box<[u8; HEADER_SIZE]>,
+        body: Bytes,
+    },
+    Eviction {
+        reason: u8,
+    },
+    Ignored,
+}
+
+impl Exchange {
+    fn verdict(self) -> Verdict {
+        match self {
+            Self::Ignored => Verdict::Ignored,
+            Self::Eviction { reason } => Verdict::Evicted(reason),
+            // A nonzero status is the pre-commit deny channel (authz etc.);
+            // fold it into the rejection space, the codes are shared.
+            Self::Reply { status, .. } if status != 0 => Verdict::Rejected(status),
+            Self::Reply { header, body, .. } => match result_code(&body) {
+                None => Verdict::NoResultSection,
+                Some(0) => {
+                    let payload_start = result_section_len(&body).unwrap();
+                    Verdict::Success(CommittedReply {
+                        header,
+                        payload: body.slice(payload_start..),
+                    })
+                }
+                Some(code) => Verdict::Rejected(code),
+            },
+        }
+    }
+}
+
+/// Write one frame and read one frame off the lockstep connection.
+async fn exchange(stream: &mut TcpStream, header: &RequestHeader, body: &Bytes) -> Exchange {
+    stream.write_all(bytemuck::bytes_of(header)).await.unwrap();
+    if !body.is_empty() {
+        stream.write_all(body).await.unwrap();
+    }
+
+    let mut reply_header = [0u8; HEADER_SIZE];
+    match timeout(REPLY_WAIT, stream.read_exact(&mut reply_header)).await {
+        Err(_elapsed) => return Exchange::Ignored,
+        Ok(read) => {
+            read.expect("reply header read failed");
+        }
+    }
+
+    let command_offset = offset_of!(RequestHeader, command);
+    if reply_header[command_offset] == Command2::Eviction as u8 {
+        return Exchange::Eviction {
+            reason: reply_header[HEADER_SIZE - 1],
+        };
+    }
+    assert_eq!(
+        reply_header[command_offset],
+        Command2::Reply as u8,
+        "expected a Reply frame"
+    );
+
+    let status_offset = offset_of!(ReplyHeader, status);
+    let status = u32::from_le_bytes(
+        reply_header[status_offset..status_offset + 4]
+            .try_into()
+            .unwrap(),
+    );
+
+    let total_size = read_size_field(&reply_header).expect("reply size field") as usize;
+    let mut body = vec![0u8; total_size - HEADER_SIZE];
+    timeout(REPLY_WAIT, stream.read_exact(&mut body))
+        .await
+        .expect("reply body timed out")
+        .expect("reply body read failed");
+    Exchange::Reply {
+        status,
+        header: Box::new(reply_header),
+        body: body.into(),
+    }
+}
+
+fn is_transient(code: u32) -> bool {
+    code == IggyError::TransientNotCommitted.as_code()
+        || code == IggyError::TransientNotAccepted.as_code()
+}

--- a/core/integration/tests/cluster/crash_durability.rs
+++ b/core/integration/tests/cluster/crash_durability.rs
@@ -1,0 +1,519 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Acked-write durability across real SIGKILL crashes.
+//!
+//! Every other harness fault is a graceful stop whose shutdown hook flushes
+//! buffers before the process exits. SIGKILL runs no hook, so these tests pin
+//! what the durability contract actually promises at the moment of the ack:
+//! a confirmation (`SendMessagesResponse::confirmations`) is granted on
+//! quorum COMMIT, which for a topic below its flush thresholds means the
+//! batch lives only in the in-memory partition journal
+//! (`PartitionJournalMemStorage`) on each node. Process death never loses a
+//! completed `write()` (the page cache survives the process), so what SIGKILL
+//! probes is precisely that written-before-acked gap, not fsync ordering.
+//!
+//! Single-node-crash tests must hold every ack via the surviving quorum;
+//! the whole-cluster-crash test must hold exactly what reached the segments.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use iggy::prelude::*;
+use integration::harness::{TestHarness, disk};
+use integration::iggy_harness;
+use tokio::time::sleep;
+
+const STREAM_NAME: &str = "crash-stream";
+const TOPIC_NAME: &str = "crash-topic";
+const PARTITION_ID: u32 = 0;
+const CONSUMER_ID: u32 = 1;
+
+/// Bounds a full election plus a rejoining node's recovery on slow CI runners.
+const CONVERGE_TIMEOUT: Duration = Duration::from_secs(60);
+/// Budget for the survivors to elect a new primary after the old one is killed.
+const ELECTION_TIMEOUT: Duration = Duration::from_secs(30);
+/// Budget for a committed consumer offset to reach a replica's disk.
+const OFFSET_REPLICATION_TIMEOUT: Duration = Duration::from_secs(15);
+/// Budget for eagerly flushed batches to land in every node's segment files.
+const FLUSH_INSTALL_TIMEOUT: Duration = Duration::from_secs(20);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Acks the producer loop in the primary-kill test must capture before the
+/// primary dies, so the surviving quorum has a meaningful prefix to preserve.
+const PRE_KILL_ACKS: usize = 50;
+
+async fn create_stream_and_topic(client: &IggyClient, eager_flush: bool) {
+    client
+        .create_stream(STREAM_NAME)
+        .await
+        .expect("create stream");
+    // `eager_flush` persists and fsyncs every committed batch on every
+    // replica before anything else happens on the partition; it is a topic
+    // creation option, so it travels with the topic to all nodes. The default
+    // shape leaves the 1024-message / 1 MiB thresholds in place, so small
+    // runs are acked from RAM only.
+    let options = if eager_flush {
+        TopicCreateOptions {
+            partitions_count: Some(1),
+            message_expiry: Some(IggyExpiry::NeverExpire),
+            messages_required_to_save: Some(1),
+            enforce_fsync: Some(true),
+            ..TopicCreateOptions::default()
+        }
+    } else {
+        TopicCreateOptions {
+            partitions_count: Some(1),
+            message_expiry: Some(IggyExpiry::NeverExpire),
+            ..TopicCreateOptions::default()
+        }
+    };
+    client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            &options,
+        )
+        .await
+        .expect("create topic");
+}
+
+/// Send `count` single-message batches, returning each confirmed
+/// `(base_offset, payload)`. One message per send, so every confirmation pins
+/// exactly one offset.
+async fn produce_acked(
+    client: &IggyClient,
+    payload_prefix: &str,
+    count: u32,
+) -> Vec<(u64, String)> {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let topic = Identifier::named(TOPIC_NAME).unwrap();
+    let mut acked = Vec::with_capacity(count as usize);
+    for index in 0..count {
+        let payload = format!("{payload_prefix}-{index:05}");
+        let mut messages = vec![
+            IggyMessage::builder()
+                .payload(payload.clone().into())
+                .build()
+                .expect("build message"),
+        ];
+        let response = client
+            .send_messages(
+                &stream,
+                &topic,
+                &Partitioning::partition_id(PARTITION_ID),
+                &mut messages,
+            )
+            .await
+            .unwrap_or_else(|error| panic!("send {payload}: {error}"));
+        let confirmation = response
+            .confirmations
+            .first()
+            .unwrap_or_else(|| panic!("the VSR server confirms every send, none for {payload}"));
+        acked.push((confirmation.base_offset, payload));
+    }
+    acked
+}
+
+/// Poll from offset 0 until every acked `(offset, payload)` reads back at its
+/// confirmed offset with offsets strictly increasing, or `budget` runs out.
+/// `Err` carries the last observed shortfall so the caller's verdict can show
+/// what was actually readable.
+async fn wait_for_acked_readable(
+    client: &IggyClient,
+    acked: &[(u64, String)],
+    budget: Duration,
+) -> Result<(), String> {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let topic = Identifier::named(TOPIC_NAME).unwrap();
+    let deadline = tokio::time::Instant::now() + budget;
+    let want = acked.len() as u32 + 16;
+    let mut state;
+    loop {
+        match client
+            .poll_messages(
+                &stream,
+                &topic,
+                Some(PARTITION_ID),
+                &Consumer::default(),
+                &PollingStrategy::offset(0),
+                want,
+                false,
+            )
+            .await
+        {
+            Ok(polled) => {
+                let offsets: Vec<u64> = polled
+                    .messages
+                    .iter()
+                    .map(|message| message.header.offset)
+                    .collect();
+                let in_order = offsets.windows(2).all(|pair| pair[0] < pair[1]);
+                let by_offset: HashMap<u64, &[u8]> = polled
+                    .messages
+                    .iter()
+                    .map(|message| (message.header.offset, message.payload.as_ref()))
+                    .collect();
+                let missing: Vec<u64> = acked
+                    .iter()
+                    .filter(|(offset, payload)| {
+                        by_offset
+                            .get(offset)
+                            .is_none_or(|bytes| *bytes != payload.as_bytes())
+                    })
+                    .map(|(offset, _)| *offset)
+                    .collect();
+                if in_order && missing.is_empty() {
+                    return Ok(());
+                }
+                state = format!(
+                    "{} of {} acked offsets readable ({} polled, in order: {in_order}), \
+                     first missing or payload-mismatched offset: {:?}",
+                    acked.len() - missing.len(),
+                    acked.len(),
+                    polled.messages.len(),
+                    missing.first(),
+                );
+            }
+            Err(error) => state = format!("poll failed: {error}"),
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(state);
+        }
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Connect a root client to the first node in `nodes` that accepts one,
+/// `None` when none do (mid-election, or a node still restarting).
+async fn connect_any(harness: &TestHarness, nodes: &[usize]) -> Option<IggyClient> {
+    for &node in nodes {
+        if let Ok(builder) = harness.node(node).tcp_client()
+            && let Ok(client) = builder.with_root_login().connect().await
+        {
+            return Some(client);
+        }
+    }
+    None
+}
+
+/// Number of nodes the metadata roster marks as leader, `None` if the query
+/// fails (mid-election, connection dropped).
+async fn leader_count(client: &IggyClient) -> Option<usize> {
+    let metadata = client.get_cluster_metadata().await.ok()?;
+    Some(
+        metadata
+            .nodes
+            .iter()
+            .filter(|node| node.role == ClusterNodeRole::Leader)
+            .count(),
+    )
+}
+
+/// Poll until one of `nodes` serves the test stream under exactly one leader,
+/// returning the connected client. Panics at the deadline.
+async fn wait_until_cluster_serves(
+    harness: &TestHarness,
+    nodes: &[usize],
+    budget: Duration,
+) -> IggyClient {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        if let Some(client) = connect_any(harness, nodes).await
+            && matches!(client.get_stream(&stream).await, Ok(Some(_)))
+            && leader_count(&client).await == Some(1)
+        {
+            return client;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "cluster did not serve the stream under a single leader within {budget:?}"
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Poll until every node's segment files hold all of `payloads`, so a
+/// follow-up SIGKILL provably erases nothing that was flushed. Replaces a
+/// settle sleep: the ack proves quorum COMMIT, but each replica flushes on
+/// its own commit walk.
+async fn wait_until_payloads_installed(
+    harness: &TestHarness,
+    payloads: &[String],
+    budget: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        let pending: Vec<String> = (0..harness.cluster_size())
+            .filter_map(|node| {
+                disk::installed_payloads_complete(&harness.node(node).data_path(), payloads)
+                    .err()
+                    .map(|error| format!("node {node}: {error}"))
+            })
+            .collect();
+        if pending.is_empty() {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "eagerly flushed batches did not reach every node's segments within {budget:?}: \
+             {pending:?}"
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Poll a node's on-disk consumer-offset record until it equals `expected`.
+/// Panics at the deadline.
+async fn wait_for_disk_consumer_offset(
+    harness: &TestHarness,
+    node: usize,
+    expected: u64,
+    budget: Duration,
+) {
+    let data_path = harness.node(node).data_path();
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        if disk::read_replicated_consumer_offset(&data_path) == Some(expected) {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "node {node} did not persist the replicated consumer offset {expected} \
+             within {budget:?} (found {:?})",
+            disk::read_replicated_consumer_offset(&data_path),
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// A backup dies by SIGKILL and rejoins from its intact data dir. Every ack
+/// granted before, during, and after the outage must poll back in order, and
+/// once converged all three replicas must hold byte-identical partition
+/// segments (the hash-chain identity recovery depends on).
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_committed_sends_when_a_backup_is_killed_and_restarts_should_preserve_all_acked_offsets_byte_identical(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&client, true).await;
+    let mut acked = produce_acked(&client, "pre-kill", 200).await;
+
+    let leader = disk::leader_node_index(harness).await;
+    let backup = (0..harness.cluster_size())
+        .find(|index| *index != leader)
+        .expect("a 3-node cluster has a backup");
+    harness.kill_node(backup).expect("SIGKILL a backup");
+
+    acked.extend(produce_acked(&client, "during-outage", 50).await);
+
+    harness
+        .restart_node(backup)
+        .expect("restart the killed backup");
+
+    wait_for_acked_readable(&client, &acked, CONVERGE_TIMEOUT)
+        .await
+        .unwrap_or_else(|state| {
+            panic!("every acked offset must poll back after the backup rejoins: {state}")
+        });
+
+    let data_paths: Vec<PathBuf> = harness
+        .all_servers()
+        .iter()
+        .map(|server| server.data_path())
+        .collect();
+    disk::wait_for_log_convergence(&data_paths).await;
+    // Stop the cluster so every segment is at rest before the byte compare.
+    harness
+        .stop()
+        .await
+        .expect("stop the cluster for the at-rest comparison");
+    disk::assert_replica_data_identical(&data_paths, false);
+}
+
+/// The primary dies by SIGKILL while a producer is mid-flight. On a DEFAULT
+/// topic an ack proves only a RAM quorum, so this pins the core VSR promise:
+/// the two survivors hold every acked batch in their journals and the new
+/// primary must serve all of them.
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_mid_flight_produce_when_the_primary_is_killed_should_elect_and_preserve_acked_offsets(
+    harness: &mut TestHarness,
+) {
+    let setup_client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&setup_client, false).await;
+
+    let producer_client = harness.tcp_root_client().await.unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let acked_count = Arc::new(AtomicUsize::new(0));
+    let producer = tokio::spawn({
+        let stop = stop.clone();
+        let acked_count = acked_count.clone();
+        async move {
+            let stream = Identifier::named(STREAM_NAME).unwrap();
+            let topic = Identifier::named(TOPIC_NAME).unwrap();
+            let partitioning = Partitioning::partition_id(PARTITION_ID);
+            let mut acked: Vec<(u64, String)> = Vec::new();
+            let mut index = 0u32;
+            loop {
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                let payload = format!("mid-flight-{index:05}");
+                let mut messages = vec![
+                    IggyMessage::builder()
+                        .payload(payload.clone().into())
+                        .build()
+                        .expect("build message"),
+                ];
+                match producer_client
+                    .send_messages(&stream, &topic, &partitioning, &mut messages)
+                    .await
+                {
+                    Ok(response) => {
+                        if let Some(confirmation) = response.confirmations.first() {
+                            acked.push((confirmation.base_offset, payload));
+                            acked_count.fetch_add(1, Ordering::Relaxed);
+                        }
+                        index += 1;
+                    }
+                    // The kill lands mid-send; whatever error surfaces ends
+                    // the run. Only Ok confirmations count as acked.
+                    Err(_) => break,
+                }
+            }
+            acked
+        }
+    });
+
+    let deadline = tokio::time::Instant::now() + ELECTION_TIMEOUT;
+    while acked_count.load(Ordering::Relaxed) < PRE_KILL_ACKS {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the producer must reach {PRE_KILL_ACKS} acked sends before the kill"
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    let leader = disk::leader_node_index(harness).await;
+    harness.kill_node(leader).expect("SIGKILL the primary");
+    stop.store(true, Ordering::Relaxed);
+
+    let survivors: Vec<usize> = (0..harness.cluster_size())
+        .filter(|index| *index != leader)
+        .collect();
+    let survivor_client = wait_until_cluster_serves(harness, &survivors, ELECTION_TIMEOUT).await;
+
+    // The producer's in-flight send may burn its full transport timeout
+    // against the dead primary before erroring out; bound the join so a
+    // wedged client fails loudly instead of hanging the test.
+    let acked = tokio::time::timeout(Duration::from_secs(120), producer)
+        .await
+        .expect("the producer client wedged after the primary kill instead of failing its send")
+        .expect("join the producer task");
+    assert!(
+        acked.len() >= PRE_KILL_ACKS,
+        "at least the pre-kill acks must have been captured: got {}, expected at least \
+         {PRE_KILL_ACKS}",
+        acked.len()
+    );
+
+    wait_for_acked_readable(&survivor_client, &acked, CONVERGE_TIMEOUT)
+        .await
+        .unwrap_or_else(|state| {
+            panic!(
+                "every offset acked before the primary died must be readable from the \
+                 surviving quorum: {state}"
+            )
+        });
+}
+
+/// A committed consumer offset must survive the crash of a backup. The offset
+/// is stored while the backup is already dead, so only the surviving quorum
+/// holds it (and persists it) and the rejoining node can converge to it only
+/// through replication, never from its own pre-crash disk.
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_a_committed_consumer_offset_when_a_backup_is_killed_should_survive_on_the_survivors(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&client, false).await;
+    let acked = produce_acked(&client, "offset-fodder", 10).await;
+    let stored_offset = acked.last().expect("ten acked sends").0;
+
+    let leader = disk::leader_node_index(harness).await;
+    let backup = (0..harness.cluster_size())
+        .find(|index| *index != leader)
+        .expect("a 3-node cluster has a backup");
+    harness.kill_node(backup).expect("SIGKILL a backup");
+
+    let consumer = Consumer::new(Identifier::numeric(CONSUMER_ID).unwrap());
+    client
+        .store_consumer_offset(
+            &consumer,
+            &Identifier::named(STREAM_NAME).unwrap(),
+            &Identifier::named(TOPIC_NAME).unwrap(),
+            Some(PARTITION_ID),
+            stored_offset,
+        )
+        .await
+        .expect("store the consumer offset (commits on the surviving quorum)");
+
+    for node in (0..harness.cluster_size()).filter(|index| *index != backup) {
+        wait_for_disk_consumer_offset(harness, node, stored_offset, OFFSET_REPLICATION_TIMEOUT)
+            .await;
+    }
+
+    harness
+        .restart_node(backup)
+        .expect("restart the killed backup");
+    wait_for_disk_consumer_offset(harness, backup, stored_offset, CONVERGE_TIMEOUT).await;
+}
+
+/// Whole-cluster SIGKILL with an eagerly flushed topic: what reached the
+/// segments before the crash must be served by the reformed cluster. The kill
+/// is gated on every node's segments holding every payload, so the recovery
+/// obligation is exact. No settled primary survives, so the replicas must
+/// give up probing and elect among their recovered logs.
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_eager_flush_topic_when_the_whole_cluster_is_killed_should_recover_flushed_data(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&client, true).await;
+    let acked = produce_acked(&client, "flushed", 30).await;
+    let payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    wait_until_payloads_installed(harness, &payloads, FLUSH_INSTALL_TIMEOUT).await;
+    drop(client);
+
+    harness.kill_cluster().expect("SIGKILL every node");
+    harness
+        .restart_cluster()
+        .await
+        .expect("restart the whole cluster");
+
+    let nodes: Vec<usize> = (0..harness.cluster_size()).collect();
+    let client = wait_until_cluster_serves(harness, &nodes, CONVERGE_TIMEOUT).await;
+    wait_for_acked_readable(&client, &acked, CONVERGE_TIMEOUT)
+        .await
+        .unwrap_or_else(|state| {
+            panic!("eagerly flushed acked data must survive a whole-cluster SIGKILL: {state}")
+        });
+}

--- a/core/integration/tests/cluster/crash_offset_reuse.rs
+++ b/core/integration/tests/cluster/crash_offset_reuse.rs
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! RED SPEC, expected to FAIL: offset identity across a crash.
+//!
+//! `SendMessagesResponse::confirmations` hands clients concrete base offsets,
+//! which makes offset reuse client-visible: a client that recorded offset N
+//! for its message must never see the server confirm a DIFFERENT message at
+//! N later. A solo node acks below the flush thresholds from RAM only and
+//! persists no offset watermark, so after a SIGKILL it restarts the partition
+//! log at the last flushed position and re-mints offsets it already
+//! confirmed. Passes only once a durable watermark (or durable journal tail)
+//! keeps post-restart offsets above everything ever acked.
+
+use std::time::Duration;
+
+use iggy::prelude::*;
+use integration::harness::TestHarness;
+use integration::iggy_harness;
+use tokio::time::sleep;
+
+const STREAM_NAME: &str = "offset-reuse-stream";
+const TOPIC_NAME: &str = "offset-reuse-topic";
+const PARTITION_ID: u32 = 0;
+/// Confirmed sends before the crash; small enough to stay far below the
+/// 1024-message / 1 MiB flush thresholds, so nothing reaches the segments.
+const PRE_CRASH_SENDS: u32 = 5;
+
+/// Bounds the restarted node's boot and its consensus groups settling.
+const SERVE_TIMEOUT: Duration = Duration::from_secs(60);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Send `count` single-message batches, returning each confirmed base offset.
+async fn produce_acked(client: &IggyClient, payload_prefix: &str, count: u32) -> Vec<u64> {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let topic = Identifier::named(TOPIC_NAME).unwrap();
+    let mut acked = Vec::with_capacity(count as usize);
+    for index in 0..count {
+        let payload = format!("{payload_prefix}-{index:03}");
+        let mut messages = vec![
+            IggyMessage::builder()
+                .payload(payload.clone().into())
+                .build()
+                .expect("build message"),
+        ];
+        let response = client
+            .send_messages(
+                &stream,
+                &topic,
+                &Partitioning::partition_id(PARTITION_ID),
+                &mut messages,
+            )
+            .await
+            .unwrap_or_else(|error| panic!("send {payload}: {error}"));
+        acked.push(
+            response
+                .confirmations
+                .first()
+                .unwrap_or_else(|| panic!("the VSR server confirms every send, none for {payload}"))
+                .base_offset,
+        );
+    }
+    acked
+}
+
+/// Poll until the restarted node serves the pre-crash stream again, returning
+/// a connected root client. Panics at the deadline.
+async fn wait_until_serving(harness: &TestHarness, budget: Duration) -> IggyClient {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        if let Ok(builder) = harness.node(0).tcp_client()
+            && let Ok(client) = builder.with_root_login().connect().await
+            && matches!(client.get_stream(&stream).await, Ok(Some(_)))
+        {
+            return client;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the restarted node did not serve the stream within {budget:?}"
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+// TODO(hubcio): fix this test
+#[ignore = "confirmed offsets re-minted after a crash; no durable offset watermark"]
+#[iggy_harness(cluster_nodes = 1)]
+async fn given_confirmed_sends_below_flush_threshold_when_a_solo_node_is_killed_should_not_remint_offsets(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    client
+        .create_stream(STREAM_NAME)
+        .await
+        .expect("create stream");
+    client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            &TopicCreateOptions {
+                partitions_count: Some(1),
+                message_expiry: Some(IggyExpiry::NeverExpire),
+                ..TopicCreateOptions::default()
+            },
+        )
+        .await
+        .expect("create topic");
+
+    let acked = produce_acked(&client, "pre-crash", PRE_CRASH_SENDS).await;
+    let highest_confirmed = *acked.last().expect("confirmed sends");
+    drop(client);
+
+    harness.kill_node(0).expect("SIGKILL the only node");
+    harness.restart_node(0).expect("restart it");
+
+    let client = wait_until_serving(harness, SERVE_TIMEOUT).await;
+    let post_crash_offset = produce_acked(&client, "post-crash", 1).await[0];
+
+    assert!(
+        post_crash_offset > highest_confirmed,
+        "a crash-restarted node re-minted offsets it already confirmed: offset \
+         {highest_confirmed} was handed to a client before the SIGKILL, yet the first \
+         post-restart send was confirmed at offset {post_crash_offset}; without a durable \
+         offset watermark the node restarts the partition log below what it acknowledged, \
+         so two different messages now share an offset and consumers reading by offset get \
+         silently different data"
+    );
+}

--- a/core/integration/tests/cluster/crash_recovery_corruption.rs
+++ b/core/integration/tests/cluster/crash_recovery_corruption.rs
@@ -1,0 +1,688 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Recovery from on-disk corruption, staged as offline byte surgery: a node is
+//! stopped gracefully, one file under its data dir is mutated, and the node is
+//! started again. The four scenarios split along the durability contract:
+//!
+//! - A torn tail of a partition segment `.log` or `.index` is the shape a
+//!   crash legitimately leaves behind; recovery must absorb it without the
+//!   replica silently diverging from its peers.
+//! - Interior damage to the metadata WAL or a superblock slot can only be
+//!   bit-rot or operator error, never a torn append, so boot must refuse
+//!   loudly and the node heals by rejoining from a clean slate.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use iggy::prelude::*;
+use integration::harness::{TestHarness, disk};
+use integration::iggy_harness;
+use tokio::time::sleep;
+
+const STREAM_NAME: &str = "corruption-stream";
+const TOPIC_NAME: &str = "corruption-topic";
+const PARTITION_ID: u32 = 0;
+
+/// Bounds an election, a rejoin, or a state-transfer heal on slow CI runners.
+const CONVERGE_TIMEOUT: Duration = Duration::from_secs(60);
+/// Budget for eagerly flushed batches to land in a node's segment files.
+const FLUSH_INSTALL_TIMEOUT: Duration = Duration::from_secs(20);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Garbage appended to a segment `.log`: shorter than a batch command header,
+/// so recovery must classify it as a torn tail, not a decodable batch.
+const TORN_LOG_GARBAGE: usize = 40;
+/// Garbage appended to a segment `.index`: deliberately NOT a multiple of the
+/// 24-byte sparse entry stride, the torn shape a mid-entry crash leaves.
+const TORN_INDEX_GARBAGE: usize = 10;
+/// Filler byte for surgery. 0xA5 decodes as neither a valid batch command
+/// header nor a plausible index position.
+const GARBAGE_BYTE: u8 = 0xA5;
+/// Metadata ops produced before the WAL surgery, so a flip at one quarter of
+/// the file provably lands ahead of many complete committed entries.
+const WAL_FODDER_STREAMS: usize = 20;
+
+async fn create_stream_and_topic(client: &IggyClient) {
+    client
+        .create_stream(STREAM_NAME)
+        .await
+        .expect("create stream");
+    // Eager flush persists and fsyncs every committed batch on every replica,
+    // so the on-disk oracles below observe exactly what was acked.
+    let options = TopicCreateOptions {
+        partitions_count: Some(1),
+        message_expiry: Some(IggyExpiry::NeverExpire),
+        messages_required_to_save: Some(1),
+        enforce_fsync: Some(true),
+        ..TopicCreateOptions::default()
+    };
+    client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            &options,
+        )
+        .await
+        .expect("create topic");
+}
+
+/// Send `count` single-message batches, returning each confirmed
+/// `(base_offset, payload)`.
+async fn produce_acked(
+    client: &IggyClient,
+    payload_prefix: &str,
+    count: u32,
+) -> Vec<(u64, String)> {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let topic = Identifier::named(TOPIC_NAME).unwrap();
+    let mut acked = Vec::with_capacity(count as usize);
+    for index in 0..count {
+        let payload = format!("{payload_prefix}-{index:05}");
+        let mut messages = vec![
+            IggyMessage::builder()
+                .payload(payload.clone().into())
+                .build()
+                .expect("build message"),
+        ];
+        let response = client
+            .send_messages(
+                &stream,
+                &topic,
+                &Partitioning::partition_id(PARTITION_ID),
+                &mut messages,
+            )
+            .await
+            .unwrap_or_else(|error| panic!("send {payload}: {error}"));
+        let confirmation = response
+            .confirmations
+            .first()
+            .unwrap_or_else(|| panic!("the VSR server confirms every send, none for {payload}"));
+        acked.push((confirmation.base_offset, payload));
+    }
+    acked
+}
+
+/// Poll from offset 0 until every acked `(offset, payload)` reads back at its
+/// confirmed offset, or `budget` runs out; `Err` carries the last shortfall.
+async fn wait_for_acked_readable(
+    client: &IggyClient,
+    acked: &[(u64, String)],
+    budget: Duration,
+) -> Result<(), String> {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let topic = Identifier::named(TOPIC_NAME).unwrap();
+    let deadline = tokio::time::Instant::now() + budget;
+    let want = acked.len() as u32 + 16;
+    let mut state;
+    loop {
+        match client
+            .poll_messages(
+                &stream,
+                &topic,
+                Some(PARTITION_ID),
+                &Consumer::default(),
+                &PollingStrategy::offset(0),
+                want,
+                false,
+            )
+            .await
+        {
+            Ok(polled) => {
+                let missing = acked.iter().find(|(offset, payload)| {
+                    !polled.messages.iter().any(|message| {
+                        message.header.offset == *offset
+                            && message.payload.as_ref() == payload.as_bytes()
+                    })
+                });
+                match missing {
+                    None => return Ok(()),
+                    Some((offset, _)) => {
+                        state = format!(
+                            "{} messages polled, offset {offset} missing or mismatched",
+                            polled.messages.len()
+                        );
+                    }
+                }
+            }
+            Err(error) => state = format!("poll failed: {error}"),
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(state);
+        }
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Connect a root client to the first node in `nodes` that accepts one.
+async fn connect_any(harness: &TestHarness, nodes: &[usize]) -> Option<IggyClient> {
+    for &node in nodes {
+        if let Ok(builder) = harness.node(node).tcp_client()
+            && let Ok(client) = builder.with_root_login().connect().await
+        {
+            return Some(client);
+        }
+    }
+    None
+}
+
+/// Number of nodes the metadata roster marks as leader.
+async fn leader_count(client: &IggyClient) -> Option<usize> {
+    let metadata = client.get_cluster_metadata().await.ok()?;
+    Some(
+        metadata
+            .nodes
+            .iter()
+            .filter(|node| node.role == ClusterNodeRole::Leader)
+            .count(),
+    )
+}
+
+/// Poll until one of `nodes` serves the test stream under exactly one leader.
+async fn wait_until_cluster_serves(
+    harness: &TestHarness,
+    nodes: &[usize],
+    budget: Duration,
+) -> IggyClient {
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        if let Some(client) = connect_any(harness, nodes).await
+            && matches!(client.get_stream(&stream).await, Ok(Some(_)))
+            && leader_count(&client).await == Some(1)
+        {
+            return client;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "cluster did not serve the stream under a single leader within {budget:?}"
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Poll until `node`'s segment files hold all of `payloads`; `context` names
+/// the phase for the deadline message.
+async fn wait_until_node_holds_payloads(
+    harness: &TestHarness,
+    node: usize,
+    payloads: &[String],
+    budget: Duration,
+    context: &str,
+) {
+    let data_path = harness.node(node).data_path();
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        match disk::installed_payloads_complete(&data_path, payloads) {
+            Ok(()) => return,
+            Err(error) => assert!(
+                tokio::time::Instant::now() < deadline,
+                "node {node} did not hold every payload within {budget:?} ({context}): {error}"
+            ),
+        }
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Under `IGGY_TEST_VERBOSE` the server's output is inherited rather than
+/// captured, so a boot-refusal error cannot carry the child's diagnostic
+/// text; the `Err` itself stays the load-bearing assertion.
+fn stderr_is_captured() -> bool {
+    std::env::var("IGGY_TEST_VERBOSE").is_err()
+}
+
+/// The leader index and the first backup index.
+async fn pick_backup(harness: &TestHarness) -> (usize, usize) {
+    let leader = disk::leader_node_index(harness).await;
+    let backup = (0..harness.cluster_size())
+        .find(|index| *index != leader)
+        .expect("a 3-node cluster has a backup");
+    (leader, backup)
+}
+
+/// The ACTIVE (highest base offset) partition segment file with `extension`
+/// under a node's data dir.
+fn find_active_segment_file(data_path: &Path, extension: &str) -> PathBuf {
+    let mut matches = Vec::new();
+    let _ = disk::walk(data_path, &mut |path| {
+        let named_like_segment = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| stem.len() == 20 && stem.bytes().all(|byte| byte.is_ascii_digit()));
+        if named_like_segment && path.extension().is_some_and(|found| found == extension) {
+            matches.push(path.to_path_buf());
+        }
+        false
+    });
+    matches.sort();
+    matches.pop().unwrap_or_else(|| {
+        panic!(
+            "no segment .{extension} found under {}",
+            data_path.display()
+        )
+    })
+}
+
+fn append_garbage(path: &Path, count: usize) {
+    let mut bytes =
+        fs::read(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    bytes.extend(std::iter::repeat_n(GARBAGE_BYTE, count));
+    fs::write(path, bytes).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+}
+
+/// Flip one interior byte at `numerator/denominator` of the file's length.
+fn flip_interior_byte(path: &Path, numerator: u64, denominator: u64) {
+    let mut bytes =
+        fs::read(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    assert!(
+        bytes.len() >= 1024,
+        "{} holds only {} bytes; the surgery needs a file large enough that an \
+         interior flip provably precedes complete entries",
+        path.display(),
+        bytes.len()
+    );
+    let at = (bytes.len() as u64 * numerator / denominator) as usize;
+    bytes[at] ^= 0xFF;
+    fs::write(path, bytes).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+}
+
+/// Byte-compare the partition segment `.log` files across all nodes, panicking
+/// with `defect` (the named bug) plus a per-file diff on divergence.
+fn assert_segment_logs_identical(data_paths: &[PathBuf], defect: &str) {
+    let per_node: Vec<_> = data_paths
+        .iter()
+        .map(|root| disk::collect_comparable_files(root, false))
+        .collect();
+    assert!(
+        per_node[0].keys().any(|key| key.ends_with(".log")),
+        "node 0 holds no segment .log; the comparison would be vacuous"
+    );
+    let mut problems = Vec::new();
+    for (key, reference) in &per_node[0] {
+        for (node, files) in per_node.iter().enumerate().skip(1) {
+            match files.get(key) {
+                None => problems.push(format!("`{key}` missing on node {node}")),
+                Some(bytes) if bytes != reference => {
+                    problems.push(disk::describe_mismatch(key, 0, reference, node, bytes));
+                }
+                Some(_) => {}
+            }
+        }
+    }
+    assert!(problems.is_empty(), "{defect}:\n{}", problems.join("\n"));
+}
+
+/// RED SPEC, expected to FAIL: a torn tail of garbage on the active segment
+/// `.log` must be truncated for good by recovery. Recovery does walk whole
+/// batches and computes the correct pre-garbage size, but reopening the
+/// segment re-stats the RAW file length into the writer's size counter
+/// (`MessagesWriter::new` with `file_exists = true`), while the recovered
+/// segment metadata keeps the walked size. Post-recovery appends then land at
+/// the raw position (after the resurrected garbage) while their index entries
+/// record the walked position, so every new index entry points below where
+/// its bytes physically landed and the NEXT recovery refuses the segment as
+/// message/index divergence. One torn tail on one replica permanently bricks
+/// that node's next restart.
+///
+/// The refusal also provokes a distinct defect this spec does not assert:
+/// the owner shard's boot refusal cascades the surviving shards into
+/// metadata STM read-handle panics (`ShardBootstrapBarrierAborted`, then
+/// `ShardPumpDied`) instead of a clean fail-stop.
+// TODO(hubcio): fix this test
+#[ignore = "torn .log tail re-stated into the size counter bricks the next restart"]
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_a_torn_segment_tail_when_a_node_recovers_should_keep_size_counter_consistent(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&client).await;
+    let mut acked = produce_acked(&client, "pre-torn", 30).await;
+    let pre_payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    for node in 0..harness.cluster_size() {
+        wait_until_node_holds_payloads(
+            harness,
+            node,
+            &pre_payloads,
+            FLUSH_INSTALL_TIMEOUT,
+            "eager flush before the surgery",
+        )
+        .await;
+    }
+
+    let (_, backup) = pick_backup(harness).await;
+    harness.stop_node(backup).expect("stop the backup");
+    let segment_log = find_active_segment_file(&harness.node(backup).data_path(), "log");
+    append_garbage(&segment_log, TORN_LOG_GARBAGE);
+
+    harness
+        .restart_node(backup)
+        .expect("recovery must absorb a torn segment tail and boot");
+
+    acked.extend(produce_acked(&client, "post-torn", 30).await);
+    let all_payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    for node in 0..harness.cluster_size() {
+        wait_until_node_holds_payloads(
+            harness,
+            node,
+            &all_payloads,
+            CONVERGE_TIMEOUT,
+            "replication after the torn-tail recovery",
+        )
+        .await;
+    }
+
+    harness.restart_node(backup).unwrap_or_else(|error| {
+        panic!(
+            "the second recovery over a repaired torn tail must boot cleanly, but the \
+             segment reopen re-stats the raw file length (garbage included) into the \
+             messages writer while the recovered segment metadata keeps the walked \
+             size, so post-recovery appends land after the resurrected garbage and \
+             their index entries point below where the bytes physically landed; the \
+             next boot then refuses the segment as message/index divergence and the \
+             node cannot restart over its own data; boot error: {error}"
+        )
+    });
+    let nodes: Vec<usize> = (0..harness.cluster_size()).collect();
+    let client = wait_until_cluster_serves(harness, &nodes, CONVERGE_TIMEOUT).await;
+    wait_for_acked_readable(&client, &acked, CONVERGE_TIMEOUT)
+        .await
+        .unwrap_or_else(|state| {
+            panic!("every acked offset must poll back after the torn-tail recovery: {state}")
+        });
+
+    let data_paths: Vec<PathBuf> = harness
+        .all_servers()
+        .iter()
+        .map(|server| server.data_path())
+        .collect();
+    harness
+        .stop()
+        .await
+        .expect("stop the cluster for the at-rest comparison");
+    assert_segment_logs_identical(
+        &data_paths,
+        "the torn segment tail was resurrected into the live byte range: recovery \
+         computes the valid size by walking whole batches past the garbage, but the \
+         segment reopen re-stats the raw file length into the shared size counter, \
+         so subsequent appends land after the garbage and this replica's segment \
+         bytes diverge from its peers for the same acked history",
+    );
+}
+
+/// RED SPEC, expected to FAIL: a torn tail on the segment `.index` (10 bytes,
+/// not a multiple of the 24-byte entry stride) must not poison later entries.
+/// The first recovery ignores the partial tail (whole-entry floor division) and
+/// boots, but the index reopen re-stats the RAW length and appends every new
+/// entry at that unaligned position, while every reader addresses entries as
+/// stride-from-0. The next recovery then decodes a garbage-straddling entry as
+/// the last flush and refuses the partition (or serves misresolved reads).
+/// The refusal provokes the same unasserted shard-cascade defect as the torn
+/// `.log` spec above.
+// TODO(hubcio): fix this test
+#[ignore = "torn .index tail misaligns subsequent entries off the 24-byte stride"]
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_a_torn_index_tail_when_a_node_recovers_should_not_misalign_subsequent_entries(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&client).await;
+    let mut acked = produce_acked(&client, "pre-torn-index", 30).await;
+    let pre_payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    for node in 0..harness.cluster_size() {
+        wait_until_node_holds_payloads(
+            harness,
+            node,
+            &pre_payloads,
+            FLUSH_INSTALL_TIMEOUT,
+            "eager flush before the surgery",
+        )
+        .await;
+    }
+
+    let (_, backup) = pick_backup(harness).await;
+    harness.stop_node(backup).expect("stop the backup");
+    let segment_index = find_active_segment_file(&harness.node(backup).data_path(), "index");
+    append_garbage(&segment_index, TORN_INDEX_GARBAGE);
+
+    harness
+        .restart_node(backup)
+        .expect("a torn index tail is a whole-entry floor away from clean; boot must succeed");
+
+    acked.extend(produce_acked(&client, "post-torn-index", 30).await);
+    let all_payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    wait_until_node_holds_payloads(
+        harness,
+        backup,
+        &all_payloads,
+        CONVERGE_TIMEOUT,
+        "replication after the torn-index recovery",
+    )
+    .await;
+
+    harness.restart_node(backup).unwrap_or_else(|error| {
+        panic!(
+            "the recovery after a torn index tail must not misalign subsequent index \
+             entries: the index reopen re-stats the raw (unaligned) file length and \
+             appends new entries off the 24-byte stride, while recovery reads entries \
+             as stride-from-0, so the second boot decodes a garbage-straddling entry \
+             and refuses the segment; boot error: {error}"
+        )
+    });
+
+    let nodes: Vec<usize> = (0..harness.cluster_size()).collect();
+    let client = wait_until_cluster_serves(harness, &nodes, CONVERGE_TIMEOUT).await;
+    wait_for_acked_readable(&client, &acked, CONVERGE_TIMEOUT)
+        .await
+        .unwrap_or_else(|state| {
+            panic!(
+                "every acked offset must poll back after the torn-index recovery \
+                 (index entries misaligned off the 24-byte stride misresolve reads): \
+                 {state}"
+            )
+        });
+}
+
+/// An interior flip in the metadata WAL is bit-rot, not a torn append: a
+/// complete committed entry follows the damage, so truncating would discard
+/// acked history. Boot must refuse with the interior-corruption diagnostic,
+/// the surviving quorum must keep serving, and the node heals by rejoining
+/// from a clean slate (state transfer).
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_interior_wal_corruption_when_a_node_boots_should_refuse_and_heal_via_clean_slate(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&client).await;
+    let mut acked = produce_acked(&client, "pre-fault", 20).await;
+    // Extra committed metadata ops so the flip at one quarter of the WAL
+    // provably precedes many complete entries.
+    for index in 0..WAL_FODDER_STREAMS {
+        client
+            .create_stream(&format!("wal-fodder-{index:02}"))
+            .await
+            .expect("create fodder stream");
+    }
+    let pre_payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    for node in 0..harness.cluster_size() {
+        wait_until_node_holds_payloads(
+            harness,
+            node,
+            &pre_payloads,
+            FLUSH_INSTALL_TIMEOUT,
+            "eager flush before the surgery",
+        )
+        .await;
+    }
+    drop(client);
+
+    let (_, backup) = pick_backup(harness).await;
+    harness.stop_node(backup).expect("stop the backup");
+    let wal_path = harness
+        .node(backup)
+        .data_path()
+        .join("metadata/journal.wal");
+    flip_interior_byte(&wal_path, 1, 4);
+
+    let error = harness
+        .restart_node(backup)
+        .expect_err("boot over an interior-corrupt WAL must refuse, not truncate");
+    if stderr_is_captured() {
+        let diagnostics = error.to_string();
+        assert!(
+            diagnostics.contains("refusing to truncate"),
+            "the boot refusal must name the interior WAL corruption (\"refusing to \
+             truncate\"), got: {diagnostics}"
+        );
+    }
+
+    let survivors: Vec<usize> = (0..harness.cluster_size())
+        .filter(|index| *index != backup)
+        .collect();
+    let survivor_client = wait_until_cluster_serves(harness, &survivors, CONVERGE_TIMEOUT).await;
+    acked.extend(produce_acked(&survivor_client, "post-fault", 10).await);
+    wait_for_acked_readable(&survivor_client, &acked, CONVERGE_TIMEOUT)
+        .await
+        .unwrap_or_else(|state| {
+            panic!("the surviving quorum must keep serving all acked offsets: {state}")
+        });
+
+    harness
+        .restart_node_from_clean_slate(backup)
+        .expect("a clean-slate rejoin heals the corrupt-WAL node");
+    let all_payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    wait_until_node_holds_payloads(
+        harness,
+        backup,
+        &all_payloads,
+        CONVERGE_TIMEOUT,
+        "state-transfer heal after the clean-slate rejoin",
+    )
+    .await;
+}
+
+/// A superblock slot whose bytes no longer verify, beside a valid sibling, is
+/// bit-rot whose lost `sequence` may have been the newer generation: falling
+/// back could walk consensus state backwards, so boot must refuse. The
+/// surviving quorum keeps serving and a clean-slate rejoin heals the node.
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_a_corrupt_superblock_slot_when_a_node_boots_should_refuse_boot(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&client).await;
+    let mut acked = produce_acked(&client, "pre-fault", 20).await;
+    let pre_payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    for node in 0..harness.cluster_size() {
+        wait_until_node_holds_payloads(
+            harness,
+            node,
+            &pre_payloads,
+            FLUSH_INSTALL_TIMEOUT,
+            "eager flush before the surgery",
+        )
+        .await;
+    }
+    drop(client);
+
+    // A quiet cluster at view 0 has an EMPTY metadata superblock: the record
+    // is first persisted when a replica adopts an advanced view. Force a view
+    // change by stopping the view-0 metadata primary (replica 0), wait for a
+    // survivor to persist `view >= 1`, then bring node 0 back so a full
+    // quorum survives the later surgery victim.
+    harness
+        .stop_node(0)
+        .expect("stop the view-0 metadata primary");
+    let view_change_deadline = tokio::time::Instant::now() + CONVERGE_TIMEOUT;
+    while (1..harness.cluster_size())
+        .all(|node| disk::read_metadata_superblock_state(&harness.node(node).data_path()).is_none())
+    {
+        assert!(
+            tokio::time::Instant::now() < view_change_deadline,
+            "no survivor persisted a metadata superblock record after the primary stop"
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+    harness
+        .restart_node(0)
+        .expect("rejoin the old primary so the cluster is whole before the surgery");
+    let nodes: Vec<usize> = (0..harness.cluster_size()).collect();
+    drop(wait_until_cluster_serves(harness, &nodes, CONVERGE_TIMEOUT).await);
+
+    // The surgery victim: a node holding a durable record that is not the
+    // current leader, so stopping it leaves a serving quorum.
+    let leader = disk::leader_node_index(harness).await;
+    let backup = (1..harness.cluster_size())
+        .find(|node| {
+            *node != leader
+                && disk::read_metadata_superblock_state(&harness.node(*node).data_path()).is_some()
+        })
+        .expect("a non-leader survivor holds a durable superblock record");
+    let backup_data = harness.node(backup).data_path();
+
+    harness.stop_node(backup).expect("stop the backup");
+    let slot_path = ["superblock.a", "superblock.b"]
+        .iter()
+        .map(|name| backup_data.join("metadata").join(name))
+        .find(|path| fs::metadata(path).is_ok_and(|meta| meta.len() > 0))
+        .expect("at least one non-empty superblock slot exists");
+    // Flip one byte halfway into the record: past the header, inside the
+    // checksummed payload, so the slot classifies as corrupt (not absent).
+    let mut bytes = fs::read(&slot_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", slot_path.display()));
+    let at = bytes.len() / 2;
+    bytes[at] ^= 0xFF;
+    fs::write(&slot_path, bytes)
+        .unwrap_or_else(|error| panic!("write {}: {error}", slot_path.display()));
+
+    let error = harness
+        .restart_node(backup)
+        .expect_err("boot over a corrupt superblock slot must refuse even beside a valid sibling");
+    if stderr_is_captured() {
+        // The refusal reaches stderr as the Debug form of the recovery error,
+        // so the variant name is the decisive marker.
+        let diagnostics = error.to_string();
+        assert!(
+            diagnostics.contains("SuperblockUnreadable"),
+            "the boot refusal must name the unreadable superblock, got: {diagnostics}"
+        );
+    }
+
+    let survivors: Vec<usize> = (0..harness.cluster_size())
+        .filter(|index| *index != backup)
+        .collect();
+    let survivor_client = wait_until_cluster_serves(harness, &survivors, CONVERGE_TIMEOUT).await;
+    acked.extend(produce_acked(&survivor_client, "post-fault", 10).await);
+    wait_for_acked_readable(&survivor_client, &acked, CONVERGE_TIMEOUT)
+        .await
+        .unwrap_or_else(|state| {
+            panic!("the surviving quorum must keep serving all acked offsets: {state}")
+        });
+
+    harness
+        .restart_node_from_clean_slate(backup)
+        .expect("a clean-slate rejoin heals the corrupt-superblock node");
+    let all_payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    wait_until_node_holds_payloads(
+        harness,
+        backup,
+        &all_payloads,
+        CONVERGE_TIMEOUT,
+        "state-transfer heal after the clean-slate rejoin",
+    )
+    .await;
+}

--- a/core/integration/tests/cluster/failover_client_continuity.rs
+++ b/core/integration/tests/cluster/failover_client_continuity.rs
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! RED SPEC, expected to FAIL: client continuity across a primary SIGKILL.
+//!
+//! A producing SDK client pinned to the primary must, after the primary dies,
+//! complete its next operation against the surviving quorum within a small
+//! budget and without an authentication error. The SDK cannot: it has no
+//! multi-endpoint failover. A client is built around a single
+//! `server_address`, so it knows no other endpoint to dial; the transport's
+//! fail-fast gate (auto-login disabled, the shape this harness client runs
+//! with) returns errors without attempting a reconnect; and the
+//! leader-redirect machinery that could reroute it needs a live connection to
+//! read the cluster roster. Every retry therefore redials the dead endpoint
+//! and fails with a connection error until the caller gives up. Surviving a
+//! primary crash needs a seed roster of endpoints, not just a redirect.
+
+use std::time::Duration;
+
+use iggy::prelude::*;
+use integration::harness::disk;
+use integration::iggy_harness;
+use tokio::time::sleep;
+
+const STREAM_NAME: &str = "failover-stream";
+const TOPIC_NAME: &str = "failover-topic";
+const PARTITION_ID: u32 = 0;
+
+/// Acks the pinned producer must capture before the kill, so the session is
+/// warm and mid-stream rather than freshly connected.
+const PRE_KILL_ACKS: usize = 20;
+
+/// Budget for reaching the pre-kill ack count.
+const WARMUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The continuity contract under test: the client's next operation after the
+/// primary dies must complete within this budget. Far above a survivor
+/// election (a few seconds) and far below the transport timeout a hang burns.
+const RESUME_BUDGET: Duration = Duration::from_secs(10);
+
+const RETRY_PAUSE: Duration = Duration::from_millis(250);
+
+fn build_message(payload: &str) -> IggyMessage {
+    IggyMessage::builder()
+        .payload(payload.to_owned().into())
+        .build()
+        .expect("build message")
+}
+
+/// A producing client pinned to the primary; SIGKILL the primary mid-stream;
+/// the same client's next send must succeed against the surviving quorum
+/// within `RESUME_BUDGET` and must never surface Unauthenticated.
+// TODO(hubcio): fix this test
+#[ignore = "SDK has no multi-endpoint failover; client redials the dead primary forever"]
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_a_client_producing_when_its_primary_is_killed_should_resume_without_hang_or_unauthenticated(
+    harness: &mut TestHarness,
+) {
+    let setup_client = harness.tcp_root_client().await.unwrap();
+    setup_client
+        .create_stream(STREAM_NAME)
+        .await
+        .expect("create stream");
+    // Eagerly flushed so every pre-kill ack is durable on the survivors and
+    // the post-kill send is a pure continuity question, not a durability one.
+    let options = TopicCreateOptions {
+        partitions_count: Some(1),
+        message_expiry: Some(IggyExpiry::NeverExpire),
+        messages_required_to_save: Some(1),
+        enforce_fsync: Some(true),
+        ..TopicCreateOptions::default()
+    };
+    setup_client
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            &options,
+        )
+        .await
+        .expect("create topic");
+    drop(setup_client);
+
+    // Pin the producing client to the primary's own endpoint, the way a
+    // leader-aware SDK ends up connected to whichever node answers as leader.
+    let leader = disk::leader_node_index(harness).await;
+    let producer = harness
+        .node(leader)
+        .tcp_client()
+        .expect("leader exposes a TCP endpoint")
+        .with_root_login()
+        .connect()
+        .await
+        .expect("connect the producer to the primary");
+
+    let stream = Identifier::named(STREAM_NAME).unwrap();
+    let topic = Identifier::named(TOPIC_NAME).unwrap();
+    let partitioning = Partitioning::partition_id(PARTITION_ID);
+
+    let warmup_deadline = tokio::time::Instant::now() + WARMUP_TIMEOUT;
+    let mut acked = 0usize;
+    while acked < PRE_KILL_ACKS {
+        assert!(
+            tokio::time::Instant::now() < warmup_deadline,
+            "the pinned producer must reach {PRE_KILL_ACKS} acked sends before the kill"
+        );
+        let mut messages = vec![build_message(&format!("pre-kill-{acked:05}"))];
+        let response = producer
+            .send_messages(&stream, &topic, &partitioning, &mut messages)
+            .await
+            .expect("pre-kill sends against the live primary must succeed");
+        assert!(
+            !response.confirmations.is_empty(),
+            "the VSR server confirms every send"
+        );
+        acked += 1;
+    }
+
+    harness.kill_node(leader).expect("SIGKILL the primary");
+
+    // The contract: the SAME client completes a send within RESUME_BUDGET.
+    // The first attempt is allowed to fail (its connection just died); what
+    // is not allowed is burning the whole budget without one success.
+    let resume_deadline = tokio::time::Instant::now() + RESUME_BUDGET;
+    let mut attempt = 0usize;
+    let mut last_error: Option<IggyError> = None;
+    let resumed = loop {
+        let now = tokio::time::Instant::now();
+        if now >= resume_deadline {
+            break false;
+        }
+        let mut messages = vec![build_message(&format!("post-kill-{attempt:05}"))];
+        attempt += 1;
+        let send = producer.send_messages(&stream, &topic, &partitioning, &mut messages);
+        match tokio::time::timeout(resume_deadline - now, send).await {
+            Ok(Ok(_)) => break true,
+            Ok(Err(error)) => {
+                last_error = Some(error);
+                sleep(RETRY_PAUSE).await;
+            }
+            // Self-bound: an attempt that outlives the remaining budget ends
+            // the loop instead of wedging the suite.
+            Err(_elapsed) => break false,
+        }
+    };
+
+    assert!(
+        resumed,
+        "a client pinned to a killed primary must complete its next operation against \
+         the surviving quorum within {RESUME_BUDGET:?}, but the SDK has no \
+         multi-endpoint failover: it holds only the dead node's server_address, its \
+         fail-fast gate (auto-login disabled) surfaces errors without reconnecting, \
+         and the leader redirect that could reroute it needs a live connection to \
+         read the roster, so every retry redialed the dead endpoint \
+         ({attempt} attempts, last error: {last_error:?})"
+    );
+}

--- a/core/integration/tests/cluster/mod.rs
+++ b/core/integration/tests/cluster/mod.rs
@@ -15,7 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+mod client_table_adversarial;
 mod client_table_restart;
+mod crash_durability;
+mod crash_offset_reuse;
+mod crash_recovery_corruption;
+mod failover_client_continuity;
 mod metadata_checkpoint_restart;
 mod metadata_state_transfer;
 mod multi_shard_partition_convergence;

--- a/core/integration/tests/data_integrity/verify_cluster_replica_data_identical.rs
+++ b/core/integration/tests/data_integrity/verify_cluster_replica_data_identical.rs
@@ -31,15 +31,15 @@
 //! which a backup commit must persist only the committed prefix and keep the
 //! uncommitted tail resident); the sequential run that follows drives many backup
 //! commit cycles and would expose a backup left permanently behind. The segment
-//! `.index` is excluded - see `is_comparable`.
+//! `.index` is excluded - see `integration::harness::disk`.
+//!
+//! The run stays far below the checkpoint margin, so the metadata WAL is still
+//! byte-identical across replicas and is included in the comparison.
 
 use iggy::prelude::*;
+use integration::harness::disk;
 use integration::iggy_harness;
-use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::Duration;
-use tokio::time::sleep;
+use std::path::PathBuf;
 
 const STREAM_NAME: &str = "di-stream";
 const TOPIC_NAME: &str = "di-topic";
@@ -64,14 +64,6 @@ const SEQUENTIAL_BATCH_MESSAGES: u32 = 3;
 const BURST_CLIENTS: usize = 8;
 const BURST_SENDS_PER_CLIENT: u32 = 3;
 const BURST_BATCH_MESSAGES: u32 = 2;
-
-// Poll the per-node segment `.log` sizes until they agree and hold steady,
-// instead of a fixed sleep: a fixed wait either flakes under CI load or hides a
-// real replication lag. `messages_required_to_save = 1` flushes every committed
-// batch, so the at-rest `.log` total tracks committed persistence while running.
-const CONVERGENCE_POLL_INTERVAL: Duration = Duration::from_millis(200);
-const CONVERGENCE_DEADLINE: Duration = Duration::from_secs(20);
-const CONVERGENCE_STABLE_POLLS: u32 = 3;
 
 // `messages_required_to_save = 1` forces every committed batch to persist to its
 // segment immediately on every node, so each replica materialises the segment
@@ -170,7 +162,9 @@ async fn should_persist_byte_identical_data_across_cluster_replicas(harness: &mu
 
     // Wait for replication + per-batch persistence to converge across nodes
     // before reading files at rest (replaces a fixed settle sleep).
-    wait_for_log_convergence(&data_paths).await;
+    // `messages_required_to_save = 1` flushes every committed batch, so the
+    // at-rest `.log` total tracks committed persistence while running.
+    disk::wait_for_log_convergence(&data_paths).await;
 
     // Stop the whole cluster so every segment / metadata file is at rest. The
     // burst connections are still held; dropping them only after stop avoids the
@@ -178,22 +172,7 @@ async fn should_persist_byte_identical_data_across_cluster_replicas(harness: &mu
     harness.stop().await.unwrap();
     drop(_burst_clients);
 
-    let per_node: Vec<BTreeMap<String, Vec<u8>>> = data_paths
-        .iter()
-        .map(|root| collect_comparable_files(root))
-        .collect();
-
-    for (idx, node) in per_node.iter().enumerate() {
-        eprintln!(
-            "node {idx}: {} comparable file(s): {:?}",
-            node.len(),
-            node.iter()
-                .map(|(rel, bytes)| format!("{rel} ({} B)", bytes.len()))
-                .collect::<Vec<_>>()
-        );
-    }
-
-    assert_replica_data_identical(&per_node);
+    disk::assert_replica_data_identical(&data_paths, true);
 }
 
 /// Drive a concurrent send burst across independent connections so the primary
@@ -248,197 +227,4 @@ async fn send_concurrent_burst(clients: Vec<IggyClient>) -> Vec<IggyClient> {
         clients.push(handle.await.unwrap());
     }
     clients
-}
-
-/// Poll each node's total segment `.log` bytes until all nodes agree and the
-/// figure holds steady for `CONVERGENCE_STABLE_POLLS` consecutive polls, or the
-/// deadline elapses. On timeout, return anyway: the byte-for-byte compare after
-/// stop then fails with a precise diff instead of this masking a real lag.
-async fn wait_for_log_convergence(data_paths: &[PathBuf]) {
-    let deadline = tokio::time::Instant::now() + CONVERGENCE_DEADLINE;
-    let mut previous: Option<Vec<u64>> = None;
-    let mut stable_polls = 0u32;
-    loop {
-        let sizes: Vec<u64> = data_paths
-            .iter()
-            .map(|root| total_log_bytes(root))
-            .collect();
-        let all_equal = sizes.iter().all(|size| *size == sizes[0]);
-        if all_equal && previous.as_ref() == Some(&sizes) {
-            stable_polls += 1;
-            if stable_polls >= CONVERGENCE_STABLE_POLLS {
-                return;
-            }
-        } else {
-            stable_polls = 0;
-        }
-        if tokio::time::Instant::now() >= deadline {
-            return;
-        }
-        previous = Some(sizes);
-        sleep(CONVERGENCE_POLL_INTERVAL).await;
-    }
-}
-
-/// Total bytes of every partition segment `.log` under a node's data dir.
-/// Mirrors the `.log` selection in `is_comparable`; sizes only, no contents.
-fn total_log_bytes(root: &Path) -> u64 {
-    let mut total = 0;
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        let Ok(entries) = fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Ok(file_type) = entry.file_type() else {
-                continue;
-            };
-            if file_type.is_dir() {
-                stack.push(path);
-            } else if file_type.is_file()
-                && let Ok(rel) = path.strip_prefix(root)
-            {
-                let rel = rel.to_string_lossy().replace('\\', "/");
-                if rel.starts_with("streams/") && rel.ends_with(".log") {
-                    total += fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
-                }
-            }
-        }
-    }
-    total
-}
-
-/// A file (relative to a node's data dir) whose bytes must match across replicas:
-/// the partition segment `.log` and the replicated metadata WAL. Per-node files
-/// (logs, runtime, config, stdout) are excluded by construction.
-///
-/// Only the replicated, byte-identical artifacts are compared. Two metadata-plane
-/// files are deliberately excluded as local, per-replica artifacts:
-///
-/// - `metadata/snapshot.bin`: a local compaction artifact stamped with
-///   `created_at = now()` and a per-replica `sequence_number` at each node's own
-///   checkpoint, plus unsorted hashmap iteration order. It can never match across
-///   replicas even when the data is identical, so comparing it would ship a
-///   nondeterministic oracle (it is only written once a node crosses the
-///   checkpoint margin, so the flake is latent, not constant).
-/// - `state/`: not populated by the VSR plane (0 bytes today); excluded for the
-///   same local-artifact reason so it cannot start flaking if that ever changes.
-///
-/// The segment `.index` is excluded for the same class of reason: a local sparse
-/// index (one entry per persist flush), not replicated and not part of the VSR
-/// hash chain; recovery rebuilds it from the `.log`. Its byte length tracks the
-/// number of `commit_messages` flushes, which differs by commit cadence - the
-/// primary commits one op per quorum ack (one flush per op), a backup commits a
-/// whole heartbeat's committed range in a single `commit_journal` (one flush for
-/// many ops). So the `.index` legitimately differs across replicas for a
-/// multi-batch stream even though every committed `.log` byte is identical.
-fn is_comparable(rel: &str) -> bool {
-    let is_segment = rel.starts_with("streams/") && rel.ends_with(".log");
-    let is_metadata_wal = rel == "metadata/journal.wal";
-    is_segment || is_metadata_wal
-}
-
-fn collect_comparable_files(root: &Path) -> BTreeMap<String, Vec<u8>> {
-    let mut files = BTreeMap::new();
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        let Ok(entries) = fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Ok(file_type) = entry.file_type() else {
-                continue;
-            };
-            if file_type.is_dir() {
-                stack.push(path);
-            } else if file_type.is_file()
-                && let Ok(rel) = path.strip_prefix(root)
-            {
-                let rel = rel.to_string_lossy().replace('\\', "/");
-                if is_comparable(&rel) {
-                    let bytes = fs::read(&path)
-                        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
-                    files.insert(rel, bytes);
-                }
-            }
-        }
-    }
-    files
-}
-
-fn assert_replica_data_identical(per_node: &[BTreeMap<String, Vec<u8>>]) {
-    // Guard against a vacuous pass: node 0 must actually hold a produced segment,
-    // otherwise nothing was persisted and the comparison proves nothing.
-    let node0 = &per_node[0];
-    assert!(
-        node0
-            .keys()
-            .any(|k| k.starts_with("streams/") && k.ends_with(".log")),
-        "node 0 holds no segment .log under streams/ - no partition data was persisted, \
-         so the cross-replica comparison would be vacuous. Comparable files: {:?}",
-        node0.keys().collect::<Vec<_>>()
-    );
-
-    let all_keys: BTreeSet<&str> = per_node
-        .iter()
-        .flat_map(|node| node.keys().map(String::as_str))
-        .collect();
-
-    let mut problems = Vec::new();
-    for key in all_keys {
-        let mut reference: Option<(usize, &[u8])> = None;
-        for (idx, node) in per_node.iter().enumerate() {
-            let Some(bytes) = node.get(key) else {
-                problems.push(format!(
-                    "`{key}` present on some replicas but MISSING on node {idx}"
-                ));
-                continue;
-            };
-            let bytes: &[u8] = bytes;
-            match reference {
-                None => reference = Some((idx, bytes)),
-                Some((ref_idx, ref_bytes)) => {
-                    if bytes != ref_bytes {
-                        problems.push(describe_mismatch(key, ref_idx, ref_bytes, idx, bytes));
-                    }
-                }
-            }
-        }
-    }
-
-    assert!(
-        problems.is_empty(),
-        "cross-replica data divergence ({} issue(s)):\n{}",
-        problems.len(),
-        problems.join("\n")
-    );
-}
-
-fn describe_mismatch(key: &str, a_idx: usize, a: &[u8], b_idx: usize, b: &[u8]) -> String {
-    let window = |buf: &[u8], at: usize| {
-        let start = at.saturating_sub(8);
-        let end = (at + 8).min(buf.len());
-        buf[start..end]
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<Vec<_>>()
-            .join(" ")
-    };
-    match a.iter().zip(b.iter()).position(|(x, y)| x != y) {
-        Some(at) => format!(
-            "`{key}`: bytes differ between node {a_idx} ({} B) and node {b_idx} ({} B) at offset {at}. \
-             node{a_idx}=[{}] node{b_idx}=[{}]",
-            a.len(),
-            b.len(),
-            window(a, at),
-            window(b, at),
-        ),
-        None => format!(
-            "`{key}`: length differs between node {a_idx} ({} B) and node {b_idx} ({} B)",
-            a.len(),
-            b.len(),
-        ),
-    }
 }

--- a/core/shard/src/router.rs
+++ b/core/shard/src/router.rs
@@ -765,3 +765,76 @@ enum ReplicaHandshakeOutcome {
     ReleaseSlot(u64),
     ClearDial(u8),
 }
+
+#[cfg(test)]
+mod tests {
+    use iggy_binary_protocol::{
+        Command2, ConsensusError, GenericHeader, HEADER_SIZE, PrepareHeader, frame_checksum_bytes,
+    };
+    use server_common::iobuf::Owned;
+    use server_common::{MESSAGE_ALIGN, Message, MessageBag};
+    use std::mem::offset_of;
+
+    /// RED SPEC, expected to FAIL: pins the mixed-cluster upgrade hole in
+    /// `dispatch`'s decode seam.
+    ///
+    /// An `Operation` discriminant this build does not know, arriving on an
+    /// otherwise wire-valid consensus frame (correct command, size, checksum:
+    /// exactly what a newer release sends after an op addition), decodes to
+    /// the same undifferentiated `ConsensusError::InvalidBitPattern` as random
+    /// memory corruption. `dispatch` answers both identically: a warn log and
+    /// a dropped frame. No metric, no peer error, no eviction, no version
+    /// fence. An old node in a mixed cluster therefore gap-stops its consensus
+    /// group silently (never journals the op, never sends a `PrepareOk`, every
+    /// later prepare dies on the gap check) while quorum hides the outage.
+    ///
+    /// Passes once the decode surfaces a dedicated unsupported-operation
+    /// signal the router can fence and account, instead of collapsing it into
+    /// the corruption error.
+    #[test]
+    // TODO(hubcio): fix this test
+    #[ignore = "unknown operation collapses into InvalidBitPattern; no upgrade fence"]
+    fn given_an_unknown_operation_when_a_consensus_frame_decodes_should_surface_an_upgrade_fence_signal()
+     {
+        // Far past every defined Operation discriminant (the highest is 165).
+        const OPERATION_FROM_A_NEWER_RELEASE: u8 = 0xEE;
+
+        let mut owned = Owned::<MESSAGE_ALIGN>::zeroed(HEADER_SIZE);
+        {
+            let frame = owned.as_mut_slice();
+            let size_offset = offset_of!(PrepareHeader, size);
+            let frame_size = u32::try_from(HEADER_SIZE).expect("header size fits in u32");
+            frame[size_offset..size_offset + 4].copy_from_slice(&frame_size.to_le_bytes());
+            frame[offset_of!(PrepareHeader, command)] = Command2::Prepare as u8;
+            let client_offset = offset_of!(PrepareHeader, client);
+            frame[client_offset..client_offset + 16].copy_from_slice(&0xCAFE_u128.to_le_bytes());
+            frame[offset_of!(PrepareHeader, operation)] = OPERATION_FROM_A_NEWER_RELEASE;
+            // Seal the checksum the way a real sender does, so the frame's
+            // only anomaly is the operation byte itself.
+            let header: &[u8; HEADER_SIZE] = frame[..HEADER_SIZE]
+                .try_into()
+                .expect("frame spans a full header");
+            let checksum = frame_checksum_bytes(header);
+            frame[..size_of::<u128>()].copy_from_slice(&checksum.to_le_bytes());
+        }
+
+        // The generic view carries no operation field, so the receive path
+        // accepts the frame; the unknown byte is first seen by the typed
+        // decode inside `MessageBag::try_from`, which is what `dispatch` runs.
+        let message = Message::<GenericHeader>::try_from(owned)
+            .expect("a sealed Prepare frame is wire-valid in the generic view");
+
+        let Err(error) = MessageBag::try_from(message) else {
+            panic!("an operation this build does not know must not decode into a bag");
+        };
+
+        assert!(
+            !matches!(error, ConsensusError::InvalidBitPattern),
+            "unknown operation {OPERATION_FROM_A_NEWER_RELEASE:#x} is silently dropped: the \
+             typed decode collapses a wire-valid frame from a newer release into the same \
+             InvalidBitPattern as corruption, and dispatch drops both with only a warn log, \
+             no operator signal and no upgrade fence, so an old node in a mixed cluster \
+             gap-stops its consensus group while quorum hides it; got {error:?}"
+        );
+    }
+}

--- a/core/shard/src/router.rs
+++ b/core/shard/src/router.rs
@@ -769,7 +769,7 @@ enum ReplicaHandshakeOutcome {
 #[cfg(test)]
 mod tests {
     use iggy_binary_protocol::{
-        Command2, ConsensusError, GenericHeader, HEADER_SIZE, PrepareHeader, frame_checksum_bytes,
+        Command, ConsensusError, GenericHeader, HEADER_SIZE, PrepareHeader, frame_checksum_bytes,
     };
     use server_common::iobuf::Owned;
     use server_common::{MESSAGE_ALIGN, Message, MessageBag};
@@ -805,7 +805,7 @@ mod tests {
             let size_offset = offset_of!(PrepareHeader, size);
             let frame_size = u32::try_from(HEADER_SIZE).expect("header size fits in u32");
             frame[size_offset..size_offset + 4].copy_from_slice(&frame_size.to_le_bytes());
-            frame[offset_of!(PrepareHeader, command)] = Command2::Prepare as u8;
+            frame[offset_of!(PrepareHeader, command)] = Command::Prepare as u8;
             let client_offset = offset_of!(PrepareHeader, client);
             frame[client_offset..client_offset + 16].copy_from_slice(&0xCAFE_u128.to_le_bytes());
             frame[offset_of!(PrepareHeader, operation)] = OPERATION_FROM_A_NEWER_RELEASE;


### PR DESCRIPTION
Every harness "crash" was a graceful SIGTERM with a 5s shutdown
flush, so no test asserted that an acked write survives a real
process kill at any node count, and the torn-tail recovery path
in segment_recovery had no coverage at all.

Add a kill() facility (SIGKILL with the watchdog stopped before
the signal), shared disk oracles under harness::disk, and 12
cluster tests covering crash durability, offset re-mint, on-disk
corruption recovery, failover client continuity, and client-table
dedup under churn. Six tests pass; seven are honest red specs
marked #[ignore] with reasons naming the defects they pin:
offset re-mint after restart, torn-tail size-counter divergence
bricking restarts, index stride misalignment, missing SDK
multi-endpoint failover, dedup-watermark eviction, reply-ring
fall-off, and unknown operations collapsing into
InvalidBitPattern.

REPLY_RING_CAPACITY is exported from consensus so the reply-ring
spec tracks the real constant instead of a copied literal.
