### PR TITLE
fix(server): restore the mimalloc global allocator

### DIFF
--- a/core/server/src/lib.rs
+++ b/core/server/src/lib.rs
@@ -18,6 +18,14 @@
 #![allow(clippy::future_not_send)]
 
 use iggy_common::SemanticVersion;
+#[cfg(all(feature = "mimalloc", not(feature = "disable-mimalloc")))]
+use mimalloc::MiMalloc;
+
+// Both features are checked because `--all-features` turns on `mimalloc` and
+// `disable-mimalloc` at once, while `--no-default-features` drops the crate.
+#[cfg(all(feature = "mimalloc", not(feature = "disable-mimalloc")))]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const SEMANTIC_VERSION: SemanticVersion = SemanticVersion::parse_const(VERSION);

--- a/core/server/src/main.rs
+++ b/core/server/src/main.rs
@@ -44,6 +44,10 @@ fn main() -> Result<(), ServerError> {
     let mut logging = Logging::new(server::VERSION);
     logging.early_init();
     server_common::print_build_info!(server::VERSION);
+    #[cfg(all(feature = "mimalloc", not(feature = "disable-mimalloc")))]
+    info!("Using mimalloc allocator");
+    #[cfg(not(all(feature = "mimalloc", not(feature = "disable-mimalloc"))))]
+    tracing::warn!("Using the default system allocator");
     if let Ok(env_path) = std::env::var("IGGY_ENV_PATH") {
         let _ = dotenvy::from_path(&env_path);
     } else {


### PR DESCRIPTION
The server has run on the system allocator since 9cfb2d93a dropped the
`#[global_allocator]` declaration while the `mimalloc` feature stayed
enabled by default. The feature, the optional dependency and every
`MIMALLOC_*` environment setting have been inert ever since. The same
commit added `mimalloc` to the `cargo-machete` ignore list, so the now
orphaned dependency raised no warning either.

Restore the allocator as the legacy server declared it, gated on both
`mimalloc` and `disable-mimalloc` so that `--no-default-features`,
`--features disable-mimalloc` and `--all-features` all build, and log
which allocator the process starts on.
