### PR TITLE
chore(repo): remove incubating references after TLP graduation

### DIFF
--- a/.github/workflows/edge-release.yml
+++ b/.github/workflows/edge-release.yml
@@ -88,12 +88,6 @@ jobs:
 
             **This release is automatically updated on every push to master.**
 
-            > Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-            >
-            > Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
-            >
-            > While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
             ## Binaries included
             - `iggy-server` - The server binary
             - `iggy` - The command-line interface

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Apache Iggy Agent Guidelines
 
-**Apache Iggy (Incubating)** is a persistent message streaming platform
+**Apache Iggy** is a persistent message streaming platform
 in Rust. Thread-per-core shared-nothing, `io_uring` + `compio`.
 Transports: QUIC, WebSocket, TCP (custom binary), HTTP (REST). SDKs:
 Rust, .NET, Java, Python, Go, C++, Node.js. A connectors subsystem

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,5 +1,0 @@
-Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-
-Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
-
-While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 ARG RUST_VERSION=1.97.1
 FROM rust:${RUST_VERSION}-slim-trixie AS builder
 

--- a/LICENSE
+++ b/LICENSE
@@ -201,11 +201,11 @@
    limitations under the License.
 
 ===============================================================================
-APACHE IGGY (INCUBATING) SUBCOMPONENTS
+APACHE IGGY SUBCOMPONENTS
 ===============================================================================
 
 This product bundles third-party software. The following third-party
-components are distributed alongside the Apache Iggy (Incubating) source
+components are distributed alongside the Apache Iggy source
 release and are licensed separately as described below.
 
 -------------------------------------------------------------------------------

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache Iggy (Incubating)
+Apache Iggy
 Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ---
 
