### PR TITLE
feat(common): add deferred poll timeout support

### DIFF
--- a/core/binary_protocol/src/requests/messages/poll_messages.rs
+++ b/core/binary_protocol/src/requests/messages/poll_messages.rs
@@ -17,7 +17,7 @@
 
 use crate::WireError;
 use crate::WireIdentifier;
-use crate::codec::{WireDecode, WireEncode, read_u8, read_u32_le};
+use crate::codec::{WireDecode, WireEncode, read_u8, read_u32_le, read_u64_le};
 use crate::primitives::consumer::WireConsumer;
 use crate::primitives::polling_strategy::WirePollingStrategy;
 use bytes::{BufMut, BytesMut};
@@ -27,7 +27,7 @@ use bytes::{BufMut, BytesMut};
 /// Wire format:
 /// ```text
 /// [consumer][stream_id][topic_id][partition_flag:1][partition_id:4 LE]
-/// [strategy:9][count:4 LE][auto_commit:1]
+/// [strategy:9][count:4 LE][auto_commit:1][wait_timeout_us:8 LE]
 /// ```
 ///
 /// `partition_id` encoding: a u8 flag (1=Some, 0=None) followed by 4 bytes
@@ -41,6 +41,7 @@ pub struct PollMessagesRequest {
     pub strategy: WirePollingStrategy,
     pub count: u32,
     pub auto_commit: bool,
+    pub wait_timeout_us: u64,
 }
 
 const PARTITION_FLAG_SIZE: usize = 1;
@@ -48,6 +49,7 @@ const PARTITION_VALUE_SIZE: usize = 4;
 const STRATEGY_SIZE: usize = 9;
 const COUNT_SIZE: usize = 4;
 const AUTO_COMMIT_SIZE: usize = 1;
