### PR TITLE
ci: replace Ana06/get-changed-files with dorny/paths-filter

### DIFF
--- a/.github/workflows/_detect.yml
+++ b/.github/workflows/_detect.yml
@@ -79,9 +79,12 @@ jobs:
 
       - name: Get changed files (PR or push)
         id: changed
-        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
-          format: json
+          filters: |
+            all:
+              - '**'
+          list-files: json
 
       - name: Load components config
         id: config
@@ -102,7 +105,7 @@ jobs:
         with:
           script: |
             const componentsJson = `${{ steps.config.outputs.components }}`;
-            const changedFilesJson = `${{ steps.changed.outputs.all || '[]' }}`;
+            const changedFilesJson = `${{ steps.changed.outputs.all_files || '[]' }}`;
 
             let componentsCfg = { components: {} };
             try { componentsCfg = JSON.parse(componentsJson); } catch {}


### PR DESCRIPTION
Ana06/get-changed-files targets node20, which runners now force
onto node24 with a deprecation warning on every detect run. The
action is unmaintained with no node24 release.

dorny/paths-filter v4.0.3 is ASF-approved (approved_patterns.yml),
targets node24, and yields the same changed-file list via a
catch-all filter with list-files: json. Its matcher sets dot: true,
so .github/** changes still match, and all_files covers added,
modified and deleted paths like Ana06's all output.
