### PR TITLE
fix(server):  apply thread pool limit carve-out to all of macOS

### DIFF
--- a/core/partitions/src/messages_writer.rs
+++ b/core/partitions/src/messages_writer.rs
@@ -187,9 +187,9 @@ fn preallocate_file(file: &File, file_path: &str, len: u64) {
     // sets `thread_pool_limit(0)` on the shard proactor, so `spawn_blocking`
     // has no worker to park a task on and compio panics the shard outright with
     // "the thread pool is needed but no worker thread is running". (That limit
-    // is skipped on macOS/aarch64, where the pool does exist -- see the FIXME
-    // there -- so the panic is Linux-and-most-targets, not universal. This arm
-    // is Linux-only regardless.)
+    // is skipped on macOS, whose polling driver routes fs through the pool, so
+    // the panic is Linux-and-most-targets, not universal. This arm is
+    // Linux-only regardless.)
     //
     // The cost is acceptable only because of what this call is: a metadata-only
     // extent reservation, microseconds on the local filesystems this option

--- a/core/server_common/src/executor.rs
+++ b/core/server_common/src/executor.rs
@@ -84,7 +84,7 @@ pub fn create_shard_executor() -> Result<Runtime, std::io::Error> {
     // io_uring targets keep the zero limit: no blocking pool exists on shard
     // threads, which `core/partitions` messages_writer relies on to justify
     // running fallocate inline (`spawn_blocking` would hit that same panic).
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(not(target_os = "macos"))]
     proactor.thread_pool_limit(0);
 
     compio::runtime::RuntimeBuilder::new()


### PR DESCRIPTION
## Which issue does this PR address?

<!--
We generally require a GitHub issue for all bug fixes and enhancements. Link it with GitHub syntax, keep the line that applies and delete the other:
-->
- Closes #3993  

## Rationale
The zero thread-pool limit was skipped only on macOS aarch64, so an Intel macOS build applied it and panicked on the first fs operation with "the thread pool is needed but no worker thread is running". compio's polling driver routes fs through the blocking pool on all of macOS, not just Apple Silicon, which is what the comment above the cfg already described and what the FIXME removed in 8ed41c7db said before it.
<!--
Why is this change needed? If the issue explains it well, a one-liner is fine.
-->

## What changed?

The zero `thread_pool_limit` was skipped on macOS `aarch64`, so an Intel macOS build applied it and panicked on the first fs operation with "the thread pool is needed but no worker thread is running". The fix now covers `target="macOS"` regardless of architecture. The related comment in `message_writer.rs` is updated to match and drop a reference to a FIXME removed in 8ed41c7db.

<!--
2-4 sentences. Problem first (before), then solution (after).

GOOD:

"Messages were unavailable when background message_saver committed the
journal and started async disk I/O before completion. Polling during
this window found neither journal nor disk data.

The fix freezes journal batches in the in-flight buffer before async persist."

GOOD:

"When many small messages accumulate in the journal, the flush passes
thousands of IO vectors to writev(), exceeding IOV_MAX (1024 on Linux)."

BAD:
- Walls of text
- "This PR adds..." (we can see the diff)
-->

## Local Execution

- [x] Passed
- [x] Pre-commit hooks ran 

<!--
You must run your code locally before submitting.
"Relying on CI" is not acceptable - PRs from authors who haven't run the code will be closed.

Did you have `prek` installed? It runs automatically on commit and covers all project languages. See [CONTRIBUTING.md](https://github.com/apache/iggy/blob/master/CONTRIBUTING.md).
-->

## AI Usage

If AI tools were used, please answer:
1. Which tools? Claude
2. Scope of usage? To debug stacktrace and location of error
3. How did you verify the generated code works correctly? Pre-produced the panic before change, made the change, built and booted the server, confirmed GET /ping returns 200 and completed stream/topic/send/poll round trip via the cli. cargo fmt --all --check and clippy clean
4. Can you explain every line of the code if asked? Yes


