### PR TITLE
docs: wait for the issue to be assigned, not for a label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Every new PR that introduces new functionality must link to an approved issue.
 PRs without one may be closed at maintainer's discretion.
 
 1. Create an issue or comment under existing
-2. Wait for maintainer approval (`good-first-issue` label or comment)
+2. Wait for the issue to be assigned to you
     - Maintainer may request for more details or a different approach
 3. Then code
 


### PR DESCRIPTION
Step 2 pointed at the `good-first-issue` label as the signal to start work. Assignment is the signal.