-## What is Apache Iggy (Incubating)?
+## What is Apache Iggy?
 
 **Iggy** is a persistent message streaming platform written in Rust, supporting QUIC, WebSocket, TCP (custom binary specification) and HTTP (regular REST API) transport protocols, **capable of processing millions of messages per second at ultra-low latency**.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Apache Iggy (Incubating) follows the [Apache Software Foundation security process](https://www.apache.org/security/).
+Apache Iggy follows the [Apache Software Foundation security process](https://www.apache.org/security/).
 Please read this before reporting anything you believe is a security issue.
 
 ## Reporting a Vulnerability
@@ -12,7 +12,7 @@ puts users at risk.
 Send reports to **[security@apache.org](mailto:security@apache.org)**.
 
 Iggy does not currently have its own project security list, so `security@apache.org` is the correct
-address. The ASF Security Team will forward your report to the Iggy PPMC's private list and confirm to
+address. The ASF Security Team will forward your report to the Iggy PMC's private list and confirm to
 you that they have done so.
 
 When reporting, please:
@@ -25,7 +25,7 @@ When reporting, please:
 
 ## What Happens Next
 
-1. The ASF Security Team acknowledges receipt and forwards the report to the Iggy PPMC.
+1. The ASF Security Team acknowledges receipt and forwards the report to the Iggy PMC.
 2. We acknowledge the report and investigate. We will tell you whether we accept or reject it, and why.
 3. If accepted, a CVE ID is allocated. The ASF Security Team is the CNA for all Apache projects and is
    the only body that can assign CVE IDs to Apache software.

--- a/about.hbs
+++ b/about.hbs
@@ -1,8 +1,8 @@
-Apache Iggy (incubating) - Third-Party License Manifest
+Apache Iggy - Third-Party License Manifest
 ========================================================
 
 The following third-party software components are statically linked into
-this Apache Iggy (incubating) convenience binary artifact. The complete
+this Apache Iggy convenience binary artifact. The complete
 license text for each component is reproduced verbatim below as required
 by the Apache Software Foundation release policy.
 

--- a/bdd/csharp/Dockerfile
+++ b/bdd/csharp/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 FROM mcr.microsoft.com/dotnet/sdk:10.0.300
 
 COPY ./foreign/csharp ./foreign/csharp

--- a/bdd/go/Dockerfile
+++ b/bdd/go/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 FROM golang:1.26.3-alpine
 
 RUN apk add --no-cache gcc musl-dev

--- a/bdd/java/Dockerfile
+++ b/bdd/java/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 FROM gradle:9.6.1-jdk17
 
 WORKDIR /workspace

--- a/bdd/node/Dockerfile
+++ b/bdd/node/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 FROM node:26-slim
 
 COPY ./foreign/node .

--- a/bdd/python/Dockerfile
+++ b/bdd/python/Dockerfile
@@ -15,17 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
 # syntax=docker/dockerfile:1
 ARG RUST_VERSION=1.97.1
 FROM rust:${RUST_VERSION}-slim-trixie

--- a/bdd/rust/Dockerfile
+++ b/bdd/rust/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 ARG RUST_VERSION=1.97.1
 FROM rust:${RUST_VERSION}-slim-trixie
 

--- a/core/bench/dashboard/frontend/assets/style.css
+++ b/core/bench/dashboard/frontend/assets/style.css
@@ -1029,17 +1029,6 @@ body.dark .segment.active {
     letter-spacing: -0.01em;
 }
 
-.footer-brand-tag {
-    padding: 1px 6px;
-    background: rgba(255, 145, 3, 0.14);
-    color: #ff9103;
-    border-radius: 4px;
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-}
-
 .footer-links {
     display: inline-flex;
     justify-content: center;

--- a/core/bench/dashboard/frontend/src/components/footer.rs
+++ b/core/bench/dashboard/frontend/src/components/footer.rs
@@ -24,7 +24,6 @@ pub fn footer() -> Html {
             <div class="footer-inner">
                 <div class="footer-brand">
                     <span class="footer-brand-name">{"Apache Iggy"}</span>
-                    <span class="footer-brand-tag">{"Incubating"}</span>
                 </div>
                 <nav class="footer-links">
                     <a href="https://iggy.apache.org" target="_blank" rel="noopener noreferrer">

--- a/core/bench/dashboard/server/Dockerfile
+++ b/core/bench/dashboard/server/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 ARG RUST_VERSION=1.97.1
 
 # Build stage

--- a/core/binary_protocol/README.md
+++ b/core/binary_protocol/README.md
@@ -14,12 +14,6 @@ Wire protocol types and codec for the [Apache Iggy](https://iggy.apache.org) bin
 
 The language-neutral wire spec for the login protocol-version handshake (packed version layout, `ClientVersionInfo` prefix, gate semantics, rejection frame offsets) lives in the [`version` module docs](src/version.rs).
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 ## Links
 
 - [Project website](https://iggy.apache.org)

--- a/core/cli/README.md
+++ b/core/cli/README.md
@@ -12,12 +12,6 @@
 
 Interactive CLI for [Apache Iggy](https://iggy.apache.org). Manage streams, topics, partitions, users, consumer groups, and produce/consume messages from your terminal.
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 ## Installation
 
 ```bash

--- a/core/common/README.md
+++ b/core/common/README.md
@@ -12,12 +12,6 @@
 
 Common types and traits shared across the [Apache Iggy](https://iggy.apache.org) ecosystem (server, SDK, CLI, tooling). This crate is an internal building block. Most users should depend on the [`iggy`](https://crates.io/crates/iggy) SDK crate instead.
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 ## Links
 
 - [Project website](https://iggy.apache.org)

--- a/core/connectors/runtime/src/main.rs
+++ b/core/connectors/runtime/src/main.rs
@@ -63,7 +63,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 static GLOBAL: MiMalloc = MiMalloc;
 
 #[derive(Parser, Debug)]
-#[command(author = "Apache Iggy (Incubating)", version)]
+#[command(author = "Apache Iggy", version)]
 struct Args {}
 
 static PLUGIN_ID: AtomicU32 = AtomicU32::new(1);

--- a/core/sdk/README.md
+++ b/core/sdk/README.md
@@ -23,12 +23,6 @@
 
 Official Rust client SDK for [Apache Iggy](https://iggy.apache.org), the persistent message streaming platform written in Rust. The SDK ships a low-level transport client (QUIC, TCP, HTTP, WebSocket) for direct command access and a high-level producer/consumer API with batching, consumer groups, and auto-commit.
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 ## Features
 
 - **Transports**: TCP (custom binary), QUIC, HTTP, WebSocket. One unified `IggyClient` API across all four.

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 ARG RUST_VERSION=1.97.1
 ARG ALPINE_VERSION=3.23
 

--- a/core/server/src/args.rs
+++ b/core/server/src/args.rs
@@ -19,10 +19,10 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(
-    author = "Apache Iggy (Incubating)",
+    author = "Apache Iggy",
     version,
     about = "Apache Iggy: Hyper-Efficient Message Streaming at Laser Speed",
-    long_about = r#"Apache Iggy (Incubating) - a persistent message streaming platform written in Rust
+    long_about = r#"Apache Iggy - a persistent message streaming platform written in Rust
 
 Iggy stores every stream in a replicated log kept consistent by Viewstamped
 Replication. One binary serves both the single-node and the clustered

--- a/foreign/cpp/README.md
+++ b/foreign/cpp/README.md
@@ -10,12 +10,6 @@
 
 C++ client for [Apache Iggy](https://iggy.apache.org) message streaming.
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 Currently, the bazel build system relies on the system-provided cargo toolchain, so concurrent runs can race and lead to data corruption if executed remotely
 
 Build commands

--- a/foreign/csharp/NOTICE
+++ b/foreign/csharp/NOTICE
@@ -1,4 +1,4 @@
-Apache Iggy (Incubating)
+Apache Iggy
 Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/foreign/csharp/README.md
+++ b/foreign/csharp/README.md
@@ -14,15 +14,6 @@ The Apache Iggy C# SDK provides a comprehensive client library for interacting w
 offers a modern, async-first API with support for multiple transport protocols and comprehensive message streaming
 capabilities.
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the
-> Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure,
-> communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate
-> that the project has yet to be fully endorsed by the ASF.
-
 ## Getting Started
 
 ### Installation

--- a/foreign/go/NOTICE
+++ b/foreign/go/NOTICE
@@ -1,4 +1,4 @@
-Apache Iggy (Incubating)
+Apache Iggy
 Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/foreign/go/README.md
+++ b/foreign/go/README.md
@@ -13,12 +13,6 @@ Official Go client SDK for [Apache Iggy](https://iggy.apache.org) message stream
 The client speaks the VSR wire protocol over TCP, with or without TLS, in a
 blocking implementation. VSR is the only protocol it supports.
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 ## Installation
 
 ```bash

--- a/foreign/java/LICENSE
+++ b/foreign/java/LICENSE
@@ -201,7 +201,7 @@
    limitations under the License.
 
 ===============================================================================
-APACHE IGGY (INCUBATING) JAVA SDK SUBCOMPONENTS
+APACHE IGGY JAVA SDK SUBCOMPONENTS
 ===============================================================================
 
 This product bundles third-party software. The following third-party

--- a/foreign/java/NOTICE
+++ b/foreign/java/NOTICE
@@ -1,4 +1,4 @@
-Apache Iggy (Incubating)
+Apache Iggy
 Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/foreign/java/README.md
+++ b/foreign/java/README.md
@@ -12,12 +12,6 @@ Official Java client SDK for [Apache Iggy](https://iggy.apache.org) message stre
 
 _This is part of the Apache Iggy monorepo. For the main project, see the [root repository](https://github.com/apache/iggy)._
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 ## Installation
 
 Add the dependency to your project:

--- a/foreign/java/external-processors/iggy-connector-flink/docker/Dockerfile.flink2_10-java21
+++ b/foreign/java/external-processors/iggy-connector-flink/docker/Dockerfile.flink2_10-java21
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 FROM flink:2.1.0-scala_2.12-java21
 
 # Set up directories for checkpoints and savepoints

--- a/foreign/java/java-sdk/build.gradle.kts
+++ b/foreign/java/java-sdk/build.gradle.kts
@@ -63,9 +63,7 @@ publishing {
         named<MavenPublication>("maven") {
             pom {
                 name = "Apache Iggy Java Client SDK"
-                description = "Official Java client SDK for Apache Iggy.\n" +
-                        "Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), " +
-                        "sponsored by the Apache Incubator PMC."
+                description = "Official Java client SDK for Apache Iggy."
                 packaging = "jar"
             }
         }

--- a/foreign/node/NOTICE
+++ b/foreign/node/NOTICE
@@ -1,4 +1,4 @@
-Apache Iggy (Incubating)
+Apache Iggy
 Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/foreign/node/README.md
+++ b/foreign/node/README.md
@@ -10,12 +10,6 @@
 
 Apache Iggy Node.js client written in typescript, it currently only supports tcp & tls transports.
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 diclaimer: although all iggy commands & basic client/stream are implemented this is still a WIP, provided as is, and has still a long way to go to be considered "battle tested".
 
 note: This lib started as _iggy-bin_ ( [github](https://github.com/T1B0/iggy-bin) / [npm](https://www.npmjs.com/package/iggy-bin)) before migrating under iggy-rs org. package iggy-bin@v1.3.4 is equivalent to @iggy.rs/sdk@v1.0.3 and migrating again under apache iggy monorepo ( [github](https://github.com/apache/iggy/tree/master/foreign/node) and is now published on npmjs as apache-iggy

--- a/foreign/php/NOTICE
+++ b/foreign/php/NOTICE
@@ -1,4 +1,4 @@
-Apache Iggy (Incubating)
+Apache Iggy
 Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/foreign/php/composer.json
+++ b/foreign/php/composer.json
@@ -16,7 +16,7 @@
     ],
     "authors": [
         {
-            "name": "Apache Iggy (Incubating) Contributors",
+            "name": "Apache Iggy Contributors",
             "homepage": "https://iggy.apache.org"
         }
     ],

--- a/foreign/python/Dockerfile.test
+++ b/foreign/python/Dockerfile.test
@@ -15,17 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
 # Multi-stage build for Python SDK testing
 FROM python:3.10-slim-trixie AS base
 

--- a/foreign/python/NOTICE
+++ b/foreign/python/NOTICE
@@ -1,4 +1,4 @@
-Apache Iggy (Incubating)
+Apache Iggy
 Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/foreign/python/README.md
+++ b/foreign/python/README.md
@@ -12,12 +12,6 @@
 
 Apache Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second.
 
-> Apache Iggy (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
->
-> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
->
-> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
 ## Installation
 
 ### Basic Installation

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -42,7 +42,6 @@ excludes = [
     "**/LICENSE",
     "LICENSE",
     "NOTICE",
-    "DISCLAIMER",
     "**/NOTICE",
     "**/.gitignore",
     "**/.dockerignore",

--- a/scripts/ci/render-node-licenses.mjs
+++ b/scripts/ci/render-node-licenses.mjs
@@ -174,11 +174,11 @@ function validate(pkgs) {
 
 function render(pkgs) {
   const out = [];
-  out.push('Apache Iggy (incubating) - Third-Party License Manifest (Node)');
+  out.push('Apache Iggy - Third-Party License Manifest (Node)');
   out.push('================================================================');
   out.push('');
   out.push('The following npm production dependencies are bundled into this');
-  out.push('Apache Iggy (incubating) convenience binary artifact. Packages are');
+  out.push('Apache Iggy convenience binary artifact. Packages are');
   out.push('grouped by license; the canonical license text appears once per');
   out.push('group as required by the Apache Software Foundation release policy.');
   out.push('');

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -42,14 +42,13 @@ VERSION=$(grep '^version' "core/server/Cargo.toml" | head -n 1 | cut -d '"' -f2)
 
 echo "Preparing release for version: $VERSION"
 
-TAR_NAME="iggy-${VERSION}-incubating-src.tar"
-ARCHIVE_NAME="iggy-${VERSION}-incubating-src.tar.gz"
+TAR_NAME="iggy-${VERSION}-src.tar"
+ARCHIVE_NAME="iggy-${VERSION}-src.tar.gz"
 
 # Files/directories to include in the release
 RELEASE_PATHS=(
   "Cargo.lock"
   "Cargo.toml"
-  "DISCLAIMER"
   "Dockerfile"
   "LICENSE"
   "NOTICE"
@@ -69,7 +68,7 @@ RELEASE_PATHS=(
 # Create tar using git archive for consistent output
 git archive \
   --format=tar \
-  --prefix="iggy-${VERSION}-incubating-src/" \
+  --prefix="iggy-${VERSION}-src/" \
   -o "$RELEASE_DIR/$TAR_NAME" \
   HEAD \
   "${RELEASE_PATHS[@]}"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Apache Iggy (Incubating) is an effort undergoing incubation at the Apache
-# Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-#
-# Incubation is required of all newly accepted projects until a further review
-# indicates that the infrastructure, communications, and decision making
-# process have stabilized in a manner consistent with other successful ASF
-# projects.
-#
-# While incubation status is not necessarily a reflection of the completeness
-# or stability of the code, it does indicate that the project has yet to be
-# fully endorsed by the ASF.
-
 # Build context for this Dockerfile is the repository root (NOT web/), so
 # that the consolidated scripts/ci/third-party-licenses.sh and its renderer
 # are reachable. See .github/actions/utils/docker-buildx/action.yml.


### PR DESCRIPTION
Apache Iggy graduated from the Apache Incubator to a
top-level project. Drop the incubation disclaimer from
Dockerfiles, READMEs, and edge release notes, delete
the DISCLAIMER file, rename release tarballs from
iggy-<version>-incubating-src to iggy-<version>-src,
and strip "(Incubating)" from NOTICE, LICENSE, package
metadata, CLI about text, and the bench dashboard
footer. SECURITY.md now says PMC instead of PPMC.
