### PR TITLE
fix(ci): bump cargo-zigbuild so arm64 images link under Rust 1.98

### DIFF
--- a/core/ai/mcp/Dockerfile
+++ b/core/ai/mcp/Dockerfile
@@ -34,7 +34,7 @@ ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
 RUN apk add --no-cache bash curl tar zig make autoconf automake libtool pkgconfig && \
-    cargo install cargo-zigbuild --version '=0.22.1' --locked && \
+    cargo install cargo-zigbuild --version '=0.23.2' --locked && \
     rustup target add \
     x86_64-unknown-linux-musl \
     aarch64-unknown-linux-musl \

--- a/core/connectors/runtime/Dockerfile
+++ b/core/connectors/runtime/Dockerfile
@@ -34,7 +34,7 @@ ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
 RUN apk add --no-cache bash curl tar zig make autoconf automake libtool pkgconfig hwloc-dev xz-dev xz-static && \
-    cargo install cargo-zigbuild --version '=0.22.1' --locked && \
+    cargo install cargo-zigbuild --version '=0.23.2' --locked && \
     rustup target add \
     x86_64-unknown-linux-musl \
     aarch64-unknown-linux-musl \

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -35,7 +35,7 @@ ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
 RUN apk add --no-cache bash curl tar zig make autoconf automake libtool pkgconfig hwloc-dev xz-dev xz-static nodejs npm && \
-    cargo install cargo-zigbuild --version '=0.22.1' --locked
+    cargo install cargo-zigbuild --version '=0.23.2' --locked
 
 COPY rust-toolchain.toml rust-toolchain.toml
 


### PR DESCRIPTION
Rust 1.98 passes -Wl,--fix-cortex-a53-843419 to the linker for every
aarch64-unknown-linux target (rust-lang/rust#155453). zig cc rejects
unknown -Wl flags, so every arm64 publish job built through
cargo-zigbuild 0.22.1 died in cargo chef cook with
"unsupported linker arg: --fix-cortex-a53-843419". The amd64 images
were unaffected and pre-merge CI never builds these Dockerfiles, so
the breakage only surfaced after the toolchain bump landed.

cargo-zigbuild 0.23.0 filters that flag
(rust-cross/cargo-zigbuild#452); pin the latest 0.23.2 in the three
Dockerfiles that link through zig.