+const WAIT_TIMEOUT_SIZE: usize = 8;
 
 impl WireEncode for PollMessagesRequest {
     fn encoded_size(&self) -> usize {
@@ -59,6 +61,7 @@ impl WireEncode for PollMessagesRequest {
             + STRATEGY_SIZE
             + COUNT_SIZE
             + AUTO_COMMIT_SIZE
+            + WAIT_TIMEOUT_SIZE
     }
 
     fn encode(&self, buf: &mut BytesMut) {
@@ -75,6 +78,7 @@ impl WireEncode for PollMessagesRequest {
         self.strategy.encode(buf);
         buf.put_u32_le(self.count);
         buf.put_u8(u8::from(self.auto_commit));
+        buf.put_u64_le(self.wait_timeout_us);
     }
 }
 
@@ -104,6 +108,13 @@ impl WireDecode for PollMessagesRequest {
         pos += 4;
         let auto_commit = read_u8(buf, pos)? != 0;
         pos += 1;
+        let wait_timeout_us = if buf.len() == pos {
+            0
+        } else {
+            let wait_timeout_us = read_u64_le(buf, pos)?;
+            pos += WAIT_TIMEOUT_SIZE;
+            wait_timeout_us
+        };
 
         Ok((
             Self {
@@ -114,6 +125,7 @@ impl WireDecode for PollMessagesRequest {
                 strategy,
                 count,
                 auto_commit,
+                wait_timeout_us,
             },
             pos,
         ))
@@ -124,9 +136,8 @@ impl WireDecode for PollMessagesRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn roundtrip_with_partition() {
-        let req = PollMessagesRequest {
+    fn request(wait_timeout_us: u64) -> PollMessagesRequest {
+        PollMessagesRequest {
             consumer: WireConsumer::consumer(WireIdentifier::numeric(1)),
             stream_id: WireIdentifier::numeric(10),
             topic_id: WireIdentifier::numeric(20),
@@ -134,7 +145,22 @@ mod tests {
             strategy: WirePollingStrategy::offset(100),
             count: 50,
             auto_commit: true,
-        };
+            wait_timeout_us,
+        }
+    }
+
+    #[test]
+    fn roundtrip_with_zero_wait_timeout() {
+        let req = request(0);
+        let bytes = req.to_bytes();
+        let (decoded, consumed) = PollMessagesRequest::decode(&bytes).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(decoded, req);
+    }
+
+    #[test]
+    fn roundtrip_with_non_zero_wait_timeout() {
+        let req = request(250_000);
         let bytes = req.to_bytes();
         let (decoded, consumed) = PollMessagesRequest::decode(&bytes).unwrap();
         assert_eq!(consumed, bytes.len());
@@ -151,6 +177,7 @@ mod tests {
             strategy: WirePollingStrategy::first(),
             count: 10,
             auto_commit: false,
+            wait_timeout_us: 0,
         };
         let bytes = req.to_bytes();
         let (decoded, consumed) = PollMessagesRequest::decode(&bytes).unwrap();
@@ -168,11 +195,60 @@ mod tests {
             strategy: WirePollingStrategy::offset(0),
             count: 1,
             auto_commit: false,
+            wait_timeout_us: 1,
         };
         let bytes = req.to_bytes();
         let (decoded, consumed) = PollMessagesRequest::decode(&bytes).unwrap();
         assert_eq!(consumed, bytes.len());
         assert_eq!(decoded, req);
+    }
+
+    #[test]
+    fn legacy_request_without_wait_timeout_decodes_as_zero() {
+        let req = request(0);
+        let bytes = req.to_bytes();
+        let legacy_len = bytes.len() - WAIT_TIMEOUT_SIZE;
+        let (decoded, consumed) = PollMessagesRequest::decode(&bytes[..legacy_len]).unwrap();
+
+        assert_eq!(consumed, legacy_len);
+        assert_eq!(decoded.wait_timeout_us, 0);
+        assert_eq!(decoded, req);
+    }
+
+    #[test]
+    fn partial_trailing_wait_timeout_returns_error() {
+        let req = request(0);
+        let bytes = req.to_bytes();
+        let legacy_len = bytes.len() - WAIT_TIMEOUT_SIZE;
+
+        for timeout_bytes in 1..WAIT_TIMEOUT_SIZE {
+            assert!(
+                PollMessagesRequest::decode(&bytes[..legacy_len + timeout_bytes]).is_err(),
+                "expected error with {timeout_bytes} trailing timeout bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn encoded_size_includes_wait_timeout() {
+        let req = request(42_000);
+        let bytes = req.to_bytes();
+        let legacy_size = req.consumer.encoded_size()
+            + req.stream_id.encoded_size()
+            + req.topic_id.encoded_size()
+            + PARTITION_FLAG_SIZE
+            + PARTITION_VALUE_SIZE
+            + STRATEGY_SIZE
+            + COUNT_SIZE
+            + AUTO_COMMIT_SIZE;
+        let wait_timeout_bytes = req.wait_timeout_us.to_le_bytes();
+
+        assert_eq!(req.encoded_size(), legacy_size + WAIT_TIMEOUT_SIZE);
+        assert_eq!(bytes.len(), req.encoded_size());
+        assert_eq!(
+            &bytes[legacy_size..legacy_size + WAIT_TIMEOUT_SIZE],
+            wait_timeout_bytes.as_slice()
+        );
     }
 
     #[test]
@@ -185,6 +261,7 @@ mod tests {
             strategy: WirePollingStrategy::first(),
             count: 1,
             auto_commit: false,
+            wait_timeout_us: 0,
         };
         let bytes = req.to_bytes();
         // After consumer(7) + stream_id(6) + topic_id(6) = offset 19
@@ -199,18 +276,11 @@ mod tests {
     }
 
     #[test]
-    fn truncated_returns_error() {
-        let req = PollMessagesRequest {
-            consumer: WireConsumer::consumer(WireIdentifier::numeric(1)),
-            stream_id: WireIdentifier::numeric(1),
-            topic_id: WireIdentifier::numeric(1),
-            partition_id: Some(1),
-            strategy: WirePollingStrategy::offset(0),
-            count: 1,
-            auto_commit: false,
-        };
+    fn truncated_required_fields_return_error() {
+        let req = request(0);
         let bytes = req.to_bytes();
-        for i in 0..bytes.len() {
+        let legacy_len = bytes.len() - WAIT_TIMEOUT_SIZE;
+        for i in 0..legacy_len {
             assert!(
                 PollMessagesRequest::decode(&bytes[..i]).is_err(),
                 "expected error for truncation at byte {i}"

--- a/core/common/src/traits/binary_impls/messages.rs
+++ b/core/common/src/traits/binary_impls/messages.rs
@@ -43,6 +43,14 @@ use std::time::Duration;
 /// coordinator rejects a stale assignment, then retry once.
 const GROUP_POLL_MAX_ATTEMPTS: usize = 2;
 
+struct PollGroupOptions<'a> {
+    consumer: &'a Consumer,
+    strategy: &'a PollingStrategy,
+    count: u32,
+    auto_commit: bool,
+    wait_timeout_us: u64,
+}
+
 fn duration_to_wait_timeout_us(wait_timeout: Duration) -> Result<u64, IggyError> {
     wait_timeout
         .as_micros()
@@ -180,12 +188,15 @@ async fn poll_group_messages<B: BinaryClient>(
     client: &B,
     stream_id: &Identifier,
     topic_id: &Identifier,
-    consumer: &Consumer,
-    strategy: &PollingStrategy,
-    count: u32,
-    auto_commit: bool,
-    wait_timeout_us: u64,
+    options: PollGroupOptions<'_>,
 ) -> Result<PolledMessages, IggyError> {
+    let PollGroupOptions {
+        consumer,
+        strategy,
+        count,
+        auto_commit,
+        wait_timeout_us,
+    } = options;
     let key = group_cache_key(stream_id, topic_id, &consumer.id);
     if !client.consumer_group_state().has_assignment(&key) {
         sync_group_assignment(client, stream_id, topic_id, &consumer.id).await?;
@@ -328,11 +339,13 @@ impl<B: BinaryClient> MessageClient for B {
                 self,
                 stream_id,
                 topic_id,
-                consumer,
-                strategy,
-                count,
-                auto_commit,
-                wait_timeout_us,
+                PollGroupOptions {
+                    consumer,
+                    strategy,
+                    count,
+                    auto_commit,
+                    wait_timeout_us,
+                },
             )
             .await;
         }

--- a/core/common/src/traits/binary_impls/messages.rs
+++ b/core/common/src/traits/binary_impls/messages.rs
@@ -37,10 +37,18 @@ use iggy_binary_protocol::requests::messages::{
     FlushUnsavedBufferRequest, PollMessagesRequest, RawMessage, SendMessagesEncoder,
 };
 use iggy_binary_protocol::responses::consumer_groups::SyncConsumerGroupResponse;
+use std::time::Duration;
 
 /// Max attempts to resolve a fenced consumer-group poll: one re-sync after the
 /// coordinator rejects a stale assignment, then retry once.
 const GROUP_POLL_MAX_ATTEMPTS: usize = 2;
+
+fn duration_to_wait_timeout_us(wait_timeout: Duration) -> Result<u64, IggyError> {
+    wait_timeout
+        .as_micros()
+        .try_into()
+        .map_err(|_| IggyError::InvalidNumberValue)
+}
 
 fn group_cache_key(stream_id: &Identifier, topic_id: &Identifier, group_id: &Identifier) -> String {
     format!("{stream_id}|{topic_id}|{group_id}")
@@ -176,6 +184,7 @@ async fn poll_group_messages<B: BinaryClient>(
     strategy: &PollingStrategy,
     count: u32,
     auto_commit: bool,
+    wait_timeout_us: u64,
 ) -> Result<PolledMessages, IggyError> {
     let key = group_cache_key(stream_id, topic_id, &consumer.id);
     if !client.consumer_group_state().has_assignment(&key) {
@@ -205,6 +214,7 @@ async fn poll_group_messages<B: BinaryClient>(
             strategy: polling_strategy_to_wire(strategy),
             count,
             auto_commit,
+            wait_timeout_us,
         };
         match client
             .send_raw_with_response(POLL_MESSAGES_CODE, request.to_bytes())
@@ -284,7 +294,32 @@ impl<B: BinaryClient> MessageClient for B {
         count: u32,
         auto_commit: bool,
     ) -> Result<PolledMessages, IggyError> {
+        self.poll_messages_with_timeout(
+            stream_id,
+            topic_id,
+            partition_id,
+            consumer,
+            strategy,
+            count,
+            auto_commit,
+            Duration::ZERO,
+        )
+        .await
+    }
+
+    async fn poll_messages_with_timeout(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+        consumer: &Consumer,
+        strategy: &PollingStrategy,
+        count: u32,
+        auto_commit: bool,
+        wait_timeout: Duration,
+    ) -> Result<PolledMessages, IggyError> {
         fail_if_not_authenticated(self).await?;
+        let wait_timeout_us = duration_to_wait_timeout_us(wait_timeout)?;
         // VSR: a consumer-group poll without an explicit partition is resolved
         // client-side from the member's cached assignment (the broker routes
         // explicit partitions only).
@@ -297,6 +332,7 @@ impl<B: BinaryClient> MessageClient for B {
                 strategy,
                 count,
                 auto_commit,
+                wait_timeout_us,
             )
             .await;
         }
@@ -308,6 +344,7 @@ impl<B: BinaryClient> MessageClient for B {
             strategy: polling_strategy_to_wire(strategy),
             count,
             auto_commit,
+            wait_timeout_us,
         };
         let response = self
             .send_raw_with_response(POLL_MESSAGES_CODE, req.to_bytes())
@@ -402,9 +439,12 @@ impl<B: BinaryClient> MessageClient for B {
 
 #[cfg(test)]
 mod tests {
-    use super::{committed_send_confirmations, decode_send_confirmations};
+    use super::{
+        committed_send_confirmations, decode_send_confirmations, duration_to_wait_timeout_us,
+    };
     use crate::{IggyError, SendMessagesConfirmationResponse, SendMessagesResponse};
     use iggy_binary_protocol::codec::WireEncode;
+    use std::time::Duration;
 
     fn response() -> SendMessagesResponse {
         SendMessagesResponse {
@@ -493,5 +533,25 @@ mod tests {
                 "expected no confirmations for truncation at byte {length}"
             );
         }
+    }
+
+    #[test]
+    fn wait_timeout_uses_microseconds() {
+        assert_eq!(
+            duration_to_wait_timeout_us(Duration::from_millis(25)).unwrap(),
+            25_000
+        );
+        assert_eq!(
+            duration_to_wait_timeout_us(Duration::from_nanos(999)).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn wait_timeout_overflow_is_rejected() {
+        assert_eq!(
+            duration_to_wait_timeout_us(Duration::new(u64::MAX, 0)),
+            Err(IggyError::InvalidNumberValue)
+        );
     }
 }

--- a/core/common/src/traits/message_client.rs
+++ b/core/common/src/traits/message_client.rs
@@ -20,6 +20,7 @@ use crate::{
     SendMessagesResponse,
 };
 use async_trait::async_trait;
+use std::time::Duration;
 
 /// This trait defines the methods to interact with the messaging module.
 #[async_trait]
@@ -40,6 +41,38 @@ pub trait MessageClient {
         count: u32,
         auto_commit: bool,
     ) -> Result<PolledMessages, IggyError>;
+
+    /// Poll messages and wait up to `wait_timeout` when no messages are
+    /// immediately available. A zero timeout preserves immediate polling.
+    /// Transports without deferred-poll support return `FeatureUnavailable`.
+    #[allow(clippy::too_many_arguments)]
+    async fn poll_messages_with_timeout(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+        consumer: &Consumer,
+        strategy: &PollingStrategy,
+        count: u32,
+        auto_commit: bool,
+        wait_timeout: Duration,
+    ) -> Result<PolledMessages, IggyError> {
+        if wait_timeout.is_zero() {
+            return self
+                .poll_messages(
+                    stream_id,
+                    topic_id,
+                    partition_id,
+                    consumer,
+                    strategy,
+                    count,
+                    auto_commit,
+                )
+                .await;
+        }
+
+        Err(IggyError::FeatureUnavailable)
+    }
 
     /// Send messages using specified partitioning strategy to the given stream and topic by unique IDs or names.
     ///

--- a/core/integration/tests/server/poll_semantics_vsr.rs
+++ b/core/integration/tests/server/poll_semantics_vsr.rs
@@ -88,6 +88,49 @@ async fn given_missing_partition_when_polling_should_reject_partition_not_found(
     assert_eq!(valid.messages.len(), 0, "empty topic polls empty");
 }
 
+#[iggy_harness(test_client_transport = [Tcp])]
+async fn given_non_zero_wait_timeout_when_polling_should_reject_feature_unavailable(
+    harness: &TestHarness,
+) {
+    let client = harness.tcp_root_client().await.expect("tcp root client");
+    client
+        .create_stream("poll-timeout-stream")
+        .await
+        .expect("create stream");
+    let stream_id = Identifier::from_str_value("poll-timeout-stream").expect("stream identifier");
+    client
+        .create_topic(
+            &stream_id,
+            "poll-timeout-topic",
+            &TopicCreateOptions {
+                partitions_count: Some(1),
+                message_expiry: Some(IggyExpiry::NeverExpire),
+                ..TopicCreateOptions::default()
+            },
+        )
+        .await
+        .expect("create topic");
+    let topic_id = Identifier::from_str_value("poll-timeout-topic").expect("topic identifier");
+
+    let result = client
+        .poll_messages_with_timeout(
+            &stream_id,
+            &topic_id,
+            Some(0),
+            &Consumer::default(),
+            &PollingStrategy::offset(0),
+            1,
+            false,
+            Duration::from_secs(1),
+        )
+        .await;
+
+    assert!(
+        matches!(&result, Err(error) if error.as_code() == IggyError::FeatureUnavailable.as_code()),
+        "the active server must reject unsupported deferred waits, got {result:?}"
+    );
+}
+
 #[iggy_harness(
     test_client_transport = [Tcp]
 )]

--- a/core/sdk/src/client_wrappers/binary_message_client.rs
+++ b/core/sdk/src/client_wrappers/binary_message_client.rs
@@ -22,6 +22,7 @@ use iggy_common::{
     Consumer, Identifier, IggyError, IggyMessage, Partitioning, PolledMessages, PollingStrategy,
     SendMessagesResponse,
 };
+use std::time::Duration;
 
 #[async_trait]
 impl MessageClient for ClientWrapper {
@@ -35,10 +36,34 @@ impl MessageClient for ClientWrapper {
         count: u32,
         auto_commit: bool,
     ) -> Result<PolledMessages, IggyError> {
+        self.poll_messages_with_timeout(
+            stream_id,
+            topic_id,
+            partition_id,
+            consumer,
+            strategy,
+            count,
+            auto_commit,
+            Duration::ZERO,
+        )
+        .await
+    }
+
+    async fn poll_messages_with_timeout(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+        consumer: &Consumer,
+        strategy: &PollingStrategy,
+        count: u32,
+        auto_commit: bool,
+        wait_timeout: Duration,
+    ) -> Result<PolledMessages, IggyError> {
         match self {
             ClientWrapper::Iggy(client) => {
                 client
-                    .poll_messages(
+                    .poll_messages_with_timeout(
                         stream_id,
                         topic_id,
                         partition_id,
@@ -46,12 +71,13 @@ impl MessageClient for ClientWrapper {
                         strategy,
                         count,
                         auto_commit,
+                        wait_timeout,
                     )
                     .await
             }
             ClientWrapper::Http(client) => {
                 client
-                    .poll_messages(
+                    .poll_messages_with_timeout(
                         stream_id,
                         topic_id,
                         partition_id,
@@ -59,12 +85,13 @@ impl MessageClient for ClientWrapper {
                         strategy,
                         count,
                         auto_commit,
+                        wait_timeout,
                     )
                     .await
             }
             ClientWrapper::Tcp(client) => {
                 client
-                    .poll_messages(
+                    .poll_messages_with_timeout(
                         stream_id,
                         topic_id,
                         partition_id,
@@ -72,12 +99,13 @@ impl MessageClient for ClientWrapper {
                         strategy,
                         count,
                         auto_commit,
+                        wait_timeout,
                     )
                     .await
             }
             ClientWrapper::Quic(client) => {
                 client
-                    .poll_messages(
+                    .poll_messages_with_timeout(
                         stream_id,
                         topic_id,
                         partition_id,
@@ -85,12 +113,13 @@ impl MessageClient for ClientWrapper {
                         strategy,
                         count,
                         auto_commit,
+                        wait_timeout,
                     )
                     .await
             }
             ClientWrapper::WebSocket(client) => {
                 client
-                    .poll_messages(
+                    .poll_messages_with_timeout(
                         stream_id,
                         topic_id,
                         partition_id,
@@ -98,6 +127,7 @@ impl MessageClient for ClientWrapper {
                         strategy,
                         count,
                         auto_commit,
+                        wait_timeout,
                     )
                     .await
             }

--- a/core/sdk/src/clients/binary_message.rs
+++ b/core/sdk/src/clients/binary_message.rs
@@ -24,6 +24,7 @@ use iggy_common::{
     Consumer, Identifier, IggyError, IggyMessage, Partitioning, PolledMessages, PollingStrategy,
     SendMessagesResponse,
 };
+use std::time::Duration;
 
 #[async_trait]
 impl MessageClient for IggyClient {
@@ -37,6 +38,30 @@ impl MessageClient for IggyClient {
         count: u32,
         auto_commit: bool,
     ) -> Result<PolledMessages, IggyError> {
+        self.poll_messages_with_timeout(
+            stream_id,
+            topic_id,
+            partition_id,
+            consumer,
+            strategy,
+            count,
+            auto_commit,
+            Duration::ZERO,
+        )
+        .await
+    }
+
+    async fn poll_messages_with_timeout(
+        &self,
+        stream_id: &Identifier,
+        topic_id: &Identifier,
+        partition_id: Option<u32>,
+        consumer: &Consumer,
+        strategy: &PollingStrategy,
+        count: u32,
+        auto_commit: bool,
+        wait_timeout: Duration,
+    ) -> Result<PolledMessages, IggyError> {
         if count == 0 {
             return Err(IggyError::InvalidMessagesCount);
         }
@@ -45,7 +70,7 @@ impl MessageClient for IggyClient {
             .client
             .read()
             .await
-            .poll_messages(
+            .poll_messages_with_timeout(
                 stream_id,
                 topic_id,
                 partition_id,
@@ -53,6 +78,7 @@ impl MessageClient for IggyClient {
                 strategy,
                 count,
                 auto_commit,
+                wait_timeout,
             )
             .await?;
 

--- a/core/server/src/dispatch.rs
+++ b/core/server/src/dispatch.rs
@@ -2115,6 +2115,32 @@ async fn evict_stale_client<B, MJ, S, SB>(
     }
 }
 
+/// Reject a non-zero wait timeout until active-server deferred waits are implemented.
+async fn reject_deferred_poll<B, MJ, S, SB>(
+    shard: &Rc<ShellShard<B, MJ, S, SB>>,
+    request: &Message<RoutedRequestHeader>,
+    transport_client_id: u128,
+    wait_timeout_us: u64,
+) where
+    B: ShellBus,
+    MJ: JournalHandle + 'static,
+    MJ::Target: Journal<Entry = Message<PrepareHeader>, Header = PrepareHeader>,
+    S: 'static,
+    SB: SuperblockStore + 'static,
+{
+    warn!(
+        transport_client_id,
+        wait_timeout_us, "deferred poll waits are not available on the active server"
+    );
+    send_non_replicated_deny(
+        shard,
+        request,
+        transport_client_id,
+        IggyError::FeatureUnavailable.as_code(),
+    )
+    .await;
+}
+
 /// Serve `poll_messages`: resolve the partition namespace, run the read on
 /// the owning shard ([`shard::IggyShard::partition_read`]), and re-encode
 /// the stored batches into the legacy wire `PolledMessages` body.
@@ -2147,18 +2173,7 @@ async fn handle_poll_messages<B, MJ, S, SB>(
         return;
     };
     if wire.wait_timeout_us != 0 {
-        warn!(
-            transport_client_id,
-            wait_timeout_us = wire.wait_timeout_us,
-            "deferred poll waits are not available on the active server"
-        );
-        send_non_replicated_deny(
-            shard,
-            request,
-            transport_client_id,
-            IggyError::FeatureUnavailable.as_code(),
-        )
-        .await;
+        reject_deferred_poll(shard, request, transport_client_id, wire.wait_timeout_us).await;
         return;
     }
     // Gate on (stream, topic) before touching the partition plane. A resolution

--- a/core/server/src/dispatch.rs
+++ b/core/server/src/dispatch.rs
@@ -2146,6 +2146,21 @@ async fn handle_poll_messages<B, MJ, S, SB>(
         .await;
         return;
     };
+    if wire.wait_timeout_us != 0 {
+        warn!(
+            transport_client_id,
+            wait_timeout_us = wire.wait_timeout_us,
+            "deferred poll waits are not available on the active server"
+        );
+        send_non_replicated_deny(
+            shard,
+            request,
+            transport_client_id,
+            IggyError::FeatureUnavailable.as_code(),
+        )
+        .await;
+        return;
+    }
     // Gate on (stream, topic) before touching the partition plane. A resolution
     // miss falls through to the resolve path below (empty-poll / not-found); a
     // denial replies status!=0 with an empty body, distinct from the empty-poll
@@ -2491,6 +2506,9 @@ where
     S: 'static,
     SB: SuperblockStore + 'static,
 {
+    if wire.wait_timeout_us != 0 {
+        return Err(IggyError::FeatureUnavailable);
+    }
     let strategy = polling_strategy_from_wire(&wire.strategy)?;
     let args = PollingArgs::new(strategy, wire.count, wire.auto_commit);
 

--- a/core/server/src/http/wire.rs
+++ b/core/server/src/http/wire.rs
@@ -118,6 +118,7 @@ pub(in crate::http) fn poll_wire_request(
         },
         count: query.count,
         auto_commit: query.auto_commit,
+        wait_timeout_us: 0,
     })
 }
 
@@ -422,6 +423,7 @@ mod tests {
         assert_eq!(wire.strategy.value, 0);
         assert_eq!(wire.count, 25);
         assert!(wire.auto_commit);
+        assert_eq!(wire.wait_timeout_us, 0);
     }
 
     #[test]

--- a/core/simulator/src/client.rs
+++ b/core/simulator/src/client.rs
@@ -575,6 +575,7 @@ impl SimClient {
             strategy: WirePollingStrategy::first(),
             count,
             auto_commit: false,
+            wait_timeout_us: 0,
         }
         .to_bytes();
 


### PR DESCRIPTION
## Which issue does this PR address?

Closes #3470

## Rationale

`PollMessages` needs a backward-compatible way for clients to request a bounded wait when no messages are available. Immediate polling remains unchanged for existing clients and for a zero timeout.

## What changed?

Empty `PollMessages` requests can now carry a trailing `wait_timeout_us` field; legacy requests decode it as zero, while partial trailing fields are rejected. The common, SDK, consumer-group, simulator, and HTTP-zero paths carry the value through the current tree.

This is a clean rebuild after closed PR #3605. The active `core/server` path currently rejects non-zero waits with typed `FeatureUnavailable` until a safe waiter/notifier implementation is designed. No `core/server-ng`, legacy server, benchmark markdown, or runbook files are included.

## Local Execution

- `cargo fmt --all` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test -p iggy_binary_protocol poll_messages` — 15 passed
- `cargo test -p iggy_common wait_timeout` — 2 passed
- `cargo check -p iggy -p server -p simulator` — passed
- `cargo check -p integration --tests` — passed
- `cargo machete` — passed
- `cargo sort --workspace` — passed; no changes needed
- `typos` — passed
- `./scripts/ci/license-headers.sh --check` — passed with HawkEye 7
- `git diff --check` — passed
- Pre-commit hooks — not run; `prek` is not installed in this environment

`cargo build --workspace` was attempted but could not link in this x86_64-targeted macOS environment because the installed Homebrew `xz` and `hwloc` libraries are arm64. Full local `cargo test` is not claimed. Fresh GitHub CI run `32720521140` passed all 74 jobs after the rebase onto current `master`.

## AI Usage

AI was used for code review, and test/CI orchestration. The changed code was reviewed and verified with the local checks above and GitHub CI; I can explain every line of the code if asked.
