### PR TITLE
feat(partitions): persist log and index concurrently, harden recovery

### DIFF
--- a/core/bench/report/src/types/group_metrics.rs
+++ b/core/bench/report/src/types/group_metrics.rs
@@ -92,23 +92,21 @@ impl<'de> Deserialize<'de> for BenchmarkGroupMetrics {
 
                 let mut updated_summary = summary.clone();
 
-                // Calculate and populate missing statistics from the time series data
+                // Backfill for reports written before the three fields
+                // existed: `serde(default)` lands them at zero together, so
+                // all three being zero is what identifies such a report.
+                // Keyed on all three rather than on each alone -- a run whose
+                // samples are all equal reports a real zero std dev beside a
+                // nonzero min and max, and refilling that from the per-bucket
+                // moving average would put back the averaged-away extremes
+                // the summary is computed from raw samples to avoid.
                 if updated_summary.min_latency_ms == 0.0
-                    && let Some(min_val) = min(&avg_latency_ts)
+                    && updated_summary.max_latency_ms == 0.0
+                    && updated_summary.std_dev_latency_ms == 0.0
                 {
-                    updated_summary.min_latency_ms = min_val;
-                }
-
-                if updated_summary.max_latency_ms == 0.0
-                    && let Some(max_val) = max(&avg_latency_ts)
-                {
-                    updated_summary.max_latency_ms = max_val;
-                }
-
-                if updated_summary.std_dev_latency_ms == 0.0
-                    && let Some(std_dev_val) = std_dev(&avg_latency_ts)
-                {
-                    updated_summary.std_dev_latency_ms = std_dev_val;
+                    updated_summary.min_latency_ms = min(&avg_latency_ts).unwrap_or(0.0);
+                    updated_summary.max_latency_ms = max(&avg_latency_ts).unwrap_or(0.0);
+                    updated_summary.std_dev_latency_ms = std_dev(&avg_latency_ts).unwrap_or(0.0);
                 }
 
                 Ok(BenchmarkGroupMetrics {

--- a/core/bench/report/src/types/individual_metrics.rs
+++ b/core/bench/report/src/types/individual_metrics.rs
@@ -89,22 +89,21 @@ impl<'de> Deserialize<'de> for BenchmarkIndividualMetrics {
 
                 let mut updated_summary = summary.clone();
 
+                // Backfill for reports written before the three fields
+                // existed: `serde(default)` lands them at zero together, so
+                // all three being zero is what identifies such a report.
+                // Keyed on all three rather than on each alone -- a run whose
+                // samples are all equal reports a real zero std dev beside a
+                // nonzero min and max, and refilling that from the per-bucket
+                // moving average would put back the averaged-away extremes
+                // the summary is computed from raw samples to avoid.
                 if updated_summary.min_latency_ms == 0.0
-                    && let Some(min_val) = min(&latency_ts)
+                    && updated_summary.max_latency_ms == 0.0
+                    && updated_summary.std_dev_latency_ms == 0.0
                 {
-                    updated_summary.min_latency_ms = min_val;
-                }
-
-                if updated_summary.max_latency_ms == 0.0
-                    && let Some(max_val) = max(&latency_ts)
-                {
-                    updated_summary.max_latency_ms = max_val;
-                }
-
-                if updated_summary.std_dev_latency_ms == 0.0
-                    && let Some(std_dev_val) = std_dev(&latency_ts)
-                {
-                    updated_summary.std_dev_latency_ms = std_dev_val;
+                    updated_summary.min_latency_ms = min(&latency_ts).unwrap_or(0.0);
+                    updated_summary.max_latency_ms = max(&latency_ts).unwrap_or(0.0);
+                    updated_summary.std_dev_latency_ms = std_dev(&latency_ts).unwrap_or(0.0);
                 }
 
                 Ok(BenchmarkIndividualMetrics {
@@ -119,5 +118,72 @@ impl<'de> Deserialize<'de> for BenchmarkIndividualMetrics {
 
         // Use the visitor to deserialize
         deserializer.deserialize_map(BenchmarkIndividualMetricsVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Report JSON carrying `summary` and the three time series, with the
+    /// summary's latency extremes spliced in as `extremes`.
+    fn report_json(extremes: &str) -> String {
+        format!(
+            r#"{{
+                "summary": {{
+                    "benchmark_kind": "pinned_producer",
+                    "actor_kind": "producer",
+                    "actor_id": 0,
+                    "total_time_secs": 1.0,
+                    "total_user_data_bytes": 1000,
+                    "total_bytes": 1000,
+                    "total_messages": 3,
+                    "total_message_batches": 3,
+                    "throughput_megabytes_per_second": 1.0,
+                    "throughput_messages_per_second": 3.0,
+                    "p50_latency_ms": 5.0,
+                    "p90_latency_ms": 5.0,
+                    "p95_latency_ms": 5.0,
+                    "p99_latency_ms": 5.0,
+                    "p999_latency_ms": 5.0,
+                    "p9999_latency_ms": 5.0,
+                    "avg_latency_ms": 5.0,
+                    "median_latency_ms": 5.0{extremes}
+                }},
+                "throughput_mb_ts": {{ "points": [] }},
+                "throughput_msg_ts": {{ "points": [] }},
+                "latency_ts": {{ "points": [
+                    {{ "time_s": 0.0, "value": 4.0 }},
+                    {{ "time_s": 1.0, "value": 6.0 }}
+                ] }}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn given_a_report_without_latency_extremes_when_deserialized_should_backfill_from_the_series() {
+        let metrics: BenchmarkIndividualMetrics =
+            serde_json::from_str(&report_json("")).expect("deserialize legacy report");
+
+        assert!((metrics.summary.min_latency_ms - 4.0).abs() < f64::EPSILON);
+        assert!((metrics.summary.max_latency_ms - 6.0).abs() < f64::EPSILON);
+        assert!(metrics.summary.std_dev_latency_ms > 0.0);
+    }
+
+    /// A run whose samples are all equal reports a real zero std dev beside a
+    /// nonzero min and max. Backfilling it from the per-bucket moving average
+    /// would put back the averaged-away extremes the summary avoids.
+    #[test]
+    fn given_a_report_with_a_real_zero_std_dev_when_deserialized_should_keep_it() {
+        let json = report_json(
+            r#","min_latency_ms": 5.0, "max_latency_ms": 5.0, "std_dev_latency_ms": 0.0"#,
+        );
+
+        let metrics: BenchmarkIndividualMetrics =
+            serde_json::from_str(&json).expect("deserialize report");
+
+        assert!((metrics.summary.min_latency_ms - 5.0).abs() < f64::EPSILON);
+        assert!((metrics.summary.max_latency_ms - 5.0).abs() < f64::EPSILON);
+        assert_eq!(metrics.summary.std_dev_latency_ms, 0.0);
     }
 }

--- a/core/bench/report/src/utils.rs
+++ b/core/bench/report/src/utils.rs
@@ -116,30 +116,36 @@ pub fn lttb_downsample(points: &[TimePoint], threshold: usize) -> Vec<TimePoint>
     result
 }
 
+/// Calculate the population standard deviation of `values`
+///
+/// Returns None if there are fewer than 2 values
+pub fn std_dev_values(values: &[f64]) -> Option<f64> {
+    let count = values.len();
+
+    if count < 2 {
+        return None;
+    }
+
+    let mean = values.iter().sum::<f64>() / count as f64;
+
+    let variance = values
+        .iter()
+        .map(|value| {
+            let diff = value - mean;
+            diff * diff
+        })
+        .sum::<f64>()
+        / count as f64;
+
+    Some(variance.sqrt())
+}
+
 /// Calculate the standard deviation of values from a TimeSeries
 ///
 /// Returns None if the TimeSeries has fewer than 2 points
 pub fn std_dev(series: &TimeSeries) -> Option<f64> {
-    let points_count = series.points.len();
-
-    if points_count < 2 {
-        return None;
-    }
-
-    let sum: f64 = series.points.iter().map(|p| p.value).sum();
-    let mean = sum / points_count as f64;
-
-    let variance = series
-        .points
-        .iter()
-        .map(|p| {
-            let diff = p.value - mean;
-            diff * diff
-        })
-        .sum::<f64>()
-        / points_count as f64;
-
-    Some(variance.sqrt())
+    let values: Vec<f64> = series.points.iter().map(|p| p.value).collect();
+    std_dev_values(&values)
 }
 
 #[cfg(test)]

--- a/core/bench/src/analytics/metrics/group.rs
+++ b/core/bench/src/analytics/metrics/group.rs
@@ -30,8 +30,9 @@ use bench_report::{
     group_metrics_summary::BenchmarkGroupMetricsSummary,
     individual_metrics::BenchmarkIndividualMetrics,
     time_series::{TimeSeries, TimeSeriesKind},
-    utils::{max, min, std_dev},
+    utils::std_dev_values,
 };
+use std::cmp::Ordering;
 use std::thread;
 
 pub fn from_producers_and_consumers_statistics(
@@ -59,8 +60,7 @@ pub fn from_individual_metrics(
     let latency_metrics = calculate_latency_metrics(stats);
     let kind = determine_group_kind(stats);
     let time_series = calculate_group_time_series(stats, moving_average_window);
-    let (min_latency_ms_value, max_latency_ms_value) =
-        calculate_min_max_latencies(stats, &time_series.2);
+    let (min_latency_ms, max_latency_ms) = calculate_min_max_latencies(stats);
 
     let mut all_latencies: Vec<f64> = stats
         .iter()
@@ -88,9 +88,9 @@ pub fn from_individual_metrics(
         average_p9999_latency_ms: latency_metrics.p9999_latency,
         average_latency_ms: latency_metrics.average_latency,
         average_median_latency_ms: latency_metrics.median_latency,
-        min_latency_ms: min_latency_ms_value,
-        max_latency_ms: max_latency_ms_value,
-        std_dev_latency_ms: std_dev(&time_series.2).unwrap_or(0.0),
+        min_latency_ms,
+        max_latency_ms,
+        std_dev_latency_ms: std_dev_values(&all_latencies).unwrap_or(0.0),
     };
 
     Some(BenchmarkGroupMetrics {
@@ -235,30 +235,18 @@ fn extract_time_series_of_kind(
     ts_vec.swap_remove(position)
 }
 
-fn calculate_min_max_latencies(
-    stats: &[BenchmarkIndividualMetrics],
-    avg_latency_ts: &TimeSeries,
-) -> (f64, f64) {
-    let min_latency_ms = if stats.is_empty() {
-        None
-    } else {
-        stats
-            .iter()
-            .map(|s| s.summary.min_latency_ms)
-            .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-    };
+fn calculate_min_max_latencies(stats: &[BenchmarkIndividualMetrics]) -> (f64, f64) {
+    let min_latency_ms = stats
+        .iter()
+        .map(|s| s.summary.min_latency_ms)
+        .min_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal))
+        .unwrap_or(0.0);
 
-    let max_latency_ms = if stats.is_empty() {
-        None
-    } else {
-        stats
-            .iter()
-            .map(|s| s.summary.max_latency_ms)
-            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-    };
+    let max_latency_ms = stats
+        .iter()
+        .map(|s| s.summary.max_latency_ms)
+        .max_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal))
+        .unwrap_or(0.0);
 
-    let min_latency_ms_value = min_latency_ms.unwrap_or_else(|| min(avg_latency_ts).unwrap_or(0.0));
-    let max_latency_ms_value = max_latency_ms.unwrap_or_else(|| max(avg_latency_ts).unwrap_or(0.0));
-
-    (min_latency_ms_value, max_latency_ms_value)
+    (min_latency_ms, max_latency_ms)
 }

--- a/core/bench/src/analytics/metrics/individual.rs
+++ b/core/bench/src/analytics/metrics/individual.rs
@@ -28,7 +28,7 @@ use bench_report::benchmark_kind::BenchmarkKind;
 use bench_report::individual_metrics::BenchmarkIndividualMetrics;
 use bench_report::individual_metrics_summary::BenchmarkIndividualMetricsSummary;
 use bench_report::time_series::TimeSeries;
-use bench_report::utils::{max, min, std_dev};
+use bench_report::utils::std_dev_values;
 use iggy::prelude::IggyDuration;
 
 pub fn from_records(
@@ -68,7 +68,7 @@ pub fn from_records(
         .collect();
     raw_latencies_ms.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
 
-    let latency_metrics = calculate_latency_metrics(&raw_latencies_ms, &latency_ts);
+    let latency_metrics = calculate_latency_metrics(&raw_latencies_ms);
 
     BenchmarkIndividualMetrics {
         summary: BenchmarkIndividualMetricsSummary {
@@ -219,10 +219,7 @@ struct LatencyMetrics {
     std_dev: f64,
 }
 
-fn calculate_latency_metrics(
-    sorted_latencies_ms: &[f64],
-    latency_ts: &TimeSeries,
-) -> LatencyMetrics {
+fn calculate_latency_metrics(sorted_latencies_ms: &[f64]) -> LatencyMetrics {
     let p50 = calculate_percentile(sorted_latencies_ms, 50.0);
     let p90 = calculate_percentile(sorted_latencies_ms, 90.0);
     let p95 = calculate_percentile(sorted_latencies_ms, 95.0);
@@ -238,9 +235,11 @@ fn calculate_latency_metrics(
         sorted_latencies_ms[len]
     };
 
-    let min = min(latency_ts).unwrap_or(0.0);
-    let max = max(latency_ts).unwrap_or(0.0);
-    let std_dev = std_dev(latency_ts).unwrap_or(0.0);
+    // Taken from raw samples, not from `latency_ts`: that series is averaged
+    // per sampling bucket, which pulls the extremes inside the percentiles.
+    let min = sorted_latencies_ms[0];
+    let max = sorted_latencies_ms[sorted_latencies_ms.len() - 1];
+    let std_dev = std_dev_values(sorted_latencies_ms).unwrap_or(0.0);
 
     LatencyMetrics {
         p50,
@@ -272,4 +271,52 @@ pub fn calculate_percentile(sorted_data: &[f64], percentile: f64) -> f64 {
 
     let weight = rank - lower as f64;
     sorted_data[lower].mul_add(1.0 - weight, sorted_data[upper] * weight)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn record(elapsed_time_us: u64, latency_us: u64) -> BenchmarkRecord {
+        BenchmarkRecord {
+            elapsed_time_us,
+            latency_us,
+            messages: 1,
+            message_batches: 1,
+            user_data_bytes: 1_000,
+            total_bytes: 1_000,
+        }
+    }
+
+    #[test]
+    fn given_latencies_averaged_into_one_bucket_when_building_metrics_should_report_raw_extremes() {
+        let records = [
+            record(1_000, 1_000),
+            record(2_000, 2_000),
+            record(3_000, 10_000),
+        ];
+
+        let metrics = from_records(
+            &records,
+            BenchmarkKind::PinnedProducer,
+            ActorKind::Producer,
+            0,
+            IggyDuration::from_str("1s").unwrap(),
+            20,
+        );
+
+        // A single sampling bucket holds every record, so the series carries
+        // only their average and hides both the 1 ms and the 10 ms sample.
+        assert_eq!(metrics.latency_ts.points.len(), 1);
+        assert!((metrics.latency_ts.points[0].value - 4.333).abs() < 1e-9);
+
+        let summary = &metrics.summary;
+        assert!((summary.min_latency_ms - 1.0).abs() < f64::EPSILON);
+        assert!((summary.max_latency_ms - 10.0).abs() < f64::EPSILON);
+        // Population std dev of [1, 2, 10]; the one-point series would give 0.
+        assert!((summary.std_dev_latency_ms - 4.027_682).abs() < 1e-6);
+        assert!(summary.min_latency_ms <= summary.p50_latency_ms);
+        assert!(summary.max_latency_ms >= summary.p9999_latency_ms);
+    }
 }

--- a/core/bench/src/args/common.rs
+++ b/core/bench/src/args/common.rs
@@ -101,11 +101,18 @@ pub struct IggyBenchArgs {
     #[arg(long, default_value_t = false)]
     pub reuse_streams: bool,
 
-    /// Fsync every write on the benchmark topic instead of leaving it to the
-    /// page cache. Set as a topic option at creation, so it has no effect with
-    /// `--reuse-streams` against an already-created topic.
+    /// Fsync each journal flush on the benchmark topic. Flush timing stays
+    /// governed by `--messages-required-to-save` (server default: 1024), so
+    /// acks are durability-gated only with `--messages-required-to-save 1`.
+    /// Topic option at creation, so it has no effect with `--reuse-streams`.
     #[arg(long, default_value_t = false)]
     pub enforce_fsync: bool,
+
+    /// Topic journal flush threshold in messages (server default: 1024).
+    /// With `--enforce-fsync`, `1` makes every produce ack wait for the fsync.
+    /// Topic option at creation, so it has no effect with `--reuse-streams`.
+    #[arg(long)]
+    pub messages_required_to_save: Option<NonZeroU32>,
 }
 
 impl IggyBenchArgs {
@@ -335,6 +342,10 @@ impl IggyBenchArgs {
 
     pub const fn enforce_fsync(&self) -> bool {
         self.enforce_fsync
+    }
+
+    pub const fn messages_required_to_save(&self) -> Option<NonZeroU32> {
+        self.messages_required_to_save
     }
 
     pub fn username(&self) -> &str {

--- a/core/bench/src/args/examples.rs
+++ b/core/bench/src/args/examples.rs
@@ -37,6 +37,12 @@ const EXAMPLES: &str = r#"EXAMPLES:
     $ cargo r -r --bin iggy-bench -- balanced-producer-and-consumer-group --partitions 24 --producers 6 --consumers 6 tcp
     $ cargo r -r --bin iggy-bench -- -T 10GB bpc tcp
 
+    Durability-matched run, where every produce ack waits for an fsync
+    (--partitions 1 routes every producer straight to that partition):
+
+    $ cargo r -r --bin iggy-bench -- --enforce-fsync --messages-required-to-save 1 \
+        balanced-producer --partitions 1 --producers 8 tcp
+
 3) End-to-End Benchmarking:
 
     Run end-to-end benchmarks that measure performance for a producer that is also a consumer:

--- a/core/bench/src/args/kinds/balanced/producer.rs
+++ b/core/bench/src/args/kinds/balanced/producer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::args::{
-    common::IggyBenchArgs,
     defaults::{
         DEFAULT_BALANCED_NUMBER_OF_PARTITIONS, DEFAULT_BALANCED_NUMBER_OF_STREAMS,
         DEFAULT_NUMBER_OF_PRODUCERS,
@@ -24,7 +23,7 @@ use crate::args::{
     props::BenchmarkKindProps,
     transport::BenchmarkTransportCommand,
 };
-use clap::{CommandFactory, Parser, error::ErrorKind};
+use clap::Parser;
 use iggy::prelude::{IggyByteSize, IggyExpiry};
 use std::num::NonZeroU32;
 
@@ -88,16 +87,8 @@ impl BenchmarkKindProps for BalancedProducerArgs {
         self.message_expiry.unwrap_or(IggyExpiry::NeverExpire)
     }
 
-    fn validate(&self) {
-        let partitions = self.partitions();
-        let mut cmd = IggyBenchArgs::command();
-
-        if partitions < 2 {
-            cmd.error(
-                ErrorKind::ArgumentConflict,
-                format!("For balanced producer, number of partitions must be at least 2, got {partitions}"),
-            )
-            .exit();
-        }
-    }
+    // No partition floor: a lone partition is a legal target (producers route
+    // straight to it and balance only across several), and it is the shape
+    // the fsync-gated benchmark needs, N producers into one partition.
+    fn validate(&self) {}
 }

--- a/core/bench/src/benchmarks/benchmark.rs
+++ b/core/bench/src/benchmarks/benchmark.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use bench_report::benchmark_kind::BenchmarkKind;
 use bench_report::individual_metrics::BenchmarkIndividualMetrics;
 use iggy::prelude::*;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
@@ -123,10 +124,17 @@ pub trait Benchmarkable: Send {
                 .map_or(MaxTopicSize::Unlimited, MaxTopicSize::Custom);
             let message_expiry = self.args().message_expiry();
             let enforce_fsync = self.args().enforce_fsync();
+            let messages_required_to_save =
+                self.args().messages_required_to_save().map(NonZeroU32::get);
 
             info!(
-                "Creating the test topic '{}' for stream '{}' with max topic size: {:?}, message expiry: {}, enforce fsync: {}",
-                topic_name, stream_name, max_topic_size, message_expiry, enforce_fsync
+                "Creating the test topic '{}' for stream '{}' with max topic size: {:?}, message expiry: {}, enforce fsync: {}, messages required to save: {:?}",
+                topic_name,
+                stream_name,
+                max_topic_size,
+                message_expiry,
+                enforce_fsync,
+                messages_required_to_save
             );
 
             client
@@ -140,6 +148,7 @@ pub trait Benchmarkable: Send {
                         max_topic_size: (max_topic_size != MaxTopicSize::ServerDefault)
                             .then_some(max_topic_size),
                         enforce_fsync: enforce_fsync.then_some(true),
+                        messages_required_to_save,
                         ..TopicCreateOptions::default()
                     },
                 )

--- a/core/integration/tests/cluster/crash_recovery_corruption.rs
+++ b/core/integration/tests/cluster/crash_recovery_corruption.rs
@@ -68,16 +68,18 @@ const INDEX_ENTRY_POSITION_AT: usize = 2 * size_of::<u64>();
 /// the damaged node's index holds several flush chunks at either role's
 /// cadence (a primary flushes per op, a backup per committed range).
 const INDEX_AHEAD_BATCHES: u32 = 30;
-/// Flush chunks the damaged node's index must hold for the surgery to leave
-/// BOTH a surviving prefix and entries pointing past the truncated log end.
+/// Flush chunks the damaged node's index must hold for the surgery to leave a
+/// real surviving prefix behind the one entry it strands past the log end.
 const MIN_INDEX_ENTRIES: usize = 4;
 /// Infix of the directory the refusal path renames a partition's segment files
 /// into (`partitions::state_transfer::quarantine_segment_files`).
 const FENCED_DIR_MARKER: &str = ".fenced.";
-/// Boot log line recovery emits when it floors an index the log cannot fully
-/// back (`server::segment_recovery::recover_segment_bounds`): the positive
-/// evidence the floor ran, as opposed to a rebuild or a refusal.
-const INDEX_FLOOR_MARKER: &str = "flooring it to the entries the log proves";
+/// Boot log line recovery emits when the log cannot back the last entry of an
+/// index (`server::segment_recovery::recover_segment_bounds`): the positive
+/// evidence that path ran, as opposed to the clean anchored walk or a refusal.
+/// Distinct from the line the self-contradicting-index check emits, which ends
+/// "rebuilding it from the log".
+const INDEX_REBUILD_MARKER: &str = "discarding the index and rebuilding it from a byte-0 walk";
 
 async fn create_stream_and_topic(client: &IggyClient) {
     client
@@ -567,17 +569,22 @@ async fn given_a_torn_index_tail_when_a_node_recovers_should_not_misalign_subseq
 
 /// A crash can leave a node's segment `.log` shorter than its already durable
 /// `.index` claims: the two files are persisted concurrently, so death between
-/// them lands the index ahead even under `enforce_fsync`, where both were
-/// durable at ack time. The index is a rebuildable local artifact and the log
-/// is the authority, so recovery must floor the index to the last entry the
-/// log still proves and keep serving the batches behind it - not refuse the
-/// chain, which fences every surviving byte aside on a cluster and tombstones
-/// the partition outright on a single replica. The spec pins the whole
-/// outcome: the node boots without a refusal, nothing is fenced, its index no
-/// longer points past its log, catch-up refills the truncated tail, every
-/// acked offset reads back, and the replicas end byte-identical.
+/// them strands the entry of the chunk that was in flight even under
+/// `enforce_fsync`. That one entry is the whole window - every earlier entry
+/// was fsync'd with its log chunk before that chunk's batch was acked - so it
+/// is the shape the surgery reproduces. The index is a rebuildable local
+/// artifact and the log is the authority, so recovery must discard the index,
+/// rebuild it from a byte-0 walk of the log, and keep serving the batches the
+/// walk proves - not refuse the chain, which fences every surviving byte aside
+/// on a cluster and tombstones the partition outright on a single replica. The
+/// walk starts at byte 0 rather than at the highest entry the log still backs
+/// because an anchor above the damage would leave everything below it unread.
+/// The spec pins the whole outcome: the node boots without a refusal, nothing
+/// is fenced, its index no longer points past its log, catch-up refills the
+/// truncated tail, every acked offset reads back, and the replicas end
+/// byte-identical.
 #[iggy_harness(cluster_nodes = 3)]
-async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_should_floor_the_index_and_serve_the_surviving_prefix(
+async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_should_rebuild_the_index_and_serve_the_surviving_prefix(
     harness: &mut TestHarness,
 ) {
     let client = harness.tcp_root_client().await.unwrap();
@@ -613,20 +620,22 @@ async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_sho
     assert!(
         positions.len() >= MIN_INDEX_ENTRIES,
         "the backup's index holds only {} flush chunk(s), fewer than the {MIN_INDEX_ENTRIES} \
-         the surgery needs to leave both a surviving prefix and entries past the log end",
+         the surgery needs to leave a real surviving prefix behind the stranded entry",
         positions.len()
     );
     let log_size = fs::metadata(&log_path)
         .map(|meta| meta.len())
         .unwrap_or_else(|error| panic!("stat {}: {error}", log_path.display()));
-    // Cutting at the midpoint entry's position lands the log end exactly on a
-    // batch boundary, keeps whole batches behind it, and leaves every entry
-    // from the midpoint on pointing at or past the end of the file - what a
-    // crash between the log write and the index write produces.
-    let cut_at = positions[positions.len() / 2];
+    // Cutting at the LAST entry's position lands the log end exactly on a
+    // batch boundary, keeps whole batches behind it, and strands exactly one
+    // entry past the end of the file - the only depth a crash can produce
+    // under `enforce_fsync`, where every earlier entry was fsync'd together
+    // with its log chunk before that chunk's batch was acked. A deeper cut
+    // would fabricate acked-data loss, which recovery refuses by design.
+    let cut_at = positions[positions.len() - 1];
     assert!(
         cut_at > 0 && cut_at < log_size,
-        "the midpoint entry's position {cut_at} must sit inside the {log_size}-byte log"
+        "the last entry's position {cut_at} must sit inside the {log_size}-byte log"
     );
     truncate_to(&log_path, cut_at);
     let truncated =
@@ -643,16 +652,21 @@ async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_sho
     harness.restart_node(backup).unwrap_or_else(|error| {
         panic!(
             "an index ahead of its log is what a crash between the two writes leaves; \
-             boot must floor the index instead of failing: {error}"
+             boot must rebuild the index instead of failing: {error}"
         )
     });
 
-    // Stat the index BEFORE the log, both right after boot: catch-up grows
+    // Read the index BEFORE the log, both right after boot: catch-up grows
     // the two files together, so a log still at the cut proves the index was
-    // read before any append landed, and the floor is then the only shape it
-    // may have. Once the log has grown the refilled tail re-mints the very
-    // entries the floor dropped, and nothing on disk tells the two apart; the
-    // boot log marker below is the evidence that survives that.
+    // read before any append landed, and the rebuild is then the only shape it
+    // may have. Once the log has grown the refilled tail re-mints entries over
+    // the same bytes, and nothing on disk tells the two apart; the boot log
+    // marker below is the evidence that survives that.
+    //
+    // The rebuild's stride is its own, so the entry COUNT is not the spec.
+    // What is: the index describes only bytes the walk proved, which is the
+    // property the stranded entry violated.
+    let recovered_positions = index_positions(&index_path);
     let recovered_index_len = fs::metadata(&index_path)
         .map(|meta| meta.len())
         .unwrap_or_else(|error| panic!("stat {}: {error}", index_path.display()));
@@ -660,22 +674,28 @@ async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_sho
         .map(|meta| meta.len())
         .unwrap_or_else(|error| panic!("stat {}: {error}", log_path.display()));
     if recovered_log_len == cut_at {
-        let floored_entries = positions
-            .iter()
-            .filter(|position| **position < cut_at)
-            .count();
         assert_eq!(
-            recovered_index_len,
-            (floored_entries * INDEX_ENTRY_SIZE) as u64,
-            "recovery must floor the index to exactly the {floored_entries} entries the \
-             {cut_at}-byte log proves"
+            recovered_index_len as usize % INDEX_ENTRY_SIZE,
+            0,
+            "the recovered index must hold whole entries; it is {recovered_index_len} bytes"
+        );
+        assert!(
+            !recovered_positions.is_empty(),
+            "the {cut_at}-byte log holds whole batches, so the rebuilt index must not be empty"
+        );
+        assert!(
+            recovered_positions
+                .iter()
+                .all(|position| *position < cut_at),
+            "every rebuilt entry must open inside the {cut_at}-byte log, got \
+             {recovered_positions:?}"
         );
     }
 
     let fenced = fenced_segment_paths(&backup_data);
     assert!(
         fenced.is_empty(),
-        "recovery must floor the index to the entries the log proves, keeping the {} \
+        "recovery must rebuild the index from the log, keeping the {} \
          surviving batches in service; instead the chain was refused and fenced aside: {fenced:?}",
         surviving.len()
     );
@@ -699,8 +719,9 @@ async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_sho
             "boot must absorb an index that outruns its log, not refuse the chain"
         );
         assert!(
-            harness.node(backup).stdout_contains(INDEX_FLOOR_MARKER),
-            "boot must log the index floor ({INDEX_FLOOR_MARKER:?}); recovery took another path"
+            harness.node(backup).stdout_contains(INDEX_REBUILD_MARKER),
+            "boot must log the byte-0 rebuild ({INDEX_REBUILD_MARKER:?}); recovery took \
+             another path"
         );
     }
 
@@ -718,7 +739,7 @@ async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_sho
     wait_for_acked_readable(&client, &acked, CONVERGE_TIMEOUT)
         .await
         .unwrap_or_else(|state| {
-            panic!("every acked offset must poll back after the floored-index recovery: {state}")
+            panic!("every acked offset must poll back after the rebuilt-index recovery: {state}")
         });
 
     let data_paths: Vec<PathBuf> = harness

--- a/core/integration/tests/cluster/crash_recovery_corruption.rs
+++ b/core/integration/tests/cluster/crash_recovery_corruption.rs
@@ -570,9 +570,9 @@ async fn given_a_torn_index_tail_when_a_node_recovers_should_not_misalign_subseq
 /// A crash can leave a node's segment `.log` shorter than its already durable
 /// `.index` claims: the two files are persisted concurrently, so death between
 /// them strands the entry of the chunk that was in flight even under
-/// `enforce_fsync`. That one entry is the whole window - every earlier entry
-/// was fsync'd with its log chunk before that chunk's batch was acked - so it
-/// is the shape the surgery reproduces. The index is a rebuildable local
+/// `enforce_fsync`. That one entry is the whole window: every earlier entry
+/// belongs to a completed serialized flush whose log fdatasync finished before
+/// the later flush began, so it is the shape the surgery reproduces. The index is a rebuildable local
 /// artifact and the log is the authority, so recovery must discard the index,
 /// rebuild it from a byte-0 walk of the log, and keep serving the batches the
 /// walk proves - not refuse the chain, which fences every surviving byte aside
@@ -629,9 +629,10 @@ async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_sho
     // Cutting at the LAST entry's position lands the log end exactly on a
     // batch boundary, keeps whole batches behind it, and strands exactly one
     // entry past the end of the file - the only depth a crash can produce
-    // under `enforce_fsync`, where every earlier entry was fsync'd together
-    // with its log chunk before that chunk's batch was acked. A deeper cut
-    // would fabricate acked-data loss, which recovery refuses by design.
+    // under `enforce_fsync`, where each serialized flush fdatasyncs the whole
+    // log before the next chunk's entry can exist. A deeper cut would
+    // fabricate previously durable data loss, which recovery refuses by
+    // design.
     let cut_at = positions[positions.len() - 1];
     assert!(
         cut_at > 0 && cut_at < log_size,

--- a/core/integration/tests/cluster/crash_recovery_corruption.rs
+++ b/core/integration/tests/cluster/crash_recovery_corruption.rs
@@ -58,6 +58,27 @@ const GARBAGE_BYTE: u8 = 0xA5;
 /// the file provably lands ahead of many complete committed entries.
 const WAL_FODDER_STREAMS: usize = 20;
 
+/// Sparse index entry layout, mirrored from `partitions::iggy_index::IggyIndex`
+/// (which the `integration` crate does not depend on): three little-endian
+/// u64s, `offset`, `timestamp`, `position`.
+const INDEX_ENTRY_SIZE: usize = 3 * size_of::<u64>();
+const INDEX_ENTRY_POSITION_AT: usize = 2 * size_of::<u64>();
+
+/// Batches produced before the index-ahead-of-log surgery. High enough that
+/// the damaged node's index holds several flush chunks at either role's
+/// cadence (a primary flushes per op, a backup per committed range).
+const INDEX_AHEAD_BATCHES: u32 = 30;
+/// Flush chunks the damaged node's index must hold for the surgery to leave
+/// BOTH a surviving prefix and entries pointing past the truncated log end.
+const MIN_INDEX_ENTRIES: usize = 4;
+/// Infix of the directory the refusal path renames a partition's segment files
+/// into (`partitions::state_transfer::quarantine_segment_files`).
+const FENCED_DIR_MARKER: &str = ".fenced.";
+/// Boot log line recovery emits when it floors an index the log cannot fully
+/// back (`server::segment_recovery::recover_segment_bounds`): the positive
+/// evidence the floor ran, as opposed to a rebuild or a refusal.
+const INDEX_FLOOR_MARKER: &str = "flooring it to the entries the log proves";
+
 async fn create_stream_and_topic(client: &IggyClient) {
     client
         .create_stream(STREAM_NAME)
@@ -285,6 +306,64 @@ fn append_garbage(path: &Path, count: usize) {
     fs::write(path, bytes).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
 }
 
+/// Cut `path` down to exactly `length` bytes. The owning process is already
+/// dead, so nothing can be holding the file open against the truncation.
+fn truncate_to(path: &Path, length: u64) {
+    fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .and_then(|file| file.set_len(length))
+        .unwrap_or_else(|error| panic!("truncate {} to {length}: {error}", path.display()));
+}
+
+/// The `position` of every whole entry in a segment `.index`, in file order.
+///
+/// One entry is written per flushed chunk and points at that chunk's FIRST
+/// batch, so every position is both an absolute byte offset into the paired
+/// `.log` and a batch boundary in it.
+fn index_positions(path: &Path) -> Vec<u64> {
+    let bytes = fs::read(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    bytes
+        .as_chunks::<INDEX_ENTRY_SIZE>()
+        .0
+        .iter()
+        .map(|entry| {
+            let mut position = [0u8; size_of::<u64>()];
+            position.copy_from_slice(&entry[INDEX_ENTRY_POSITION_AT..]);
+            u64::from_le_bytes(position)
+        })
+        .collect()
+}
+
+/// Payloads from `expected` whose bytes appear anywhere in `haystack`. The
+/// payloads are fixed-width, so none is a prefix of another and a plain
+/// substring search cannot cross-match them.
+fn payloads_within(haystack: &[u8], expected: &[String]) -> Vec<String> {
+    expected
+        .iter()
+        .filter(|payload| {
+            haystack
+                .windows(payload.len())
+                .any(|window| window == payload.as_bytes())
+        })
+        .cloned()
+        .collect()
+}
+
+/// Segment files a boot refusal renamed aside on this node. Once written the
+/// fenced directory stays, so an empty result is a stable verdict rather than
+/// a snapshot that catch-up could invalidate.
+fn fenced_segment_paths(data_path: &Path) -> Vec<PathBuf> {
+    let mut fenced = Vec::new();
+    let _ = disk::walk(data_path, &mut |path| {
+        if path.to_string_lossy().contains(FENCED_DIR_MARKER) {
+            fenced.push(path.to_path_buf());
+        }
+        false
+    });
+    fenced
+}
+
 /// Flip one interior byte at `numerator/denominator` of the file's length.
 fn flip_interior_byte(path: &Path, numerator: u64, denominator: u64) {
     let mut bytes =
@@ -484,6 +563,174 @@ async fn given_a_torn_index_tail_when_a_node_recovers_should_not_misalign_subseq
         .unwrap_or_else(|state| {
             panic!("every acked offset must poll back after the torn-index recovery: {state}")
         });
+}
+
+/// A crash can leave a node's segment `.log` shorter than its already durable
+/// `.index` claims: the two files are persisted concurrently, so death between
+/// them lands the index ahead even under `enforce_fsync`, where both were
+/// durable at ack time. The index is a rebuildable local artifact and the log
+/// is the authority, so recovery must floor the index to the last entry the
+/// log still proves and keep serving the batches behind it - not refuse the
+/// chain, which fences every surviving byte aside on a cluster and tombstones
+/// the partition outright on a single replica. The spec pins the whole
+/// outcome: the node boots without a refusal, nothing is fenced, its index no
+/// longer points past its log, catch-up refills the truncated tail, every
+/// acked offset reads back, and the replicas end byte-identical.
+#[iggy_harness(cluster_nodes = 3)]
+async fn given_a_durable_index_ahead_of_a_truncated_log_when_a_node_recovers_should_floor_the_index_and_serve_the_surviving_prefix(
+    harness: &mut TestHarness,
+) {
+    let client = harness.tcp_root_client().await.unwrap();
+    create_stream_and_topic(&client).await;
+    let acked = produce_acked(&client, "index-ahead", INDEX_AHEAD_BATCHES).await;
+    let payloads: Vec<String> = acked.iter().map(|(_, payload)| payload.clone()).collect();
+    for node in 0..harness.cluster_size() {
+        wait_until_node_holds_payloads(
+            harness,
+            node,
+            &payloads,
+            FLUSH_INSTALL_TIMEOUT,
+            "eager flush before the surgery",
+        )
+        .await;
+    }
+
+    drop(client);
+
+    // The leader keeps quorum and serving throughout, so the damaged node
+    // always has a peer to catch up from. SIGKILL rather than a graceful stop:
+    // the shape under test is a crash, and no shutdown hook may run to
+    // reconcile the two files first.
+    let (_, backup) = pick_backup(harness).await;
+    harness.kill_node(backup).expect("SIGKILL the backup");
+
+    let backup_data = harness.node(backup).data_path();
+    let log_path = find_active_segment_file(&backup_data, "log");
+    // Paired by stem, not by a second `find_active_segment_file` sweep, so the
+    // index provably describes the log being cut.
+    let index_path = log_path.with_extension("index");
+    let positions = index_positions(&index_path);
+    assert!(
+        positions.len() >= MIN_INDEX_ENTRIES,
+        "the backup's index holds only {} flush chunk(s), fewer than the {MIN_INDEX_ENTRIES} \
+         the surgery needs to leave both a surviving prefix and entries past the log end",
+        positions.len()
+    );
+    let log_size = fs::metadata(&log_path)
+        .map(|meta| meta.len())
+        .unwrap_or_else(|error| panic!("stat {}: {error}", log_path.display()));
+    // Cutting at the midpoint entry's position lands the log end exactly on a
+    // batch boundary, keeps whole batches behind it, and leaves every entry
+    // from the midpoint on pointing at or past the end of the file - what a
+    // crash between the log write and the index write produces.
+    let cut_at = positions[positions.len() / 2];
+    assert!(
+        cut_at > 0 && cut_at < log_size,
+        "the midpoint entry's position {cut_at} must sit inside the {log_size}-byte log"
+    );
+    truncate_to(&log_path, cut_at);
+    let truncated =
+        fs::read(&log_path).unwrap_or_else(|error| panic!("read {}: {error}", log_path.display()));
+    let surviving = payloads_within(&truncated, &payloads);
+    assert!(
+        !surviving.is_empty() && surviving.len() < payloads.len(),
+        "the surgery must keep a real prefix and remove a real tail; {} of {} payloads \
+         survived the cut at byte {cut_at}",
+        surviving.len(),
+        payloads.len()
+    );
+
+    harness.restart_node(backup).unwrap_or_else(|error| {
+        panic!(
+            "an index ahead of its log is what a crash between the two writes leaves; \
+             boot must floor the index instead of failing: {error}"
+        )
+    });
+
+    // Stat the index BEFORE the log, both right after boot: catch-up grows
+    // the two files together, so a log still at the cut proves the index was
+    // read before any append landed, and the floor is then the only shape it
+    // may have. Once the log has grown the refilled tail re-mints the very
+    // entries the floor dropped, and nothing on disk tells the two apart; the
+    // boot log marker below is the evidence that survives that.
+    let recovered_index_len = fs::metadata(&index_path)
+        .map(|meta| meta.len())
+        .unwrap_or_else(|error| panic!("stat {}: {error}", index_path.display()));
+    let recovered_log_len = fs::metadata(&log_path)
+        .map(|meta| meta.len())
+        .unwrap_or_else(|error| panic!("stat {}: {error}", log_path.display()));
+    if recovered_log_len == cut_at {
+        let floored_entries = positions
+            .iter()
+            .filter(|position| **position < cut_at)
+            .count();
+        assert_eq!(
+            recovered_index_len,
+            (floored_entries * INDEX_ENTRY_SIZE) as u64,
+            "recovery must floor the index to exactly the {floored_entries} entries the \
+             {cut_at}-byte log proves"
+        );
+    }
+
+    let fenced = fenced_segment_paths(&backup_data);
+    assert!(
+        fenced.is_empty(),
+        "recovery must floor the index to the entries the log proves, keeping the {} \
+         surviving batches in service; instead the chain was refused and fenced aside: {fenced:?}",
+        surviving.len()
+    );
+    // `fenced_segment_paths` walks past unreadable directories, so an empty
+    // result alone could be vacuous: the files must still be where boot found
+    // them.
+    assert!(
+        log_path.exists() && index_path.exists(),
+        "the segment files must stay in place after recovery; missing under {}",
+        backup_data.display()
+    );
+    // `restart_node` truncates the node's stdout log, so a marker found here
+    // was logged by the boot just performed. Under `IGGY_TEST_VERBOSE` the
+    // child's output is inherited and no file exists to read, which would make
+    // either check vacuous.
+    if stderr_is_captured() {
+        assert!(
+            !harness
+                .node(backup)
+                .stdout_contains("refusing the recovered segment chain"),
+            "boot must absorb an index that outruns its log, not refuse the chain"
+        );
+        assert!(
+            harness.node(backup).stdout_contains(INDEX_FLOOR_MARKER),
+            "boot must log the index floor ({INDEX_FLOOR_MARKER:?}); recovery took another path"
+        );
+    }
+
+    wait_until_node_holds_payloads(
+        harness,
+        backup,
+        &payloads,
+        CONVERGE_TIMEOUT,
+        "catch-up refilling the truncated tail",
+    )
+    .await;
+
+    let nodes: Vec<usize> = (0..harness.cluster_size()).collect();
+    let client = wait_until_cluster_serves(harness, &nodes, CONVERGE_TIMEOUT).await;
+    wait_for_acked_readable(&client, &acked, CONVERGE_TIMEOUT)
+        .await
+        .unwrap_or_else(|state| {
+            panic!("every acked offset must poll back after the floored-index recovery: {state}")
+        });
+
+    let data_paths: Vec<PathBuf> = harness
+        .all_servers()
+        .iter()
+        .map(|server| server.data_path())
+        .collect();
+    harness
+        .stop()
+        .await
+        .expect("stop the cluster for the at-rest comparison");
+    disk::assert_replica_data_identical(&data_paths, false);
 }
 
 /// An interior flip in the metadata WAL is bit-rot, not a torn append: a

--- a/core/partitions/src/iggy_index.rs
+++ b/core/partitions/src/iggy_index.rs
@@ -17,6 +17,12 @@
 
 pub const IGGY_INDEX_SIZE: usize = std::mem::size_of::<u64>() * 3;
 
+/// One sparse index entry.
+///
+/// On disk it is the three fields as little-endian u64s in declaration
+/// order, `IGGY_INDEX_SIZE` bytes per entry. The server's segment recovery
+/// and the cluster crash tests decode that layout by hand (the `integration`
+/// crate does not depend on this one), so a change here must change them too.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct IggyIndex {
     pub offset: u64,

--- a/core/partitions/src/iggy_index_writer.rs
+++ b/core/partitions/src/iggy_index_writer.rs
@@ -105,7 +105,7 @@ impl IggyIndexWriter {
     /// # Errors
     ///
     /// Returns an error if the index bytes cannot be written or synced to disk.
-    pub async fn save_indexes(&self, indexes: Vec<u8>) -> Result<u64, IggyError> {
+    pub(crate) async fn save_indexes(&self, indexes: Vec<u8>) -> Result<u64, IggyError> {
         if indexes.is_empty() {
             return Ok(0);
         }

--- a/core/partitions/src/iggy_index_writer.rs
+++ b/core/partitions/src/iggy_index_writer.rs
@@ -97,14 +97,17 @@ impl IggyIndexWriter {
         })
     }
 
-    /// Appends encoded sparse index bytes to the backing file.
+    /// Appends encoded sparse index bytes at the current write cursor and
+    /// returns how many bytes landed. The cursor is left where it was: the
+    /// caller advances it with `advance` once the companion segment save has
+    /// also succeeded.
     ///
     /// # Errors
     ///
     /// Returns an error if the index bytes cannot be written or synced to disk.
-    pub async fn save_indexes(&self, indexes: Vec<u8>) -> Result<(), IggyError> {
+    pub async fn save_indexes(&self, indexes: Vec<u8>) -> Result<u64, IggyError> {
         if indexes.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         let len = indexes.len();
@@ -120,12 +123,6 @@ impl IggyIndexWriter {
             self.fsync().await?;
         }
 
-        // Advance the write cursor last: if the write or fsync fails, the
-        // counter must stay put so the retry overwrites the same slot instead
-        // of appending a duplicate entry that boot recovery would refuse.
-        self.index_size_bytes
-            .fetch_add(len as u64, Ordering::Release);
-
         trace!(
             target: "iggy.partitions.storage",
             file = self.file_path.as_str(),
@@ -133,7 +130,14 @@ impl IggyIndexWriter {
             position,
             "saved sparse index bytes to file"
         );
-        Ok(())
+        Ok(len as u64)
+    }
+
+    /// Move the write cursor forward over `bytes` that are now durable. Split
+    /// out of the save so the index and segment cursors advance together, only
+    /// once both halves have succeeded.
+    pub(crate) fn advance(&self, bytes: u64) {
+        self.index_size_bytes.fetch_add(bytes, Ordering::Release);
     }
 
     /// Flushes buffered index file contents to disk.

--- a/core/partitions/src/iggy_partition.rs
+++ b/core/partitions/src/iggy_partition.rs
@@ -3091,12 +3091,20 @@ where
             };
 
             // Persist BEFORE eviction so a write failure leaves the rest of the
-            // committed prefix resident for retry. The persist is idempotent on
-            // failure: it advances its write cursors only once both the batch
-            // and the index are durable, so the retry overwrites the same
-            // positions instead of appending a duplicate. Chunks already durable
-            // are evicted before the error propagates, so the retry cannot
-            // re-read them (and re-write them past a rotation).
+            // committed prefix resident instead of dropping it. Nothing retries
+            // the persist: on the commit path a failure panics
+            // `handle_committed_entries`, the shutdown flush warns and moves to
+            // the next namespace, and the transfer offer turns it into
+            // `FlushFailed`. Recovery is a restart, which reopens each writer at
+            // the on-disk length boot recovery validated.
+            //
+            // The ordering therefore buys a non-corrupting failure, not an
+            // in-process one. Write cursors advance only once both the batch and the
+            // index are durable, so where the error does not panic the partition,
+            // its next flush rewrites the same positions instead of appending a
+            // duplicate. Chunks already durable are evicted before the error
+            // propagates, so it cannot re-read them (and re-write them past a
+            // rotation).
             if let Err(error) = self
                 .persist_frozen_batches_to_disk(frozen_batches, index_bytes, batch_count)
                 .await
@@ -3106,9 +3114,9 @@ where
             }
             // Insert the flushed sparse-index entry into the in-mem cache only now
             // that the batch + index are durable. Inserting in the build loop (before
-            // persist) re-inserts a duplicate on a persist-failure retry, which
-            // re-reads the same prefix. The active segment has not rotated yet, so
-            // this targets the segment that received the batches.
+            // persist) re-inserts a duplicate on the next flush after a persist
+            // failure, which re-reads the same prefix. The active segment has not
+            // rotated yet, so this targets the segment that received the batches.
             if let Some(index) = flush_index {
                 self.log.ensure_indexes();
                 let indexes = self.log.active_indexes_mut().expect("indexes must exist");
@@ -3723,6 +3731,22 @@ where
         )
         .await;
 
+        // The match below collapses to the log's error (the durable record, the
+        // index being derived from it). The halves write different files and can
+        // fail for unrelated reasons, so name the index failure here instead of
+        // letting the log's error stand for both.
+        if let (Err(log_error), Err(index_error)) = (&log_result, &index_result) {
+            warn!(
+                target: "iggy.partitions.diag",
+                plane = "partitions",
+                namespace_raw = self.namespace().inner(),
+                batch_count,
+                %log_error,
+                %index_error,
+                "failed to persist frozen batches: log and index both failed"
+            );
+        }
+
         let (saved, saved_index_bytes) = match (log_result, index_result) {
             (Ok(saved), Ok(saved_index_bytes)) => (saved, saved_index_bytes),
             (Err(error), _) | (Ok(_), Err(error)) => {
@@ -3739,12 +3763,13 @@ where
         };
 
         // Advance both cursors only here, back to back with no await between.
-        // They are the writers' next-write positions: a half whose save failed
-        // must keep its cursor so the retry overwrites the same slot instead of
-        // appending a duplicate index entry or leaving a hole in the segment.
-        // Moving them together keeps the pair describing one durable prefix,
-        // which is what a re-opened writer asserts against the length of the
-        // file it finds.
+        // They are the writers' next-write positions, so a half whose save
+        // failed must keep its cursor: the pair then still describes one durable
+        // prefix, which is what a writer re-opened by boot recovery asserts
+        // against the length of the file it finds
+        // (`SegmentSizeMismatchAtOpen`). In-process it also keeps a later flush
+        // rewriting the same slot rather than appending a duplicate index entry
+        // or leaving a hole in the segment.
         messages_writer.advance(saved.as_bytes_u64());
         index_writer.advance(saved_index_bytes);
 

--- a/core/partitions/src/iggy_partition.rs
+++ b/core/partitions/src/iggy_partition.rs
@@ -1643,20 +1643,22 @@ where
         let (start_segment, start_position) = self.disk_poll_start(&query);
         // Cap resident sealed read handles: touch this poll's start segment so
         // the LRU keeps the hot set and drops the least-recently-used fd +
-        // index (a no-op for the active segment, whose handle never caches).
+        // index (a no-op for the active segment, whose slot is bounded by
+        // rotation instead).
         self.log.touch_sealed_read_state(start_segment);
         // Snapshot only the segments the disk walk visits (`start_segment..`),
-        // so `start_position` applies to the first snapshotted segment. A sealed
-        // segment carries its shared read-state handle (fd + sparse index) so
-        // the off-borrow read reuses (or fills) it; the active segment opens
-        // fresh and resolves from its resident index.
+        // so `start_position` applies to the first snapshotted segment. Every
+        // segment carries its shared read-state handle so the off-borrow read
+        // reuses (or fills) the cached fd; only a sealed one also resolves its
+        // start byte from the shared sparse index.
         let segments = self.log.segments()[start_segment..]
             .iter()
             .zip(self.log.sealed_read_state()[start_segment..].iter())
             .map(|(segment, read_state)| DiskSegment {
                 start_offset: segment.start_offset,
                 persisted: segment.size.as_bytes_u64(),
-                read_state: segment.sealed.then(|| Rc::clone(read_state)),
+                read_state: Rc::clone(read_state),
+                sealed: segment.sealed,
             })
             .collect();
         let disk = DiskReadPlan {
@@ -3840,6 +3842,10 @@ where
         // segment's cache is ever read (the `commit_messages` flush staging),
         // so a sealed cache is dead weight.
         self.log.indexes_mut()[old_segment_index] = None;
+        // The read fd cached while this segment was active is not counted by
+        // the sealed LRU budget, so it must not survive the seal; the next
+        // sealed poll re-fills the fresh slot under the LRU's rules.
+        self.log.reset_read_state(old_segment_index);
 
         self.log
             .add_persisted_segment(segment, storage, Some(messages_writer), Some(index_writer));
@@ -5936,12 +5942,14 @@ mod tests {
                 DiskSegment {
                     start_offset: 0,
                     persisted: 512,
-                    read_state: None,
+                    read_state: SealedSegmentHandle::default(),
+                    sealed: false,
                 },
                 DiskSegment {
                     start_offset: 5,
                     persisted: later_len,
-                    read_state: None,
+                    read_state: SealedSegmentHandle::default(),
+                    sealed: false,
                 },
             ],
             start_position: 0,
@@ -6022,12 +6030,14 @@ mod tests {
                 DiskSegment {
                     start_offset: 0,
                     persisted: corrupt_len,
-                    read_state: None,
+                    read_state: SealedSegmentHandle::default(),
+                    sealed: false,
                 },
                 DiskSegment {
                     start_offset: 5,
                     persisted: later_len,
-                    read_state: None,
+                    read_state: SealedSegmentHandle::default(),
+                    sealed: false,
                 },
             ],
             start_position: 0,
@@ -6094,7 +6104,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: record_len,
-                read_state: None,
+                read_state: SealedSegmentHandle::default(),
+                sealed: false,
             }],
             start_position: 0,
             namespace_raw: namespace.inner(),
@@ -6131,7 +6142,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: 512,
-                read_state: None,
+                read_state: SealedSegmentHandle::default(),
+                sealed: false,
             }],
             start_position: 0,
             namespace_raw: IggyNamespace::new(1, 1, 0).inner(),
@@ -6162,7 +6174,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: 512,
-                read_state: None,
+                read_state: SealedSegmentHandle::default(),
+                sealed: false,
             }],
             start_position: 0,
             namespace_raw: IggyNamespace::new(1, 1, 0).inner(),
@@ -6229,7 +6242,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: record_len,
-                read_state: Some(Rc::clone(&handle)),
+                read_state: Rc::clone(&handle),
+                sealed: true,
             }],
             start_position: 0,
             namespace_raw: namespace.inner(),
@@ -6260,7 +6274,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: record_len,
-                read_state: Some(Rc::clone(&handle)),
+                read_state: Rc::clone(&handle),
+                sealed: true,
             }],
             start_position: 0,
             namespace_raw: namespace.inner(),
@@ -6320,7 +6335,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: record_len,
-                read_state: Some(Rc::clone(&handle)),
+                read_state: Rc::clone(&handle),
+                sealed: true,
             }],
             start_position: 0,
             namespace_raw: namespace.inner(),
@@ -6404,7 +6420,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: log_len,
-                read_state: Some(Rc::clone(&handle)),
+                read_state: Rc::clone(&handle),
+                sealed: true,
             }],
             // Byte 0, exactly what disk_poll_start returns for a sealed segment
             // whose resident index was dropped.
@@ -6503,7 +6520,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: log_len,
-                read_state: Some(Rc::clone(&handle)),
+                read_state: Rc::clone(&handle),
+                sealed: true,
             }],
             start_position: 0,
             namespace_raw: namespace.inner(),
@@ -6580,7 +6598,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: record_len,
-                read_state: Some(Rc::clone(&handle)),
+                read_state: Rc::clone(&handle),
+                sealed: true,
             }],
             start_position: 0,
             namespace_raw: namespace.inner(),
@@ -6628,7 +6647,8 @@ mod tests {
             segments: vec![DiskSegment {
                 start_offset: 0,
                 persisted: record_len,
-                read_state: Some(Rc::clone(&handle)),
+                read_state: Rc::clone(&handle),
+                sealed: true,
             }],
             start_position: 0,
             namespace_raw: namespace.inner(),

--- a/core/partitions/src/iggy_partition.rs
+++ b/core/partitions/src/iggy_partition.rs
@@ -30,7 +30,7 @@ use crate::poll_plan::{
 };
 use crate::segment::Segment;
 use crate::state_transfer::{PartitionTransferSession, PendingTransferRearm};
-use crate::types::{RepairConclusion, RepairSession};
+use crate::types::{FatalCommit, RepairConclusion, RepairSession};
 use crate::{
     AppendResult, Partition, PartitionOffsets, PartitionsConfig, PollQueryResult, PollingArgs,
     PollingConsumer,
@@ -83,7 +83,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::Mutex as TokioMutex;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 // This struct aliases in terms of the code contained the `LocalPartition from `core/server/src/streaming/partitions/local_partition.rs`.
 //
@@ -147,6 +147,11 @@ where
     /// also gates repaired-batch persistence -- overstating THAT field would
     /// silently drop the `(commit_op, commit_max]` replay window.
     pub installed_frontier: Option<u64>,
+    /// Set once a local commit fails for an op the cluster already committed.
+    /// Fences the partition: every path that would advance or serve it turns
+    /// into a no-op, so the shard's tick can observe the fault and shut the
+    /// server down without the partition moving again in the meantime.
+    fatal: Option<FatalCommit>,
     pub(crate) pending_consumer_offset_commits: HashMap<u64, PendingConsumerOffsetCommit>,
     /// Committed-only mirror of each consumer's persisted offset file: the
     /// last value this replica durably wrote per (kind, consumer id). Fed
@@ -474,6 +479,7 @@ where
             repair: None,
             recovered_durable_offset: None,
             installed_frontier: None,
+            fatal: None,
             pending_consumer_offset_commits: HashMap::new(),
             persisted_offsets: RefCell::new(HashMap::new()),
             observed_view,
@@ -1833,6 +1839,12 @@ where
         IggyNamespace::from_raw(self.consensus.group())
     }
 
+    /// The commit fault that fenced this partition, if one has.
+    #[must_use]
+    pub const fn fatal(&self) -> Option<&FatalCommit> {
+        self.fatal.as_ref()
+    }
+
     fn partition_dir(&self) -> Option<String> {
         if self.partition_dir.is_some() {
             return self.partition_dir.clone();
@@ -2480,6 +2492,9 @@ where
 
     #[allow(clippy::future_not_send)]
     pub async fn on_ack(&mut self, message: Message<PrepareOkHeader>, config: &PartitionsConfig) {
+        if self.fatal.is_some() {
+            return;
+        }
         self.clear_pending_consumer_offset_commits_if_view_changed();
         let header = *message.header();
         {
@@ -2534,6 +2549,9 @@ where
 
     #[allow(clippy::future_not_send)]
     pub async fn commit_journal(&mut self, config: &PartitionsConfig) {
+        if self.fatal.is_some() {
+            return;
+        }
         self.clear_pending_consumer_offset_commits_if_view_changed();
 
         // The primary commits inline via `on_ack` (it drains its own pipeline).
@@ -3248,12 +3266,32 @@ where
                 // advanced; next advance_commit_min(op+1) would assert
                 // op+1 == commit_min + 1, panics cryptically.
                 //
-                // Fatal: better to suicide than serve stale or panic later.
-                // Operator restarts; recovery+repair re-syncs.
-                panic!(
-                    "partition local commit failed at op={} ({:?}): replica is divergent from cluster commit; restart required",
-                    prepare_header.op, prepare_header.operation
+                // Fatal, but NOT by panicking: this runs on the shard's
+                // message pump, and `compio::runtime::spawn` swallows a panic
+                // there, leaving every partition on the shard unable to
+                // commit, tick or reply while the process still reports
+                // healthy and answers on its other shards. Fence the
+                // partition and stop draining; the shard's tick picks the
+                // fault up and takes the server down through the ordinary
+                // shutdown path, so the remaining partitions flush and the
+                // exit code is non-zero. Operator restarts; recovery+repair
+                // re-syncs.
+                error!(
+                    target: "iggy.partitions.diag",
+                    plane = "partitions",
+                    replica_id,
+                    namespace_raw,
+                    op = prepare_header.op,
+                    operation = ?prepare_header.operation,
+                    "partition local commit failed for a cluster-committed op; \
+                     replica is divergent, fencing the partition and shutting down"
                 );
+                self.fatal = Some(FatalCommit {
+                    namespace_raw,
+                    op: prepare_header.op,
+                    operation: prepare_header.operation,
+                });
+                return;
             }
 
             self.consensus.advance_commit_min(prepare_header.op);
@@ -7605,6 +7643,63 @@ mod tests {
     /// A half that failed never advanced its cursor, so the retry rewrites
     /// the same positions: one copy of the batch, one index entry.
     #[cfg(target_os = "linux")]
+    #[compio::test]
+    async fn given_a_persist_failure_on_a_committed_op_should_fence_the_partition_not_panic() {
+        // The op is cluster-committed and the local write cannot be made, so
+        // the replica is divergent. This used to `panic!`, which the pump
+        // task swallows: the shard stopped serving every partition it owned
+        // while the process reported healthy. The partition must fence itself
+        // instead, so the shard's tick can see the fault and stop the server.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let log_path = dir.path().join("segment.log");
+        let log_cursor = Rc::new(AtomicU64::new(0));
+        let index_cursor = Rc::new(AtomicU64::new(0));
+        let messages_writer = MessagesWriter::new(
+            log_path.to_str().expect("utf-8 path"),
+            log_cursor,
+            true,
+            false,
+            None,
+        )
+        .await
+        .expect("open segment log writer");
+        // The index half writes to a device that is always full, so the
+        // persist fails the way a full disk fails.
+        let index_writer = IggyIndexWriter::new(DEV_FULL, index_cursor, true, false)
+            .await
+            .expect("open segment index writer");
+
+        let mut partition = test_partition();
+        partition.log.add_persisted_segment(
+            Segment::new(0, IggyByteSize::from(1024 * 1024_u64)),
+            SegmentStorage::default(),
+            Some(Rc::new(messages_writer)),
+            Some(Rc::new(index_writer)),
+        );
+
+        journal_send_batch(&mut partition, 1).await;
+        partition.consensus().advance_commit_max(1);
+
+        // Would abort the test process before the fence existed.
+        partition.commit_journal(&repair_config()).await;
+
+        let fault = partition
+            .fatal()
+            .expect("a failed commit of a cluster-committed op must fence the partition");
+        assert_eq!(fault.op, 1);
+        assert_eq!(fault.operation, Operation::SendMessages);
+
+        // The fence holds: a fenced partition must not advance again, or the
+        // pump's tail drain walks it into the `advance_commit_min` assert.
+        let commit_min = partition.consensus().commit_min();
+        partition.commit_journal(&repair_config()).await;
+        assert_eq!(
+            partition.consensus().commit_min(),
+            commit_min,
+            "a fenced partition must not advance on a later commit"
+        );
+    }
+
     #[compio::test]
     async fn given_failed_persist_when_retried_with_a_healthy_writer_should_overwrite_the_same_positions()
      {

--- a/core/partitions/src/iggy_partition.rs
+++ b/core/partitions/src/iggy_partition.rs
@@ -1845,6 +1845,22 @@ where
         self.fatal.as_ref()
     }
 
+    /// Fence this partition after the shutdown flush failed to persist its
+    /// committed journal prefix: that data is cluster-committed and now lives
+    /// only in this process's memory, so the shard must not report a clean
+    /// exit over it. A fault the commit path already recorded is kept, since
+    /// it names the op that first diverged; `commit_min` here only bounds
+    /// where the unpersisted prefix ends.
+    pub fn fence_flush_failure(&mut self) {
+        if self.fatal.is_none() {
+            self.fatal = Some(FatalCommit {
+                namespace_raw: self.namespace().inner(),
+                op: self.consensus.commit_min(),
+                operation: Operation::SendMessages,
+            });
+        }
+    }
+
     fn partition_dir(&self) -> Option<String> {
         if self.partition_dir.is_some() {
             return self.partition_dir.clone();
@@ -2986,8 +3002,8 @@ where
         // re-appends the whole retained tail, so a per-chunk call would
         // re-walk that tail once per segment crossed, quadratic in the flush
         // span -- all under the partition write lock. On an error mid-flush
-        // the accumulated prefix is evicted before propagating, so the retry
-        // re-reads only what did not land.
+        // the accumulated prefix is evicted before propagating, so any later
+        // flush attempt re-reads only what did not land.
         let mut evictable = 0usize;
         while entries.peek().is_some() {
             // A recovered active segment can already sit at or past the cap
@@ -3110,21 +3126,21 @@ where
             };
 
             // Persist BEFORE eviction so a write failure leaves the rest of the
-            // committed prefix resident instead of dropping it. Nothing retries
-            // the persist: on the commit path a failure panics out of
-            // `handle_committed_entries` and takes this shard's message pump with
-            // it, so every partition on the shard stops committing, ticking and
-            // replying until the process is restarted. The shutdown flush warns and
-            // moves to the next namespace, and the transfer offer turns it into
-            // `FlushFailed`. Recovery is a restart, which reopens each writer at
-            // the on-disk length boot recovery validated.
+            // committed prefix resident instead of dropping it. On the commit
+            // path a failure fences the partition and stops the shard pump; the
+            // server then shuts down non-zero after one final best-effort flush
+            // of every partition. A shutdown-flush failure warns and moves to
+            // the next namespace, while the transfer offer turns it into
+            // `FlushFailed`. Recovery reopens each writer at the on-disk length
+            // boot recovery validated.
             //
             // The ordering therefore buys a non-corrupting failure, not an
             // in-process one. Write cursors advance only once both the batch and the
-            // index are durable, so on the paths that survive the error, the next
-            // flush rewrites the same positions instead of appending a duplicate.
-            // Chunks already durable are evicted before the error propagates, so it
-            // cannot re-read them (and re-write them past a rotation).
+            // index are durable, so a later attempt, including the final
+            // shutdown flush, rewrites the same positions instead of appending
+            // a duplicate. Chunks already durable are evicted before the error
+            // propagates, so it cannot re-read them and write them past a
+            // rotation.
             if let Err(error) = self
                 .persist_frozen_batches_to_disk(frozen_batches, index_bytes, batch_count)
                 .await
@@ -7698,6 +7714,34 @@ mod tests {
             commit_min,
             "a fenced partition must not advance on a later commit"
         );
+    }
+
+    #[compio::test]
+    async fn given_a_shutdown_flush_failure_when_fencing_should_keep_an_earlier_commit_fault() {
+        let mut partition = test_partition();
+
+        // A flush failure on a healthy partition fences it, so the pump's
+        // post-flush scan turns the exit non-zero instead of reporting a
+        // clean shutdown over unpersisted cluster-committed data.
+        partition.fence_flush_failure();
+        let fault = partition
+            .fatal()
+            .expect("a failed shutdown flush must fence the partition");
+        assert_eq!(fault.op, partition.consensus().commit_min());
+        assert_eq!(fault.operation, Operation::SendMessages);
+
+        // A partition the commit path already fenced keeps that fault: it
+        // names the op that first diverged.
+        let commit_fault = FatalCommit {
+            namespace_raw: fault.namespace_raw,
+            op: 42,
+            operation: Operation::StoreConsumerOffset,
+        };
+        partition.fatal = Some(commit_fault);
+        partition.fence_flush_failure();
+        let kept = partition.fatal().expect("the fence must hold");
+        assert_eq!(kept.op, 42);
+        assert_eq!(kept.operation, Operation::StoreConsumerOffset);
     }
 
     #[compio::test]

--- a/core/partitions/src/iggy_partition.rs
+++ b/core/partitions/src/iggy_partition.rs
@@ -3090,9 +3090,9 @@ where
 
             // Persist BEFORE eviction so a write failure leaves the rest of the
             // committed prefix resident for retry. The persist is idempotent on
-            // failure: a batch write that lands but whose index save then fails
-            // rewinds the segment write cursor, so the retry overwrites those
-            // bytes instead of appending a duplicate. Chunks already durable
+            // failure: it advances its write cursors only once both the batch
+            // and the index are durable, so the retry overwrites the same
+            // positions instead of appending a duplicate. Chunks already durable
             // are evicted before the error propagates, so the retry cannot
             // re-read them (and re-write them past a rotation).
             if let Err(error) = self
@@ -3711,37 +3711,40 @@ where
         let messages_writer = messages_writer.expect("checked above");
         let index_writer = index_writer.expect("checked above");
 
-        let saved = messages_writer
-            .save_frozen_batches(&stripped_batches)
-            .await
-            .map_err(|error| {
+        // Both writes are in flight before either completes, so under
+        // `enforce_fsync` the two fdatasync round trips overlap instead of
+        // serializing. `join` never cancels a half, so no write is dropped
+        // mid-flight when the other one fails.
+        let (log_result, index_result) = futures::future::join(
+            messages_writer.save_frozen_batches(&stripped_batches),
+            index_writer.save_indexes(index_bytes),
+        )
+        .await;
+
+        let (saved, saved_index_bytes) = match (log_result, index_result) {
+            (Ok(saved), Ok(saved_index_bytes)) => (saved, saved_index_bytes),
+            (Err(error), _) | (Ok(_), Err(error)) => {
                 warn!(
                     target: "iggy.partitions.diag",
                     plane = "partitions",
                     namespace_raw = self.namespace().inner(),
                     batch_count,
                     %error,
-                    "failed to save frozen batches"
+                    "failed to persist frozen batches"
                 );
-                error
-            })?;
+                return Err(error);
+            }
+        };
 
-        if let Err(error) = index_writer.save_indexes(index_bytes).await {
-            warn!(
-                target: "iggy.partitions.diag",
-                plane = "partitions",
-                namespace_raw = self.namespace().inner(),
-                batch_count,
-                %error,
-                "failed to save sparse indexes; rewinding segment write cursor"
-            );
-            // The batch bytes landed but the index did not, so the whole persist
-            // fails and the committed prefix stays resident for retry. Rewind the
-            // writer cursor by exactly what this call advanced so the retry
-            // overwrites those bytes instead of appending a duplicate copy.
-            messages_writer.rewind(saved.as_bytes_u64());
-            return Err(error);
-        }
+        // Advance both cursors only here, back to back with no await between.
+        // They are the writers' next-write positions: a half whose save failed
+        // must keep its cursor so the retry overwrites the same slot instead of
+        // appending a duplicate index entry or leaving a hole in the segment.
+        // Moving them together keeps the pair describing one durable prefix,
+        // which is what a re-opened writer asserts against the length of the
+        // file it finds.
+        messages_writer.advance(saved.as_bytes_u64());
+        index_writer.advance(saved_index_bytes);
 
         debug!(
             target: "iggy.partitions.diag",
@@ -5086,6 +5089,8 @@ fn nth_oldest_sealed_end(segments: &[Segment], count: u32) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::iggy_index::{IGGY_INDEX_SIZE, IggyIndex, IggyIndexCache};
+    use crate::iggy_index_reader::IggyIndexReader;
     use crate::poll_plan::{DiskReadOutcome, SealedSegmentHandle};
     use bytes::Bytes;
     use compio::io::AsyncWriteAtExt;
@@ -7342,6 +7347,264 @@ mod tests {
     #[test]
     fn given_unframed_operation_when_committed_should_reply_empty_body() {
         assert!(committed_reply_body(Operation::DeleteSegments).is_empty());
+    }
+
+    /// Every write to this device fails with `ENOSPC`, which is how the
+    /// persist failure cases below inject a fault into one half of the flush
+    /// without any production-side plumbing.
+    #[cfg(target_os = "linux")]
+    const DEV_FULL: &str = "/dev/full";
+
+    const FIRST_PAYLOAD: &[u8] = b"first-chunk";
+    const SECOND_PAYLOAD: &[u8] = b"second-chunk-is-longer";
+
+    /// Partition whose active segment carries real writers over the given
+    /// paths, both with fsync on. Point either path at [`DEV_FULL`] to make
+    /// that half's save fail.
+    struct PersistFixture {
+        partition: IggyPartition<IggyMessageBus>,
+        log_cursor: Rc<AtomicU64>,
+        index_cursor: Rc<AtomicU64>,
+    }
+
+    impl PersistFixture {
+        async fn new(log_path: &str, index_path: &str) -> Self {
+            let log_cursor = Rc::new(AtomicU64::new(0));
+            let index_cursor = Rc::new(AtomicU64::new(0));
+            let messages_writer =
+                MessagesWriter::new(log_path, log_cursor.clone(), true, false, None)
+                    .await
+                    .expect("open segment log writer");
+            let index_writer = IggyIndexWriter::new(index_path, index_cursor.clone(), true, false)
+                .await
+                .expect("open segment index writer");
+
+            let mut partition = test_partition();
+            partition.log.add_persisted_segment(
+                Segment::new(0, IggyByteSize::from(1024 * 1024_u64)),
+                SegmentStorage::default(),
+                Some(Rc::new(messages_writer)),
+                Some(Rc::new(index_writer)),
+            );
+
+            Self {
+                partition,
+                log_cursor,
+                index_cursor,
+            }
+        }
+
+        /// Mirrors one `commit_messages` chunk: the sparse entry addresses the
+        /// byte the batch is about to land on, taken from the segment size the
+        /// way production takes it, so a second persist can only index
+        /// correctly if the first one advanced the segment in step with the
+        /// writer's cursor.
+        async fn persist(&mut self, payload: &[u8], offset: u64) -> Result<(), IggyError> {
+            let index = IggyIndex::new(offset, offset + 1, self.segment_size());
+            self.partition
+                .persist_frozen_batches_to_disk(
+                    vec![prepare_framed(payload)],
+                    IggyIndexCache::serialize(&index),
+                    1,
+                )
+                .await
+        }
+
+        fn cursors(&self) -> (u64, u64) {
+            (
+                self.log_cursor.load(Ordering::Relaxed),
+                self.index_cursor.load(Ordering::Relaxed),
+            )
+        }
+
+        fn segment_size(&self) -> u64 {
+            self.partition.log.active_segment().size.as_bytes_u64()
+        }
+    }
+
+    /// Journaled entry in the shape the persist path expects: a `PrepareHeader`
+    /// prefix it strips, followed by the bytes that reach the segment file.
+    fn prepare_framed(payload: &[u8]) -> Frozen<4096> {
+        let mut bytes = vec![0u8; size_of::<PrepareHeader>()];
+        bytes.extend_from_slice(payload);
+        Owned::<4096>::copy_from_slice(&bytes).into()
+    }
+
+    fn file_len(path: &std::path::Path) -> u64 {
+        std::fs::metadata(path).expect("stat file").len()
+    }
+
+    #[cfg(target_os = "linux")]
+    #[compio::test]
+    async fn given_index_save_failure_when_persisting_should_leave_both_cursors_and_segment_size_untouched()
+     {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let log_path = dir.path().join("segment.log");
+        let mut fixture =
+            PersistFixture::new(log_path.to_str().expect("utf-8 path"), DEV_FULL).await;
+
+        let result = fixture.persist(FIRST_PAYLOAD, 0).await;
+
+        assert!(
+            matches!(result, Err(IggyError::CannotSaveIndexToSegment)),
+            "index save over {DEV_FULL} must fail, got {result:?}"
+        );
+        assert_eq!(
+            file_len(&log_path),
+            FIRST_PAYLOAD.len() as u64,
+            "the segment bytes landed; only the cursor is withheld"
+        );
+        assert_eq!(
+            fixture.cursors(),
+            (0, 0),
+            "neither cursor may advance when the index half failed"
+        );
+        assert_eq!(fixture.segment_size(), 0, "segment size must not advance");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[compio::test]
+    async fn given_log_save_failure_when_persisting_should_leave_both_cursors_and_segment_size_untouched()
+     {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let index_path = dir.path().join("segment.index");
+        let mut fixture =
+            PersistFixture::new(DEV_FULL, index_path.to_str().expect("utf-8 path")).await;
+
+        let result = fixture.persist(FIRST_PAYLOAD, 0).await;
+
+        assert!(
+            matches!(result, Err(IggyError::CannotWriteToFile)),
+            "segment save over {DEV_FULL} must fail, got {result:?}"
+        );
+        assert_eq!(
+            file_len(&index_path),
+            IGGY_INDEX_SIZE as u64,
+            "the index entry landed; only the cursor is withheld"
+        );
+        assert_eq!(
+            fixture.cursors(),
+            (0, 0),
+            "neither cursor may advance when the segment half failed"
+        );
+        assert_eq!(fixture.segment_size(), 0, "segment size must not advance");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[compio::test]
+    async fn given_both_saves_failing_when_persisting_should_leave_both_cursors_untouched() {
+        let mut fixture = PersistFixture::new(DEV_FULL, DEV_FULL).await;
+
+        let result = fixture.persist(FIRST_PAYLOAD, 0).await;
+
+        assert!(
+            matches!(result, Err(IggyError::CannotWriteToFile)),
+            "a failed segment save must win over the index error, got {result:?}"
+        );
+        assert_eq!(fixture.cursors(), (0, 0), "no cursor may advance");
+        assert_eq!(fixture.segment_size(), 0, "segment size must not advance");
+    }
+
+    /// The two saves run concurrently, so each must read its own cursor
+    /// without observing the other's advance: the second chunk lands exactly
+    /// where the first one ended, and its index entry says so.
+    #[compio::test]
+    async fn given_two_successful_persists_when_reading_back_should_place_second_chunk_at_first_chunk_end()
+     {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let log_path = dir.path().join("segment.log");
+        let index_path = dir.path().join("segment.index");
+        let mut fixture = PersistFixture::new(
+            log_path.to_str().expect("utf-8 path"),
+            index_path.to_str().expect("utf-8 path"),
+        )
+        .await;
+
+        fixture
+            .persist(FIRST_PAYLOAD, 0)
+            .await
+            .expect("first persist");
+        fixture
+            .persist(SECOND_PAYLOAD, 7)
+            .await
+            .expect("second persist");
+
+        let log_bytes = (FIRST_PAYLOAD.len() + SECOND_PAYLOAD.len()) as u64;
+        let index_bytes = 2 * IGGY_INDEX_SIZE as u64;
+        assert_eq!(
+            fixture.cursors(),
+            (log_bytes, index_bytes),
+            "both cursors must cover both persists"
+        );
+        assert_eq!(file_len(&log_path), log_bytes, "segment file length");
+        assert_eq!(file_len(&index_path), index_bytes, "index file length");
+        assert_eq!(fixture.segment_size(), log_bytes, "segment size");
+
+        let reader = IggyIndexReader::new(index_path.to_str().expect("utf-8 path"))
+            .await
+            .expect("open index reader");
+        let last = reader
+            .load_last()
+            .await
+            .expect("read last index entry")
+            .expect("index entry present");
+        assert_eq!(
+            last,
+            IggyIndex::new(7, 8, FIRST_PAYLOAD.len() as u64),
+            "the second entry must address the first chunk's end"
+        );
+    }
+
+    /// A half that failed never advanced its cursor, so the retry rewrites
+    /// the same positions: one copy of the batch, one index entry.
+    #[cfg(target_os = "linux")]
+    #[compio::test]
+    async fn given_failed_persist_when_retried_with_a_healthy_writer_should_overwrite_the_same_positions()
+     {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let log_path = dir.path().join("segment.log");
+        let index_path = dir.path().join("segment.index");
+        let mut fixture =
+            PersistFixture::new(log_path.to_str().expect("utf-8 path"), DEV_FULL).await;
+
+        assert!(
+            fixture.persist(FIRST_PAYLOAD, 0).await.is_err(),
+            "index save over {DEV_FULL} must fail"
+        );
+
+        // The committed prefix stays resident, so the retry re-persists the
+        // identical bytes; only the broken index writer is swapped out.
+        let index_writer = IggyIndexWriter::new(
+            index_path.to_str().expect("utf-8 path"),
+            fixture.index_cursor.clone(),
+            true,
+            false,
+        )
+        .await
+        .expect("open replacement index writer");
+        let active = fixture.partition.log.index_writers().len() - 1;
+        fixture.partition.log.index_writers_mut()[active] = Some(Rc::new(index_writer));
+
+        fixture
+            .persist(FIRST_PAYLOAD, 0)
+            .await
+            .expect("retry persist");
+
+        assert_eq!(
+            file_len(&log_path),
+            FIRST_PAYLOAD.len() as u64,
+            "the retry must overwrite the batch, not append a second copy"
+        );
+        assert_eq!(
+            file_len(&index_path),
+            IGGY_INDEX_SIZE as u64,
+            "the retry must write exactly one index entry"
+        );
+        assert_eq!(
+            fixture.cursors(),
+            (FIRST_PAYLOAD.len() as u64, IGGY_INDEX_SIZE as u64),
+            "both cursors must advance once the retry succeeded"
+        );
     }
 }
 

--- a/core/partitions/src/iggy_partition.rs
+++ b/core/partitions/src/iggy_partition.rs
@@ -2929,12 +2929,13 @@ where
         // commit frontier; flushing the uncommitted tail would write
         // per-replica-timing bytes to its segment (cross-replica divergence) and
         // drop the headers those ops need when their own commit later lands
-        // (commit_min wedge). Eviction is deferred until the bytes are durable:
-        // on a persist failure the prefix stays resident so the next commit
-        // re-reads it instead of losing a committed batch (a live-process I/O
-        // fault only; the in-memory journal does not survive a crash). All
-        // segment range / stats / durable-offset accounting below is computed
-        // from the committed entries, not the resident-journal snapshot above.
+        // (commit_min wedge). Eviction is deferred until the bytes are durable,
+        // so a persist failure retains the prefix rather than losing a committed
+        // batch (a live-process I/O fault only; the in-memory journal does not
+        // survive a crash). Only the transfer-offer flush survives to re-read it;
+        // the commit path panics the shard pump instead. All segment range /
+        // stats / durable-offset accounting below is computed from the committed
+        // entries, not the resident-journal snapshot above.
         let commit_max = self.consensus.commit_max();
         let committed_entries = self.log.journal().inner.committed_prefix(commit_max);
         if committed_entries.is_empty() {
@@ -3092,19 +3093,20 @@ where
 
             // Persist BEFORE eviction so a write failure leaves the rest of the
             // committed prefix resident instead of dropping it. Nothing retries
-            // the persist: on the commit path a failure panics
-            // `handle_committed_entries`, the shutdown flush warns and moves to
-            // the next namespace, and the transfer offer turns it into
+            // the persist: on the commit path a failure panics out of
+            // `handle_committed_entries` and takes this shard's message pump with
+            // it, so every partition on the shard stops committing, ticking and
+            // replying until the process is restarted. The shutdown flush warns and
+            // moves to the next namespace, and the transfer offer turns it into
             // `FlushFailed`. Recovery is a restart, which reopens each writer at
             // the on-disk length boot recovery validated.
             //
             // The ordering therefore buys a non-corrupting failure, not an
             // in-process one. Write cursors advance only once both the batch and the
-            // index are durable, so where the error does not panic the partition,
-            // its next flush rewrites the same positions instead of appending a
-            // duplicate. Chunks already durable are evicted before the error
-            // propagates, so it cannot re-read them (and re-write them past a
-            // rotation).
+            // index are durable, so on the paths that survive the error, the next
+            // flush rewrites the same positions instead of appending a duplicate.
+            // Chunks already durable are evicted before the error propagates, so it
+            // cannot re-read them (and re-write them past a rotation).
             if let Err(error) = self
                 .persist_frozen_batches_to_disk(frozen_batches, index_bytes, batch_count)
                 .await

--- a/core/partitions/src/lib.rs
+++ b/core/partitions/src/lib.rs
@@ -46,9 +46,9 @@ pub use segment::Segment;
 use server_common::Message;
 pub use server_common::send_messages::{IggyMessage, IggyMessageHeader, IggyMessages};
 pub use types::{
-    AppendResult, Fragment, PartitionOffsets, PartitionPathLayout, PartitionsConfig, PollFragments,
-    PollQueryResult, PollingArgs, PollingConsumer, REPAIR_RETRY_TICKS, RepairConclusion,
-    RepairSession, SendMessagesResult,
+    AppendResult, FatalCommit, Fragment, PartitionOffsets, PartitionPathLayout, PartitionsConfig,
+    PollFragments, PollQueryResult, PollingArgs, PollingConsumer, REPAIR_RETRY_TICKS,
+    RepairConclusion, RepairSession, SendMessagesResult,
 };
 
 /// A partition's message log, named so a caller can carry one across a rebuild.

--- a/core/partitions/src/log.rs
+++ b/core/partitions/src/log.rs
@@ -148,9 +148,9 @@ where
     messages_writers: Vec<Option<Rc<MessagesWriter>>>,
     index_writers: Vec<Option<Rc<IggyIndexWriter>>>,
     // Parallel to `segments`: a shared read-state handle (fd + sparse index)
-    // per segment, filled lazily on the first sealed-segment poll and cloned
-    // into the off-borrow poll plan. Maintained in lockstep with `segments`
-    // (push/remove together).
+    // per segment, filled lazily on the first poll that reads the segment and
+    // cloned into the off-borrow poll plan. Maintained in lockstep with
+    // `segments` (push/remove together).
     sealed_read_state: Vec<SealedSegmentHandle>,
     // LRU of sealed-segment `start_offset`s (most-recently-used at the front)
     // bounding how many `sealed_read_state` handles stay resident, capped at
@@ -199,7 +199,7 @@ where
     }
 
     /// Shared read-state handles, parallel to [`Self::segments`]. Cloned into
-    /// the poll plan for sealed segments (see [`SealedSegmentHandle`]).
+    /// the poll plan (see [`SealedSegmentHandle`]).
     pub fn sealed_read_state(&self) -> &[SealedSegmentHandle] {
         &self.sealed_read_state
     }
@@ -207,15 +207,18 @@ where
     /// Record a sealed-segment access and enforce [`SEALED_READ_STATE_CAP`]
     /// (LRU). `slot` indexes [`Self::segments`]; an out-of-range slot or an
     /// unsealed (active) segment is a no-op, so the poll path passes its start
-    /// segment unconditionally. The LRU is keyed by `start_offset` - stable
-    /// across retire, unlike the slot index. The touched segment moves to the
-    /// most-recently-used front and its handle is marked tracked (eligible to
-    /// cache a read fd, see `SealedSegmentReadState::tracked`); once more than
-    /// the cap distinct sealed segments are tracked, the least-recently-used
-    /// one's handle is untracked and dropped (replaced with a fresh empty
-    /// handle) so its fd + sparse index free. An in-flight poll holding a clone
-    /// of the dropped handle keeps it alive until it finishes (see
-    /// [`SealedSegmentHandle`]).
+    /// segment unconditionally. Keeping the active segment out is deliberate:
+    /// its read fd must not be evictable by unrelated sealed traffic, and its
+    /// `start_offset` is not a stable LRU key across rotation. Its slot is
+    /// bounded by [`Self::reset_read_state`] instead. The LRU is keyed by
+    /// `start_offset` - stable across retire, unlike the slot index. The
+    /// touched segment moves to the most-recently-used front and its handle is
+    /// marked tracked (eligible to cache a read fd, see
+    /// `SealedSegmentReadState::tracked`); once more than the cap distinct
+    /// sealed segments are tracked, the least-recently-used one's handle is
+    /// untracked and dropped (replaced with a fresh empty handle) so its fd +
+    /// sparse index free. An in-flight poll holding a clone of the dropped
+    /// handle keeps it alive until it finishes (see [`SealedSegmentHandle`]).
     pub fn touch_sealed_read_state(&mut self, slot: usize) {
         let Some(touched) = self.segments.get(slot) else {
             return;
@@ -248,6 +251,25 @@ where
                 self.sealed_read_state[evicted_slot] = SealedSegmentHandle::default();
             }
         }
+    }
+
+    /// Orphan `slot`'s read-state handle (replaced with a fresh empty one) and
+    /// purge its sealed-LRU entry. Called wherever a segment changes
+    /// sealed-ness, because the two states cache under different rules: the
+    /// active segment's fd lives outside the LRU budget and must not carry into
+    /// sealed tracking, and a sealed handle must not carry into active use
+    /// while an LRU entry survives that could evict the now-active fd.
+    /// Replacing (rather than clearing in place) also detaches an in-flight
+    /// poll that snapshotted the old sealed-ness, so its store-back lands in
+    /// the orphan and frees when the poll finishes.
+    pub fn reset_read_state(&mut self, slot: usize) {
+        let Some(segment) = self.segments.get(slot) else {
+            return;
+        };
+        let start_offset = segment.start_offset;
+        self.sealed_read_state[slot].tracked.set(false);
+        self.sealed_read_state[slot] = SealedSegmentHandle::default();
+        self.sealed_lru.retain(|&offset| offset != start_offset);
     }
 
     /// Wipe every shared read-state handle in place (cached fd + sparse index
@@ -575,6 +597,32 @@ mod tests {
         // awaits): must be a no-op, not a panic.
         log.touch_sealed_read_state(1);
         assert!(log.sealed_lru.is_empty());
+    }
+
+    #[test]
+    fn reset_read_state_orphans_the_handle_and_purges_its_lru_entry() {
+        let mut log = TestLog::default();
+        let handle = push_resident_sealed(&mut log, 0);
+        push_resident_sealed(&mut log, 5);
+        log.touch_sealed_read_state(0);
+        log.touch_sealed_read_state(1);
+
+        // Un-sealing slot 0 back into the active segment: its handle must not
+        // stay in the LRU, which could evict it while it is the active fd.
+        log.reset_read_state(0);
+
+        assert!(
+            !Rc::ptr_eq(&handle, &log.sealed_read_state()[0]),
+            "an in-flight poll's clone must not keep filling the live slot",
+        );
+        assert!(!handle.tracked.get());
+        assert!(!log.sealed_lru.contains(&0));
+        assert!(log.sealed_lru.contains(&5), "other slots are untouched");
+        assert!(log.sealed_read_state()[0].index.borrow().is_none());
+
+        // Out-of-range slot (the purge drain window empties the vec across
+        // awaits): a no-op, not a panic.
+        log.reset_read_state(2);
     }
 
     #[test]

--- a/core/partitions/src/messages_writer.rs
+++ b/core/partitions/src/messages_writer.rs
@@ -104,7 +104,10 @@ impl MessagesWriter {
         })
     }
 
-    /// Appends a batch of frozen message buffers to the segment file.
+    /// Appends a batch of frozen message buffers at the current write cursor
+    /// and returns how many bytes landed. The cursor is left where it was: the
+    /// caller advances it with `advance` once the companion index save has
+    /// also succeeded.
     ///
     /// # Errors
     ///
@@ -126,26 +129,14 @@ impl MessagesWriter {
             self.fsync().await?;
         }
 
-        self.messages_size_bytes
-            .fetch_add(messages_size, Ordering::Release);
-
         Ok(IggyByteSize::from(messages_size))
     }
 
-    /// Roll the in-memory write cursor back by `bytes`, undoing the advance of a
-    /// `save_frozen_batches` whose batch was written but whose companion index
-    /// save then failed. The committed prefix stays resident and is
-    /// re-persisted on the next `commit_messages`; rewinding the cursor makes
-    /// that retry overwrite the same region instead of appending a second copy
-    /// of the committed batch. Crash-safe without truncating: the rewound
-    /// bytes are whole batch records past the last index entry, so boot
-    /// recovery's indexed walk absorbs them and its truncate is a no-op.
-    pub(crate) fn rewind(&self, bytes: u64) {
-        debug_assert!(
-            bytes <= self.messages_size_bytes.load(Ordering::Relaxed),
-            "rewind underflow: bytes ({bytes}) exceeds the write cursor"
-        );
-        self.messages_size_bytes.fetch_sub(bytes, Ordering::Release);
+    /// Move the write cursor forward over `bytes` that are now durable. Split
+    /// out of the save so the segment and index cursors advance together, only
+    /// once both halves have succeeded.
+    pub(crate) fn advance(&self, bytes: u64) {
+        self.messages_size_bytes.fetch_add(bytes, Ordering::Release);
     }
 
     #[must_use]

--- a/core/partitions/src/messages_writer.rs
+++ b/core/partitions/src/messages_writer.rs
@@ -112,7 +112,7 @@ impl MessagesWriter {
     /// # Errors
     ///
     /// Returns an error if any chunk cannot be written or synced to disk.
-    pub async fn save_frozen_batches<const ALIGN: usize>(
+    pub(crate) async fn save_frozen_batches<const ALIGN: usize>(
         &self,
         buffers: &[Frozen<ALIGN>],
     ) -> Result<IggyByteSize, IggyError> {

--- a/core/partitions/src/poll_plan.rs
+++ b/core/partitions/src/poll_plan.rs
@@ -86,12 +86,15 @@ pub enum PartitionDirResolution {
 /// wipes the slots in place (`SegmentedLog::invalidate_sealed_read_state`):
 /// it recreates the same paths, so a clone surviving in a suspended walk must
 /// re-open by path and observe the fresh files rather than serve purged data.
-/// The active segment is never cached.
+/// The active segment uses the [`Self::fd`] slot only: it grows under the
+/// reader, so a size-derived memo on it would go stale, and its slot sits
+/// outside the sealed LRU (`SegmentedLog::reset_read_state` drops it wherever
+/// a segment changes sealed-ness).
 #[derive(Debug, Default)]
 pub struct SealedSegmentReadState {
     /// Read-only descriptor; compio `File` clones share the kernel fd, so a hit
     /// avoids the per-poll `openat` (an `io_uring` op prone to io-wq punts) and
-    /// preserves kernel readahead. `None` until the first sealed poll opens it.
+    /// preserves kernel readahead. `None` until the first poll opens it.
     pub(crate) fd: RefCell<Option<compio::fs::File>>,
     /// Sparse offset/timestamp index reloaded from the `.index` file the
     /// segment dropped at rotation, so a poll resolves the start byte in
@@ -99,7 +102,9 @@ pub struct SealedSegmentReadState {
     /// `None` until the first sealed poll loads it.
     pub(crate) index: RefCell<Option<IggyIndexCache>>,
     /// Whether the owning partition's sealed LRU currently tracks this handle.
-    /// Gates the fd store-back in `resolve_segment_file`: a walk crosses every
+    /// Gates the fd store-back in `resolve_segment_file` for a SEALED segment
+    /// (the active segment's slot is outside the LRU, so it always fills): a
+    /// walk crosses every
     /// sealed segment from the poll's start onward, but only the start segment
     /// is LRU-touched, so an untracked fill would retain a descriptor the
     /// `SEALED_READ_STATE_CAP` budget never counts. Set on touch, cleared on
@@ -132,8 +137,8 @@ pub type SealedSegmentHandle = Rc<SealedSegmentReadState>;
 
 /// Owned, borrow-free inputs for the disk tier of a poll (see module docs). A
 /// sealed segment reuses its cached [`SealedSegmentReadState`] (read fd + sparse
-/// index); the active segment (and any cache miss) opens by path and resolves
-/// from its resident index, because sealed segments drop both at rotation.
+/// index); the active segment reuses the cached fd but resolves from its
+/// resident index, because sealed segments drop that index at rotation.
 pub struct DiskReadPlan {
     pub(crate) partition_dir: PartitionDirResolution,
     /// Segments to walk, snapshotted from the poll's starting segment onward
@@ -150,10 +155,13 @@ pub struct DiskReadPlan {
 pub struct DiskSegment {
     pub(crate) start_offset: u64,
     pub(crate) persisted: u64,
-    /// Shared read state, cloned from the owning partition at plan time for a
-    /// SEALED segment; `None` for the active segment, which always opens fresh
-    /// and resolves from its resident index. See [`SealedSegmentReadState`].
-    pub(crate) read_state: Option<SealedSegmentHandle>,
+    /// Shared read state, cloned from the owning partition at plan time. See
+    /// [`SealedSegmentReadState`].
+    pub(crate) read_state: SealedSegmentHandle,
+    /// Whether the segment was sealed when the plan was built. Only a sealed
+    /// segment resolves its start byte from the shared sparse index; the active
+    /// one grows under the reader and uses its resident index instead.
+    pub(crate) sealed: bool,
 }
 
 /// Owned auto-commit input, applied off the partition borrow after a poll (see
@@ -519,8 +527,8 @@ impl DiskReadPlan {
         // then cached) and resolve the start byte so the walk skips straight to
         // the target instead of scanning the whole segment - the poll stall. A
         // miss or load failure keeps `start_position` (the pre-existing
-        // full-scan fallback). The active segment carries no read state, so its
-        // resident-index-resolved `start_position` is left untouched.
+        // full-scan fallback). An active first segment keeps its
+        // resident-index-resolved `start_position` untouched.
         let mut position = match self.segments.first() {
             Some(first) => self
                 .resolve_sealed_start(first, query, partition_dir)
@@ -620,31 +628,30 @@ impl DiskReadPlan {
         }
     }
 
-    /// Resolve the read-only descriptor for `segment`'s file. A sealed segment
-    /// clones its cached fd on a hit (sharing the kernel fd, no syscall) and, on
-    /// a miss, opens by path and stores the fd back so later polls skip the
-    /// `openat`. The active segment (no cache slot) always opens fresh. Returns
-    /// `None` only when the open exhausts its retries (the caller fails closed).
+    /// Resolve the read-only descriptor for `segment`'s file. A hit clones the
+    /// cached fd (sharing the kernel fd, no syscall); a miss opens by path and
+    /// stores the fd back so later polls skip the `openat`. Returns `None` only
+    /// when the open exhausts its retries (the caller fails closed).
     async fn resolve_segment_file(
         &self,
         segment: &DiskSegment,
         path: &str,
     ) -> Option<compio::fs::File> {
-        let Some(handle) = &segment.read_state else {
-            return self.open_segment_with_retry(path).await;
-        };
+        let handle = &segment.read_state;
         // Borrow only to clone the `Option<File>` out, never across the await.
         if let Some(cached) = handle.fd.borrow().clone() {
             return Some(cached);
         }
         let file = self.open_segment_with_retry(path).await?;
-        // Store back only while the pump tracks this handle; an untracked
-        // fill (walk-through segment, or a slot evicted mid-poll) would pin an
-        // fd outside the LRU budget, so it opens transiently instead. Benign
-        // race: a concurrent poll of the same segment may have filled the slot
-        // while this open was in flight; overwriting with an equivalent fd
-        // (same inode) is harmless.
-        if handle.tracked.get() {
+        // A sealed segment stores back only while the pump tracks its handle;
+        // an untracked fill (walk-through segment, or a slot evicted mid-poll)
+        // would pin an fd outside the LRU budget, so it opens transiently
+        // instead. The active segment's slot is not LRU-budgeted (one per
+        // partition, dropped when it seals), so it always fills. Benign race: a
+        // concurrent poll of the same segment may have filled the slot while
+        // this open was in flight; overwriting with an equivalent fd (same
+        // inode) is harmless, as is filling a slot the pump orphaned mid-poll.
+        if !segment.sealed || handle.tracked.get() {
             *handle.fd.borrow_mut() = Some(file.clone());
         }
         Some(file)
@@ -655,14 +662,20 @@ impl DiskReadPlan {
     /// whole on the first sealed poll and is cached on the shared handle; a
     /// larger one is binary-searched on file every poll and never materialized
     /// (see the constant). Returns `None` (keep the byte-0 fallback) for the
-    /// active segment (no handle), a below-range query, or an IO failure.
+    /// active segment, a below-range query, or an IO failure.
     async fn resolve_sealed_start(
         &self,
         segment: &DiskSegment,
         query: MessageLookup,
         partition_dir: &str,
     ) -> Option<u64> {
-        let handle = segment.read_state.as_ref()?;
+        // The active segment grows under the reader, so neither the shared
+        // sparse index nor the offset memo can describe it; its own resident
+        // index already resolved `start_position`.
+        if !segment.sealed {
+            return None;
+        }
+        let handle = &segment.read_state;
         // Cache hit: resolve under a short borrow, never across the await.
         let cached = handle
             .index
@@ -1074,7 +1087,8 @@ mod tests {
         let segment = DiskSegment {
             start_offset: 0,
             persisted: u64::MAX,
-            read_state: Some(Rc::clone(&handle)),
+            read_state: Rc::clone(&handle),
+            sealed: true,
         };
         let plan = DiskReadPlan {
             partition_dir: PartitionDirResolution::Resolved(dir.display().to_string()),

--- a/core/partitions/src/state_transfer.rs
+++ b/core/partitions/src/state_transfer.rs
@@ -2347,6 +2347,10 @@ where
                 self.log.index_writers_mut()[last] = Some(Rc::new(index_writer));
             }
             self.log.segments_mut()[last].sealed = false;
+            // The active and sealed read-state caches live under different
+            // rules (see `SegmentedLog::reset_read_state`), so the slot cannot
+            // carry its sealed identity into active use.
+            self.log.reset_read_state(last);
         }
 
         // The installed segments supersede every journaled op; stale
@@ -2663,6 +2667,10 @@ where
         minted_next_offset: u64,
         staged_was_empty: bool,
     ) -> Result<(), iggy_common::IggyError> {
+        // The empty plant below can land on a base offset this sweep unlinks,
+        // so an in-flight poll's cached read fd would keep serving the retired
+        // inodes as live data. Same hazard and same fix as `purge`.
+        self.log.invalidate_sealed_read_state();
         while let Some((_, mut storage)) = self.log.retire_front() {
             let _ = storage.shutdown();
         }

--- a/core/partitions/src/types.rs
+++ b/core/partitions/src/types.rs
@@ -15,10 +15,29 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use iggy_binary_protocol::Operation;
 use iggy_common::{EncryptorKind, IggyByteSize, PollingStrategy};
 use server_common::iobuf::Frozen;
 use smallvec::SmallVec;
 use std::sync::Arc;
+
+/// A local commit that failed for an op the cluster had already committed.
+///
+/// The replica is divergent from here on: `drain_committable_prefix` popped
+/// the op, its `commit_min` never advanced, and the next
+/// `advance_commit_min` would assert on the gap. Continuing would either
+/// serve a prefix the cluster has moved past or panic somewhere less
+/// legible, so the partition fences itself on this and the shard brings the
+/// server down through the ordinary shutdown path. Recorded rather than
+/// panicked because a panic on the pump task is swallowed by the runtime,
+/// which wedges every partition on the shard while the process reports
+/// healthy.
+#[derive(Debug, Clone)]
+pub struct FatalCommit {
+    pub namespace_raw: u64,
+    pub op: u64,
+    pub operation: Operation,
+}
 
 #[derive(Debug, Clone)]
 pub struct Fragment<const ALIGN: usize = 4096> {

--- a/core/server/config.toml
+++ b/core/server/config.toml
@@ -480,15 +480,16 @@ recreate_missing_state = false
 # already held, so an index is never evidence about the log: one the log
 # contradicts is repaired, not believed. It is DROPPED whole and rebuilt from
 # a byte-0 walk when it holds no whole 24-byte entry, when its entries
-# regress in offset or position, when its first entry is not the segment's
-# own start offset at position 0, or when the log cannot back its LAST
-# entry. Only an index whose
+# regress in offset or position, when an entry does not match the log batch's
+# offset, timestamp, partition and position, when its first entry is not the
+# segment's own start offset at position 0, or when the log cannot back its
+# LAST entry. Only an index whose
 # last entry the log proves anchors a walk, which then runs from that entry
 # to the file end. Under the topic's enforce_fsync = true an index the log
 # cannot back is measured against the log first: a gap of more than ONE entry
 # refuses the partition instead of rebuilding, because fsync lets the index
 # outrun the log by at most the chunk in flight at the crash, so a wider gap
-# is acknowledged data the log lost.
+# is previously durable data the log lost.
 #
 # The byte-0 walk is deliberately not narrowed to the entries the log still
 # proves. An anchor picked that way can sit ABOVE damage, and the residue
@@ -497,23 +498,23 @@ recreate_missing_state = false
 # over it. Reaching that branch means the index and the log already disagree,
 # so the extra bytes read are bounded by the segments a crash actually tore.
 #
-# Every batch a walk accepts passes its own checksum: the two files are
-# written unordered, so a durable index entry no longer implies a durable
-# chunk beneath it, and one chunk can hold several batches. Bytes below where
-# a walk starts are never read at boot -- on a healthy boot that is
-# everything before the last index entry, where at-rest damage surfaces only
-# on the read path via validate_checksum. Wherever a walk does reach, boot
-# acts on the damage it finds: truncating when nothing decodable follows,
-# refusing when something does.
+# Every batch a walk accepts passes its own checksum. With enforce_fsync =
+# false, the index only locates data because page-cache writeback can preserve
+# a later log page while losing an earlier one, so recovery walks every segment
+# from byte 0. A clean walk preserves the existing index and performs no disk
+# mutation. With enforce_fsync = true, completed serialized log fdatasyncs
+# prove the prefix before the last index entry, so a healthy boot starts at
+# that last entry and leaves earlier at-rest damage to the read path's
+# validate_checksum. Wherever a recovery walk finds damage, it truncates only
+# when nothing decodable follows and refuses when something does.
 #
-# A byte-0 walk therefore re-reads and re-checksums every byte of the
-# segments it covers and rebuilds each index durably, two fsyncs per segment:
-# budget minutes, not seconds, where it covers thousands of them. A restore
-# that dropped every .index hits every segment; an ordinary crash reaches the
-# same walk for the segments whose index no longer matches its log, usually
-# just the tail one. Either way a boot that looks hung is doing that work, and
-# a slow boot with no restore in the change log is not by itself evidence of
-# anything wrong. Before, every one of those shapes refused the boot outright.
+# The non-fsync verification pass therefore reads and checksums every log byte
+# at boot, although it keeps a clean index in place. A byte-0 repair walk also
+# rebuilds a missing or contradicted index durably, adding two fsyncs per
+# repaired segment. Either path can take minutes over thousands of segments.
+# A restore that dropped every .index repairs every segment; an ordinary
+# fsynced crash usually repairs only its tail segment. A slow boot is therefore
+# not by itself evidence of a stall. Before, the repair shapes refused boot.
 #
 # Either walk refuses a verifying batch whose base offset does not continue
 # the chain, or whose partition_id stamp is not this partition's. The one

--- a/core/server/config.toml
+++ b/core/server/config.toml
@@ -471,30 +471,54 @@ recreate_missing_state = false
 
 # At boot, segment recovery walks each partition's segments: bytes after the
 # last decodable batch of a genuinely torn tail are physically truncated from
-# the .log/.index files. A LOST index is rebuilt from the batches the walk
-# proves -- lost meaning absent altogether, or holding no whole 24-byte
-# entry. An index that still holds whole entries is NEVER rebuilt, only
-# floored to whole entries, or the partition is refused when its entries
-# contradict the log. Only the walk of a segment whose index was lost
-# re-checksums every batch; with an intact index the walk trusts batch
-# headers, except that a batch contradicting the walk (see below) must pass
-# its batch checksum before the contradiction is believed. Bytes before the
-# last index entry are not re-examined at boot at all -- at-rest damage
-# there surfaces on the read path via validate_checksum.
+# the .log/.index files. Every index entry is derived from a batch the log
+# already held, so an index is never evidence about the log: one the log
+# contradicts is repaired, not believed. It is DROPPED whole and rebuilt from
+# a byte-0 walk when it holds no whole 24-byte entry, when its entries
+# regress in offset or position, when they open below the segment's own start
+# offset, or when the log cannot back its LAST entry. Only an index whose
+# last entry the log proves anchors a walk, which then runs from that entry
+# to the file end. Under the topic's enforce_fsync = true an index the log
+# cannot back is measured against the log first: a gap of more than ONE entry
+# refuses the partition instead of rebuilding, because fsync lets the index
+# outrun the log by at most the chunk in flight at the crash, so a wider gap
+# is acknowledged data the log lost.
 #
-# A restore that dropped every .index therefore boots by re-reading and
-# re-checksumming every byte of every segment and rebuilding each index
-# durably, two fsyncs per segment: budget minutes, not seconds, on a
-# partition holding thousands of segments. A boot that looks hung after such
-# a restore is doing that work. Before, that same shape refused the boot
-# outright.
+# The byte-0 walk is deliberately not narrowed to the entries the log still
+# proves. An anchor picked that way can sit ABOVE damage, and the residue
+# probe only ever looks forward from where a walk stopped, so a hole under
+# the anchor would go unread while end_offset still advertised the offsets
+# over it. Reaching that branch means the index and the log already disagree,
+# so the extra bytes read are bounded by the segments a crash actually tore.
 #
-# Either walk refuses a batch whose base offset does not continue the chain,
-# or whose partition_id stamp is not this partition's. A contradiction whose
-# batch fails its own checksum is damage rather than data: the walk stops
-# there and the residue goes through the damage probe like any other torn
-# tail, so a bit flip in a tail batch's offset truncates instead of refusing
-# the partition, regardless of the flip's direction.
+# Every batch a walk accepts passes its own checksum: the two files are
+# written unordered, so a durable index entry no longer implies a durable
+# chunk beneath it, and one chunk can hold several batches. Bytes below where
+# a walk starts are never read at boot -- on a healthy boot that is
+# everything before the last index entry, where at-rest damage surfaces only
+# on the read path via validate_checksum. Wherever a walk does reach, boot
+# acts on the damage it finds: truncating when nothing decodable follows,
+# refusing when something does.
+#
+# A byte-0 walk therefore re-reads and re-checksums every byte of the
+# segments it covers and rebuilds each index durably, two fsyncs per segment:
+# budget minutes, not seconds, where it covers thousands of them. A restore
+# that dropped every .index hits every segment; an ordinary crash reaches the
+# same walk for the segments whose index no longer matches its log, usually
+# just the tail one. Either way a boot that looks hung is doing that work, and
+# a slow boot with no restore in the change log is not by itself evidence of
+# anything wrong. Before, every one of those shapes refused the boot outright.
+#
+# Either walk refuses a verifying batch whose base offset does not continue
+# the chain, or whose partition_id stamp is not this partition's. The one
+# exception is the first batch at an index-derived anchor: the offset it
+# fails to match is the ENTRY's, not the log's, so a mismatch there breaks
+# the walk as a stale entry, leaving the verdict to the byte-0 rebuild. A
+# batch that fails its own checksum is damage rather than data
+# whatever its fields claim: the walk stops there and the residue goes
+# through the damage probe like any other torn tail, so a bit flip in a tail
+# batch's offset truncates instead of refusing the partition, regardless of
+# the flip's direction.
 #
 # Damage in the middle of a segment is never silently truncated: the
 # partition is refused, as is trailing residue whose verification cost

--- a/core/server/config.toml
+++ b/core/server/config.toml
@@ -443,9 +443,14 @@ path = "partitions"
 validate_checksum = true
 
 # Durability and flush cadence are per topic, set at CreateTopic:
-#   enforce_fsync                     - fsync each write (false when unset)
+#   enforce_fsync                     - fdatasync each flush (false when unset)
 #   messages_required_to_save         - flush after this many messages (1024)
 #   size_of_messages_required_to_save - flush after this many bytes (1 MiB)
+# enforce_fsync decides whether a flush syncs, never whether one happens. A
+# write is acknowledged when it commits, which precedes its flush unless that
+# commit trips a threshold, and the partition journal holding the unflushed
+# remainder is in memory and is not replayed at boot. Acks are therefore
+# durability-gated only at messages_required_to_save = 1.
 
 # Segment configuration
 [system.segment]
@@ -475,8 +480,9 @@ recreate_missing_state = false
 # already held, so an index is never evidence about the log: one the log
 # contradicts is repaired, not believed. It is DROPPED whole and rebuilt from
 # a byte-0 walk when it holds no whole 24-byte entry, when its entries
-# regress in offset or position, when they open below the segment's own start
-# offset, or when the log cannot back its LAST entry. Only an index whose
+# regress in offset or position, when its first entry is not the segment's
+# own start offset at position 0, or when the log cannot back its LAST
+# entry. Only an index whose
 # last entry the log proves anchors a walk, which then runs from that entry
 # to the file end. Under the topic's enforce_fsync = true an index the log
 # cannot back is measured against the log first: a gap of more than ONE entry

--- a/core/server/src/bootstrap.rs
+++ b/core/server/src/bootstrap.rs
@@ -2549,6 +2549,10 @@ fn restore_metadata_consensus(
 /// Recover this partition's persisted segment chain, stamping each segment
 /// with the topic's effective segment size (the per-topic value when the
 /// topic was created with one, else the shard-wide configured size).
+///
+/// The topic's effective `enforce_fsync` goes in for the same reason: it is
+/// what tells recovery whether a durable index entry the log cannot back is a
+/// benign torn index or acknowledged data the log lost.
 async fn recover_partition_segments(
     config: &ServerConfig,
     namespace: IggyNamespace,
@@ -2561,12 +2565,16 @@ async fn recover_partition_segments(
     let segment_size = runtime_options
         .segment_size
         .unwrap_or_else(|| IggyByteSize::from(iggy_common::DEFAULT_SEGMENT_SIZE));
+    let enforce_fsync = runtime_options
+        .enforce_fsync
+        .unwrap_or(iggy_common::DEFAULT_ENFORCE_FSYNC);
     load_persisted_segments(
         config,
         stream_id,
         topic_id,
         partition_id,
         segment_size,
+        enforce_fsync,
         stats,
     )
     .await

--- a/core/server/src/bootstrap.rs
+++ b/core/server/src/bootstrap.rs
@@ -1273,14 +1273,18 @@ async fn shard_main(
     // tail that had not hit a flush threshold yet.
     let pump_shutdown_flag = Arc::clone(&shutdown_flag_for_handoff);
     let mut pump_handle = Some(compio::runtime::spawn(async move {
-        let fatal = pump_shard.run_message_pump(stop_rx).await;
+        // The pump itself flips the shared flag when a commit fault stops it,
+        // BEFORE its final flush, so a flush stalling on the failed device
+        // still reaches the watchdog and the bounded drain. Every sibling
+        // shard's watchdog drives its own graceful stop off the same flag;
+        // this shard's watchdog is what fires the token `shard_main` is
+        // parked on. The store below backstops the one fault the pump can
+        // only observe after that flip: a partition fenced by the final
+        // flush itself.
+        let fatal = pump_shard
+            .run_message_pump(stop_rx, Arc::clone(&pump_shutdown_flag))
+            .await;
         if fatal.is_some() {
-            // A commit fault fenced a partition on this shard. Flip the
-            // shared flag so every sibling shard's watchdog drives its own
-            // graceful stop; this shard's watchdog sees it too, which is what
-            // fires the token `shard_main` is parked on. Set after the pump
-            // returns rather than at the fault, so the siblings keep serving
-            // healthy partitions until this shard has finished flushing.
             pump_shutdown_flag.store(true, Ordering::Relaxed);
         }
         fatal
@@ -2582,7 +2586,7 @@ fn restore_metadata_consensus(
 ///
 /// The topic's effective `enforce_fsync` goes in for the same reason: it is
 /// what tells recovery whether a durable index entry the log cannot back is a
-/// benign torn index or acknowledged data the log lost.
+/// benign torn index or previously durable data the log lost.
 async fn recover_partition_segments(
     config: &ServerConfig,
     namespace: IggyNamespace,

--- a/core/server/src/bootstrap.rs
+++ b/core/server/src/bootstrap.rs
@@ -86,7 +86,7 @@ use metadata::stm::snapshot::Snapshot;
 use metadata::stm::stream::{Partition, Streams};
 use metadata::stm::user::Users;
 use partitions::{
-    IggyIndexWriter, IggyPartition, IggyPartitions, MessagesWriter, PartitionsConfig,
+    FatalCommit, IggyIndexWriter, IggyPartition, IggyPartitions, MessagesWriter, PartitionsConfig,
 };
 use rustls::pki_types::ServerName;
 use server_common::Message;
@@ -1271,8 +1271,19 @@ async fn shard_main(
     // tracked pump would be cancelled by runtime teardown mid final-flush
     // and every graceful shutdown would silently drop the committed journal
     // tail that had not hit a flush threshold yet.
+    let pump_shutdown_flag = Arc::clone(&shutdown_flag_for_handoff);
     let mut pump_handle = Some(compio::runtime::spawn(async move {
-        pump_shard.run_message_pump(stop_rx).await;
+        let fatal = pump_shard.run_message_pump(stop_rx).await;
+        if fatal.is_some() {
+            // A commit fault fenced a partition on this shard. Flip the
+            // shared flag so every sibling shard's watchdog drives its own
+            // graceful stop; this shard's watchdog sees it too, which is what
+            // fires the token `shard_main` is parked on. Set after the pump
+            // returns rather than at the fault, so the siblings keep serving
+            // healthy partitions until this shard has finished flushing.
+            pump_shutdown_flag.store(true, Ordering::Relaxed);
+        }
+        fatal
     }));
 
     let reconciler_ctx = Rc::new(crate::partition_reconciler::ReconcilerCtx::new(
@@ -1513,7 +1524,7 @@ async fn shard_main(
 /// wrapper alone cannot see it, and a shard that swallows it prints
 /// "exited cleanly" over a corpse.
 async fn await_pump_drain(
-    pump_handle: Option<compio::runtime::JoinHandle<()>>,
+    pump_handle: Option<compio::runtime::JoinHandle<Option<FatalCommit>>>,
     config: &ServerConfig,
     shard_id: u16,
 ) -> Result<(), ServerError> {
@@ -1541,7 +1552,26 @@ async fn await_pump_drain(
     // reaches the tracing sink too.
     let reason = match panic::catch_unwind(panic::AssertUnwindSafe(|| join_result.resume_unwind()))
     {
-        Ok(Some(())) => return Ok(()),
+        Ok(Some(None)) => return Ok(()),
+        // The pump drained and flushed; it just has nothing left to serve.
+        // Fail the shard so the process exits non-zero: a node that stopped
+        // because it could not persist a cluster-committed op must not look
+        // to an orchestrator like a clean shutdown.
+        Ok(Some(Some(fault))) => {
+            error!(
+                shard = shard_id,
+                namespace_raw = fault.namespace_raw,
+                op = fault.op,
+                operation = ?fault.operation,
+                "message pump stopped on a partition commit fault; \
+                 the server is shutting down"
+            );
+            return Err(ServerError::ShardFatal {
+                shard_id,
+                namespace_raw: fault.namespace_raw,
+                op: fault.op,
+            });
+        }
         Ok(None) => "task was cancelled".to_string(),
         Err(payload) => payload
             .downcast_ref::<&str>()
@@ -4748,7 +4778,7 @@ mod tests {
             .expect("a fresh ServerConfig owns its system config")
             .sharding
             .shutdown_drain_timeout = iggy_common::IggyDuration::new(timeout);
-        let pump = compio::runtime::spawn(std::future::pending::<()>());
+        let pump = compio::runtime::spawn(std::future::pending::<Option<FatalCommit>>());
 
         let error = await_pump_drain(Some(pump), &config, 7)
             .await
@@ -4759,6 +4789,32 @@ mod tests {
                 shard_id: 7,
                 timeout: actual,
             } if actual == timeout
+        ));
+    }
+
+    #[compio::test]
+    async fn pump_stopped_by_a_commit_fault_is_not_reported_as_clean() {
+        // The pump drained and flushed, so the join succeeds. Reporting that
+        // as a clean exit would hand an orchestrator exit code 0 for a node
+        // that stopped because it could not persist a cluster-committed op.
+        let config = ServerConfig::default();
+        let fault = FatalCommit {
+            namespace_raw: 42,
+            op: 7,
+            operation: iggy_binary_protocol::Operation::SendMessages,
+        };
+        let pump = compio::runtime::spawn(async move { Some(fault) });
+
+        let error = await_pump_drain(Some(pump), &config, 3)
+            .await
+            .expect_err("a pump that stopped on a commit fault is not a clean exit");
+        assert!(matches!(
+            error,
+            ServerError::ShardFatal {
+                shard_id: 3,
+                namespace_raw: 42,
+                op: 7,
+            }
         ));
     }
 

--- a/core/server/src/dispatch.rs
+++ b/core/server/src/dispatch.rs
@@ -3854,6 +3854,7 @@ mod tests {
     use std::future::Future;
     use std::mem::size_of;
     use std::rc::Rc;
+    use std::sync::atomic::AtomicBool;
 
     type TestMux = MuxStateMachine<variadic!(Users, Streams)>;
     type TestShard = IggyShard<SpyBus, PrepareJournal, IggySnapshot, TestMux, PapayaShardsTable>;
@@ -4514,7 +4515,9 @@ mod tests {
         let (stop_tx, stop_rx) = shard::channel::<()>(1);
         let pump_shard = Rc::clone(&shard);
         let pump = compio::runtime::spawn(async move {
-            pump_shard.run_message_pump(stop_rx).await;
+            pump_shard
+                .run_message_pump(stop_rx, Arc::new(AtomicBool::new(false)))
+                .await;
         });
 
         lane_sender
@@ -4560,7 +4563,9 @@ mod tests {
         // post-loop drain must still deliver the reply-lane frame.
         let (stop_tx, stop_rx) = shard::channel::<()>(1);
         stop_tx.try_send(()).expect("stop channel has capacity");
-        shard.run_message_pump(stop_rx).await;
+        shard
+            .run_message_pump(stop_rx, Arc::new(AtomicBool::new(false)))
+            .await;
 
         let replies = bus.client_replies.borrow();
         assert_eq!(

--- a/core/server/src/segment_recovery.rs
+++ b/core/server/src/segment_recovery.rs
@@ -64,6 +64,14 @@ const SCAN_WINDOW_CAPACITY: usize = 4 * 1024 * 1024;
 /// batch always gets one.
 const REBUILT_INDEX_STRIDE_BYTES: u64 = 64 * 1024;
 
+/// Sparse index entries the anchor search steps through between reactor
+/// yields, on top of the per-refill yield it shares with the walks. An entry
+/// whose position is past the log end is rejected on arithmetic alone, so it
+/// never refills the scan window, and an index floored back to a short log is
+/// mostly those: without this the search would hold the shard core -- signal
+/// handling included -- for one pread per entry over the whole file.
+const ANCHOR_SEARCH_YIELD_STRIDE: u64 = 1024;
+
 /// Units the damage probes of one partition load may spend per byte of
 /// residue they are asked to classify, at one unit per candidate offset
 /// examined. Candidates never outnumber residue bytes, so an honest
@@ -413,6 +421,13 @@ struct PlannedSegment {
 /// Scoped to the LOAD, not to one probe: pass A probes every segment before
 /// pass B can refuse the chain, so a per-probe budget would multiply the
 /// worst case by the segment count.
+///
+/// The limits are therefore a sum of grants, not a function of any one
+/// residue: the index anchor search grows them over the log spans it steps
+/// across and the damage probe grows them again over residue that can overlap
+/// those spans, so a segment whose index was walked backward carries a larger
+/// allowance than its own residue would buy. Exhaustion only ever refuses and
+/// never truncates, so the looser bound buys boot work, not a weaker verdict.
 #[derive(Default)]
 struct ProbeBudget {
     limit_units: u64,
@@ -1140,6 +1155,14 @@ async fn recover_segment_bounds(
                     anchor,
                 )
                 .await?;
+                // The anchor passed the same checks this walk applies to its
+                // first batch, so it proves at least that one. Pass C relies
+                // on it: the retained entries stop at the anchor, and only a
+                // walk that got past it leaves them inside the truncated log.
+                debug_assert!(
+                    walk.proved_any,
+                    "a provable anchor must prove its own batch to the walk"
+                );
             }
             refuse_if_survivor_past_damage(
                 identity,
@@ -1451,7 +1474,10 @@ async fn walk_chain_from_anchor(
 /// every such span and its verify always fits the residue multiple; entries
 /// packed closer together than the batches they claim exhaust it and refuse,
 /// rather than paying a verify per entry over an index that never proves.
-/// Yields once per window of disk reads, like the walks.
+/// Yields once per window of disk reads, like the walks, and additionally
+/// every [`ANCHOR_SEARCH_YIELD_STRIDE`] entries: an entry that overshoots the
+/// log reads nothing from it, so there is no refill to key the yield on, and
+/// a floored index is full of exactly those.
 async fn find_provable_index_anchor(
     identity: PartitionIdentity<'_>,
     index_path: &str,
@@ -1527,9 +1553,9 @@ async fn find_provable_index_anchor(
                     return Ok(Some((entry_index + 1, entry)));
                 }
             }
-            if scanner.take_refilled() {
-                yield_to_reactor().await;
-            }
+        }
+        if scanner.take_refilled() || entry_index.is_multiple_of(ANCHOR_SEARCH_YIELD_STRIDE) {
+            yield_to_reactor().await;
         }
         let Some(next) = entry_index.checked_sub(1) else {
             return Ok(None);

--- a/core/server/src/segment_recovery.rs
+++ b/core/server/src/segment_recovery.rs
@@ -134,9 +134,8 @@ pub struct RecoveredSegment {
 ///
 /// Transient I/O failures (listing, stat, open, read, truncate, fsync) are
 /// returned as-is and abort the boot so it can be retried. Structural
-/// contradictions -- a holed chain, an index diverging from its log, damage
-/// with intact batches after it, residue the damage probe could not classify
-/// within its limits -- return
+/// contradictions -- a holed chain, damage with intact batches after it,
+/// residue the damage probe could not classify within its limits -- return
 /// [`ServerError::PartitionRecoveryRefused`] so the caller can fence this one
 /// partition instead of taking the node down.
 #[allow(clippy::too_many_lines)]
@@ -205,9 +204,9 @@ pub async fn load_persisted_segments(
         // bytes with `end_offset == start_offset` would fabricate one
         // phantom message for the bootstrap non-empty filters and strand
         // undecodable garbage inside the readable range. Note this is NOT
-        // tail-only -- a torn index is reachable mid-chain on the shipped
-        // `enforce_fsync = false`, which is why the walk exists rather than
-        // refusing the partition.
+        // tail-only -- the log and the index persist concurrently under
+        // every config, so a torn index is reachable mid-chain, which is why
+        // the walk exists rather than refusing the partition.
         let recovered_empty = bounds.is_none();
         let bounds = bounds.unwrap_or_else(|| {
             if raw_messages_size > 0 {
@@ -283,13 +282,17 @@ pub async fn load_persisted_segments(
             )?;
         }
         // Log first, index second: a walk only accepts bounds when a whole
-        // batch decodes at the last index entry's position, so the walked log
-        // length strictly exceeds that position and every surviving index
-        // entry still points inside the shortened log even if a crash lands
-        // between the two mutations. The staged-rebuild install keeps the
-        // same property: until its rename lands, the on-disk index still
-        // holds no whole entry, so a crash between the two re-runs the
-        // index-less walk over the already-truncated log.
+        // batch verifies at the last RETAINED index entry's position, so the
+        // walked log length strictly exceeds that position and every
+        // surviving index entry still points inside the shortened log even if
+        // a crash lands between the two mutations -- and a crash that lands
+        // there anyway leaves an index running ahead of its log, which the
+        // next boot floors instead of refusing. The staged-rebuild install is
+        // reached from a populated index too (one the log backs nowhere), so
+        // a crash between the truncate and the rename leaves that unbacked
+        // index over the shortened log; the next boot re-discards it and
+        // rebuilds from the log again, and truncation is monotone, so the
+        // pair converges.
         truncate_to(&plan.messages_path, messages_size)?;
         if let Some(staging_path) = &plan.rebuilt_index_staging {
             install_rebuilt_index(staging_path, &plan.index_path, identity.partition_path)?;
@@ -452,6 +455,17 @@ struct WalkedBounds {
     messages_size: u64,
     index_size: u64,
     rebuilt_index: Option<Vec<u8>>,
+}
+
+/// What the batch chain walked from one index entry proves.
+struct AnchoredWalk {
+    /// False when not one whole batch decoded at the anchor itself, leaving
+    /// the fields below at the anchor's own values.
+    proved_any: bool,
+    end_offset: u64,
+    end_timestamp: u64,
+    /// First byte past the last whole batch the walk proved.
+    position: u64,
 }
 
 /// Reusable buffers for the walk, probe, and index validation scans, plus the
@@ -980,11 +994,16 @@ async fn load_index_anchors(
 ///
 /// With a whole index entry present, the last entry's `position` is only the
 /// last flushed chunk's START byte, so the batch chain is walked from there to
-/// prove where the segment really ends -- without `enforce_fsync` there is no
-/// ordering barrier between the message write and the index write, and a tail
-/// torn mid-flush would otherwise pass while `end_offset` claims offsets whose
-/// bytes are incomplete. Without one, the log itself is walked from byte 0 and
-/// the index is rebuilt from the batches found. Either way, bytes left past
+/// prove where the segment really ends -- the log and the index persist
+/// concurrently under every config, so there is no ordering barrier between
+/// the message write and the index write, and a tail torn mid-flush would
+/// otherwise pass while `end_offset` claims offsets whose bytes are
+/// incomplete. When the log cannot back that entry, the search steps
+/// down to the highest entry it can and the index is floored to it; when it
+/// backs no entry at all, or the entries contradict each other, the index
+/// is dropped whole. Without one -- dropped or never present -- the log
+/// itself is walked from byte 0 and the index is rebuilt from the batches
+/// found. Either way, bytes left past
 /// the walked prefix go through the damage probe: a torn tail truncates, but
 /// damage with intact batches after it -- or residue the probe cannot
 /// classify within its limits -- refuses recovery.
@@ -1001,143 +1020,143 @@ async fn recover_segment_bounds(
 
     match (first, last) {
         (Some(first), Some(last)) => {
-            // Interior entries were never validated before: a mis-strided
-            // index can decode to garbage entries that binary searches then
-            // trust. Monotonicity plus the walk's own anchor bound them: the
-            // walk below only accepts bounds when a whole batch decodes at
-            // the LAST entry's position, so ascending positions keep every
-            // surviving entry inside the truncated log.
-            validate_index_entries(identity, index_path, start_offset, entry_count, scratch)?;
+            // A mis-strided or foreign index decodes to garbage entries that
+            // binary searches would trust, and the walk's anchor bounds only
+            // the tail. Ascending positions keep every surviving entry inside
+            // the truncated log once the tail is floored, so an index that
+            // contradicts itself is dropped whole and rebuilt from the log,
+            // exactly like one the log backs nowhere: entries are derived
+            // from the log, so the index can never say more than the log.
+            let consistent =
+                index_is_consistent(identity, index_path, start_offset, entry_count, scratch)?;
 
             let messages = open_messages_file(identity, messages_path)?;
             let mut scanner = FileScanner::new(&messages, messages_size, scratch);
+            if !consistent {
+                return recover_by_walking_log(
+                    identity,
+                    &mut scanner,
+                    messages_path,
+                    start_offset,
+                    messages_size,
+                )
+                .await;
+            }
             // The sparse index holds ONE entry per flushed chunk, pointing
             // at the chunk's FIRST batch -- `last.offset` is where the last
             // chunk STARTS, not where the segment ends (a whole journal
             // flushed as one chunk indexes only its first offset). Walk the
             // batch chain from that position to the file end to recover the
             // true end offset.
-            let mut position = last.position;
-            let mut end_offset = last.offset;
-            let mut end_timestamp = last.timestamp;
-            let mut expected_offset = last.offset;
-            let mut walked_any = false;
-            // TODO(hubcio): for batches that continue the chain exactly this
-            // indexed walk trusts the header decode alone (batches that
-            // contradict the walk checksum-verify below), so a torn flush
-            // that persisted the header page but zeroed the body is absorbed
-            // silently; the index-less walk below checksums every batch.
-            // Decide whether the indexed arm should checksum too (boot cost)
-            // or leave body rot to protocol-aware repair.
-            while position < messages_size {
-                let header = match scanner.peek_header(position) {
-                    Ok(Some(header)) => header,
-                    Ok(None) => break,
-                    Err(source) => {
-                        return Err(scan_read_failure(identity, messages_path, &source));
-                    }
-                };
-                let extent = position.saturating_add(header.total_size() as u64);
-                if extent > messages_size {
-                    break;
-                }
-                // A header contradicting the walk -- a foreign partition_id,
-                // or a base offset that does not continue the chain in
-                // EITHER direction -- is either damage wearing a decodable
-                // header or a real record that does not belong at this
-                // position. The batch checksum tells them apart, because it
-                // covers both fields and the server mints every legal record
-                // with it: a batch that fails it is damage, so break and let
-                // the probe below classify the residue (a bit flip in a tail
-                // batch then truncates like any torn tail, regardless of the
-                // flip's direction), while a batch that VERIFIES is durable
-                // evidence -- of a misdirected or copied write when the
-                // partition stamp is foreign, of duplicated or lost offsets
-                // when the chain breaks -- and both absorbing it and
-                // truncating it would hide that, so refuse and keep the
-                // bytes. Refusing the verified forward gap over absorbing it
-                // is deliberate: state transfer's own walk refuses any gap,
-                // so an absorbed one would mint a segment no peer can ever
-                // install, and the offsets it fabricates seed current_offset
-                // under an advance-only superblock persist.
-                let foreign_partition = header.partition_id != identity.partition_id as u64;
-                if foreign_partition || header.base_offset != expected_offset {
-                    let verifies = scanner
-                        .slice_at(position, header.total_size())
-                        .map_err(|source| scan_read_failure(identity, messages_path, &source))?
-                        .is_some_and(|batch| decode_batch_slice(batch).is_ok());
-                    if !verifies {
-                        break;
-                    }
-                    if foreign_partition {
-                        return Err(identity.refusal(PartitionRecoveryRefusal::ForeignBatch {
-                            start_offset,
-                            batch_partition_id: header.partition_id,
-                            position,
-                        }));
-                    }
-                    return Err(
-                        identity.refusal(PartitionRecoveryRefusal::OffsetDiscontinuity {
-                            start_offset,
-                            expected_offset,
-                            found_offset: header.base_offset,
-                            position,
-                        }),
+            let mut walk = walk_chain_from_anchor(
+                identity,
+                &mut scanner,
+                messages_path,
+                start_offset,
+                messages_size,
+                last,
+            )
+            .await?;
+            let mut retained_entries = entry_count;
+            if !walk.proved_any {
+                // An index entry is not independent evidence about the log:
+                // the writer derives every entry from a batch the log
+                // already held, so an entry the log cannot back is a torn
+                // tail of the INDEX, never proof that the log lost data.
+                // That shape is ordinary: the two files persist concurrently
+                // under every config, so they have no write ordering between
+                // them, and pass C truncates the log before the index, so a
+                // crash between those two mutations leaves exactly this.
+                // Refusing it handed a benign torn tail a permanent tombstone
+                // on a single-replica node. Step down
+                // to the highest entry the log still proves and floor the
+                // index there, so pass C drops the entries nothing backs.
+                let anchor = find_provable_index_anchor(
+                    identity,
+                    index_path,
+                    messages_path,
+                    &mut scanner,
+                    start_offset,
+                    entry_count,
+                    messages_size,
+                )
+                .await?;
+                let Some((provable_entries, anchor)) = anchor else {
+                    // Not one entry is backed by the log, so the index
+                    // describes a file this segment does not hold and every
+                    // entry in it is worthless. The log still describes
+                    // itself, so drop the index whole and walk the log from
+                    // byte 0, which rebuilds the index from what it proves.
+                    // The common shape is the first persist into a fresh
+                    // segment: its one entry and its log chunk fsync
+                    // concurrently, and a crash in between leaves the entry
+                    // durable over an empty or torn log. No ack was ever sent
+                    // for those bytes (persist completes before the reply),
+                    // so recovering from the log alone loses nothing a client
+                    // was promised -- where refusing tombstoned the partition
+                    // on a single-replica node. The walk runs its own residue
+                    // probe from the real break point, so a survivor past
+                    // damage still refuses there.
+                    warn!(
+                        stream_id = identity.stream_id,
+                        topic_id = identity.topic_id,
+                        partition_id = identity.partition_id,
+                        start_offset,
+                        messages_size,
+                        entry_count,
+                        last_entry_offset = last.offset,
+                        last_entry_position = last.position,
+                        "no sparse index entry is backed by the log; \
+                         discarding the index and rebuilding it from the log"
                     );
-                }
-                if header.message_count > 0 {
-                    end_offset = header
-                        .base_offset
-                        .saturating_add(u64::from(header.message_count) - 1);
-                    end_timestamp = header.base_timestamp;
-                    expected_offset = end_offset.saturating_add(1);
-                }
-                walked_any = true;
-                position = extent;
-                if scanner.take_refilled() {
-                    yield_to_reactor().await;
-                }
-            }
-            if !walked_any {
-                // Probe before concluding: a verifying batch past the bytes
-                // that broke the walk at the anchor is a survivor, and
-                // refusing it as a divergence would claim the log holds
-                // nothing while durable data sits in it.
-                refuse_if_survivor_past_damage(
+                    return recover_by_walking_log(
+                        identity,
+                        &mut scanner,
+                        messages_path,
+                        start_offset,
+                        messages_size,
+                    )
+                    .await;
+                };
+                warn!(
+                    stream_id = identity.stream_id,
+                    topic_id = identity.topic_id,
+                    partition_id = identity.partition_id,
+                    start_offset,
+                    messages_size,
+                    entry_count,
+                    provable_entries,
+                    anchor_position = anchor.position,
+                    "sparse index runs ahead of the log it indexes; flooring \
+                     it to the entries the log proves"
+                );
+                retained_entries = provable_entries;
+                walk = walk_chain_from_anchor(
                     identity,
                     &mut scanner,
                     messages_path,
-                    position,
-                    messages_size,
-                    Some(end_offset),
                     start_offset,
+                    messages_size,
+                    anchor,
                 )
                 .await?;
-                return Err(
-                    identity.refusal(PartitionRecoveryRefusal::IndexLogDivergence {
-                        start_offset,
-                        end_offset: last.offset,
-                        messages_size_bytes: messages_size,
-                        indexed_size_bytes: last.position,
-                    }),
-                );
             }
             refuse_if_survivor_past_damage(
                 identity,
                 &mut scanner,
                 messages_path,
-                position,
+                walk.position,
                 messages_size,
-                Some(end_offset),
+                Some(walk.end_offset),
                 start_offset,
             )
             .await?;
             Ok(Some(WalkedBounds {
                 start_timestamp: first.timestamp,
-                end_timestamp,
-                end_offset,
-                messages_size: position,
-                index_size: entry_count * SPARSE_INDEX_ENTRY_SIZE as u64,
+                end_timestamp: walk.end_timestamp,
+                end_offset: walk.end_offset,
+                messages_size: walk.position,
+                index_size: retained_entries * SPARSE_INDEX_ENTRY_SIZE as u64,
                 rebuilt_index: None,
             }))
         }
@@ -1145,10 +1164,10 @@ async fn recover_segment_bounds(
         // WALKING the log from byte 0 instead of declaring the segment empty.
         //
         // The index is not the only self-describing copy -- batch headers carry
-        // their own offsets, timestamps and lengths -- and with the shipped
-        // `enforce_fsync = false` there is no write ordering between a log and
-        // its index, so a torn index is reachable on default config for a
-        // MID-CHAIN segment too, not just the tail. Recovering that as empty
+        // their own offsets, timestamps and lengths -- and the log and its
+        // index persist concurrently under every config, so a torn index is
+        // reachable for a MID-CHAIN segment too, not just the tail.
+        // Recovering that as empty
         // then trips the contiguity guard and refuses the whole partition:
         // total serve loss (and offset reuse from 0) for a chain whose bytes
         // are all present. The walk keeps the torn-tail truncation the indexed
@@ -1157,142 +1176,387 @@ async fn recover_segment_bounds(
         _ if messages_size > 0 => {
             let messages = open_messages_file(identity, messages_path)?;
             let mut scanner = FileScanner::new(&messages, messages_size, scratch);
-            let mut position = 0u64;
-            let mut start_timestamp = None;
-            let mut end_offset = start_offset;
-            let mut end_timestamp = 0;
-            let mut expected_offset = start_offset;
-            let mut rebuilt_index = Vec::new();
-            let mut last_indexed_position: Option<u64> = None;
-            while position < messages_size {
-                let header = match scanner.peek_header(position) {
-                    Ok(Some(header)) => header,
-                    Ok(None) => break,
-                    Err(source) => {
-                        return Err(scan_read_failure(identity, messages_path, &source));
-                    }
-                };
-                let extent = position.saturating_add(header.total_size() as u64);
-                if extent > messages_size {
-                    break;
-                }
-                // The FILENAME is the only trustworthy anchor once the index
-                // is gone, and the header decode checks a length, not a
-                // checksum. So the batch has to verify before its header is
-                // believed, and the chain has to be contiguous from the
-                // filename onward.
-                let verifies = scanner
-                    .slice_at(position, header.total_size())
-                    .map_err(|source| scan_read_failure(identity, messages_path, &source))?
-                    .is_some_and(|batch| decode_batch_slice(batch).is_ok());
-                if !verifies {
-                    break;
-                }
-                if header.partition_id != identity.partition_id as u64 {
-                    // Verified above, so this is a real record minted for
-                    // another partition (a misdirected write, an operator
-                    // copy), not damage: preserve it as evidence.
-                    return Err(identity.refusal(PartitionRecoveryRefusal::ForeignBatch {
-                        start_offset,
-                        batch_partition_id: header.partition_id,
-                        position,
-                    }));
-                }
-                if header.base_offset != expected_offset {
-                    // A batch that VERIFIES but does not continue the chain is
-                    // durable data past a hole (or a duplicated range): the
-                    // offsets in between are exactly what a truncation here
-                    // would silently erase, so refuse instead.
-                    return Err(
-                        identity.refusal(PartitionRecoveryRefusal::OffsetDiscontinuity {
-                            start_offset,
-                            expected_offset,
-                            found_offset: header.base_offset,
-                            position,
-                        }),
-                    );
-                }
-                if header.message_count > 0 {
-                    end_offset = header
-                        .base_offset
-                        .saturating_add(u64::from(header.message_count) - 1);
-                    end_timestamp = header.base_timestamp;
-                    start_timestamp.get_or_insert(header.base_timestamp);
-                    expected_offset = end_offset.saturating_add(1);
-                    if last_indexed_position.is_none_or(|indexed| {
-                        position.saturating_sub(indexed) >= REBUILT_INDEX_STRIDE_BYTES
-                    }) {
-                        push_index_entry(
-                            &mut rebuilt_index,
-                            header.base_offset,
-                            header.base_timestamp,
-                            position,
-                        );
-                        last_indexed_position = Some(position);
-                    }
-                }
-                position = extent;
-                if scanner.take_refilled() {
-                    yield_to_reactor().await;
-                }
-            }
-            refuse_if_survivor_past_damage(
+            recover_by_walking_log(
                 identity,
                 &mut scanner,
                 messages_path,
-                position,
-                messages_size,
-                start_timestamp.map(|_| end_offset),
                 start_offset,
+                messages_size,
             )
-            .await?;
-            let Some(start_timestamp) = start_timestamp else {
-                // Not one whole batch, and the probe above proved nothing
-                // decodable follows either: the bytes really are unusable, so
-                // the caller's empty recovery is right after all.
-                return Ok(None);
-            };
-            warn!(
-                stream_id = identity.stream_id,
-                topic_id = identity.topic_id,
-                partition_id = identity.partition_id,
-                start_offset,
-                messages_size,
-                walked_size = position,
-                rebuilt_entries = rebuilt_index.len() / SPARSE_INDEX_ENTRY_SIZE,
-                "sparse index holds no whole entry; recovered segment bounds \
-                 by walking the log and rebuilding its index from the walked \
-                 batches"
-            );
-            Ok(Some(WalkedBounds {
-                start_timestamp,
-                end_timestamp,
-                end_offset,
-                messages_size: position,
-                index_size: rebuilt_index.len() as u64,
-                rebuilt_index: Some(rebuilt_index),
-            }))
+            .await
         }
         _ => Ok(None),
     }
 }
 
-/// Validates every whole index entry: the first must not claim an offset
-/// below the segment's own start, and offsets and positions must strictly
-/// ascend (the writer appends one entry per flushed chunk over a growing
-/// log, and every chunk covers at least one message and one byte).
+/// Recovers a segment's bounds from the log alone, walking the batch chain
+/// from byte 0 and rebuilding the sparse index from the batches it proves.
+/// `None` when no whole batch decodes anywhere (the caller recovers the
+/// segment as empty).
+///
+/// Reached both when the index holds no whole entry and when it holds
+/// entries the log cannot back. Every batch is checksum-verified, as in the
+/// anchored walk; here the FILENAME is the only anchor at all, and the
+/// header decode checks a length, not a checksum.
+async fn recover_by_walking_log(
+    identity: PartitionIdentity<'_>,
+    scanner: &mut FileScanner<'_>,
+    messages_path: &str,
+    start_offset: u64,
+    messages_size: u64,
+) -> Result<Option<WalkedBounds>, ServerError> {
+    let mut position = 0u64;
+    let mut start_timestamp = None;
+    let mut end_offset = start_offset;
+    let mut end_timestamp = 0;
+    let mut expected_offset = start_offset;
+    let mut rebuilt_index = Vec::new();
+    let mut last_indexed_position: Option<u64> = None;
+    while position < messages_size {
+        let Some(header) = header_at(identity, scanner, messages_path, position)? else {
+            break;
+        };
+        let extent = position.saturating_add(header.total_size() as u64);
+        if extent > messages_size {
+            break;
+        }
+        let verifies = batch_verifies(
+            identity,
+            scanner,
+            messages_path,
+            position,
+            header.total_size(),
+        )?;
+        if !verifies {
+            break;
+        }
+        if header.partition_id != identity.partition_id as u64 {
+            // Verified above, so this is a real record minted for another
+            // partition (a misdirected write, an operator copy), not damage:
+            // preserve it as evidence.
+            return Err(identity.refusal(PartitionRecoveryRefusal::ForeignBatch {
+                start_offset,
+                batch_partition_id: header.partition_id,
+                position,
+            }));
+        }
+        if header.base_offset != expected_offset {
+            // A batch that VERIFIES but does not continue the chain is
+            // durable data past a hole (or a duplicated range): the offsets
+            // in between are exactly what a truncation here would silently
+            // erase, so refuse instead.
+            return Err(
+                identity.refusal(PartitionRecoveryRefusal::OffsetDiscontinuity {
+                    start_offset,
+                    expected_offset,
+                    found_offset: header.base_offset,
+                    position,
+                }),
+            );
+        }
+        if header.message_count > 0 {
+            end_offset = header
+                .base_offset
+                .saturating_add(u64::from(header.message_count) - 1);
+            end_timestamp = header.base_timestamp;
+            start_timestamp.get_or_insert(header.base_timestamp);
+            expected_offset = end_offset.saturating_add(1);
+            if last_indexed_position.is_none_or(|indexed| {
+                position.saturating_sub(indexed) >= REBUILT_INDEX_STRIDE_BYTES
+            }) {
+                push_index_entry(
+                    &mut rebuilt_index,
+                    header.base_offset,
+                    header.base_timestamp,
+                    position,
+                );
+                last_indexed_position = Some(position);
+            }
+        }
+        position = extent;
+        if scanner.take_refilled() {
+            yield_to_reactor().await;
+        }
+    }
+    refuse_if_survivor_past_damage(
+        identity,
+        scanner,
+        messages_path,
+        position,
+        messages_size,
+        start_timestamp.map(|_| end_offset),
+        start_offset,
+    )
+    .await?;
+    let Some(start_timestamp) = start_timestamp else {
+        // Not one whole batch, and the probe above proved nothing decodable
+        // follows either: the bytes really are unusable, so the caller's
+        // empty recovery is right after all.
+        return Ok(None);
+    };
+    warn!(
+        stream_id = identity.stream_id,
+        topic_id = identity.topic_id,
+        partition_id = identity.partition_id,
+        start_offset,
+        messages_size,
+        walked_size = position,
+        rebuilt_entries = rebuilt_index.len() / SPARSE_INDEX_ENTRY_SIZE,
+        "recovered segment bounds by walking the log and rebuilding its \
+         index from the walked batches"
+    );
+    Ok(Some(WalkedBounds {
+        start_timestamp,
+        end_timestamp,
+        end_offset,
+        messages_size: position,
+        index_size: rebuilt_index.len() as u64,
+        rebuilt_index: Some(rebuilt_index),
+    }))
+}
+
+/// Walks the batch chain forward from one sparse index entry to the end of
+/// the log, proving where the segment really ends.
+///
+/// The anchor is only a starting byte and the offset the chain must continue
+/// from; nothing about it is assumed to hold. Every batch the walk accepts
+/// passes its batch checksum: an index entry proves nothing about the bytes
+/// under it, because the log and the index persist concurrently and a crash
+/// can leave a batch's header page durable over a body that never landed.
+/// The header decode still runs first, so a header that does not fit the
+/// file breaks the walk before any checksum is paid, and the verify covers
+/// one flushed chunk per segment in the ordinary boot (the last entry points
+/// at the last chunk's first batch). When not one whole batch verifies at
+/// the anchor the returned walk is `proved_any == false` and still carries
+/// the anchor's own position and offset, which is what the caller hands to
+/// the step-back and the damage probe.
+async fn walk_chain_from_anchor(
+    identity: PartitionIdentity<'_>,
+    scanner: &mut FileScanner<'_>,
+    messages_path: &str,
+    start_offset: u64,
+    messages_size: u64,
+    anchor: IggyIndex,
+) -> Result<AnchoredWalk, ServerError> {
+    let mut position = anchor.position;
+    let mut end_offset = anchor.offset;
+    let mut end_timestamp = anchor.timestamp;
+    let mut expected_offset = anchor.offset;
+    // The anchor's offset comes from the INDEX; only a batch this walk has
+    // already proved makes the expectation the LOG's own.
+    let mut expectation_from_log = false;
+    let mut proved_any = false;
+    while position < messages_size {
+        let Some(header) = header_at(identity, scanner, messages_path, position)? else {
+            break;
+        };
+        let extent = position.saturating_add(header.total_size() as u64);
+        if extent > messages_size {
+            break;
+        }
+        // The batch checksum covers every header field and the body, and the
+        // server mints every legal record with it, so it is what tells
+        // damage wearing a decodable header from a real record: a batch that
+        // fails it is damage whatever its fields claim -- a torn body under
+        // an intact header page, a bit flip in either direction -- so break
+        // and let the probe classify the residue (a torn tail truncates). A
+        // batch that VERIFIES is durable evidence, and only the verified
+        // contradictions below earn a refusal.
+        if !batch_verifies(
+            identity,
+            scanner,
+            messages_path,
+            position,
+            header.total_size(),
+        )? {
+            break;
+        }
+        if header.partition_id != identity.partition_id as u64 {
+            // A real record minted for another partition (a misdirected or
+            // copied write), not damage: adopting it would seed this
+            // partition's offsets from foreign data and truncating it would
+            // destroy the evidence, so refuse and keep the bytes.
+            return Err(identity.refusal(PartitionRecoveryRefusal::ForeignBatch {
+                start_offset,
+                batch_partition_id: header.partition_id,
+                position,
+            }));
+        }
+        if header.base_offset != expected_offset {
+            if !expectation_from_log {
+                // Still the anchor: the offset this batch failed to match is
+                // the INDEX ENTRY's, so a verifying batch here contradicts
+                // the entry, not the chain. Calling that a discontinuity
+                // would refuse a healthy log over a stale entry, so break and
+                // leave the verdict to the step-back and the log rebuild,
+                // which read the chain from the filename onward.
+                break;
+            }
+            // A verified batch that does not continue the chain is durable
+            // data past a hole or a duplicated range. Absorbing it would
+            // mint a segment no peer can ever install (state transfer's own
+            // walk refuses any gap) and seed current_offset with fabricated
+            // offsets under an advance-only superblock persist; truncating
+            // it would hide the loss. Refuse and keep the bytes.
+            return Err(
+                identity.refusal(PartitionRecoveryRefusal::OffsetDiscontinuity {
+                    start_offset,
+                    expected_offset,
+                    found_offset: header.base_offset,
+                    position,
+                }),
+            );
+        }
+        if header.message_count > 0 {
+            end_offset = header
+                .base_offset
+                .saturating_add(u64::from(header.message_count) - 1);
+            end_timestamp = header.base_timestamp;
+            expected_offset = end_offset.saturating_add(1);
+            expectation_from_log = true;
+        }
+        proved_any = true;
+        position = extent;
+        if scanner.take_refilled() {
+            yield_to_reactor().await;
+        }
+    }
+    Ok(AnchoredWalk {
+        proved_any,
+        end_offset,
+        end_timestamp,
+        position,
+    })
+}
+
+/// Highest index entry below the last one that the log can still prove,
+/// returned as the number of entries to keep plus that entry itself. `None`
+/// when no entry proves out, which drops the index whole.
+///
+/// An entry proves when the log holds, at its position, the whole batch it
+/// describes: decoding, fitting inside the log, carrying this partition's
+/// stamp and the entry's own base offset, and passing its batch checksum,
+/// so the anchor the whole recovered end offset hangs on is verified before
+/// it is believed. Entries are read one at a time from the back rather than
+/// slurped: an index can run to megabytes, and the search stops at the first
+/// entry that proves. The dominant shape costs no log read at all -- an
+/// entry pointing past the log end is rejected on arithmetic alone -- so a
+/// torn tail pays a header read for the one entry it lands on and nothing
+/// more.
+///
+/// Budgeted like the damage probe, because the search reads BACKWARD and
+/// nothing else bounds it: the log span between one probed entry and the
+/// one probed before it is the residue that entry classifies. An honest
+/// index holds one entry per flushed chunk, so a whole batch fits inside
+/// every such span and its verify always fits the residue multiple; entries
+/// packed closer together than the batches they claim exhaust it and refuse,
+/// rather than paying a verify per entry over an index that never proves.
+/// Yields once per window of disk reads, like the walks.
+async fn find_provable_index_anchor(
+    identity: PartitionIdentity<'_>,
+    index_path: &str,
+    messages_path: &str,
+    scanner: &mut FileScanner<'_>,
+    start_offset: u64,
+    entry_count: u64,
+    messages_size: u64,
+) -> Result<Option<(u64, IggyIndex)>, ServerError> {
+    // The last entry is the one that just failed to prove out.
+    let Some(mut entry_index) = entry_count.checked_sub(2) else {
+        return Ok(None);
+    };
+    let file = fs::File::open(index_path).map_err(|source| {
+        error!(
+            stream_id = identity.stream_id,
+            topic_id = identity.topic_id,
+            partition_id = identity.partition_id,
+            path = %index_path,
+            error = %source,
+            "failed to open sparse index for anchor search during recovery"
+        );
+        ServerError::from(IggyError::CannotReadFile)
+    })?;
+    let mut raw = [0u8; SPARSE_INDEX_ENTRY_SIZE];
+    // Lowest log byte a probed entry has already paid for; the next probed
+    // entry is budgeted by the span from its own position up to here.
+    let mut budgeted_down_to = messages_size;
+    loop {
+        file.read_exact_at(&mut raw, entry_index * SPARSE_INDEX_ENTRY_SIZE as u64)
+            .map_err(|source| {
+                error!(
+                    stream_id = identity.stream_id,
+                    topic_id = identity.topic_id,
+                    partition_id = identity.partition_id,
+                    path = %index_path,
+                    error = %source,
+                    "failed to read a sparse index entry for anchor search during recovery"
+                );
+                ServerError::from(IggyError::CannotReadFile)
+            })?;
+        let entry = IggyIndex::new(
+            read_u64_le(&raw, 0),
+            read_u64_le(&raw, 8),
+            read_u64_le(&raw, 16),
+        );
+        if entry.position < messages_size {
+            scanner
+                .budget
+                .grow_for_residue(budgeted_down_to.saturating_sub(entry.position));
+            budgeted_down_to = entry.position;
+            if let Some(header) = header_at(identity, scanner, messages_path, entry.position)?
+                && header.partition_id == identity.partition_id as u64
+                && header.base_offset == entry.offset
+                && entry.position.saturating_add(header.total_size() as u64) <= messages_size
+            {
+                if !scanner.budget.charge_verify(header.total_size() as u64) {
+                    return Err(unverified_residue(
+                        identity,
+                        scanner,
+                        start_offset,
+                        entry.position,
+                        messages_size,
+                    ));
+                }
+                if batch_verifies(
+                    identity,
+                    scanner,
+                    messages_path,
+                    entry.position,
+                    header.total_size(),
+                )? {
+                    return Ok(Some((entry_index + 1, entry)));
+                }
+            }
+            if scanner.take_refilled() {
+                yield_to_reactor().await;
+            }
+        }
+        let Some(next) = entry_index.checked_sub(1) else {
+            return Ok(None);
+        };
+        entry_index = next;
+    }
+}
+
+/// Checks every whole index entry: the first must not claim an offset below
+/// the segment's own start, and offsets and positions must strictly ascend
+/// (the writer appends one entry per flushed chunk over a growing log, and
+/// every chunk covers at least one message and one byte). A regression means
+/// the file was written mis-strided or over foreign bytes and describes no
+/// log at all; it is logged here, where the entry is known, and the caller
+/// rebuilds the index from the log.
 ///
 /// Timestamps are deliberately NOT validated: a primary clock rewind across a
 /// restart can legitimately regress persisted `base_timestamp` today, and the
 /// lower-bound searches degrade gracefully on a non-monotone run, so refusing
 /// would trade availability for nothing.
-fn validate_index_entries(
+fn index_is_consistent(
     identity: PartitionIdentity<'_>,
     index_path: &str,
     start_offset: u64,
     entry_count: u64,
     scratch: &mut ScanScratch,
-) -> Result<(), ServerError> {
+) -> Result<bool, ServerError> {
     let file = fs::File::open(index_path).map_err(|source| {
         error!(
             stream_id = identity.stream_id,
@@ -1333,34 +1597,42 @@ fn validate_index_entries(
             if let Some((previous_offset, previous_position)) = previous
                 && (entry_offset <= previous_offset || entry_position <= previous_position)
             {
-                return Err(
-                    identity.refusal(PartitionRecoveryRefusal::IndexEntriesNotMonotone {
-                        start_offset,
-                        entry_index,
-                    }),
+                warn!(
+                    stream_id = identity.stream_id,
+                    topic_id = identity.topic_id,
+                    partition_id = identity.partition_id,
+                    start_offset,
+                    entry_index,
+                    "sparse index entry regresses in offset or position; \
+                     discarding the index and rebuilding it from the log"
                 );
+                return Ok(false);
             }
             if previous.is_none() && entry_offset < start_offset {
-                return Err(identity.refusal(
-                    PartitionRecoveryRefusal::IndexEntryBeforeSegmentStart {
-                        start_offset,
-                        first_entry_offset: entry_offset,
-                    },
-                ));
+                warn!(
+                    stream_id = identity.stream_id,
+                    topic_id = identity.topic_id,
+                    partition_id = identity.partition_id,
+                    start_offset,
+                    first_entry_offset = entry_offset,
+                    "sparse index claims an offset below the segment start; \
+                     discarding the index and rebuilding it from the log"
+                );
+                return Ok(false);
             }
             previous = Some((entry_offset, entry_position));
             entry_index += 1;
         }
         byte_position += chunk_bytes as u64;
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Opens a segment's messages file for the recovery walk. Fail-stop on any
 /// failure, mirroring `file_len`: recovery truncates to the bounds the walk
-/// produces, so folding an open failure into "walked nothing" would route a
-/// healthy indexed segment into a divergence refusal -- or an index-less one
-/// into recover-as-empty, fencing the whole log out of service.
+/// produces, so folding an open failure into "walked nothing" would discard
+/// a healthy indexed segment's index -- or route an index-less one into
+/// recover-as-empty, fencing the whole log out of service.
 fn open_messages_file(
     identity: PartitionIdentity<'_>,
     messages_path: &str,
@@ -1376,6 +1648,35 @@ fn open_messages_file(
         );
         ServerError::from(IggyError::CannotReadFile)
     })
+}
+
+/// The batch header at `position`, or `None` when the walk must stop there
+/// (nothing decodes, or the header runs past the end of the walked file).
+fn header_at(
+    identity: PartitionIdentity<'_>,
+    scanner: &mut FileScanner<'_>,
+    messages_path: &str,
+    position: u64,
+) -> Result<Option<BatchHeader>, ServerError> {
+    scanner
+        .peek_header(position)
+        .map_err(|source| scan_read_failure(identity, messages_path, &source))
+}
+
+/// Whether the whole batch at `position` passes its batch checksum. `false`
+/// when the claimed extent runs past the end of the walked file, which is
+/// the torn-tail shape and not a read failure.
+fn batch_verifies(
+    identity: PartitionIdentity<'_>,
+    scanner: &mut FileScanner<'_>,
+    messages_path: &str,
+    position: u64,
+    total_size: usize,
+) -> Result<bool, ServerError> {
+    Ok(scanner
+        .slice_at(position, total_size)
+        .map_err(|source| scan_read_failure(identity, messages_path, &source))?
+        .is_some_and(|batch| decode_batch_slice(batch).is_ok()))
 }
 
 /// A read failure inside the walk or probe is transient I/O, not evidence
@@ -1447,19 +1748,36 @@ async fn refuse_if_survivor_past_damage(
             }))
         }
         ProbeOutcome::BudgetExhausted if chain_end_offset.is_none() => Ok(()),
-        ProbeOutcome::BudgetExhausted => Err(identity.refusal(
-            PartitionRecoveryRefusal::UnverifiedResidue {
-                start_offset,
-                damage_position,
-                residue_bytes,
-                candidates_examined: scanner.budget.spent_units,
-                budget_units: scanner.budget.limit_units,
-                verified_bytes: scanner.budget.verify_spent_bytes,
-                verify_budget_bytes: scanner.budget.verify_limit_bytes,
-            },
+        ProbeOutcome::BudgetExhausted => Err(unverified_residue(
+            identity,
+            scanner,
+            start_offset,
+            damage_position,
+            messages_size,
         )),
         ProbeOutcome::NoSurvivor => Ok(()),
     }
+}
+
+/// Refusal for a scan that ran out of its work budget before classifying
+/// the bytes from `damage_position` to the end of the walked file. The
+/// counters are diagnostic: they say which budget broke and by how much.
+fn unverified_residue(
+    identity: PartitionIdentity<'_>,
+    scanner: &FileScanner<'_>,
+    start_offset: u64,
+    damage_position: u64,
+    messages_size: u64,
+) -> ServerError {
+    identity.refusal(PartitionRecoveryRefusal::UnverifiedResidue {
+        start_offset,
+        damage_position,
+        residue_bytes: messages_size.saturating_sub(damage_position),
+        candidates_examined: scanner.budget.spent_units,
+        budget_units: scanner.budget.limit_units,
+        verified_bytes: scanner.budget.verify_spent_bytes,
+        verify_budget_bytes: scanner.budget.verify_limit_bytes,
+    })
 }
 
 /// Verdict of the damage probe over the residue past the walked prefix.
@@ -1476,8 +1794,9 @@ enum ProbeOutcome {
     BudgetExhausted,
 }
 
-/// Forward-only buffered reads over one segment file for the recovery walk
-/// and the damage probe. Parsing and checksumming happen against an in-memory
+/// Buffered reads over one segment file for the recovery walks, the index
+/// anchor search, and the damage probe. Parsing and checksumming happen
+/// against an in-memory
 /// window so neither pays a syscall per batch -- the probe advances its
 /// candidate one byte at a time, and per-candidate preads would turn one
 /// damaged multi-GiB segment into a boot-length stall.
@@ -1544,11 +1863,24 @@ impl<'scan> FileScanner<'scan> {
         }
         let window_end = self.window_start + self.window.len() as u64;
         if position < self.window_start || end > window_end {
-            let fill = usize::try_from((self.file_len - position).min(SCAN_WINDOW_CAPACITY as u64))
-                .unwrap_or(SCAN_WINDOW_CAPACITY);
+            // A forward move anchors the window at `position`, so the walks
+            // and the probe stream ahead through it. A backward move (the
+            // index anchor search stepping down its entries) anchors the
+            // window to END at `end` instead, so the entries below it land in
+            // the same window and the refills stay linear in the file rather
+            // than costing one window per entry.
+            let window_start = if position < self.window_start {
+                end.saturating_sub(SCAN_WINDOW_CAPACITY as u64)
+            } else {
+                position
+            };
+            let fill =
+                usize::try_from((self.file_len - window_start).min(SCAN_WINDOW_CAPACITY as u64))
+                    .unwrap_or(SCAN_WINDOW_CAPACITY);
             self.window.resize(fill, 0);
-            self.file.read_exact_at(&mut self.window[..], position)?;
-            self.window_start = position;
+            self.file
+                .read_exact_at(&mut self.window[..], window_start)?;
+            self.window_start = window_start;
             self.refilled = true;
         }
         // In-window by the branch above, and the window is capacity-bounded,
@@ -1885,6 +2217,16 @@ mod tests {
         fs::read(path).expect("read fixture file")
     }
 
+    /// Bytes of a segment file after recovery moved it into the first fence
+    /// directory, keyed by the name it had at its original path.
+    fn fenced_bytes(partition_path: &str, original_path: &str) -> Vec<u8> {
+        let fenced_dir = format!("{partition_path}.fenced.0");
+        let name = Path::new(original_path)
+            .file_name()
+            .expect("fixture file name");
+        fs::read(Path::new(&fenced_dir).join(name)).expect("read fenced fixture file")
+    }
+
     async fn recover(config: &ServerConfig) -> Result<Vec<RecoveredSegment>, ServerError> {
         load_persisted_segments(
             config,
@@ -1959,17 +2301,13 @@ mod tests {
         assert_eq!(segment.end_offset, 0);
         assert_eq!(len_of(&messages_path), 0, "the served log must be empty");
         assert_eq!(len_of(&index_path), 0, "the served index must be empty");
-        let fenced_dir = format!("{partition_path}.fenced.0");
-        let fenced = |original: &str| {
-            Path::new(&fenced_dir).join(Path::new(original).file_name().expect("fixture file name"))
-        };
         assert_eq!(
-            fs::read(fenced(&messages_path)).expect("read fenced log"),
+            fenced_bytes(&partition_path, &messages_path),
             GARBAGE,
             "the unreadable log bytes must survive in the fence directory"
         );
         assert_eq!(
-            fs::read(fenced(&index_path)).expect("read fenced index"),
+            fenced_bytes(&partition_path, &index_path),
             &GARBAGE[..10],
             "the unreadable index bytes must survive in the fence directory"
         );
@@ -2317,7 +2655,8 @@ mod tests {
     }
 
     #[compio::test]
-    async fn given_non_monotone_index_entries_when_recovering_should_refuse() {
+    async fn given_non_monotone_index_entries_when_recovering_should_rebuild_the_index_from_the_log()
+     {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
@@ -2329,63 +2668,64 @@ mod tests {
         log.extend_from_slice(&batch2);
         let last_position = (batch0.len() + batch1.len()) as u64;
         // Interior garbage entry: ascending against its predecessor, so only
-        // the offset regression to the (valid) last entry exposes it.
+        // the offset regression to the (valid) last entry exposes it. That
+        // last entry alone would anchor a clean walk and keep the garbage,
+        // so the interior check must run before the walk trusts the tail.
         let mut index = index_entry(0, 0);
         index.extend_from_slice(&index_entry(50, 100));
         index.extend_from_slice(&index_entry(2, last_position));
         let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
 
-        let error = recover(&config)
+        let recovered = recover(&config)
             .await
-            .err()
-            .expect("a non-monotone index must refuse recovery");
+            .expect("a self-contradicting index over a whole log must be rebuilt, not refused");
 
-        assert!(
-            matches!(
-                &error,
-                ServerError::PartitionRecoveryRefused {
-                    reason: PartitionRecoveryRefusal::IndexEntriesNotMonotone {
-                        entry_index: 2,
-                        ..
-                    },
-                    ..
-                }
-            ),
-            "expected a non-monotone index refusal, got {error:?}"
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 2);
+        assert_eq!(
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "the index must be rebuilt from the walked batches"
         );
-        assert_eq!(bytes_of(&messages_path), log);
-        assert_eq!(bytes_of(&index_path), index);
+        assert_eq!(
+            bytes_of(&messages_path),
+            log,
+            "rebuilding the index must not touch a whole log"
+        );
     }
 
     #[compio::test]
-    async fn given_index_entry_below_segment_start_when_recovering_should_refuse() {
+    async fn given_index_entry_below_segment_start_when_recovering_should_rebuild_the_index_from_the_log()
+     {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
-        let log = encoded_batch(5, 1);
-        let index = index_entry(3, 0);
+        let first = encoded_batch(5, 1);
+        let second = encoded_batch(6, 1);
+        let mut log = first.clone();
+        log.extend_from_slice(&second);
+        // The last entry is valid and would anchor a clean walk on its own;
+        // only the first-entry check catches the offset below the start.
+        let mut index = index_entry(3, 0);
+        index.extend_from_slice(&index_entry(6, first.len() as u64));
         let (messages_path, index_path) = write_segment(&config, 5, &log, &index);
 
-        let error = recover(&config)
-            .await
-            .err()
-            .expect("an index claiming offsets below the segment start must refuse recovery");
-
-        assert!(
-            matches!(
-                &error,
-                ServerError::PartitionRecoveryRefused {
-                    reason: PartitionRecoveryRefusal::IndexEntryBeforeSegmentStart {
-                        first_entry_offset: 3,
-                        ..
-                    },
-                    ..
-                }
-            ),
-            "expected a below-start index refusal, got {error:?}"
+        let recovered = recover(&config).await.expect(
+            "an index claiming offsets below the segment start must be rebuilt, not refused",
         );
-        assert_eq!(bytes_of(&messages_path), log);
-        assert_eq!(bytes_of(&index_path), index);
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 6);
+        assert_eq!(
+            bytes_of(&index_path),
+            index_entry(5, 0),
+            "the index must be rebuilt from the walked batches"
+        );
+        assert_eq!(
+            bytes_of(&messages_path),
+            log,
+            "rebuilding the index must not touch a whole log"
+        );
     }
 
     #[compio::test]
@@ -2850,10 +3190,10 @@ mod tests {
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
         // The failing gap batch is the FIRST thing past the last index
-        // entry, so the walk breaks with nothing walked. The probe must
-        // still run: a verifying batch past the damage is a survivor and
-        // refuses as interior damage, not as a divergence claiming the log
-        // holds nothing.
+        // entry, so the anchored walk breaks with nothing walked and the log
+        // rebuild takes over. Its probe must still find the verifying batch
+        // past the damage and refuse as interior damage, rather than
+        // truncating a survivor away with the index.
         let mut corrupt = encoded_batch(5, 1);
         corrupt[HEADER_BASE_OFFSET_OFFSET] ^= 0x04;
         let mut log = corrupt;
@@ -2881,36 +3221,444 @@ mod tests {
     }
 
     #[compio::test]
-    async fn given_failing_gap_batch_at_index_anchor_with_no_survivor_when_recovering_should_refuse_divergence()
+    async fn given_failing_gap_batch_at_index_anchor_with_no_survivor_when_recovering_should_fence_and_recover_empty()
      {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
-        prepare_partition_dir(&config);
-        // Same anchor shape with nothing verifying past it: the index claims
-        // a batch where none decodes and verifies, which is the divergence
-        // verdict -- non-destructive, bytes preserved.
+        let partition_path = prepare_partition_dir(&config);
+        // Same anchor shape with nothing verifying past it. The index backs
+        // nothing, so it is dropped and the log walked on its own; the log
+        // proves nothing either, which is the ordinary unreadable-pair
+        // verdict: bytes fenced aside, fresh empty files seeded.
         let mut log = encoded_batch(5, 1);
         log[HEADER_BASE_OFFSET_OFFSET] ^= 0x04;
         let index = index_entry(0, 0);
         let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
 
+        let recovered = recover(&config)
+            .await
+            .expect("an anchor batch that fails its checksum must not refuse the partition");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.size, IggyByteSize::default());
+        assert_eq!(len_of(&messages_path), 0, "the served log must be empty");
+        assert_eq!(len_of(&index_path), 0, "the served index must be empty");
+        assert_eq!(
+            fenced_bytes(&partition_path, &messages_path),
+            log,
+            "the undecodable log bytes must survive in the fence directory"
+        );
+        assert_eq!(
+            fenced_bytes(&partition_path, &index_path),
+            index,
+            "the unbacked index bytes must survive in the fence directory"
+        );
+    }
+
+    #[compio::test]
+    async fn given_index_entry_past_the_log_end_when_recovering_should_floor_index_to_last_provable_entry()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The index reached disk one entry ahead of the log it indexes -- no
+        // barrier orders the two files -- so the last entry points exactly at
+        // the log end. The log is whole; only the index overshot.
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let mut log = batch0.clone();
+        log.extend_from_slice(&batch1);
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, batch0.len() as u64));
+        index.extend_from_slice(&index_entry(2, log.len() as u64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("an index running ahead of a whole log must recover, not refuse");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 1);
+        assert_eq!(
+            len_of(&index_path),
+            2 * SPARSE_INDEX_ENTRY_SIZE as u64,
+            "the entry nothing in the log backs must be gone from disk"
+        );
+        assert_eq!(
+            bytes_of(&messages_path),
+            log,
+            "flooring the index must not touch a whole log"
+        );
+    }
+
+    #[compio::test]
+    async fn given_index_anchor_on_torn_batch_when_recovering_should_floor_index_and_truncate_log_tail()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The last entry points at a batch whose header made it to disk but
+        // whose body did not: a torn tail on both files at once.
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let batch2 = encoded_batch(2, 1);
+        let mut log = batch0.clone();
+        log.extend_from_slice(&batch1);
+        let torn_position = log.len() as u64;
+        log.extend_from_slice(&batch2[..COMMAND_HEADER_SIZE + 8]);
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, batch0.len() as u64));
+        index.extend_from_slice(&index_entry(2, torn_position));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("a torn batch under the last index entry must truncate, not refuse");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 1);
+        assert_eq!(
+            len_of(&messages_path),
+            torn_position,
+            "the torn batch must be gone from disk"
+        );
+        assert_eq!(
+            len_of(&index_path),
+            2 * SPARSE_INDEX_ENTRY_SIZE as u64,
+            "the entry pointing at the torn batch must be gone from disk"
+        );
+        drop(recovered);
+
+        // A floored pair must be a fixpoint: a boot loop that re-refused
+        // what it just repaired is the failure this replaces.
+        let reopened = recover(&config)
+            .await
+            .expect("re-recovering a floored segment must not refuse");
+
+        assert_eq!(reopened[0].segment.end_offset, 1);
+        assert_eq!(
+            (len_of(&messages_path), len_of(&index_path)),
+            (torn_position, 2 * SPARSE_INDEX_ENTRY_SIZE as u64),
+            "a second recovery must not move the files"
+        );
+    }
+
+    #[compio::test]
+    async fn given_index_anchor_past_the_log_end_with_survivor_past_damage_when_recovering_should_refuse_interior_damage()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // Stepping back must not weaken the survivor rule: the walk from the
+        // stepped-back anchor still ends at the garbage, and the batch
+        // verifying past it is durable data truncation would erase.
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let mut log = batch0.clone();
+        log.extend_from_slice(&batch1);
+        log.extend_from_slice(&GARBAGE);
+        log.extend_from_slice(&encoded_batch(6, 1));
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, batch0.len() as u64));
+        index.extend_from_slice(&index_entry(2, log.len() as u64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
         let error = recover(&config)
             .await
             .err()
-            .expect("an anchor batch that fails its checksum must refuse recovery");
+            .expect("a survivor past the damage must refuse recovery even after stepping back");
 
         assert!(
             matches!(
                 &error,
                 ServerError::PartitionRecoveryRefused {
-                    reason: PartitionRecoveryRefusal::IndexLogDivergence { .. },
+                    reason: PartitionRecoveryRefusal::InteriorDamage { .. },
                     ..
                 }
             ),
-            "expected an index-log divergence refusal, got {error:?}"
+            "expected an interior-damage refusal, got {error:?}"
         );
         assert_eq!(bytes_of(&messages_path), log);
         assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_no_provable_index_entry_when_recovering_should_rebuild_the_index_from_the_log() {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // Every entry points past the log end, so the step-back exhausts the
+        // index without finding anything the log backs. The log is whole and
+        // describes itself, so the index is dropped and rebuilt from it.
+        let log = encoded_batch(0, 2);
+        let mut index = index_entry(0, log.len() as u64);
+        index.extend_from_slice(&index_entry(2, log.len() as u64 + 64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("an index the log backs nowhere must be rebuilt, not refused");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 1);
+        assert_eq!(
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "the index must be rebuilt from the walked batches"
+        );
+        assert_eq!(
+            bytes_of(&messages_path),
+            log,
+            "rebuilding the index must not touch a whole log"
+        );
+    }
+
+    #[compio::test]
+    async fn given_an_index_entry_over_an_empty_log_when_recovering_should_fence_and_recover_empty()
+    {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        let partition_path = prepare_partition_dir(&config);
+        // The crash shape concurrent persists make ordinary: the first
+        // persist into a fresh segment fsyncs its one index entry and its log
+        // chunk at the same time, and the entry lands while the log does not.
+        // Nothing was acked for those bytes, so the segment is simply empty.
+        let index = index_entry(0, 0);
+        let (messages_path, index_path) = write_segment(&config, 0, &[], &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("an index entry over an empty log must not refuse the partition");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.size, IggyByteSize::default());
+        assert_eq!(len_of(&messages_path), 0);
+        assert_eq!(len_of(&index_path), 0, "the unbacked entry must be gone");
+        assert_eq!(
+            fenced_bytes(&partition_path, &index_path),
+            index,
+            "the unbacked index bytes must survive in the fence directory"
+        );
+        drop(recovered);
+
+        // Fixpoint: the seeded empty pair holds no bytes to fence, so a
+        // second boot must not open another fence directory.
+        recover(&config).await.expect("second recovery");
+
+        assert_eq!((len_of(&messages_path), len_of(&index_path)), (0, 0));
+        assert!(
+            !Path::new(&format!("{partition_path}.fenced.1")).exists(),
+            "a repaired empty segment must not be fenced again"
+        );
+    }
+
+    #[compio::test]
+    async fn given_an_index_entry_over_a_torn_batch_when_recovering_should_fence_and_recover_empty()
+    {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        let partition_path = prepare_partition_dir(&config);
+        // The same crash one flush later: the entry is durable and the log
+        // holds only the head of the batch it points at.
+        let batch = encoded_batch(0, 1);
+        let log = batch[..COMMAND_HEADER_SIZE + 8].to_vec();
+        let index = index_entry(0, 0);
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("an index entry over a torn batch must not refuse the partition");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.size, IggyByteSize::default());
+        assert_eq!(len_of(&messages_path), 0, "the torn head must be gone");
+        assert_eq!(len_of(&index_path), 0, "the unbacked entry must be gone");
+        assert_eq!(
+            fenced_bytes(&partition_path, &messages_path),
+            log,
+            "the torn bytes must survive in the fence directory"
+        );
+        assert_eq!(fenced_bytes(&partition_path, &index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_an_index_entry_contradicting_a_healthy_log_when_recovering_should_rebuild_the_index()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The entry claims offset 7 where the log holds offset 0. The log
+        // verifies and the entry is derived data, so the entry is what is
+        // wrong: rebuild the index rather than reading the mismatch as a
+        // break in the chain.
+        let batch0 = encoded_batch(0, 1);
+        let mut log = batch0.clone();
+        log.extend_from_slice(&encoded_batch(1, 1));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index_entry(7, 0));
+
+        let recovered = recover(&config)
+            .await
+            .expect("an index entry contradicting a healthy log must be rebuilt, not refused");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 1);
+        assert_eq!(
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "the rebuilt entry must describe the batch the log actually holds"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+    }
+
+    #[compio::test]
+    async fn given_two_unprovable_index_entries_when_recovering_should_floor_to_the_provable_prefix()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // Two unprovable entries for two different reasons: one lands
+        // mid-batch inside the log, the next past its end. The floor must
+        // reach the highest entry the log proves, not stop at the first
+        // step back.
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let mut log = batch0.clone();
+        log.extend_from_slice(&batch1);
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, batch0.len() as u64));
+        index.extend_from_slice(&index_entry(2, batch0.len() as u64 + 8));
+        index.extend_from_slice(&index_entry(3, log.len() as u64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("a multi-entry index overshoot must floor to what the log proves");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 1);
+        assert_eq!(
+            len_of(&index_path),
+            2 * SPARSE_INDEX_ENTRY_SIZE as u64,
+            "both unbacked entries must be gone, not just the last one"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+    }
+
+    #[compio::test]
+    async fn given_index_anchor_on_batch_with_torn_body_when_recovering_should_truncate_it_and_floor_index()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The last entry points at a batch whose header page reached disk
+        // whole but whose body did not: the header decodes, fits the file,
+        // and continues the chain from the entry, so only the checksum can
+        // tell it from a durable batch. The entry is no evidence for the
+        // bytes under it, because the log and the index persist
+        // concurrently.
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let mut torn = encoded_batch(2, 1);
+        torn[COMMAND_HEADER_SIZE..].fill(0);
+        let mut log = batch0.clone();
+        log.extend_from_slice(&batch1);
+        let torn_position = log.len() as u64;
+        log.extend_from_slice(&torn);
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, batch0.len() as u64));
+        index.extend_from_slice(&index_entry(2, torn_position));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("a torn body under an intact header must truncate, not refuse");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(
+            recovered[0].segment.end_offset, 1,
+            "the torn batch's offset must not be minted from its header"
+        );
+        assert_eq!(
+            len_of(&messages_path),
+            torn_position,
+            "the torn batch must be gone from disk"
+        );
+        assert_eq!(
+            len_of(&index_path),
+            2 * SPARSE_INDEX_ENTRY_SIZE as u64,
+            "the entry pointing at the torn batch must be gone from disk"
+        );
+        drop(recovered);
+
+        let reopened = recover(&config)
+            .await
+            .expect("re-recovering a floored segment must not refuse");
+
+        assert_eq!(reopened[0].segment.end_offset, 1);
+        assert_eq!(
+            (len_of(&messages_path), len_of(&index_path)),
+            (torn_position, 2 * SPARSE_INDEX_ENTRY_SIZE as u64),
+            "a second recovery must not move the files"
+        );
+    }
+
+    #[compio::test]
+    async fn given_index_entries_packed_closer_than_their_batches_when_stepping_back_should_refuse_on_verify_budget()
+     {
+        // A mis-strided index over a log of back-to-back headers, each
+        // claiming a batch 8 KiB wide: every entry lands on a header that
+        // decodes, matches the entry, and fits the file, so each step back
+        // costs a whole-batch verify that never passes. The claims overlap
+        // many times over, so an unbudgeted search would hash close to
+        // entries x claim bytes; it must give up and refuse instead, leaving
+        // the files byte-identical.
+        const CLAIMED_BATCH_BYTES: usize = 8 * 1024;
+        const ENTRIES: u64 = 64;
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        let mut log = Vec::new();
+        let mut index = Vec::new();
+        for offset in 0..ENTRIES {
+            let mut header = encoded_batch(offset, 1)[..COMMAND_HEADER_SIZE].to_vec();
+            header[HEADER_BATCH_LENGTH_OFFSET..HEADER_BATCH_LENGTH_OFFSET + 8]
+                .copy_from_slice(&(CLAIMED_BATCH_BYTES as u64).to_le_bytes());
+            index.extend_from_slice(&index_entry(offset, log.len() as u64));
+            log.extend_from_slice(&header);
+        }
+        // Padding so the last claim still fits inside the file.
+        log.resize(log.len() + CLAIMED_BATCH_BYTES, 0);
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover(&config)
+            .await
+            .err()
+            .expect("exhausting the verify budget while stepping back must refuse");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::UnverifiedResidue {
+                        verified_bytes,
+                        verify_budget_bytes,
+                        ..
+                    },
+                    ..
+                } if verified_bytes > verify_budget_bytes
+            ),
+            "expected a verify-budget refusal, got {error:?}"
+        );
+        assert_eq!(
+            bytes_of(&messages_path),
+            log,
+            "a refusal must leave the log byte-identical"
+        );
+        assert_eq!(
+            bytes_of(&index_path),
+            index,
+            "a refusal must leave the index byte-identical"
+        );
     }
 
     #[compio::test]

--- a/core/server/src/segment_recovery.rs
+++ b/core/server/src/segment_recovery.rs
@@ -64,13 +64,26 @@ const SCAN_WINDOW_CAPACITY: usize = 4 * 1024 * 1024;
 /// batch always gets one.
 const REBUILT_INDEX_STRIDE_BYTES: u64 = 64 * 1024;
 
-/// Sparse index entries the anchor search steps through between reactor
-/// yields, on top of the per-refill yield it shares with the walks. An entry
-/// whose position is past the log end is rejected on arithmetic alone, so it
-/// never refills the scan window, and an index floored back to a short log is
-/// mostly those: without this the search would hold the shard core -- signal
-/// handling included -- for one pread per entry over the whole file.
-const ANCHOR_SEARCH_YIELD_STRIDE: u64 = 1024;
+/// Sparse index entries either index scan steps through between reactor
+/// yields, on top of the per-refill yield the anchor search shares with the
+/// walks. Neither scan is bounded by disk reads: an entry whose position is
+/// past the log end is rejected on arithmetic alone (an index floored back to
+/// a short log is mostly those), and the consistency scan reads a whole window
+/// of entries per pread and then compares them in memory. Without this a
+/// megabyte-scale index would hold the shard core -- signal handling included
+/// -- for its whole length on every clean boot.
+const INDEX_SCAN_YIELD_STRIDE: u64 = 1024;
+
+/// Index entries the log may legitimately fail to back under `enforce_fsync`.
+/// Persistence writes exactly one entry per flush chunk, chunks never overlap,
+/// and it completes before the client reply. The two halves fdatasync
+/// concurrently WITHIN one flush, but flushes are serialized, and the log's
+/// fdatasync covers the whole file: an entry existing above entry N therefore
+/// proves the log was synced through chunk N. Only the chunk in flight when
+/// the process died can leave an entry the log never backed. See
+/// [`PartitionRecoveryRefusal::FsyncedLogLoss`] for why a deeper step-back is
+/// evidence about the log rather than about the index.
+const MAX_FSYNCED_INDEX_STEP_BACK_ENTRIES: u64 = 1;
 
 /// Units the damage probes of one partition load may spend per byte of
 /// residue they are asked to classify, at one unit per candidate offset
@@ -146,6 +159,11 @@ pub struct RecoveredSegment {
 /// residue the damage probe could not classify within its limits -- return
 /// [`ServerError::PartitionRecoveryRefused`] so the caller can fence this one
 /// partition instead of taking the node down.
+///
+/// `enforce_fsync` is the topic's own effective value, not a hint: it is what
+/// makes a durable index entry evidence about the log (see
+/// [`PartitionRecoveryRefusal::FsyncedLogLoss`]), so passing it wrong either
+/// refuses healthy chains or hides acknowledged data loss.
 #[allow(clippy::too_many_lines)]
 pub async fn load_persisted_segments(
     config: &ServerConfig,
@@ -153,6 +171,7 @@ pub async fn load_persisted_segments(
     topic_id: usize,
     partition_id: usize,
     segment_size: IggyByteSize,
+    enforce_fsync: bool,
     stats: &PartitionStats,
 ) -> Result<Vec<RecoveredSegment>, ServerError> {
     let partition_path = config
@@ -200,6 +219,7 @@ pub async fn load_persisted_segments(
             &messages_path,
             start_offset,
             raw_messages_size,
+            enforce_fsync,
             &mut scratch,
         )
         .await?;
@@ -289,14 +309,14 @@ pub async fn load_persisted_segments(
                 plan.segment.start_offset,
             )?;
         }
-        // Log first, index second: a walk only accepts bounds when a whole
-        // batch verifies at the last RETAINED index entry's position, so the
-        // walked log length strictly exceeds that position and every
-        // surviving index entry still points inside the shortened log even if
+        // Log first, index second: an index is kept only when a whole batch
+        // verifies at its LAST entry's position, so the walked log length
+        // strictly exceeds that position and every kept
+        // entry still points inside the shortened log even if
         // a crash lands between the two mutations -- and a crash that lands
         // there anyway leaves an index running ahead of its log, which the
-        // next boot floors instead of refusing. The staged-rebuild install is
-        // reached from a populated index too (one the log backs nowhere), so
+        // next boot discards and rebuilds instead of refusing. The
+        // staged-rebuild install is reached from a populated index too, so
         // a crash between the truncate and the rename leaves that unbacked
         // index over the shortened log; the next boot re-discards it and
         // rebuilds from the log again, and truncation is monotone, so the
@@ -346,10 +366,14 @@ pub async fn load_persisted_segments(
         stats.increment_segments_count(1);
         stats.increment_size_bytes(messages_size);
         if messages_size > 0 {
-            // Offsets in a segment are contiguous (either walk refuses a
-            // discontinuity), so the message count is the inclusive span
-            // between the first (segment start) and last offset. Saturating:
-            // an end offset at u64::MAX must not wrap the counter.
+            // The count is the offset span this segment now advertises, which
+            // is what a consumer can ask for. It is only as verified as the
+            // bounds are: a byte-0 walk proved every offset in the span
+            // contiguous, while the anchored walk proved the span from its
+            // anchor on and inherited the rest from the index -- the same
+            // trust the bounds themselves carry, so counting the whole span
+            // does not widen it. Saturating: an end offset at u64::MAX must
+            // not wrap the counter.
             stats.increment_messages_count(
                 plan.segment
                     .end_offset
@@ -1013,12 +1037,14 @@ async fn load_index_anchors(
 /// concurrently under every config, so there is no ordering barrier between
 /// the message write and the index write, and a tail torn mid-flush would
 /// otherwise pass while `end_offset` claims offsets whose bytes are
-/// incomplete. When the log cannot back that entry, the search steps
-/// down to the highest entry it can and the index is floored to it; when it
-/// backs no entry at all, or the entries contradict each other, the index
-/// is dropped whole. Without one -- dropped or never present -- the log
-/// itself is walked from byte 0 and the index is rebuilt from the batches
-/// found. Either way, bytes left past
+/// incomplete. An index whose last entry the log cannot back, or whose entries
+/// contradict each other, is dropped whole instead: no entry in it anchors a
+/// walk, so the log is walked from byte 0 and the index is rebuilt from the
+/// batches that walk proves. Under `enforce_fsync` the drop is preceded by a
+/// step-back measurement, and a gap deeper than one entry refuses as
+/// acknowledged log loss rather than rebuilding. The byte-0 walk costs a whole
+/// segment of checksums, but only for segments whose index the log already
+/// contradicts, never on a clean boot. Either way, bytes left past
 /// the walked prefix go through the damage probe: a torn tail truncates, but
 /// damage with intact batches after it -- or residue the probe cannot
 /// classify within its limits -- refuses recovery.
@@ -1029,6 +1055,7 @@ async fn recover_segment_bounds(
     messages_path: &str,
     start_offset: u64,
     messages_size: u64,
+    enforce_fsync: bool,
     scratch: &mut ScanScratch,
 ) -> Result<Option<WalkedBounds>, ServerError> {
     let (entry_count, first, last) = load_index_anchors(identity, index_path).await?;
@@ -1036,14 +1063,14 @@ async fn recover_segment_bounds(
     match (first, last) {
         (Some(first), Some(last)) => {
             // A mis-strided or foreign index decodes to garbage entries that
-            // binary searches would trust, and the walk's anchor bounds only
-            // the tail. Ascending positions keep every surviving entry inside
-            // the truncated log once the tail is floored, so an index that
-            // contradicts itself is dropped whole and rebuilt from the log,
-            // exactly like one the log backs nowhere: entries are derived
-            // from the log, so the index can never say more than the log.
+            // binary searches would trust, so an index that contradicts itself
+            // is dropped whole and rebuilt from the log. No `enforce_fsync`
+            // gate here, unlike the step-back below: the writer cannot emit a
+            // non-ascending run, so this file is foreign or mis-strided and is
+            // no witness to what the log once held.
             let consistent =
-                index_is_consistent(identity, index_path, start_offset, entry_count, scratch)?;
+                index_is_consistent(identity, index_path, start_offset, entry_count, scratch)
+                    .await?;
 
             let messages = open_messages_file(identity, messages_path)?;
             let mut scanner = FileScanner::new(&messages, messages_size, scratch);
@@ -1063,7 +1090,7 @@ async fn recover_segment_bounds(
             // flushed as one chunk indexes only its first offset). Walk the
             // batch chain from that position to the file end to recover the
             // true end offset.
-            let mut walk = walk_chain_from_anchor(
+            let walk = walk_chain_from_anchor(
                 identity,
                 &mut scanner,
                 messages_path,
@@ -1072,67 +1099,53 @@ async fn recover_segment_bounds(
                 last,
             )
             .await?;
-            let mut retained_entries = entry_count;
             if !walk.proved_any {
-                // An index entry is not independent evidence about the log:
-                // the writer derives every entry from a batch the log
-                // already held, so an entry the log cannot back is a torn
-                // tail of the INDEX, never proof that the log lost data.
-                // That shape is ordinary: the two files persist concurrently
-                // under every config, so they have no write ordering between
-                // them, and pass C truncates the log before the index, so a
-                // crash between those two mutations leaves exactly this.
-                // Refusing it handed a benign torn tail a permanent tombstone
-                // on a single-replica node. Step down
-                // to the highest entry the log still proves and floor the
-                // index there, so pass C drops the entries nothing backs.
-                let anchor = find_provable_index_anchor(
-                    identity,
-                    index_path,
-                    messages_path,
-                    &mut scanner,
-                    start_offset,
-                    entry_count,
-                    messages_size,
-                )
-                .await?;
-                let Some((provable_entries, anchor)) = anchor else {
-                    // Not one entry is backed by the log, so the index
-                    // describes a file this segment does not hold and every
-                    // entry in it is worthless. The log still describes
-                    // itself, so drop the index whole and walk the log from
-                    // byte 0, which rebuilds the index from what it proves.
-                    // The common shape is the first persist into a fresh
-                    // segment: its one entry and its log chunk fsync
-                    // concurrently, and a crash in between leaves the entry
-                    // durable over an empty or torn log. No ack was ever sent
-                    // for those bytes (persist completes before the reply),
-                    // so recovering from the log alone loses nothing a client
-                    // was promised -- where refusing tombstoned the partition
-                    // on a single-replica node. The walk runs its own residue
-                    // probe from the real break point, so a survivor past
-                    // damage still refuses there.
-                    warn!(
-                        stream_id = identity.stream_id,
-                        topic_id = identity.topic_id,
-                        partition_id = identity.partition_id,
-                        start_offset,
-                        messages_size,
-                        entry_count,
-                        last_entry_offset = last.offset,
-                        last_entry_position = last.position,
-                        "no sparse index entry is backed by the log; \
-                         discarding the index and rebuilding it from the log"
-                    );
-                    return recover_by_walking_log(
+                // Under `enforce_fsync` the DEPTH of the step-back that would
+                // find a usable anchor is evidence about the LOG. Flushes are
+                // serialized and each one fdatasyncs the whole log file before
+                // the next one writes, so an entry existing above entry N
+                // proves the log's fdatasync through chunk N completed. Only
+                // the chunk in flight at the crash can strand an entry; a
+                // deeper gap is the log missing bytes it already acknowledged.
+                // Refuse and keep every byte for the operator.
+                if enforce_fsync {
+                    let anchor = find_provable_index_anchor(
                         identity,
-                        &mut scanner,
+                        index_path,
                         messages_path,
+                        &mut scanner,
                         start_offset,
+                        entry_count,
                         messages_size,
                     )
-                    .await;
-                };
+                    .await?;
+                    let (provable_entries, provable_position) =
+                        anchor.map_or((0, 0), |(entries, entry)| (entries, entry.position));
+                    let step_back_entries = entry_count.saturating_sub(provable_entries);
+                    if step_back_entries > MAX_FSYNCED_INDEX_STEP_BACK_ENTRIES {
+                        return Err(identity.refusal(PartitionRecoveryRefusal::FsyncedLogLoss {
+                            start_offset,
+                            entry_count,
+                            provable_entries,
+                            provable_position,
+                        }));
+                    }
+                }
+                // The log cannot back its own last entry, so this index is no
+                // longer a description of this log and nothing in it is a
+                // trustworthy anchor. Anchoring on the highest entry that
+                // still proves would leave `[0, anchor.position)` unread, and
+                // the damage probe only scans FORWARD from where a walk
+                // stopped: a hole below the anchor would be invisible, while
+                // `end_offset` still advertised the offsets over it. That hole
+                // is exactly what the crash reaching this branch can leave --
+                // without `enforce_fsync` writeback order is arbitrary, so an
+                // unprovable tail entry is equally a torn INDEX tail and
+                // evidence the LOG lost an interior page. Walk from byte 0
+                // instead: it reads the damage, finds the anchor's own batch
+                // as a survivor past it, and refuses with the bytes preserved,
+                // and where the log is whole every rebuilt entry is one the
+                // walk proved rather than one it inherited.
                 warn!(
                     stream_id = identity.stream_id,
                     topic_id = identity.topic_id,
@@ -1140,29 +1153,20 @@ async fn recover_segment_bounds(
                     start_offset,
                     messages_size,
                     entry_count,
-                    provable_entries,
-                    anchor_position = anchor.position,
-                    "sparse index runs ahead of the log it indexes; flooring \
-                     it to the entries the log proves"
+                    last_entry_offset = last.offset,
+                    last_entry_position = last.position,
+                    "the log does not back its last sparse index entry; \
+                     discarding the index and rebuilding it from a byte-0 \
+                     walk of the log"
                 );
-                retained_entries = provable_entries;
-                walk = walk_chain_from_anchor(
+                return recover_by_walking_log(
                     identity,
                     &mut scanner,
                     messages_path,
                     start_offset,
                     messages_size,
-                    anchor,
                 )
-                .await?;
-                // The anchor passed the same checks this walk applies to its
-                // first batch, so it proves at least that one. Pass C relies
-                // on it: the retained entries stop at the anchor, and only a
-                // walk that got past it leaves them inside the truncated log.
-                debug_assert!(
-                    walk.proved_any,
-                    "a provable anchor must prove its own batch to the walk"
-                );
+                .await;
             }
             refuse_if_survivor_past_damage(
                 identity,
@@ -1179,7 +1183,7 @@ async fn recover_segment_bounds(
                 end_timestamp: walk.end_timestamp,
                 end_offset: walk.end_offset,
                 messages_size: walk.position,
-                index_size: retained_entries * SPARSE_INDEX_ENTRY_SIZE as u64,
+                index_size: entry_count * SPARSE_INDEX_ENTRY_SIZE as u64,
                 rebuilt_index: None,
             }))
         }
@@ -1350,9 +1354,9 @@ async fn recover_by_walking_log(
 /// file breaks the walk before any checksum is paid, and the verify covers
 /// one flushed chunk per segment in the ordinary boot (the last entry points
 /// at the last chunk's first batch). When not one whole batch verifies at
-/// the anchor the returned walk is `proved_any == false` and still carries
-/// the anchor's own position and offset, which is what the caller hands to
-/// the step-back and the damage probe.
+/// the anchor the returned walk is `proved_any == false`, which tells the
+/// caller the index does not describe this log; the bounds it carries are
+/// then the anchor's own and must not be used.
 async fn walk_chain_from_anchor(
     identity: PartitionIdentity<'_>,
     scanner: &mut FileScanner<'_>,
@@ -1411,8 +1415,8 @@ async fn walk_chain_from_anchor(
                 // the INDEX ENTRY's, so a verifying batch here contradicts
                 // the entry, not the chain. Calling that a discontinuity
                 // would refuse a healthy log over a stale entry, so break and
-                // leave the verdict to the step-back and the log rebuild,
-                // which read the chain from the filename onward.
+                // leave the verdict to the byte-0 rebuild, which reads the
+                // chain from the filename onward.
                 break;
             }
             // A verified batch that does not continue the chain is durable
@@ -1453,14 +1457,19 @@ async fn walk_chain_from_anchor(
 }
 
 /// Highest index entry below the last one that the log can still prove,
-/// returned as the number of entries to keep plus that entry itself. `None`
-/// when no entry proves out, which drops the index whole.
+/// returned as the number of entries at or below it plus the entry itself.
+/// `None` when no entry proves out.
+///
+/// Reached only under `enforce_fsync`, and only to measure how far the index
+/// has outrun the log: the index is dropped whole either way, so nothing is
+/// anchored on the entry this returns. What the DEPTH decides is whether the
+/// gap is the one chunk a crash can strand or acknowledged data the log lost
+/// (see [`MAX_FSYNCED_INDEX_STEP_BACK_ENTRIES`]).
 ///
 /// An entry proves when the log holds, at its position, the whole batch it
 /// describes: decoding, fitting inside the log, carrying this partition's
-/// stamp and the entry's own base offset, and passing its batch checksum,
-/// so the anchor the whole recovered end offset hangs on is verified before
-/// it is believed. Entries are read one at a time from the back rather than
+/// stamp and the entry's own base offset, and passing its batch checksum.
+/// Entries are read one at a time from the back rather than
 /// slurped: an index can run to megabytes, and the search stops at the first
 /// entry that proves. The dominant shape costs no log read at all -- an
 /// entry pointing past the log end is rejected on arithmetic alone -- so a
@@ -1475,9 +1484,9 @@ async fn walk_chain_from_anchor(
 /// packed closer together than the batches they claim exhaust it and refuse,
 /// rather than paying a verify per entry over an index that never proves.
 /// Yields once per window of disk reads, like the walks, and additionally
-/// every [`ANCHOR_SEARCH_YIELD_STRIDE`] entries: an entry that overshoots the
+/// every [`INDEX_SCAN_YIELD_STRIDE`] entries: an entry that overshoots the
 /// log reads nothing from it, so there is no refill to key the yield on, and
-/// a floored index is full of exactly those.
+/// an index that outran a truncated log is full of exactly those.
 async fn find_provable_index_anchor(
     identity: PartitionIdentity<'_>,
     index_path: &str,
@@ -1554,7 +1563,7 @@ async fn find_provable_index_anchor(
                 }
             }
         }
-        if scanner.take_refilled() || entry_index.is_multiple_of(ANCHOR_SEARCH_YIELD_STRIDE) {
+        if scanner.take_refilled() || entry_index.is_multiple_of(INDEX_SCAN_YIELD_STRIDE) {
             yield_to_reactor().await;
         }
         let Some(next) = entry_index.checked_sub(1) else {
@@ -1576,7 +1585,11 @@ async fn find_provable_index_anchor(
 /// restart can legitimately regress persisted `base_timestamp` today, and the
 /// lower-bound searches degrade gracefully on a non-monotone run, so refusing
 /// would trade availability for nothing.
-fn index_is_consistent(
+///
+/// Runs on EVERY clean boot over the whole index, and a window holds tens of
+/// thousands of entries, so the per-read yield the walks rely on is far too
+/// coarse here: yields every [`INDEX_SCAN_YIELD_STRIDE`] entries instead.
+async fn index_is_consistent(
     identity: PartitionIdentity<'_>,
     index_path: &str,
     start_offset: u64,
@@ -1648,6 +1661,9 @@ fn index_is_consistent(
             }
             previous = Some((entry_offset, entry_position));
             entry_index += 1;
+            if entry_index.is_multiple_of(INDEX_SCAN_YIELD_STRIDE) {
+                yield_to_reactor().await;
+            }
         }
         byte_position += chunk_bytes as u64;
     }
@@ -1730,6 +1746,11 @@ fn scan_read_failure(
 /// decodes, checksums, and plausibly extends the chain is durable data -- it
 /// can only exist because an append completed after the damaged region -- so
 /// discarding it would hide real loss behind a silent boot-time repair.
+///
+/// Scans FORWARD from `damage_position` only, and a walk that consumed the
+/// whole file leaves it nothing to do. Damage BELOW where the caller's walk
+/// began is invisible to it, which is why no caller may start a walk part way
+/// into a log it has reason to distrust.
 ///
 /// The residue is deliberately NOT width-gated: a torn flush chunk is
 /// bounded by the CHUNK, not by one record, and with `enforce_fsync = false`
@@ -2254,12 +2275,20 @@ mod tests {
     }
 
     async fn recover(config: &ServerConfig) -> Result<Vec<RecoveredSegment>, ServerError> {
+        recover_under_fsync(config, false).await
+    }
+
+    async fn recover_under_fsync(
+        config: &ServerConfig,
+        enforce_fsync: bool,
+    ) -> Result<Vec<RecoveredSegment>, ServerError> {
         load_persisted_segments(
             config,
             STREAM_ID,
             TOPIC_ID,
             PARTITION_ID,
             IggyByteSize::from(SEGMENT_MAX_SIZE),
+            enforce_fsync,
             &PartitionStats::default(),
         )
         .await
@@ -3282,7 +3311,7 @@ mod tests {
     }
 
     #[compio::test]
-    async fn given_index_entry_past_the_log_end_when_recovering_should_floor_index_to_last_provable_entry()
+    async fn given_index_entry_past_the_log_end_when_recovering_should_rebuild_the_index_from_the_log()
      {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
@@ -3306,19 +3335,19 @@ mod tests {
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered[0].segment.end_offset, 1);
         assert_eq!(
-            len_of(&index_path),
-            2 * SPARSE_INDEX_ENTRY_SIZE as u64,
-            "the entry nothing in the log backs must be gone from disk"
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "an index the log contradicts must be rebuilt from the walked batches"
         );
         assert_eq!(
             bytes_of(&messages_path),
             log,
-            "flooring the index must not touch a whole log"
+            "rebuilding the index must not touch a whole log"
         );
     }
 
     #[compio::test]
-    async fn given_index_anchor_on_torn_batch_when_recovering_should_floor_index_and_truncate_log_tail()
+    async fn given_index_anchor_on_torn_batch_when_recovering_should_rebuild_index_and_truncate_log_tail()
      {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
@@ -3349,22 +3378,22 @@ mod tests {
             "the torn batch must be gone from disk"
         );
         assert_eq!(
-            len_of(&index_path),
-            2 * SPARSE_INDEX_ENTRY_SIZE as u64,
-            "the entry pointing at the torn batch must be gone from disk"
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "the index must describe the batches the walk proved, not the torn one"
         );
         drop(recovered);
 
-        // A floored pair must be a fixpoint: a boot loop that re-refused
+        // A repaired pair must be a fixpoint: a boot loop that re-refused
         // what it just repaired is the failure this replaces.
         let reopened = recover(&config)
             .await
-            .expect("re-recovering a floored segment must not refuse");
+            .expect("re-recovering a repaired segment must not refuse");
 
         assert_eq!(reopened[0].segment.end_offset, 1);
         assert_eq!(
             (len_of(&messages_path), len_of(&index_path)),
-            (torn_position, 2 * SPARSE_INDEX_ENTRY_SIZE as u64),
+            (torn_position, SPARSE_INDEX_ENTRY_SIZE as u64),
             "a second recovery must not move the files"
         );
     }
@@ -3375,9 +3404,9 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
-        // Stepping back must not weaken the survivor rule: the walk from the
-        // stepped-back anchor still ends at the garbage, and the batch
-        // verifying past it is durable data truncation would erase.
+        // Dropping the index must not weaken the survivor rule: the byte-0
+        // walk still ends at the garbage, and the batch verifying past it is
+        // durable data truncation would erase.
         let batch0 = encoded_batch(0, 1);
         let batch1 = encoded_batch(1, 1);
         let mut log = batch0.clone();
@@ -3408,14 +3437,147 @@ mod tests {
         assert_eq!(bytes_of(&index_path), index);
     }
 
+    /// The `.log` and `.index` fixtures for a segment whose SECOND chunk lost
+    /// its body while its header page survived, and whose last index entry
+    /// points past the log end. Anchoring on the highest entry the log still
+    /// proves lands on the third chunk, ABOVE the damage, and the damage probe
+    /// only ever looks forward from where a walk stopped -- so an anchored
+    /// walk runs clean to EOF and mints an `end_offset` covering an offset
+    /// whose bytes are gone. Returned with the damaged and surviving positions
+    /// so the tests can name them.
+    fn segment_damaged_below_its_last_provable_entry() -> (Vec<u8>, Vec<u8>, u64, u64) {
+        let mut torn = encoded_batch(1, 1);
+        torn[COMMAND_HEADER_SIZE..].fill(0);
+        let batch2 = encoded_batch(2, 1);
+        let mut log = encoded_batch(0, 1);
+        let damage_position = log.len() as u64;
+        log.extend_from_slice(&torn);
+        let survivor_position = log.len() as u64;
+        log.extend_from_slice(&batch2);
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, damage_position));
+        index.extend_from_slice(&index_entry(2, survivor_position));
+        index.extend_from_slice(&index_entry(3, log.len() as u64));
+        (log, index, damage_position, survivor_position)
+    }
+
+    #[compio::test]
+    async fn given_damage_below_the_highest_provable_index_entry_when_recovering_should_refuse() {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        let (log, index, damage_position, survivor_position) =
+            segment_damaged_below_its_last_provable_entry();
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover(&config)
+            .await
+            .err()
+            .expect("damage below the highest provable entry must refuse, not be walked past");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::InteriorDamage {
+                        damage_position: at,
+                        survivor_position: past,
+                        ..
+                    },
+                    ..
+                } if *at == damage_position && *past == survivor_position
+            ),
+            "expected an interior-damage refusal naming the damaged chunk, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_damage_below_the_highest_provable_index_entry_under_fsync_when_recovering_should_refuse()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The gap between the index and the log is exactly one entry here, so
+        // the `enforce_fsync` guard reads this as the benign in-flight chunk
+        // and lets it through. That verdict is about the INDEX; the log is
+        // still walked from byte 0, which is what catches the damage.
+        let (log, index, damage_position, _) = segment_damaged_below_its_last_provable_entry();
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover_under_fsync(&config, true)
+            .await
+            .err()
+            .expect("a passing step-back depth must not stand in for reading the log");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::InteriorDamage {
+                        damage_position: at,
+                        ..
+                    },
+                    ..
+                } if *at == damage_position
+            ),
+            "expected an interior-damage refusal, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_an_offset_gap_below_the_highest_provable_index_entry_when_recovering_should_refuse()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // Nothing here is damaged: both batches verify. What is missing is
+        // offsets 1..4, and only a walk that starts at byte 0 can notice.
+        // An anchor on the entry for offset 5 takes that entry's own offset
+        // as the chain expectation, so the gap below it reads as continuous.
+        let mut log = encoded_batch(0, 1);
+        let gap_position = log.len() as u64;
+        log.extend_from_slice(&encoded_batch(5, 1));
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(5, gap_position));
+        index.extend_from_slice(&index_entry(6, log.len() as u64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover(&config)
+            .await
+            .err()
+            .expect("an offset gap below the highest provable entry must refuse");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::OffsetDiscontinuity {
+                        expected_offset: 1,
+                        found_offset: 5,
+                        position,
+                        ..
+                    },
+                    ..
+                } if *position == gap_position
+            ),
+            "expected an offset-discontinuity refusal at the gap, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
     #[compio::test]
     async fn given_no_provable_index_entry_when_recovering_should_rebuild_the_index_from_the_log() {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
-        // Every entry points past the log end, so the step-back exhausts the
-        // index without finding anything the log backs. The log is whole and
-        // describes itself, so the index is dropped and rebuilt from it.
+        // Every entry points past the log end, so nothing in the index backs
+        // the walk. The log is whole and describes itself, so the index is
+        // dropped and rebuilt from it.
         let log = encoded_batch(0, 2);
         let mut index = index_entry(0, log.len() as u64);
         index.extend_from_slice(&index_entry(2, log.len() as u64 + 64));
@@ -3537,15 +3699,15 @@ mod tests {
     }
 
     #[compio::test]
-    async fn given_two_unprovable_index_entries_when_recovering_should_floor_to_the_provable_prefix()
+    async fn given_two_unprovable_index_entries_when_recovering_should_rebuild_the_index_from_the_log()
      {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
         // Two unprovable entries for two different reasons: one lands
-        // mid-batch inside the log, the next past its end. The floor must
-        // reach the highest entry the log proves, not stop at the first
-        // step back.
+        // mid-batch inside the log, the next past its end. Neither the depth
+        // of the gap nor the reason for it changes the verdict without
+        // `enforce_fsync`: the whole index goes and the log speaks for itself.
         let batch0 = encoded_batch(0, 1);
         let batch1 = encoded_batch(1, 1);
         let mut log = batch0.clone();
@@ -3558,20 +3720,149 @@ mod tests {
 
         let recovered = recover(&config)
             .await
-            .expect("a multi-entry index overshoot must floor to what the log proves");
+            .expect("a multi-entry index overshoot must rebuild from what the log proves");
 
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered[0].segment.end_offset, 1);
         assert_eq!(
-            len_of(&index_path),
-            2 * SPARSE_INDEX_ENTRY_SIZE as u64,
-            "both unbacked entries must be gone, not just the last one"
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "every entry must come from the walk, not just the unbacked ones be dropped"
         );
         assert_eq!(bytes_of(&messages_path), log);
     }
 
     #[compio::test]
-    async fn given_index_anchor_on_batch_with_torn_body_when_recovering_should_truncate_it_and_floor_index()
+    async fn given_two_unprovable_index_entries_under_fsync_when_recovering_should_refuse() {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The same fixture the lenient rebuild above accepts. Under
+        // `enforce_fsync` the second-from-last entry was durable before its
+        // chunk was acked, so a log that cannot back it lost acked bytes.
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let mut log = batch0.clone();
+        log.extend_from_slice(&batch1);
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, batch0.len() as u64));
+        index.extend_from_slice(&index_entry(2, batch0.len() as u64 + 8));
+        index.extend_from_slice(&index_entry(3, log.len() as u64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover_under_fsync(&config, true)
+            .await
+            .err()
+            .expect("a multi-entry overshoot under enforce_fsync must refuse");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::FsyncedLogLoss {
+                        entry_count: 4,
+                        provable_entries: 2,
+                        ..
+                    },
+                    ..
+                }
+            ),
+            "expected an fsynced-log-loss refusal naming the step-back, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_one_unprovable_index_entry_under_fsync_when_recovering_should_rebuild_the_index()
+    {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The crash window `enforce_fsync` cannot close: the entry for the
+        // chunk still in flight reached disk, its log bytes did not, and no
+        // ack was ever sent for them. Exactly one entry deep, so it recovers.
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let mut log = batch0.clone();
+        log.extend_from_slice(&batch1);
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, batch0.len() as u64));
+        index.extend_from_slice(&index_entry(2, log.len() as u64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover_under_fsync(&config, true)
+            .await
+            .expect("a one-entry overshoot is the crash window, not data loss");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 1);
+        assert_eq!(
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "the index must be rebuilt from the walk, not floored to the entry below"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+    }
+
+    #[compio::test]
+    async fn given_an_index_the_log_backs_nowhere_under_fsync_when_recovering_should_refuse() {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The gap is measured the same way when no entry proves at all: two
+        // entries the log backs nowhere is one more than the in-flight chunk
+        // can explain, so the rebuild never runs.
+        let log = encoded_batch(0, 2);
+        let mut index = index_entry(0, log.len() as u64);
+        index.extend_from_slice(&index_entry(2, log.len() as u64 + 64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover_under_fsync(&config, true)
+            .await
+            .err()
+            .expect("an index backed nowhere under enforce_fsync must refuse, not rebuild");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::FsyncedLogLoss {
+                        entry_count: 2,
+                        provable_entries: 0,
+                        ..
+                    },
+                    ..
+                }
+            ),
+            "expected an fsynced-log-loss refusal over the dropped index, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_a_lone_entry_over_an_empty_log_under_fsync_when_recovering_should_not_refuse() {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The first persist into a fresh segment, crashed between the two
+        // fsyncs: one entry, no log bytes, no ack ever sent. `enforce_fsync`
+        // must not turn the shape the PR exists for into a tombstone.
+        let index = index_entry(0, 0);
+        let (messages_path, index_path) = write_segment(&config, 0, &[], &index);
+
+        let recovered = recover_under_fsync(&config, true)
+            .await
+            .expect("one entry over an empty log is the crash window, not data loss");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.size, IggyByteSize::default());
+        assert_eq!((len_of(&messages_path), len_of(&index_path)), (0, 0));
+    }
+
+    #[compio::test]
+    async fn given_index_anchor_on_batch_with_torn_body_when_recovering_should_truncate_it_and_rebuild_index()
      {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
@@ -3610,26 +3901,26 @@ mod tests {
             "the torn batch must be gone from disk"
         );
         assert_eq!(
-            len_of(&index_path),
-            2 * SPARSE_INDEX_ENTRY_SIZE as u64,
+            bytes_of(&index_path),
+            index_entry(0, 0),
             "the entry pointing at the torn batch must be gone from disk"
         );
         drop(recovered);
 
         let reopened = recover(&config)
             .await
-            .expect("re-recovering a floored segment must not refuse");
+            .expect("re-recovering a repaired segment must not refuse");
 
         assert_eq!(reopened[0].segment.end_offset, 1);
         assert_eq!(
             (len_of(&messages_path), len_of(&index_path)),
-            (torn_position, 2 * SPARSE_INDEX_ENTRY_SIZE as u64),
+            (torn_position, SPARSE_INDEX_ENTRY_SIZE as u64),
             "a second recovery must not move the files"
         );
     }
 
     #[compio::test]
-    async fn given_index_entries_packed_closer_than_their_batches_when_stepping_back_should_refuse_on_verify_budget()
+    async fn given_index_entries_packed_closer_than_their_batches_under_fsync_when_measuring_the_gap_should_refuse_on_verify_budget()
      {
         // A mis-strided index over a log of back-to-back headers, each
         // claiming a batch 8 KiB wide: every entry lands on a header that
@@ -3637,7 +3928,9 @@ mod tests {
         // costs a whole-batch verify that never passes. The claims overlap
         // many times over, so an unbudgeted search would hash close to
         // entries x claim bytes; it must give up and refuse instead, leaving
-        // the files byte-identical.
+        // the files byte-identical. Only `enforce_fsync` walks the index
+        // backward at all -- without it the gap is not measured, so there is
+        // nothing here to bound.
         const CLAIMED_BATCH_BYTES: usize = 8 * 1024;
         const ENTRIES: u64 = 64;
         let tmp = tempdir().expect("tempdir");
@@ -3656,10 +3949,10 @@ mod tests {
         log.resize(log.len() + CLAIMED_BATCH_BYTES, 0);
         let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
 
-        let error = recover(&config)
+        let error = recover_under_fsync(&config, true)
             .await
             .err()
-            .expect("exhausting the verify budget while stepping back must refuse");
+            .expect("exhausting the verify budget while measuring the gap must refuse");
 
         assert!(
             matches!(

--- a/core/server/src/segment_recovery.rs
+++ b/core/server/src/segment_recovery.rs
@@ -172,7 +172,7 @@ pub struct RecoveredSegment {
 /// `enforce_fsync` is the topic's own effective value, not a hint: it is what
 /// makes a durable index entry evidence about the log (see
 /// [`PartitionRecoveryRefusal::FsyncedLogLoss`]), so passing it wrong either
-/// refuses healthy chains or hides acknowledged data loss.
+/// refuses healthy chains or hides previously durable data loss.
 #[allow(clippy::too_many_lines)]
 pub async fn load_persisted_segments(
     config: &ServerConfig,
@@ -376,13 +376,12 @@ pub async fn load_persisted_segments(
         stats.increment_size_bytes(messages_size);
         if messages_size > 0 {
             // The count is the offset span this segment now advertises, which
-            // is what a consumer can ask for. It is only as verified as the
-            // bounds are: a byte-0 walk proved every offset in the span
-            // contiguous, while the anchored walk proved the span from its
-            // anchor on and inherited the rest from the index -- the same
-            // trust the bounds themselves carry, so counting the whole span
-            // does not widen it. Saturating: an end offset at u64::MAX must
-            // not wrap the counter.
+            // is what a consumer can ask for. A byte-0 walk proves every
+            // offset in a non-fsynced or rebuilt span. An fsynced anchored
+            // walk proves the final chunk and inherits the earlier prefix from
+            // completed serialized log fdatasyncs. Counting the whole span
+            // therefore does not widen the recovery claim. Saturating: an end
+            // offset at u64::MAX must not wrap the counter.
             stats.increment_messages_count(
                 plan.segment
                     .end_offset
@@ -507,9 +506,8 @@ struct WalkedBounds {
 
 /// What the batch chain walked from one index entry proves.
 struct AnchoredWalk {
-    /// False when not one whole batch decoded at the anchor itself, leaving
-    /// the fields below at the anchor's own values.
-    proved_any: bool,
+    /// Timestamp of the first non-empty batch proved by this walk.
+    start_timestamp: Option<u64>,
     end_offset: u64,
     end_timestamp: u64,
     /// First byte past the last whole batch the walk proved.
@@ -1040,23 +1038,23 @@ async fn load_index_anchors(
 /// Derives a segment's readable bounds. `None` when the log holds no whole
 /// batch at all (the caller recovers the segment as empty).
 ///
-/// With a whole index entry present, the last entry's `position` is only the
-/// last flushed chunk's START byte, so the batch chain is walked from there to
-/// prove where the segment really ends -- the log and the index persist
-/// concurrently under every config, so there is no ordering barrier between
-/// the message write and the index write, and a tail torn mid-flush would
-/// otherwise pass while `end_offset` claims offsets whose bytes are
-/// incomplete. An index whose last entry the log cannot back, or whose entries
-/// contradict each other, is dropped whole instead: no entry in it anchors a
-/// walk, so the log is walked from byte 0 and the index is rebuilt from the
-/// batches that walk proves. Under `enforce_fsync` the drop is preceded by a
-/// step-back measurement, and a gap deeper than one entry refuses as
-/// acknowledged log loss rather than rebuilding. The byte-0 walk costs a whole
-/// segment of checksums, but only for segments whose index the log already
-/// contradicts, never on a clean boot. Either way, bytes left past
-/// the walked prefix go through the damage probe: a torn tail truncates, but
-/// damage with intact batches after it -- or residue the probe cannot
-/// classify within its limits -- refuses recovery.
+/// Without `enforce_fsync`, a consistent index locates batches but cannot prove
+/// any log page reached disk: page-cache writeback may preserve a later chunk
+/// while losing an earlier one. Recovery therefore checksum-walks the log from
+/// byte 0. A clean walk preserves the existing index, while a break falls
+/// through to the rebuilding walk so every retained entry describes verified
+/// bytes.
+///
+/// With `enforce_fsync`, completed serialized flushes prove the prefix before
+/// the final index entry, so the last entry's `position` anchors the walk that
+/// proves where the segment really ends. An index whose last entry the log
+/// cannot back, or whose entries contradict each other, is dropped whole: the
+/// log is walked from byte 0 and the index is rebuilt from the batches that
+/// walk proves. The unbacked-last path first measures the step-back, and a gap
+/// deeper than one entry refuses as previously durable log loss rather than
+/// rebuilding. Bytes left past either walked prefix go through the damage
+/// probe: a torn tail truncates, while damage with intact batches after it, or
+/// residue the probe cannot classify within its limits, refuses recovery.
 #[allow(clippy::too_many_lines)]
 async fn recover_segment_bounds(
     identity: PartitionIdentity<'_>,
@@ -1077,13 +1075,20 @@ async fn recover_segment_bounds(
             // gate here, unlike the step-back below: the writer cannot emit a
             // non-ascending run, so this file is foreign or mis-strided and is
             // no witness to what the log once held.
-            let consistent =
-                index_is_consistent(identity, index_path, start_offset, entry_count, scratch)
-                    .await?;
+            let validation = index_is_consistent(
+                identity,
+                index_path,
+                messages_path,
+                start_offset,
+                entry_count,
+                messages_size,
+                scratch,
+            )
+            .await?;
 
             let messages = open_messages_file(identity, messages_path)?;
             let mut scanner = FileScanner::new(&messages, messages_size, scratch);
-            if !consistent {
+            if !validation.structurally_consistent {
                 return recover_by_walking_log(
                     identity,
                     &mut scanner,
@@ -1093,6 +1098,7 @@ async fn recover_segment_bounds(
                 )
                 .await;
             }
+
             // The sparse index holds ONE entry per flushed chunk, pointing
             // at the chunk's FIRST batch -- `last.offset` is where the last
             // chunk STARTS, not where the segment ends (a whole journal
@@ -1108,14 +1114,17 @@ async fn recover_segment_bounds(
                 last,
             )
             .await?;
-            if !walk.proved_any {
+            if walk.start_timestamp.is_none() {
                 // Under `enforce_fsync` the DEPTH of the step-back that would
-                // find a usable anchor is evidence about the LOG. Flushes are
-                // serialized and each one fdatasyncs the whole log file before
-                // the next one writes, so an entry existing above entry N
-                // proves the log's fdatasync through chunk N completed. Only
-                // the chunk in flight at the crash can strand an entry; a
-                // deeper gap is the log missing bytes it already acknowledged.
+                // find a usable non-empty anchor is evidence about the LOG.
+                // Flushes are serialized and each one fdatasyncs the whole log
+                // file before the next one writes, so an entry existing above
+                // entry N proves the log's fdatasync through chunk N completed.
+                // Only the chunk in flight at the crash can strand an entry; a
+                // deeper gap is the log missing bytes a completed flush had
+                // already made durable. A checksum-valid empty anchor reaches
+                // this path too: it carries no message range recovery may
+                // advertise and the production writer never emits one.
                 // Refuse and keep every byte for the operator.
                 if enforce_fsync {
                     let search = find_provable_index_anchor(
@@ -1163,10 +1172,83 @@ async fn recover_segment_bounds(
                     entry_count,
                     last_entry_offset = last.offset,
                     last_entry_position = last.position,
-                    "the log does not back its last sparse index entry; \
+                    "the log does not back its last sparse index entry with a non-empty batch; \
                      discarding the index and rebuilding it from a byte-0 \
                      walk of the log"
                 );
+                let rebuilt = recover_by_walking_log(
+                    identity,
+                    &mut scanner,
+                    messages_path,
+                    start_offset,
+                    messages_size,
+                )
+                .await?;
+                if enforce_fsync {
+                    ensure_fsynced_rebuild_reaches(
+                        identity,
+                        rebuilt.as_ref(),
+                        start_offset,
+                        entry_count,
+                        last.position,
+                    )?;
+                }
+                return Ok(rebuilt);
+            }
+
+            if !validation.mappings_match {
+                let rebuilt = recover_by_walking_log(
+                    identity,
+                    &mut scanner,
+                    messages_path,
+                    start_offset,
+                    messages_size,
+                )
+                .await?;
+                if enforce_fsync {
+                    ensure_fsynced_rebuild_reaches(
+                        identity,
+                        rebuilt.as_ref(),
+                        start_offset,
+                        entry_count,
+                        last.position,
+                    )?;
+                }
+                return Ok(rebuilt);
+            }
+
+            if !enforce_fsync {
+                // The last entry proved that the index still describes this
+                // log. It does not prove earlier log pages reached disk. The
+                // first entry is exactly `(start_offset, position 0)` by the
+                // consistency check above, so use it only to seed the expected
+                // offset and checksum every batch, including unindexed spans.
+                let full_walk = walk_chain_from_anchor(
+                    identity,
+                    &mut scanner,
+                    messages_path,
+                    start_offset,
+                    messages_size,
+                    first,
+                )
+                .await?;
+                if full_walk.position == messages_size
+                    && let Some(start_timestamp) = full_walk.start_timestamp
+                {
+                    return Ok(Some(WalkedBounds {
+                        start_timestamp,
+                        end_timestamp: full_walk.end_timestamp,
+                        end_offset: full_walk.end_offset,
+                        messages_size: full_walk.position,
+                        index_size: entry_count * SPARSE_INDEX_ENTRY_SIZE as u64,
+                        rebuilt_index: None,
+                    }));
+                }
+
+                // The full walk found damage or no non-empty batch. Re-run
+                // through the rebuilding path: it probes any residue before a
+                // destructive verdict and emits an index containing only the
+                // batches the log itself proves.
                 return recover_by_walking_log(
                     identity,
                     &mut scanner,
@@ -1176,6 +1258,7 @@ async fn recover_segment_bounds(
                 )
                 .await;
             }
+
             refuse_if_survivor_past_damage(
                 identity,
                 &mut scanner,
@@ -1222,6 +1305,30 @@ async fn recover_segment_bounds(
         }
         _ => Ok(None),
     }
+}
+
+/// Refuse an fsynced rebuild that stops before the durable prefix implied by
+/// the index entry whose flush could begin only after the preceding log
+/// fdatasync completed.
+fn ensure_fsynced_rebuild_reaches(
+    identity: PartitionIdentity<'_>,
+    rebuilt: Option<&WalkedBounds>,
+    start_offset: u64,
+    entry_count: u64,
+    durable_position: u64,
+) -> Result<(), ServerError> {
+    let walked_position = rebuilt.map_or(0, |bounds| bounds.messages_size);
+    if walked_position < durable_position {
+        return Err(
+            identity.refusal(PartitionRecoveryRefusal::FsyncedRebuildShortfall {
+                start_offset,
+                entry_count,
+                walked_position,
+                durable_position,
+            }),
+        );
+    }
+    Ok(())
 }
 
 /// Recovers a segment's bounds from the log alone, walking the batch chain
@@ -1361,10 +1468,10 @@ async fn recover_by_walking_log(
 /// The header decode still runs first, so a header that does not fit the
 /// file breaks the walk before any checksum is paid, and the verify covers
 /// one flushed chunk per segment in the ordinary boot (the last entry points
-/// at the last chunk's first batch). When not one whole batch verifies at
-/// the anchor the returned walk is `proved_any == false`, which tells the
-/// caller the index does not describe this log; the bounds it carries are
-/// then the anchor's own and must not be used.
+/// at the last chunk's first batch). When no non-empty batch verifies at the
+/// anchor, `start_timestamp` remains `None`, which tells the caller the index
+/// does not describe a recoverable message range; the other bounds are then
+/// the anchor's own and must not be used.
 async fn walk_chain_from_anchor(
     identity: PartitionIdentity<'_>,
     scanner: &mut FileScanner<'_>,
@@ -1374,13 +1481,13 @@ async fn walk_chain_from_anchor(
     anchor: IggyIndex,
 ) -> Result<AnchoredWalk, ServerError> {
     let mut position = anchor.position;
+    let mut start_timestamp = None;
     let mut end_offset = anchor.offset;
     let mut end_timestamp = anchor.timestamp;
     let mut expected_offset = anchor.offset;
     // The anchor's offset comes from the INDEX; only a batch this walk has
     // already proved makes the expectation the LOG's own.
     let mut expectation_from_log = false;
-    let mut proved_any = false;
     while position < messages_size {
         let Some(header) = header_at(identity, scanner, messages_path, position)? else {
             break;
@@ -1443,21 +1550,26 @@ async fn walk_chain_from_anchor(
             );
         }
         if header.message_count > 0 {
+            start_timestamp.get_or_insert(header.base_timestamp);
             end_offset = header
                 .base_offset
                 .saturating_add(u64::from(header.message_count) - 1);
             end_timestamp = header.base_timestamp;
             expected_offset = end_offset.saturating_add(1);
-            expectation_from_log = true;
         }
-        proved_any = true;
+        // Any verified batch that matched the expectation makes it the LOG's
+        // own, an empty batch included: its header carried the offset. Gating
+        // this on message_count would let a verified empty anchor batch turn
+        // a real discontinuity after it into the benign anchor-mismatch break
+        // above, which truncates instead of refusing.
+        expectation_from_log = true;
         position = extent;
         if scanner.take_refilled() {
             yield_to_reactor().await;
         }
     }
     Ok(AnchoredWalk {
-        proved_any,
+        start_timestamp,
         end_offset,
         end_timestamp,
         position,
@@ -1476,6 +1588,96 @@ struct IndexAnchorSearch {
     searched_entries: u64,
 }
 
+/// Independent sparse-index validation verdicts.
+///
+/// A structural contradiction means the index cannot be writer-produced and
+/// carries no fsync evidence, so recovery drops it immediately. A mapping
+/// mismatch can instead be the ordinary index-ahead-of-log crash shape, so an
+/// fsynced topic must still run the step-back and durable-position gates before
+/// rebuilding it.
+struct IndexValidation {
+    structurally_consistent: bool,
+    mappings_match: bool,
+}
+
+/// Buffered log-header reader used while validating sparse index mappings.
+/// Index positions ascend, so each window moves forward and every log byte is
+/// read at most once even for an index with one entry per batch.
+struct IndexLogScanner<'scan> {
+    identity: PartitionIdentity<'scan>,
+    file: &'scan fs::File,
+    path: &'scan str,
+    file_len: u64,
+    window: &'scan mut Vec<u8>,
+    window_start: u64,
+}
+
+impl<'scan> IndexLogScanner<'scan> {
+    fn new(
+        identity: PartitionIdentity<'scan>,
+        file: &'scan fs::File,
+        path: &'scan str,
+        file_len: u64,
+        window: &'scan mut Vec<u8>,
+    ) -> Self {
+        window.clear();
+        Self {
+            identity,
+            file,
+            path,
+            file_len,
+            window,
+            window_start: 0,
+        }
+    }
+
+    fn entry_matches(
+        &mut self,
+        offset: u64,
+        timestamp: u64,
+        position: u64,
+    ) -> Result<bool, ServerError> {
+        let Some(header_end) = position.checked_add(COMMAND_HEADER_SIZE as u64) else {
+            return Ok(false);
+        };
+        if header_end > self.file_len {
+            return Ok(false);
+        }
+        let window_end = self.window_start + self.window.len() as u64;
+        if position < self.window_start || header_end > window_end {
+            let fill = usize::try_from((self.file_len - position).min(SCAN_WINDOW_CAPACITY as u64))
+                .unwrap_or(SCAN_WINDOW_CAPACITY);
+            self.window.resize(fill, 0);
+            self.file
+                .read_exact_at(&mut self.window[..], position)
+                .map_err(|source| {
+                    error!(
+                        stream_id = self.identity.stream_id,
+                        topic_id = self.identity.topic_id,
+                        partition_id = self.identity.partition_id,
+                        path = %self.path,
+                        position,
+                        error = %source,
+                        "failed to read a segment log header for sparse index validation"
+                    );
+                    ServerError::from(IggyError::CannotReadFile)
+                })?;
+            self.window_start = position;
+        }
+        let at = usize::try_from(position - self.window_start).unwrap_or(0);
+        Ok(
+            BatchHeader::decode(&self.window[at..at + COMMAND_HEADER_SIZE]).is_ok_and(|header| {
+                header.partition_id == self.identity.partition_id as u64
+                    && header.base_offset == offset
+                    && header.base_timestamp == timestamp
+                    && header.message_count > 0
+                    && header.total_size() as u64 <= MAX_RECOVERABLE_BATCH_BYTES
+                    && position.saturating_add(header.total_size() as u64) <= self.file_len
+            }),
+        )
+    }
+}
+
 /// Highest index entry below the last one that the log can still prove,
 /// reported as the number of entries at or below it plus that entry's
 /// position, alongside how deep the search went.
@@ -1483,12 +1685,13 @@ struct IndexAnchorSearch {
 /// Reached only under `enforce_fsync`, and only to measure how far the index
 /// has outrun the log: the index is dropped whole either way, so nothing is
 /// anchored on the entry this returns. What the DEPTH decides is whether the
-/// gap is the one chunk a crash can strand or acknowledged data the log lost
+/// gap is the one chunk a crash can strand or previously durable data the log lost
 /// (see [`MAX_FSYNCED_INDEX_STEP_BACK_ENTRIES`]).
 ///
-/// An entry proves when the log holds, at its position, the whole batch it
-/// describes: decoding, fitting inside the log, carrying this partition's
-/// stamp and the entry's own base offset, and passing its batch checksum.
+/// An entry proves when the log holds, at its position, the whole non-empty
+/// batch it describes: decoding, fitting inside the log, carrying this
+/// partition's stamp and the entry's own base offset, and passing its batch
+/// checksum.
 /// Entries are read one at a time from the back rather than
 /// slurped: an index can run to megabytes, and the search stops at the first
 /// entry that proves. The dominant shape costs no LOG read at all -- an
@@ -1569,6 +1772,7 @@ async fn find_provable_index_anchor(
             if let Some(header) = header_at(identity, scanner, messages_path, entry.position)?
                 && header.partition_id == identity.partition_id as u64
                 && header.base_offset == entry.offset
+                && header.message_count > 0
                 && entry.position.saturating_add(header.total_size() as u64) <= messages_size
             {
                 if !scanner.budget.charge_verify(header.total_size() as u64) {
@@ -1617,6 +1821,11 @@ async fn find_provable_index_anchor(
 /// start -- its start offset, at byte 0 -- and offsets and positions must
 /// strictly ascend (the writer appends one entry per flushed chunk over a
 /// growing log, and every chunk covers at least one message and one byte).
+/// Every entry must also point at a whole non-empty batch in this partition
+/// whose offset and timestamp exactly match the entry. Monotonic columns alone
+/// are insufficient: an ascending corrupt position can land on a different
+/// valid batch, and an offset poll would then silently skip the requested
+/// range instead of failing to decode.
 /// Every producer of an index mints its first entry there: the writer at
 /// `file_position == 0` on a fresh segment, [`recover_by_walking_log`]'s
 /// rebuild, and the state-transfer install's own walk. A first entry
@@ -1626,22 +1835,26 @@ async fn find_provable_index_anchor(
 /// another segment is not merely unused. Logged here, where the entry is
 /// known, and the caller rebuilds the index from the log.
 ///
-/// Timestamps are deliberately NOT validated: a primary clock rewind across a
-/// restart can legitimately regress persisted `base_timestamp` today, and the
-/// lower-bound searches degrade gracefully on a non-monotone run, so refusing
-/// would trade availability for nothing.
+/// Timestamp MONOTONICITY is deliberately not required: a primary clock rewind
+/// across a restart can legitimately regress persisted `base_timestamp` today,
+/// and the lower-bound searches degrade gracefully on a non-monotone run. Each
+/// individual entry must still equal the batch timestamp it indexes, or a
+/// timestamp lookup can seek to an unrelated valid batch and skip data.
 ///
 /// Runs on EVERY clean boot over the whole index, and a window holds tens of
 /// thousands of entries, so the per-read yield the walks rely on is far too
 /// coarse here: yields every [`INDEX_SCAN_YIELD_STRIDE`] entries instead.
+#[allow(clippy::too_many_lines)]
 async fn index_is_consistent(
     identity: PartitionIdentity<'_>,
     index_path: &str,
+    messages_path: &str,
     start_offset: u64,
     entry_count: u64,
+    messages_size: u64,
     scratch: &mut ScanScratch,
-) -> Result<bool, ServerError> {
-    let file = fs::File::open(index_path).map_err(|source| {
+) -> Result<IndexValidation, ServerError> {
+    let index_file = fs::File::open(index_path).map_err(|source| {
         error!(
             stream_id = identity.stream_id,
             topic_id = identity.topic_id,
@@ -1652,9 +1865,32 @@ async fn index_is_consistent(
         );
         ServerError::from(IggyError::CannotReadFile)
     })?;
-    let window = &mut scratch.window;
+    let messages_file = fs::File::open(messages_path).map_err(|source| {
+        error!(
+            stream_id = identity.stream_id,
+            topic_id = identity.topic_id,
+            partition_id = identity.partition_id,
+            path = %messages_path,
+            error = %source,
+            "failed to open segment log for sparse index validation"
+        );
+        ServerError::from(IggyError::CannotReadFile)
+    })?;
+    let ScanScratch {
+        window: index_window,
+        spill: log_window,
+        ..
+    } = scratch;
+    let mut log_scanner = IndexLogScanner::new(
+        identity,
+        &messages_file,
+        messages_path,
+        messages_size,
+        log_window,
+    );
     let per_chunk_entries = SCAN_WINDOW_CAPACITY / SPARSE_INDEX_ENTRY_SIZE;
     let mut previous: Option<(u64, u64)> = None;
+    let mut mappings_match = true;
     let mut entry_index = 0u64;
     let mut byte_position = 0u64;
     while entry_index < entry_count {
@@ -1662,8 +1898,9 @@ async fn index_is_consistent(
         // Bounded by the window capacity, so the try_from cannot fail.
         let chunk_bytes =
             usize::try_from(chunk_entries).unwrap_or(per_chunk_entries) * SPARSE_INDEX_ENTRY_SIZE;
-        window.resize(chunk_bytes, 0);
-        file.read_exact_at(&mut window[..], byte_position)
+        index_window.resize(chunk_bytes, 0);
+        index_file
+            .read_exact_at(&mut index_window[..], byte_position)
             .map_err(|source| {
                 error!(
                     stream_id = identity.stream_id,
@@ -1675,8 +1912,9 @@ async fn index_is_consistent(
                 );
                 ServerError::from(IggyError::CannotReadFile)
             })?;
-        for entry in window.as_chunks::<SPARSE_INDEX_ENTRY_SIZE>().0 {
+        for entry in index_window.as_chunks::<SPARSE_INDEX_ENTRY_SIZE>().0 {
             let entry_offset = read_u64_le(entry, 0);
+            let entry_timestamp = read_u64_le(entry, 8);
             let entry_position = read_u64_le(entry, 16);
             if let Some((previous_offset, previous_position)) = previous
                 && (entry_offset <= previous_offset || entry_position <= previous_position)
@@ -1690,7 +1928,10 @@ async fn index_is_consistent(
                     "sparse index entry regresses in offset or position; \
                      discarding the index and rebuilding it from the log"
                 );
-                return Ok(false);
+                return Ok(IndexValidation {
+                    structurally_consistent: false,
+                    mappings_match: false,
+                });
             }
             if previous.is_none() && (entry_offset != start_offset || entry_position != 0) {
                 warn!(
@@ -1703,7 +1944,28 @@ async fn index_is_consistent(
                     "sparse index does not start at the segment's own first batch; \
                      discarding the index and rebuilding it from the log"
                 );
-                return Ok(false);
+                return Ok(IndexValidation {
+                    structurally_consistent: false,
+                    mappings_match: false,
+                });
+            }
+
+            if mappings_match
+                && !log_scanner.entry_matches(entry_offset, entry_timestamp, entry_position)?
+            {
+                warn!(
+                    stream_id = identity.stream_id,
+                    topic_id = identity.topic_id,
+                    partition_id = identity.partition_id,
+                    start_offset,
+                    entry_index,
+                    entry_offset,
+                    entry_timestamp,
+                    entry_position,
+                    "sparse index entry does not describe the log batch at its position; \
+                         discarding the index and rebuilding it from the log"
+                );
+                mappings_match = false;
             }
             previous = Some((entry_offset, entry_position));
             entry_index += 1;
@@ -1713,7 +1975,10 @@ async fn index_is_consistent(
         }
         byte_position += chunk_bytes as u64;
     }
-    Ok(true)
+    Ok(IndexValidation {
+        structurally_consistent: true,
+        mappings_match,
+    })
 }
 
 /// Opens a segment's messages file for the recovery walk. Fail-stop on any
@@ -1807,12 +2072,11 @@ fn scan_read_failure(
 /// (candidates examined, bytes handed to verification), whose exhaustion
 /// REFUSES and keeps the bytes rather than truncating: past the limits the
 /// probe has proven nothing, and the cheapest input to construct must never
-/// earn the destructive verdict. One exception folds exhaustion forward
-/// instead: when the walk proved not a single batch (`chain_end_offset` is
-/// `None`), the refusal and the no-survivor verdict converge on the same
-/// recover-as-empty outcome -- the pair is fenced aside whole, bytes
-/// preserved either way -- so exhaustion there returns `Ok` rather than
-/// trading a fence for a tombstone.
+/// earn the destructive verdict. That holds even when the walk proved not a
+/// single batch: recover-as-empty SERVES the segment and re-mints offsets
+/// from the previous frontier, so a residue the probe could not finish
+/// scanning may still hide the very survivor that would have refused, and
+/// only the refusal keeps the partition dark until an operator looks.
 async fn refuse_if_survivor_past_damage(
     identity: PartitionIdentity<'_>,
     scanner: &mut FileScanner<'_>,
@@ -1840,7 +2104,6 @@ async fn refuse_if_survivor_past_damage(
                 survivor_position: position,
             }))
         }
-        ProbeOutcome::BudgetExhausted if chain_end_offset.is_none() => Ok(()),
         ProbeOutcome::BudgetExhausted => Err(unverified_residue(
             identity,
             scanner,
@@ -2796,6 +3059,46 @@ mod tests {
     }
 
     #[compio::test]
+    async fn given_ascending_index_entry_pointing_at_another_batch_when_recovering_should_rebuild_the_index()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let batch2 = encoded_batch(2, 1);
+        let batch3 = encoded_batch(3, 1);
+        let batch2_position = (batch0.len() + batch1.len()) as u64;
+        let batch3_position = batch2_position + batch2.len() as u64;
+        let mut log = batch0.clone();
+        log.extend_from_slice(&batch1);
+        log.extend_from_slice(&batch2);
+        log.extend_from_slice(&batch3);
+
+        // Both columns ascend and the last entry is valid, but the interior
+        // entry for offset 1 points at the valid batch for offset 2. A poll
+        // starting from this entry decodes cleanly and can skip offset 1, so
+        // structural monotonicity alone cannot make the index safe to retain.
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, batch2_position));
+        index.extend_from_slice(&index_entry(3, batch3_position));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("an index entry pointing at another batch must be rebuilt");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 3);
+        assert_eq!(
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "every retained index entry must match its log batch"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+    }
+
+    #[compio::test]
     async fn given_index_entry_below_segment_start_when_recovering_should_rebuild_the_index_from_the_log()
      {
         let tmp = tempdir().expect("tempdir");
@@ -2936,18 +3239,18 @@ mod tests {
     }
 
     #[compio::test]
-    async fn given_zero_padded_records_when_probing_should_scan_whole_residue_and_recover_empty() {
+    async fn given_zero_padded_records_when_probing_should_refuse_on_verify_budget() {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
-        let partition_path = prepare_partition_dir(&config);
+        prepare_partition_dir(&config);
         // Torn index forces the index-less walk, and the garbage head keeps
         // it from decoding anything, so the whole file is probe residue.
         // Each record's header decodes and claims an 8 KiB batch that fits,
-        // so aligned candidates pay a (fast-failing) verify. Whether the
-        // verify budget survives all 128 claims or gives up partway, the
-        // outcome is the same by design: with no walked batch, exhaustion
-        // converges with survivor-free on recover-as-empty, and the empty
-        // recovery fences the pair whole.
+        // so aligned candidates pay a (fast-failing) verify; 128 claims
+        // exhaust the residue-derived verify budget partway. Exhaustion must
+        // refuse rather than recover empty: nothing past the budget horizon
+        // was scanned, so serving an empty segment would re-mint offsets
+        // over bytes the probe never classified.
         let mut log = GARBAGE.to_vec();
         for record in 0..128u32 {
             log.extend_from_slice(&zero_padded_record(
@@ -2957,22 +3260,25 @@ mod tests {
         }
         let (messages_path, _index_path) = write_segment(&config, 0, &log, &GARBAGE[..10]);
 
-        let recovered = recover(&config)
+        let error = recover(&config)
             .await
-            .expect("a survivor-free residue must recover as empty, not refuse");
+            .err()
+            .expect("an exhausted probe over an unwalked residue must refuse");
 
-        assert_eq!(recovered.len(), 1);
-        assert_eq!(recovered[0].segment.size, IggyByteSize::default());
-        assert_eq!(len_of(&messages_path), 0, "the served log must be empty");
-        let fenced_log = Path::new(&format!("{partition_path}.fenced.0")).join(
-            Path::new(&messages_path)
-                .file_name()
-                .expect("log file name"),
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::UnverifiedResidue { .. },
+                    ..
+                }
+            ),
+            "expected a budget-exhausted refusal, got {error:?}"
         );
         assert_eq!(
-            fs::read(fenced_log).expect("read fenced log"),
+            bytes_of(&messages_path),
             log,
-            "the unclassifiable bytes must survive in the fence directory"
+            "a refusal must leave the log byte-identical"
         );
     }
 
@@ -3056,37 +3362,40 @@ mod tests {
     }
 
     #[compio::test]
-    async fn given_overlapping_verify_claims_with_no_walked_batch_when_probing_should_recover_empty()
-     {
+    async fn given_overlapping_verify_claims_with_no_walked_batch_when_probing_should_refuse() {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
-        let partition_path = prepare_partition_dir(&config);
-        // Same bait with a garbage head, so the walk proves not one batch:
-        // exhaustion and survivor-free converge on recover-as-empty here,
-        // and the pair is fenced whole -- bytes preserved without minting a
-        // tombstone for a file that provably serves nothing.
+        prepare_partition_dir(&config);
+        // Same bait with a garbage head, so the walk proves not one batch.
+        // Exhaustion must still refuse: recover-as-empty would SERVE the
+        // segment and re-mint offsets while a real survivor may hide past
+        // the budget horizon, which is exactly the destructive verdict the
+        // cheapest-to-construct residue must never earn.
         let mut log = GARBAGE.to_vec();
         for sequence in 0..64u32 {
             log.extend_from_slice(&bait_record(100, 8 * 1024, sequence + 1));
         }
         let (messages_path, _index_path) = write_segment(&config, 0, &log, &GARBAGE[..10]);
 
-        let recovered = recover(&config)
+        let error = recover(&config)
             .await
-            .expect("verify-budget exhaustion with no walked batch must recover as empty");
+            .err()
+            .expect("verify-budget exhaustion must refuse even with no walked batch");
 
-        assert_eq!(recovered.len(), 1);
-        assert_eq!(recovered[0].segment.size, IggyByteSize::default());
-        assert_eq!(len_of(&messages_path), 0, "the served log must be empty");
-        let fenced_log = Path::new(&format!("{partition_path}.fenced.0")).join(
-            Path::new(&messages_path)
-                .file_name()
-                .expect("log file name"),
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::UnverifiedResidue { .. },
+                    ..
+                }
+            ),
+            "expected a budget-exhausted refusal, got {error:?}"
         );
         assert_eq!(
-            fs::read(fenced_log).expect("read fenced log"),
+            bytes_of(&messages_path),
             log,
-            "the unclassifiable bytes must survive in the fence directory"
+            "a refusal must leave the log byte-identical"
         );
     }
 
@@ -3187,6 +3496,52 @@ mod tests {
             log,
             "a refusal must leave the log byte-identical"
         );
+    }
+
+    #[compio::test]
+    async fn given_exhausted_probe_budget_with_no_walked_batch_when_classifying_should_refuse() {
+        let tmp = tempdir().expect("tempdir");
+        let log = GARBAGE.to_vec();
+        let messages_path = tmp.path().join("00000000000000000000.log");
+        fs::write(&messages_path, &log).expect("write log fixture");
+        let file = fs::File::open(&messages_path).expect("open log fixture");
+        let partition_path = tmp.path().to_string_lossy().into_owned();
+        let identity = PartitionIdentity {
+            partition_path: &partition_path,
+            stream_id: STREAM_ID,
+            topic_id: TOPIC_ID,
+            partition_id: PARTITION_ID,
+        };
+        let mut scratch = ScanScratch::default();
+        scratch.probe_budget.spent_units = u64::MAX / 2;
+        let mut scanner = FileScanner::new(&file, log.len() as u64, &mut scratch);
+
+        // A walk that proved nothing exhausts the probe over the whole file.
+        // Recover-as-empty here would SERVE the segment and re-mint offsets
+        // over bytes the probe never finished scanning; only refusal holds.
+        let error = refuse_if_survivor_past_damage(
+            identity,
+            &mut scanner,
+            &messages_path.to_string_lossy(),
+            0,
+            log.len() as u64,
+            None,
+            0,
+        )
+        .await
+        .expect_err("an exhausted probe with no walked batch must refuse, not recover empty");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::UnverifiedResidue { .. },
+                    ..
+                }
+            ),
+            "expected a budget-exhausted refusal, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path.to_string_lossy()), log);
     }
 
     #[compio::test]
@@ -3615,6 +3970,40 @@ mod tests {
     }
 
     #[compio::test]
+    async fn given_damage_below_a_valid_last_index_entry_without_fsync_when_recovering_should_refuse()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        let (log, mut index, damage_position, survivor_position) =
+            segment_damaged_below_its_last_provable_entry();
+        index.truncate(index.len() - SPARSE_INDEX_ENTRY_SIZE);
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover(&config)
+            .await
+            .err()
+            .expect("a valid last entry must not hide earlier damage without fsync");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::InteriorDamage {
+                        damage_position: at,
+                        survivor_position: past,
+                        ..
+                    },
+                    ..
+                } if *at == damage_position && *past == survivor_position
+            ),
+            "expected an interior-damage refusal below the valid last entry, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
     async fn given_damage_below_the_highest_provable_index_entry_under_fsync_when_recovering_should_refuse()
      {
         let tmp = tempdir().expect("tempdir");
@@ -3929,6 +4318,119 @@ mod tests {
     }
 
     #[compio::test]
+    async fn given_a_mid_chunk_tear_below_the_last_entry_under_fsync_when_recovering_should_refuse()
+    {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // Chunk 1 held two batches under one entry; its second batch is torn
+        // and the in-flight chunk 2's log bytes never landed. Entry 2 exists,
+        // so the log completed an fdatasync through its position: the tear
+        // sits inside bytes a completed flush made durable, a loss the
+        // entry-granular step-back (depth 1 here) cannot see.
+        let batch0 = encoded_batch(0, 1);
+        let batch1 = encoded_batch(1, 1);
+        let mut torn = encoded_batch(2, 1);
+        torn[COMMAND_HEADER_SIZE..].fill(0);
+        let mut log = batch0.clone();
+        let chunk1_position = log.len() as u64;
+        log.extend_from_slice(&batch1);
+        let torn_position = log.len() as u64;
+        log.extend_from_slice(&torn);
+        let durable = log.len() as u64;
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(1, chunk1_position));
+        index.extend_from_slice(&index_entry(3, durable));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover_under_fsync(&config, true)
+            .await
+            .err()
+            .expect("a rebuild proving less than the last entry's position must refuse");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::FsyncedRebuildShortfall {
+                        walked_position,
+                        durable_position,
+                        ..
+                    },
+                    ..
+                } if *walked_position == torn_position && *durable_position == durable
+            ),
+            "expected an fsynced-rebuild-shortfall refusal, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_a_verified_offset_gap_past_an_empty_anchor_batch_when_recovering_should_refuse()
+    {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        // The empty batch verifies and carries the anchor's own offset, so
+        // the expectation it confirms is the log's, not the index's. The
+        // verified batch after it that does not continue the chain is durable
+        // data past a hole; treating the mismatch as a stale-anchor break
+        // would truncate it and re-mint the offsets in between.
+        let empty = encoded_batch(0, 0);
+        let mut log = empty.clone();
+        let survivor_position = log.len() as u64;
+        log.extend_from_slice(&encoded_batch(5, 1));
+        let index = index_entry(0, 0);
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover_under_fsync(&config, true)
+            .await
+            .err()
+            .expect("a verified offset gap past an empty anchor batch must refuse");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::OffsetDiscontinuity {
+                        expected_offset: 0,
+                        found_offset: 5,
+                        position,
+                        ..
+                    },
+                    ..
+                } if *position == survivor_position
+            ),
+            "expected an offset-discontinuity refusal past the empty anchor, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_only_an_empty_anchor_batch_under_fsync_when_recovering_should_not_count_a_phantom_message()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        let partition_path = prepare_partition_dir(&config);
+        let log = encoded_batch(0, 0);
+        let index = index_entry(0, 0);
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover_under_fsync(&config, true)
+            .await
+            .expect("a checksum-valid empty record carries no message range");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.size, IggyByteSize::default());
+        assert_eq!(len_of(&messages_path), 0, "the served log must be empty");
+        assert_eq!(len_of(&index_path), 0, "the served index must be empty");
+        assert_eq!(fenced_bytes(&partition_path, &messages_path), log);
+        assert_eq!(fenced_bytes(&partition_path, &index_path), index);
+    }
+
+    #[compio::test]
     async fn given_an_index_the_log_backs_nowhere_under_fsync_when_recovering_should_refuse() {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
@@ -4017,9 +4519,11 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
-        // The first persist into a fresh segment, crashed between the two
-        // fsyncs: one entry, no log bytes, no ack ever sent. `enforce_fsync`
-        // must not turn the shape the PR exists for into a tombstone.
+        // The first flush into a fresh segment, crashed between the two
+        // fsyncs: one entry and no log bytes. Whether any batches in that
+        // flush were acknowledged depends on the flush thresholds, but only
+        // one entry can belong to the interrupted flush. `enforce_fsync` must
+        // not turn that shape into a tombstone.
         let index = index_entry(0, 0);
         let (messages_path, index_path) = write_segment(&config, 0, &[], &index);
 

--- a/core/server/src/segment_recovery.rs
+++ b/core/server/src/segment_recovery.rs
@@ -75,15 +75,24 @@ const REBUILT_INDEX_STRIDE_BYTES: u64 = 64 * 1024;
 const INDEX_SCAN_YIELD_STRIDE: u64 = 1024;
 
 /// Index entries the log may legitimately fail to back under `enforce_fsync`.
-/// Persistence writes exactly one entry per flush chunk, chunks never overlap,
-/// and it completes before the client reply. The two halves fdatasync
-/// concurrently WITHIN one flush, but flushes are serialized, and the log's
-/// fdatasync covers the whole file: an entry existing above entry N therefore
-/// proves the log was synced through chunk N. Only the chunk in flight when
-/// the process died can leave an entry the log never backed. See
-/// [`PartitionRecoveryRefusal::FsyncedLogLoss`] for why a deeper step-back is
-/// evidence about the log rather than about the index.
+/// Persistence writes exactly one entry per flush chunk and chunks never
+/// overlap. The two halves fdatasync concurrently WITHIN one flush, but
+/// flushes are serialized, and the log's fdatasync covers the whole file: an
+/// entry existing above entry N therefore proves the log was synced through
+/// chunk N. Only the chunk in flight when the process died can leave an entry
+/// the log never backed. See [`PartitionRecoveryRefusal::FsyncedLogLoss`] for
+/// why a deeper step-back is evidence about the log rather than about the
+/// index.
 const MAX_FSYNCED_INDEX_STEP_BACK_ENTRIES: u64 = 1;
+
+/// Index entries the backward anchor search probes before giving up, at one
+/// 24-byte pread each. Capping the walk cannot change a verdict: only the
+/// FIRST entry probed can leave the step-back within
+/// [`MAX_FSYNCED_INDEX_STEP_BACK_ENTRIES`], so past that entry the refusal is
+/// already decided and deeper probes only sharpen the byte it names. The
+/// refusal carries the depth actually searched, so a capped search never
+/// reads as "the log backs nothing".
+const MAX_INDEX_ANCHOR_PROBE_ENTRIES: u64 = 4096;
 
 /// Units the damage probes of one partition load may spend per byte of
 /// residue they are asked to classify, at one unit per candidate offset
@@ -1109,7 +1118,7 @@ async fn recover_segment_bounds(
                 // deeper gap is the log missing bytes it already acknowledged.
                 // Refuse and keep every byte for the operator.
                 if enforce_fsync {
-                    let anchor = find_provable_index_anchor(
+                    let search = find_provable_index_anchor(
                         identity,
                         index_path,
                         messages_path,
@@ -1119,15 +1128,14 @@ async fn recover_segment_bounds(
                         messages_size,
                     )
                     .await?;
-                    let (provable_entries, provable_position) =
-                        anchor.map_or((0, 0), |(entries, entry)| (entries, entry.position));
-                    let step_back_entries = entry_count.saturating_sub(provable_entries);
+                    let step_back_entries = entry_count.saturating_sub(search.provable_entries);
                     if step_back_entries > MAX_FSYNCED_INDEX_STEP_BACK_ENTRIES {
                         return Err(identity.refusal(PartitionRecoveryRefusal::FsyncedLogLoss {
                             start_offset,
                             entry_count,
-                            provable_entries,
-                            provable_position,
+                            provable_entries: search.provable_entries,
+                            provable_position: search.provable_position,
+                            searched_entries: search.searched_entries,
                         }));
                     }
                 }
@@ -1456,9 +1464,21 @@ async fn walk_chain_from_anchor(
     })
 }
 
+/// How far the index has outrun the log, in the terms the refusal reports.
+struct IndexAnchorSearch {
+    /// Entries at or below the highest one the log still proves, that entry
+    /// included; 0 when nothing in the searched window proved.
+    provable_entries: u64,
+    /// Position of that entry, or 0 when nothing proved.
+    provable_position: u64,
+    /// Entries actually probed, capped by
+    /// [`MAX_INDEX_ANCHOR_PROBE_ENTRIES`].
+    searched_entries: u64,
+}
+
 /// Highest index entry below the last one that the log can still prove,
-/// returned as the number of entries at or below it plus the entry itself.
-/// `None` when no entry proves out.
+/// reported as the number of entries at or below it plus that entry's
+/// position, alongside how deep the search went.
 ///
 /// Reached only under `enforce_fsync`, and only to measure how far the index
 /// has outrun the log: the index is dropped whole either way, so nothing is
@@ -1471,18 +1491,20 @@ async fn walk_chain_from_anchor(
 /// stamp and the entry's own base offset, and passing its batch checksum.
 /// Entries are read one at a time from the back rather than
 /// slurped: an index can run to megabytes, and the search stops at the first
-/// entry that proves. The dominant shape costs no log read at all -- an
+/// entry that proves. The dominant shape costs no LOG read at all -- an
 /// entry pointing past the log end is rejected on arithmetic alone -- so a
-/// torn tail pays a header read for the one entry it lands on and nothing
-/// more.
+/// torn tail pays one header read for the entry it lands on; the index side
+/// still costs a 24-byte pread per entry stepped over, which is what
+/// [`MAX_INDEX_ANCHOR_PROBE_ENTRIES`] caps.
 ///
-/// Budgeted like the damage probe, because the search reads BACKWARD and
-/// nothing else bounds it: the log span between one probed entry and the
-/// one probed before it is the residue that entry classifies. An honest
-/// index holds one entry per flushed chunk, so a whole batch fits inside
-/// every such span and its verify always fits the residue multiple; entries
-/// packed closer together than the batches they claim exhaust it and refuse,
-/// rather than paying a verify per entry over an index that never proves.
+/// The log reads are budgeted like the damage probe's: the log span between
+/// one probed entry and the one probed before it is the residue that entry
+/// classifies. An honest index holds one entry per flushed chunk, so a whole
+/// batch fits inside every such span and its verify always fits the residue
+/// multiple; entries packed closer together than the batches they claim
+/// exhaust it and refuse, rather than paying a verify per entry over an index
+/// that never proves. That budget bounds hashed BYTES, so the step count is
+/// capped separately.
 /// Yields once per window of disk reads, like the walks, and additionally
 /// every [`INDEX_SCAN_YIELD_STRIDE`] entries: an entry that overshoots the
 /// log reads nothing from it, so there is no refill to key the yield on, and
@@ -1495,10 +1517,14 @@ async fn find_provable_index_anchor(
     start_offset: u64,
     entry_count: u64,
     messages_size: u64,
-) -> Result<Option<(u64, IggyIndex)>, ServerError> {
+) -> Result<IndexAnchorSearch, ServerError> {
     // The last entry is the one that just failed to prove out.
     let Some(mut entry_index) = entry_count.checked_sub(2) else {
-        return Ok(None);
+        return Ok(IndexAnchorSearch {
+            provable_entries: 0,
+            provable_position: 0,
+            searched_entries: 0,
+        });
     };
     let file = fs::File::open(index_path).map_err(|source| {
         error!(
@@ -1515,6 +1541,7 @@ async fn find_provable_index_anchor(
     // Lowest log byte a probed entry has already paid for; the next probed
     // entry is budgeted by the span from its own position up to here.
     let mut budgeted_down_to = messages_size;
+    let mut searched_entries = 0u64;
     loop {
         file.read_exact_at(&mut raw, entry_index * SPARSE_INDEX_ENTRY_SIZE as u64)
             .map_err(|source| {
@@ -1533,6 +1560,7 @@ async fn find_provable_index_anchor(
             read_u64_le(&raw, 8),
             read_u64_le(&raw, 16),
         );
+        searched_entries += 1;
         if entry.position < messages_size {
             scanner
                 .budget
@@ -1559,27 +1587,44 @@ async fn find_provable_index_anchor(
                     entry.position,
                     header.total_size(),
                 )? {
-                    return Ok(Some((entry_index + 1, entry)));
+                    return Ok(IndexAnchorSearch {
+                        provable_entries: entry_index + 1,
+                        provable_position: entry.position,
+                        searched_entries,
+                    });
                 }
             }
         }
         if scanner.take_refilled() || entry_index.is_multiple_of(INDEX_SCAN_YIELD_STRIDE) {
             yield_to_reactor().await;
         }
+        if searched_entries == MAX_INDEX_ANCHOR_PROBE_ENTRIES {
+            break;
+        }
         let Some(next) = entry_index.checked_sub(1) else {
-            return Ok(None);
+            break;
         };
         entry_index = next;
     }
+    Ok(IndexAnchorSearch {
+        provable_entries: 0,
+        provable_position: 0,
+        searched_entries,
+    })
 }
 
-/// Checks every whole index entry: the first must not claim an offset below
-/// the segment's own start, and offsets and positions must strictly ascend
-/// (the writer appends one entry per flushed chunk over a growing log, and
-/// every chunk covers at least one message and one byte). A regression means
-/// the file was written mis-strided or over foreign bytes and describes no
-/// log at all; it is logged here, where the entry is known, and the caller
-/// rebuilds the index from the log.
+/// Checks every whole index entry: the first must name the segment's own
+/// start -- its start offset, at byte 0 -- and offsets and positions must
+/// strictly ascend (the writer appends one entry per flushed chunk over a
+/// growing log, and every chunk covers at least one message and one byte).
+/// Every producer of an index mints its first entry there: the writer at
+/// `file_position == 0` on a fresh segment, [`recover_by_walking_log`]'s
+/// rebuild, and the state-transfer install's own walk. A first entry
+/// elsewhere means the file was written mis-strided or over foreign bytes
+/// and describes no log at all -- and the accepted path reads that entry's
+/// timestamp as the SEGMENT's start timestamp, so a head that belongs to
+/// another segment is not merely unused. Logged here, where the entry is
+/// known, and the caller rebuilds the index from the log.
 ///
 /// Timestamps are deliberately NOT validated: a primary clock rewind across a
 /// restart can legitimately regress persisted `base_timestamp` today, and the
@@ -1647,14 +1692,15 @@ async fn index_is_consistent(
                 );
                 return Ok(false);
             }
-            if previous.is_none() && entry_offset < start_offset {
+            if previous.is_none() && (entry_offset != start_offset || entry_position != 0) {
                 warn!(
                     stream_id = identity.stream_id,
                     topic_id = identity.topic_id,
                     partition_id = identity.partition_id,
                     start_offset,
                     first_entry_offset = entry_offset,
-                    "sparse index claims an offset below the segment start; \
+                    first_entry_position = entry_position,
+                    "sparse index does not start at the segment's own first batch; \
                      discarding the index and rebuilding it from the log"
                 );
                 return Ok(false);
@@ -2784,6 +2830,81 @@ mod tests {
     }
 
     #[compio::test]
+    async fn given_index_entry_above_segment_start_when_recovering_should_rebuild_the_index_from_the_log()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        let first = encoded_batch(5, 1);
+        let second = encoded_batch(6, 1);
+        let third = encoded_batch(7, 1);
+        let mut log = first.clone();
+        log.extend_from_slice(&second);
+        log.extend_from_slice(&third);
+        // An index that lost its own head: the last entry is valid and
+        // anchors a clean walk, so the segment would be accepted with a start
+        // timestamp taken from a chunk that is not its first.
+        let mut index = index_entry(6, 0);
+        index.extend_from_slice(&index_entry(7, (first.len() + second.len()) as u64));
+        let (messages_path, index_path) = write_segment(&config, 5, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("an index starting above the segment start must be rebuilt, not refused");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 7);
+        assert_eq!(
+            bytes_of(&index_path),
+            index_entry(5, 0),
+            "the rebuilt index must start at the segment's own first batch"
+        );
+        assert_eq!(
+            bytes_of(&messages_path),
+            log,
+            "rebuilding the index must not touch a whole log"
+        );
+    }
+
+    #[compio::test]
+    async fn given_index_first_entry_past_byte_zero_when_recovering_should_rebuild_the_index_from_the_log()
+     {
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        let first = encoded_batch(0, 1);
+        let second = encoded_batch(1, 1);
+        let third = encoded_batch(2, 1);
+        let mut log = first.clone();
+        log.extend_from_slice(&second);
+        log.extend_from_slice(&third);
+        // The offset column opens where the segment does and the entries
+        // ascend, so every other check reads this index as healthy. Only the
+        // position is wrong: byte 0 is described by nothing, while the last
+        // entry lands on its batch and would anchor a clean walk.
+        let mut index = index_entry(0, first.len() as u64);
+        index.extend_from_slice(&index_entry(2, (first.len() + second.len()) as u64));
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let recovered = recover(&config)
+            .await
+            .expect("an index whose first entry skips byte 0 must be rebuilt, not refused");
+
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].segment.end_offset, 2);
+        assert_eq!(
+            bytes_of(&index_path),
+            index_entry(0, 0),
+            "the rebuilt index must open at byte 0"
+        );
+        assert_eq!(
+            bytes_of(&messages_path),
+            log,
+            "rebuilding the index must not touch a whole log"
+        );
+    }
+
+    #[compio::test]
     async fn given_index_less_wide_batches_when_recovering_should_rebuild_strided_index() {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
@@ -3576,7 +3697,9 @@ mod tests {
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
         // Every entry points past the log end, so nothing in the index backs
-        // the walk. The log is whole and describes itself, so the index is
+        // the walk -- and the first entry is not even at the segment's first
+        // byte, which the consistency scan catches before the walk runs. The
+        // log is whole and describes itself either way, so the index is
         // dropped and rebuilt from it.
         let log = encoded_batch(0, 2);
         let mut index = index_entry(0, log.len() as u64);
@@ -3810,12 +3933,15 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let config = test_config(&tmp);
         prepare_partition_dir(&config);
-        // The gap is measured the same way when no entry proves at all: two
-        // entries the log backs nowhere is one more than the in-flight chunk
-        // can explain, so the rebuild never runs.
-        let log = encoded_batch(0, 2);
-        let mut index = index_entry(0, log.len() as u64);
-        index.extend_from_slice(&index_entry(2, log.len() as u64 + 64));
+        // The gap is measured the same way when no entry proves at all. The
+        // index still starts at the segment's own first byte, so it is not
+        // the mis-strided shape the consistency scan drops; the log simply
+        // lost the tail of its FIRST indexed chunk, which two entries the log
+        // backs nowhere is one more than the in-flight chunk can explain.
+        let whole = encoded_batch(0, 2);
+        let log = whole[..COMMAND_HEADER_SIZE + 8].to_vec();
+        let mut index = index_entry(0, 0);
+        index.extend_from_slice(&index_entry(2, whole.len() as u64));
         let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
 
         let error = recover_under_fsync(&config, true)
@@ -3836,6 +3962,51 @@ mod tests {
                 }
             ),
             "expected an fsynced-log-loss refusal over the dropped index, got {error:?}"
+        );
+        assert_eq!(bytes_of(&messages_path), log);
+        assert_eq!(bytes_of(&index_path), index);
+    }
+
+    #[compio::test]
+    async fn given_an_index_deeper_than_the_probe_cap_under_fsync_when_recovering_should_refuse_with_the_searched_depth()
+     {
+        // Entry 0 is the one entry the log does back, and it sits below the
+        // cap: the search stops before reaching it and proves nothing. The
+        // refusal is still the right verdict -- a step-back this deep is log
+        // loss whatever a deeper probe would find -- which is exactly why it
+        // must name the depth it searched instead of letting zero provable
+        // entries read as "the log backs nothing".
+        const OVERSHOOTING_ENTRIES: u64 = MAX_INDEX_ANCHOR_PROBE_ENTRIES + 1;
+        let tmp = tempdir().expect("tempdir");
+        let config = test_config(&tmp);
+        prepare_partition_dir(&config);
+        let log = encoded_batch(0, 1);
+        let mut index = index_entry(0, 0);
+        for step in 0..OVERSHOOTING_ENTRIES {
+            index.extend_from_slice(&index_entry(step + 1, log.len() as u64 + step));
+        }
+        let (messages_path, index_path) = write_segment(&config, 0, &log, &index);
+
+        let error = recover_under_fsync(&config, true)
+            .await
+            .err()
+            .expect("an index outrunning the log past the probe cap must refuse");
+
+        assert!(
+            matches!(
+                &error,
+                ServerError::PartitionRecoveryRefused {
+                    reason: PartitionRecoveryRefusal::FsyncedLogLoss {
+                        entry_count,
+                        provable_entries: 0,
+                        searched_entries,
+                        ..
+                    },
+                    ..
+                } if *entry_count == OVERSHOOTING_ENTRIES + 1
+                    && *searched_entries == MAX_INDEX_ANCHOR_PROBE_ENTRIES
+            ),
+            "expected a capped fsynced-log-loss refusal naming its search depth, got {error:?}"
         );
         assert_eq!(bytes_of(&messages_path), log);
         assert_eq!(bytes_of(&index_path), index);

--- a/core/server/src/server_error.rs
+++ b/core/server/src/server_error.rs
@@ -307,11 +307,11 @@ pub enum ServerError {
 /// gap is deeper than the single in-flight entry: entries are derived from the
 /// log, so recovery drops such an index whole and rebuilds it from a byte-0
 /// walk of the log rather than believing any part of it. What `enforce_fsync`
-/// adds is a durability promise -- every entry below the last was made durable
-/// alongside the log chunk it describes, before that chunk's batch was
-/// acknowledged -- which turns a deeper gap into evidence about the LOG.
-/// Absent that promise the index is never evidence about the log; only the
-/// log is.
+/// adds is evidence from serialized completed flushes: an entry above chunk N
+/// means the log fdatasync covering chunk N completed before the later flush
+/// began. This is independent of reply timing and turns a deeper gap into
+/// evidence about the LOG. Absent that evidence the index only locates data;
+/// recovery verifies the log from byte 0.
 #[derive(Debug)]
 pub enum PartitionRecoveryRefusal {
     /// `recoverable_bytes` on the two chain-shape refusals is the sum of
@@ -387,14 +387,13 @@ pub enum PartitionRecoveryRefusal {
     /// log by more than the one entry a crash can legitimately strand there.
     /// Persistence writes exactly one entry per flush chunk, chunks never
     /// overlap, and flushes are serialized, so every entry below the last one
-    /// names a chunk whose log bytes completed their fdatasync. A flush covers
-    /// the whole committed journal prefix, so every batch in a completed chunk
-    /// was already acknowledged, or is acknowledged by the commit that
-    /// triggered the flush. Only the chunk in flight when the process died
-    /// can have an entry the log never backed. A deeper step-back therefore
-    /// says the LOG lost acknowledged bytes it had already made durable, and
-    /// rebuilding this segment from what the log still holds would let the
-    /// partition re-mint offsets a client was already promised.
+    /// names a chunk whose log bytes completed their fdatasync. A completed
+    /// chunk can contain batches acknowledged before the flush threshold was
+    /// reached, while the in-flight chunk can do so too. Reply timing is not
+    /// the proof. Only the chunk in flight when the process died can have an
+    /// entry the log never backed. A deeper step-back therefore says the LOG
+    /// lost bytes it had already made durable, and rebuilding from what remains
+    /// could re-mint offsets, including offsets already returned to clients.
     FsyncedLogLoss {
         start_offset: u64,
         entry_count: u64,
@@ -407,6 +406,20 @@ pub enum PartitionRecoveryRefusal {
         /// then means nothing proved in the searched window, not that the log
         /// backs nothing.
         searched_entries: u64,
+    },
+    /// Under `enforce_fsync`, the byte-0 rebuild after a dropped index proved
+    /// the log only through `walked_position`, short of `durable_position`,
+    /// the byte the index's own last entry proves the log had already
+    /// fdatasynced through (the flush that wrote the entry began only after
+    /// the previous chunk's log sync completed). The step-back gate measures
+    /// loss at entry granularity; this catches the sub-chunk shape it cannot:
+    /// bytes a completed flush made durable are gone mid-chunk, so truncating
+    /// to the walked prefix would re-mint their offsets.
+    FsyncedRebuildShortfall {
+        start_offset: u64,
+        entry_count: u64,
+        walked_position: u64,
+        durable_position: u64,
     },
     /// A writer reopening over recovered bounds found the on-disk length
     /// diverging from the size recovery just validated and truncated to.
@@ -503,9 +516,23 @@ impl std::fmt::Display for PartitionRecoveryRefusal {
                 "segment {start_offset} runs under enforce_fsync with {entry_count} sparse \
                  index entries, but its log backs only {provable_entries} of the \
                  {searched_entries} searched from the top (up to byte {provable_position}); \
-                 every entry below the last was fsync'd together with the acknowledged log \
-                 chunk it describes, so the log has lost acknowledged data rather than the \
+                 every entry below the last describes a log chunk whose fdatasync had \
+                 completed, so the log has lost previously durable data rather than the \
                  index having outrun it"
+            ),
+            Self::FsyncedRebuildShortfall {
+                start_offset,
+                entry_count,
+                walked_position,
+                durable_position,
+            } => write!(
+                f,
+                "segment {start_offset} runs under enforce_fsync with {entry_count} sparse \
+                 index entries, and the byte-0 rebuild proved its log only through byte \
+                 {walked_position}, short of byte {durable_position} which the last \
+                 entry's own fdatasync ordering proves the log had already made durable; \
+                 the log has lost previously durable bytes mid-chunk, so rebuilding \
+                 would re-mint their offsets"
             ),
             Self::StorageSizeMismatch {
                 start_offset,

--- a/core/server/src/server_error.rs
+++ b/core/server/src/server_error.rs
@@ -287,11 +287,16 @@ pub enum ServerError {
 /// appended over), and offsets that do not continue the chain can be minted
 /// into byte-clean files by an upstream crash window as well as by damage.
 ///
-/// An index the log cannot back, or that contradicts itself, is deliberately
-/// NOT here: entries are derived from the log, so recovery floors the index
-/// to the last entry the log proves and rebuilds it from the log when none
-/// does or when the entries are out of order. The index is never evidence
-/// about the log; only the log is.
+/// An index that contradicts itself is deliberately NOT here, and neither is
+/// one the log cannot back UNLESS the topic runs under `enforce_fsync` and the
+/// gap is deeper than the single in-flight entry: entries are derived from the
+/// log, so recovery drops such an index whole and rebuilds it from a byte-0
+/// walk of the log rather than believing any part of it. What `enforce_fsync`
+/// adds is a durability promise -- every entry below the last was made durable
+/// alongside the log chunk it describes, before that chunk's batch was
+/// acknowledged -- which turns a deeper gap into evidence about the LOG.
+/// Absent that promise the index is never evidence about the log; only the
+/// log is.
 #[derive(Debug)]
 pub enum PartitionRecoveryRefusal {
     /// `recoverable_bytes` on the two chain-shape refusals is the sum of
@@ -362,6 +367,24 @@ pub enum PartitionRecoveryRefusal {
         start_offset: u64,
         batch_partition_id: u64,
         position: u64,
+    },
+    /// The sparse index of a topic running under `enforce_fsync` outruns its
+    /// log by more than the one entry a crash can legitimately strand there.
+    /// Persistence writes exactly one entry per flush chunk, chunks never
+    /// overlap, and it completes before the client reply, so every entry below
+    /// the last one names a chunk whose log bytes were fsync'd before its
+    /// batch was acknowledged. Only the chunk in flight when the process died
+    /// can have an entry the log never backed. A deeper step-back therefore
+    /// says the LOG lost acknowledged bytes it had already made durable, and
+    /// rebuilding this segment from what the log still holds would let the
+    /// partition re-mint offsets a client was already promised.
+    FsyncedLogLoss {
+        start_offset: u64,
+        entry_count: u64,
+        provable_entries: u64,
+        /// Position of the highest entry the log still proves; 0 when it
+        /// proves none, which `provable_entries` disambiguates.
+        provable_position: u64,
     },
     /// A writer reopening over recovered bounds found the on-disk length
     /// diverging from the size recovery just validated and truncated to.
@@ -446,6 +469,19 @@ impl std::fmt::Display for PartitionRecoveryRefusal {
                 "segment {start_offset} holds a verified batch at byte {position} \
                  stamped for partition {batch_partition_id}; a foreign record in \
                  this log is preserved as evidence, not truncated"
+            ),
+            Self::FsyncedLogLoss {
+                start_offset,
+                entry_count,
+                provable_entries,
+                provable_position,
+            } => write!(
+                f,
+                "segment {start_offset} runs under enforce_fsync with {entry_count} sparse \
+                 index entries, but its log backs only {provable_entries} of them (up to \
+                 byte {provable_position}); every entry below the last was fsync'd with \
+                 the log chunk it describes before that chunk was acknowledged, so the \
+                 log has lost acknowledged data rather than the index having outrun it"
             ),
             Self::StorageSizeMismatch {
                 start_offset,

--- a/core/server/src/server_error.rs
+++ b/core/server/src/server_error.rs
@@ -284,9 +284,14 @@ pub enum ServerError {
 /// causes, and not all of them are at-rest corruption: an empty non-tail
 /// segment is a failed rebuild's orphan pairing, a hole is a stray or
 /// half-unlinked file, interior damage is bit rot (or a resurrected tail
-/// appended over), a divergent index is a mis-strided or foreign write, and
-/// offsets that do not continue the chain can be minted into byte-clean files
-/// by an upstream crash window as well as by damage.
+/// appended over), and offsets that do not continue the chain can be minted
+/// into byte-clean files by an upstream crash window as well as by damage.
+///
+/// An index the log cannot back, or that contradicts itself, is deliberately
+/// NOT here: entries are derived from the log, so recovery floors the index
+/// to the last entry the log proves and rebuilds it from the log when none
+/// does or when the entries are out of order. The index is never evidence
+/// about the log; only the log is.
 #[derive(Debug)]
 pub enum PartitionRecoveryRefusal {
     /// `recoverable_bytes` on the two chain-shape refusals is the sum of
@@ -305,16 +310,6 @@ pub enum PartitionRecoveryRefusal {
         next_start: u64,
         recoverable_bytes: u64,
     },
-    /// The index holds entries but no whole batch decodes AND verifies where
-    /// its last entry points, so index and log describe different files. The
-    /// damage probe ran first: anything verifying past the anchor's damage
-    /// refuses as [`Self::InteriorDamage`] instead.
-    IndexLogDivergence {
-        start_offset: u64,
-        end_offset: u64,
-        messages_size_bytes: u64,
-        indexed_size_bytes: u64,
-    },
     /// A complete, checksum-verifying batch survives PAST bytes that do not
     /// decode. A torn tail has nothing after it, so this is interior damage,
     /// and truncating at it would silently discard the surviving batches.
@@ -330,9 +325,12 @@ pub enum PartitionRecoveryRefusal {
     /// were re-examined -- a probe defect); the verification budget bounds
     /// the bytes handed to checksum verifies, whose claimed slices overlap,
     /// so residue packed with plausible headers can exhaust it from an
-    /// on-disk shape. Truncation is only ever sound for a proven torn tail,
-    /// so giving up keeps the bytes. The residue width is diagnostic only;
-    /// it is not a gate.
+    /// on-disk shape. The index anchor search charges the same verification
+    /// budget as it steps back through entries the log cannot back, so an
+    /// index packed with claims the log never proves ends here too instead
+    /// of paying a verify per entry. Truncation is only ever sound for a
+    /// proven torn tail, so giving up keeps the bytes. The residue width is
+    /// diagnostic only; it is not a gate.
     UnverifiedResidue {
         start_offset: u64,
         damage_position: u64,
@@ -364,14 +362,6 @@ pub enum PartitionRecoveryRefusal {
         start_offset: u64,
         batch_partition_id: u64,
         position: u64,
-    },
-    /// Index entries must ascend in offset and position (they are appended,
-    /// one per flushed chunk, over a growing log); a regression means the
-    /// file was written mis-strided or over foreign bytes.
-    IndexEntriesNotMonotone { start_offset: u64, entry_index: u64 },
-    IndexEntryBeforeSegmentStart {
-        start_offset: u64,
-        first_entry_offset: u64,
     },
     /// A writer reopening over recovered bounds found the on-disk length
     /// diverging from the size recovery just validated and truncated to.
@@ -407,18 +397,6 @@ impl std::fmt::Display for PartitionRecoveryRefusal {
                 "segment {previous_start} ends at offset {previous_end} but the next \
                  starts at {next_start}, leaving a hole in a chain holding \
                  {recoverable_bytes} recoverable bytes"
-            ),
-            Self::IndexLogDivergence {
-                start_offset,
-                end_offset,
-                messages_size_bytes,
-                indexed_size_bytes,
-            } => write!(
-                f,
-                "segment {start_offset} has message/index divergence: the index ends \
-                 at offset {end_offset}, byte {indexed_size_bytes}, where the \
-                 {messages_size_bytes}-byte log holds no batch that decodes and \
-                 verifies"
             ),
             Self::InteriorDamage {
                 start_offset,
@@ -468,22 +446,6 @@ impl std::fmt::Display for PartitionRecoveryRefusal {
                 "segment {start_offset} holds a verified batch at byte {position} \
                  stamped for partition {batch_partition_id}; a foreign record in \
                  this log is preserved as evidence, not truncated"
-            ),
-            Self::IndexEntriesNotMonotone {
-                start_offset,
-                entry_index,
-            } => write!(
-                f,
-                "segment {start_offset} index entry {entry_index} regresses in \
-                 offset or position; the index was not appended over this log"
-            ),
-            Self::IndexEntryBeforeSegmentStart {
-                start_offset,
-                first_entry_offset,
-            } => write!(
-                f,
-                "segment {start_offset} index claims offset {first_entry_offset}, \
-                 below the segment's own start"
             ),
             Self::StorageSizeMismatch {
                 start_offset,

--- a/core/server/src/server_error.rs
+++ b/core/server/src/server_error.rs
@@ -371,9 +371,11 @@ pub enum PartitionRecoveryRefusal {
     /// The sparse index of a topic running under `enforce_fsync` outruns its
     /// log by more than the one entry a crash can legitimately strand there.
     /// Persistence writes exactly one entry per flush chunk, chunks never
-    /// overlap, and it completes before the client reply, so every entry below
-    /// the last one names a chunk whose log bytes were fsync'd before its
-    /// batch was acknowledged. Only the chunk in flight when the process died
+    /// overlap, and flushes are serialized, so every entry below the last one
+    /// names a chunk whose log bytes completed their fdatasync. A flush covers
+    /// the whole committed journal prefix, so every batch in a completed chunk
+    /// was already acknowledged, or is acknowledged by the commit that
+    /// triggered the flush. Only the chunk in flight when the process died
     /// can have an entry the log never backed. A deeper step-back therefore
     /// says the LOG lost acknowledged bytes it had already made durable, and
     /// rebuilding this segment from what the log still holds would let the
@@ -385,6 +387,11 @@ pub enum PartitionRecoveryRefusal {
         /// Position of the highest entry the log still proves; 0 when it
         /// proves none, which `provable_entries` disambiguates.
         provable_position: u64,
+        /// Entries the backward search actually probed, which its own cap
+        /// holds below `entry_count` on a long index: `provable_entries == 0`
+        /// then means nothing proved in the searched window, not that the log
+        /// backs nothing.
+        searched_entries: u64,
     },
     /// A writer reopening over recovered bounds found the on-disk length
     /// diverging from the size recovery just validated and truncated to.
@@ -475,13 +482,15 @@ impl std::fmt::Display for PartitionRecoveryRefusal {
                 entry_count,
                 provable_entries,
                 provable_position,
+                searched_entries,
             } => write!(
                 f,
                 "segment {start_offset} runs under enforce_fsync with {entry_count} sparse \
-                 index entries, but its log backs only {provable_entries} of them (up to \
-                 byte {provable_position}); every entry below the last was fsync'd with \
-                 the log chunk it describes before that chunk was acknowledged, so the \
-                 log has lost acknowledged data rather than the index having outrun it"
+                 index entries, but its log backs only {provable_entries} of the \
+                 {searched_entries} searched from the top (up to byte {provable_position}); \
+                 every entry below the last was fsync'd together with the acknowledged log \
+                 chunk it describes, so the log has lost acknowledged data rather than the \
+                 index having outrun it"
             ),
             Self::StorageSizeMismatch {
                 start_offset,

--- a/core/server/src/server_error.rs
+++ b/core/server/src/server_error.rs
@@ -77,6 +77,21 @@ pub enum ServerError {
          committed journal tail may not have flushed"
     )]
     ShardPumpDied { shard_id: u16, reason: String },
+    /// A shard's message pump stopped because a partition could not commit
+    /// an op the cluster had already committed. The partition is fenced and
+    /// the server is shutting down; the exit is non-zero so an orchestrator
+    /// does not read a durability fault as a clean stop.
+    #[error(
+        "shard {shard_id} stopped: partition {namespace_raw} could not commit op {op}, \
+         which the cluster had already committed. The replica is divergent and was \
+         fenced; the server shut down so it cannot serve a prefix the cluster has \
+         moved past"
+    )]
+    ShardFatal {
+        shard_id: u16,
+        namespace_raw: u64,
+        op: u64,
+    },
     #[error(
         "shard {shard_id} message pump did not drain within {timeout:?}. \
          Committed journal tail may not have flushed"

--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -63,7 +63,9 @@ use metadata::impls::metadata::StreamsFrontend;
 use metadata::stm::StateMachine;
 use metadata::{BoundSession, MetadataSubmitError};
 use partitions::state_transfer::TransferArtifact;
-use partitions::{IggyPartition, IggyPartitions, PollFragments, PollingArgs, PollingConsumer};
+use partitions::{
+    FatalCommit, IggyPartition, IggyPartitions, PollFragments, PollingArgs, PollingConsumer,
+};
 use server_common::sharding::{IggyNamespace, PartitionLocation, ShardId};
 use server_common::{MESSAGE_ALIGN, Message, MessageBag, iobuf::Frozen};
 use shards_table::ShardsTable;
@@ -6428,7 +6430,15 @@ where
     /// Tick partition consensuses. Loop partitions. No partitions-plane journal.
     #[allow(clippy::future_not_send)]
     #[allow(clippy::too_many_lines)]
-    pub async fn tick_partitions(&self, namespace_scratch: &mut Vec<IggyNamespace>)
+    /// Returns the commit fault that fenced a partition on this shard, if one
+    /// has. The pump turns it into a server shutdown: a fenced partition is
+    /// divergent from the cluster and can never advance again, so the tick
+    /// stops driving it and the node stops rather than serving a prefix the
+    /// cluster has moved past.
+    pub async fn tick_partitions(
+        &self,
+        namespace_scratch: &mut Vec<IggyNamespace>,
+    ) -> Option<FatalCommit>
     where
         B: MessageBus,
         MJ: JournalHandle,
@@ -6498,10 +6508,19 @@ where
         // already accepts.
         let mut transfers_inflight: Option<usize> = None;
 
+        let mut fatal: Option<FatalCommit> = None;
         for namespace in namespace_scratch.drain(..) {
             let Some(partition) = partitions.get_by_ns(&namespace) else {
                 continue;
             };
+            // A fenced partition must not tick: its consensus would emit
+            // view-scoped sends for a log the cluster has already passed.
+            if let Some(fault) = partition.fatal() {
+                if fatal.is_none() {
+                    fatal = Some(fault.clone());
+                }
+                continue;
+            }
 
             let consensus = partition.consensus();
             // Only while a view change is live. A `Normal` tick has no consumer:
@@ -6705,6 +6724,8 @@ where
                 }
             }
         }
+
+        fatal
     }
 
     /// Flush every owned partition's committed journal prefix to segment

--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -6752,11 +6752,16 @@ where
                 .flush_committed_messages(partitions.config())
                 .await
             {
-                tracing::warn!(
+                tracing::error!(
                     namespace_raw = namespace.inner(),
                     %error,
                     "failed to flush partition journal on shutdown"
                 );
+                // The bytes left behind are cluster-committed, so the pump
+                // must not let this exit report clean (it re-scans for faults
+                // after this flush). A partition already fenced by the commit
+                // path keeps its original fault.
+                partition.fence_flush_failure();
             }
         }
     }

--- a/core/shard/src/router.rs
+++ b/core/shard/src/router.rs
@@ -27,6 +27,7 @@ use iggy_binary_protocol::{Command, ConsensusError, GenericHeader, Operation, Pr
 use journal::superblock::SuperblockStore;
 use journal::{Journal, JournalHandle};
 use message_bus::{ConnectionInstaller, MessageBus, ReplicaHandshakeDoneFn};
+use partitions::FatalCommit;
 use server_common::sharding::{IggyNamespace, METADATA_GROUP};
 use server_common::{Message, MessageBag};
 
@@ -254,8 +255,14 @@ where
     /// Drain this shard's inbox and process each frame locally until the
     /// `stop` signal fires or the inbox disconnects, then drain any frames
     /// still queued so in-flight requests still get a response.
+    ///
+    /// Returns the commit fault that ended the pump, if one did. A fault
+    /// skips that queued drain: the frames in it are requests for a shard
+    /// holding a divergent partition, and answering them means re-entering
+    /// the commit path that just failed. The final flush still runs, so
+    /// every partition that CAN still reach disk does.
     #[allow(clippy::future_not_send)]
-    pub async fn run_message_pump(&self, stop: Receiver<()>)
+    pub async fn run_message_pump(&self, stop: Receiver<()>) -> Option<FatalCommit>
     where
         B: MessageBus + 'static,
         MJ: JournalHandle,
@@ -281,6 +288,7 @@ where
         // simulator (see `MessageBus::sleep`).
         let rearm_tick = || self.bus.sleep(CONSENSUS_TICK_INTERVAL).fuse();
         let mut consensus_tick = std::pin::pin!(rearm_tick());
+        let mut fatal: Option<FatalCommit> = None;
         loop {
             // `select_biased!`, not `select!`: the unbiased macro draws its
             // arm order from a process-random thread-local PRNG, which the
@@ -299,7 +307,10 @@ where
                     // decoupled from the pump again without reintroducing the
                     // partition-ref-across-`.await` UB this fold closed.
                     self.tick_metadata().await;
-                    self.tick_partitions(&mut namespace_scratch).await;
+                    if let Some(fault) = self.tick_partitions(&mut namespace_scratch).await {
+                        fatal = Some(fault);
+                        break;
+                    }
                     // Runs here, not inside `tick_metadata`: that early-returns
                     // on shards without metadata consensus, and partition-plane
                     // offers live on every shard that hosts a serving group --
@@ -368,25 +379,38 @@ where
 
         // Drain remaining frames so in-flight requests get a response, and
         // the reply lane so already-forwarded replies still reach their
-        // clients before the bus tears down.
-        while let Ok(frame) = self.inbox.try_recv() {
-            if self.accept_frame_for_self(&frame) {
-                self.process_frame(frame).await;
-                self.process_loopback(&mut loopback_buf, &mut namespace_scratch)
-                    .await;
-                self.apply_reconcile_ops();
+        // clients before the bus tears down. Skipped on a commit fault: a
+        // queued Ack or Commit frame for the fenced partition would re-enter
+        // the commit path that just failed, and `advance_commit_min` asserts
+        // on the gap the fault left. Those requests go unanswered and their
+        // clients time out, which is what a node stopping on a durability
+        // fault owes them.
+        if fatal.is_none() {
+            while let Ok(frame) = self.inbox.try_recv() {
+                if self.accept_frame_for_self(&frame) {
+                    self.process_frame(frame).await;
+                    self.process_loopback(&mut loopback_buf, &mut namespace_scratch)
+                        .await;
+                    self.apply_reconcile_ops();
+                }
             }
-        }
-        while let Ok(frame) = self.reply_inbox.try_recv() {
-            if self.accept_frame_for_self(&frame) {
-                self.process_frame(frame).await;
+            while let Ok(frame) = self.reply_inbox.try_recv() {
+                if self.accept_frame_for_self(&frame) {
+                    self.process_frame(frame).await;
+                }
             }
         }
 
         // Final flush: committed messages still resident in the in-memory
         // journal must reach segment storage before the process exits, or a
-        // graceful restart recovers consumer offsets ahead of the data.
+        // graceful restart recovers consumer offsets ahead of the data. Runs
+        // on a fault too, the fenced partition included: its resident prefix
+        // is cluster-committed data, so writing what still reaches disk is
+        // strictly better than dropping it, and a second failure is warned
+        // per partition rather than propagated.
         self.flush_partitions().await;
+
+        fatal
     }
 
     /// Sanity check at pump entry: every Consensus frame routed through

--- a/core/shard/src/router.rs
+++ b/core/shard/src/router.rs
@@ -30,6 +30,8 @@ use message_bus::{ConnectionInstaller, MessageBus, ReplicaHandshakeDoneFn};
 use partitions::FatalCommit;
 use server_common::sharding::{IggyNamespace, METADATA_GROUP};
 use server_common::{Message, MessageBag};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// How often the shard pump drives `VsrConsensus::tick`.
 ///
@@ -261,8 +263,19 @@ where
     /// holding a divergent partition, and answering them means re-entering
     /// the commit path that just failed. The final flush still runs, so
     /// every partition that CAN still reach disk does.
+    ///
+    /// `shutdown_flag` is the cross-thread server shutdown signal. The pump
+    /// flips it as soon as a commit fault is resolved, BEFORE the final
+    /// flush: the flush writes to the device whose failure raised the fault,
+    /// so it can stall indefinitely, and only the flag arms the watchdog and
+    /// the bounded pump drain that turn a stalled flush into a timed-out
+    /// non-zero exit instead of a process that reports healthy forever.
     #[allow(clippy::future_not_send)]
-    pub async fn run_message_pump(&self, stop: Receiver<()>) -> Option<FatalCommit>
+    pub async fn run_message_pump(
+        &self,
+        stop: Receiver<()>,
+        shutdown_flag: Arc<AtomicBool>,
+    ) -> Option<FatalCommit>
     where
         B: MessageBus + 'static,
         MJ: JournalHandle,
@@ -377,6 +390,13 @@ where
             }
         }
 
+        // A stop can win the select immediately after a frame fenced a
+        // partition, before the next tick observes it. Preserve that fault so
+        // shutdown cannot turn a durability failure into a clean pump exit.
+        if fatal.is_none() {
+            fatal = self.first_partition_commit_fault();
+        }
+
         // Drain remaining frames so in-flight requests get a response, and
         // the reply lane so already-forwarded replies still reach their
         // clients before the bus tears down. Skipped on a commit fault: a
@@ -392,13 +412,32 @@ where
                     self.process_loopback(&mut loopback_buf, &mut namespace_scratch)
                         .await;
                     self.apply_reconcile_ops();
+                    if let Some(fault) = self.first_partition_commit_fault() {
+                        fatal = Some(fault);
+                        break;
+                    }
                 }
             }
+        }
+        if fatal.is_none() {
             while let Ok(frame) = self.reply_inbox.try_recv() {
                 if self.accept_frame_for_self(&frame) {
                     self.process_frame(frame).await;
+                    if let Some(fault) = self.first_partition_commit_fault() {
+                        fatal = Some(fault);
+                        break;
+                    }
                 }
             }
+        }
+
+        if fatal.is_some() {
+            // Flipped BEFORE the final flush, not after the pump returns: the
+            // flush writes to the device whose failure raised the fault and
+            // can stall there indefinitely, and the flag is what arms the
+            // watchdog and the bounded pump drain. Siblings give up at most
+            // the flush window of extra serving.
+            shutdown_flag.store(true, Ordering::Relaxed);
         }
 
         // Final flush: committed messages still resident in the in-memory
@@ -406,11 +445,32 @@ where
         // graceful restart recovers consumer offsets ahead of the data. Runs
         // on a fault too, the fenced partition included: its resident prefix
         // is cluster-committed data, so writing what still reaches disk is
-        // strictly better than dropping it, and a second failure is warned
-        // per partition rather than propagated.
+        // strictly better than dropping it, and a second failure of an
+        // already-fenced partition is warned rather than propagated.
         self.flush_partitions().await;
 
+        // A failed flush fences its partition: the data it could not write is
+        // cluster-committed and now lives only in this process's memory, so a
+        // clean exit here would report a durability loss as a good shutdown.
+        if fatal.is_none() {
+            fatal = self.first_partition_commit_fault();
+        }
+
         fatal
+    }
+
+    /// First partition commit fault currently fenced on this shard.
+    ///
+    /// The regular path observes faults in `tick_partitions`. This scan covers
+    /// the pump-exit edges where a stop signal wins before that tick, or a
+    /// queued frame fails while the pump is draining during shutdown.
+    fn first_partition_commit_fault(&self) -> Option<FatalCommit> {
+        let partitions = self.plane.partitions();
+        partitions.namespaces().find_map(|namespace| {
+            partitions
+                .get_by_ns(namespace)
+                .and_then(|partition| partition.fatal().cloned())
+        })
     }
 
     /// Sanity check at pump entry: every Consensus frame routed through

--- a/core/simulator/src/lib.rs
+++ b/core/simulator/src/lib.rs
@@ -56,6 +56,8 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 /// Poll budget per [`DetExecutor::run_until_stalled`]. Pumps are event-driven, so
 /// hitting it means a task is spin-waking: a bug, panicked with the seed.
@@ -433,8 +435,13 @@ impl Simulator {
                 // the held stop channel or a crash abort.
                 let (stop_tx, stop_rx) = shard::channel::<()>(1);
                 let pump_shard = Rc::clone(&shard);
+                // The simulator crashes replicas explicitly, so nothing reads
+                // the shutdown flag a commit fault would flip.
+                let pump_shutdown_flag = Arc::new(AtomicBool::new(false));
                 pump_tasks.push(executor.spawn(async move {
-                    pump_shard.run_message_pump(stop_rx).await;
+                    pump_shard
+                        .run_message_pump(stop_rx, pump_shutdown_flag)
+                        .await;
                 }));
                 stop_txs.push(stop_tx);
                 shards.push(shard);
@@ -1117,8 +1124,11 @@ impl Simulator {
             }
             let (stop_tx, stop_rx) = shard::channel::<()>(1);
             let pump_shard = Rc::clone(&shard);
+            let pump_shutdown_flag = Arc::new(AtomicBool::new(false));
             pump_tasks.push(self.executor.spawn(async move {
-                pump_shard.run_message_pump(stop_rx).await;
+                pump_shard
+                    .run_message_pump(stop_rx, pump_shutdown_flag)
+                    .await;
             }));
             stop_txs.push(stop_tx);
             shards.push(shard);


### PR DESCRIPTION
## Concurrent log and index fsync

Every journal flush issued two serialized fdatasyncs, log then index, so an fsync-gated topic paid two device round trips per ack. Both files now persist under one `futures::future::join`: 13.4k to 26.1k msg/s and p50 5.83 to 3.01 ms on ext4 with `enforce_fsync` and `messages_required_to_save = 1`, 8 producers into one partition. Cursors advance only after both saves succeed, so a failed half keeps its slot and the callers that survive rewrite the same positions rather than appending a duplicate.

## Recovery had to change first

The old ordering was a barrier only under `enforce_fsync = true`. With the shipped default the page cache already wrote the two inodes back in any order, and recovery's own pass C truncates the log before the index, so an index holding entries the log does not back was already ordinary. Boot refused it as `IndexLogDivergence`, which on a single-replica node permanently tombstoned a partition whose log was healthy.

An index entry is derived from the log, so it is never evidence about the log. Recovery now drops such an index whole and rebuilds it from a byte-0 walk rather than stepping back to the highest entry the log still proves. Stepping back is unsound: that anchor can sit above interior damage, and the residue probe only scans forward from where a walk stopped, so a hole under it goes unread while `end_offset` still advertises the offsets over it. The byte-0 walk reads the damage and refuses with every byte preserved, and checksums every batch it accepts, since unordered files mean a durable index entry no longer implies a durable chunk.

Under `enforce_fsync = true` the step-back depth is measured first, because there it is evidence about the log. Flushes are serialized and each fdatasyncs the whole log file, so an entry above entry N proves the log was synced through chunk N, and only the chunk in flight at the crash can strand one. A deeper gap refuses as the new `FsyncedLogLoss` rather than rebuilding, which would let the partition re-mint offsets a client was already promised. The probe measuring that depth is capped, since past the cap the verdict is refusal either way.

That allowance is **not** a promise that nothing acked is lost. The partition journal is in memory and never replayed at boot, and `enforce_fsync` decides whether a flush fdatasyncs, never whether one happens, so at the default `messages_required_to_save = 1024` up to 1023 acked messages sit unflushed. Only `messages_required_to_save = 1` gates every ack on its own fdatasync. The refusal is unaffected: an acked-but-unflushed message writes neither log bytes nor an index entry, so it can neither manufacture a step-back nor mask one.

Called out rather than fixed: when the log does back the last index entry, the walk starts there and `[0, last.position)` is not re-read at boot, where at-rest damage surfaces on the read path via `validate_checksum` instead. Closing it would mean re-hashing every segment on every boot, since no clean-shutdown marker exists on disk.

## A persist failure now stops the server, not one shard

A local commit failing for an op the cluster had already committed panicked on purpose: the replica is divergent, its `commit_min` never advanced, and the next advance would assert. That panic was meant to end the process and never did. It runs on the shard's message pump, and `compio::runtime::spawn` catches the unwind, so the process lived on with one pump dead. That pump drives every partition on its shard, so all of them stopped committing, ticking and replying while the listeners and other shards kept answering. Clients got no error either: frames to the dead shard were dropped once its inbox filled, so each request blocked until the client's own read timeout.

The partition now records the fault instead of panicking, which also fences it, so `on_ack`, `commit_journal` and the tick become no-ops. The tick reports it to the pump, which breaks, skips the queued tail drain (those frames re-enter the commit path that just failed) and still runs its final flush. The spawn site flips the shared shutdown flag so sibling shards stop gracefully, and the verdict leaves as `ShardFatal`, so the process exits non-zero.

Quarantining only the faulting partition was the alternative. A runtime persist failure is a device signal rather than one bad chain, and a quarantined partition cannot resume without a restart anyway.

## Also in this PR

The active segment now fills the same per-segment read-state slot that sealed segments use. It was populated for sealed segments only, so a consumer following the head paid one `openat` per poll, each an io_uring operation prone to an io-wq punt. It is demand-filled, dropped when the segment seals, and outside the sealed LRU budget so unrelated traffic cannot evict it.

Three smaller fixes: latency extremes are backfilled only when all three of min, max and standard deviation are absent, since backfilling individually let a report mix a raw value with two derived ones. The segment writer save methods are narrowed to the crate. And both index scans yield on a stride, since each can run a megabyte-scale index with no disk read to key a yield on.

## Tests and verification

The integration test SIGKILLs a node after an eager flush with its log cut at the last index entry's position, the only depth a crash can produce under `enforce_fsync`, then asserts the rebuild marker in the boot log, that every rebuilt entry opens inside the truncated log, the surviving prefix served, nothing fenced, and the node caught up. Unit tests cover the refusal, the probe cap, and the commit fault fencing instead of panicking.

fmt, sort and clippy clean with all features and targets. partitions 134, shard 45, server 326, and the `cluster::` suite against a server binary rebuilt from the branch head, since the integration crate does not rebuild it.
