### PR TITLE
test(java): boot the edge server consistently in both Java suites

### DIFF
--- a/foreign/java/external-processors/iggy-connector-pinot/src/test/java/org/apache/iggy/connector/pinot/IggyPinotIntegrationTest.java
+++ b/foreign/java/external-processors/iggy-connector-pinot/src/test/java/org/apache/iggy/connector/pinot/IggyPinotIntegrationTest.java
@@ -38,7 +38,6 @@ import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
@@ -63,7 +62,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 class IggyPinotIntegrationTest {
 
-    // The Java SDK speaks VSR, so use the same VSR-capable image as its integration tests.
+    // Mirrors the container in the SDK's BaseIntegrationTest so both suites exercise the same server.
     private static final DockerImageName IGGY_IMAGE = DockerImageName.parse("apache/iggy:edge");
     private static final DockerImageName PINOT_IMAGE = DockerImageName.parse(
             Objects.requireNonNull(System.getProperty("iggy.pinot.image"), "Missing iggy.pinot.image system property"));
@@ -74,6 +73,7 @@ class IggyPinotIntegrationTest {
     private static final int PINOT_CONTROLLER_PORT = 9000;
     private static final int PINOT_BROKER_PORT = 8099;
     private static final int PINOT_SERVER_ADMIN_PORT = 8097;
+    private static final String IGGY_NETWORK_ALIAS = "iggy";
     private static final String EXTERNAL_SERVER_HOST = "127.0.0.1";
     private static final String TESTCONTAINERS_HOST = "host.testcontainers.internal";
     private static final boolean USE_EXTERNAL_SERVER = System.getenv("USE_EXTERNAL_SERVER") != null;
@@ -220,25 +220,20 @@ class IggyPinotIntegrationTest {
 
     private static void startIggy() {
         iggy = new GenericContainer<>(IGGY_IMAGE)
-                .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withNetwork(network)
-                .withNetworkAliases("iggy")
+                .withNetworkAliases(IGGY_NETWORK_ALIAS)
                 .withExposedPorts(IGGY_HTTP_PORT, IGGY_TCP_PORT)
-                .withEnv("IGGY_SYSTEM_LOGGING_LEVEL", "info")
-                .withEnv("IGGY_TCP_ADDRESS", "0.0.0.0:8090")
-                .withEnv("IGGY_HTTP_ENABLED", "true")
-                .withEnv("IGGY_HTTP_ADDRESS", "0.0.0.0:3000")
                 .withEnv("IGGY_ROOT_USERNAME", "iggy")
                 .withEnv("IGGY_ROOT_PASSWORD", "iggy")
-                .withEnv("IGGY_SYSTEM_SHARDING_CPU_ALLOCATION", "1")
+                .withEnv("IGGY_TCP_ADDRESS", "0.0.0.0:" + IGGY_TCP_PORT)
+                .withEnv("IGGY_HTTP_ADDRESS", "0.0.0.0:" + IGGY_HTTP_PORT)
+                .withEnv("IGGY_NODE_ADVERTISED_ADDRESS", IGGY_NETWORK_ALIAS)
+                .withEnv("IGGY_SYSTEM_SHARDING_CPU_ALLOCATION", "all")
                 .withCreateContainerCmdModifier(cmd -> cmd.getHostConfig()
                         .withCapAdd(Capability.SYS_NICE)
                         .withSecurityOpts(List.of("seccomp:unconfined"))
                         .withUlimits(List.of(new Ulimit("memlock", -1L, -1L))))
-                .waitingFor(Wait.forHttp("/")
-                        .forPort(IGGY_HTTP_PORT)
-                        .forStatusCodeMatching(status -> status >= 200 && status < 500)
-                        .withStartupTimeout(STARTUP_TIMEOUT));
+                .waitingFor(Wait.forHttp("/ping").forPort(IGGY_HTTP_PORT).withStartupTimeout(STARTUP_TIMEOUT));
         iggy.start();
     }
 

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/BaseIntegrationTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/BaseIntegrationTest.java
@@ -27,30 +27,30 @@ import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
 
 /**
- * Base for integration tests. The SDK speaks the VSR wire protocol, so the
- * server under test must support it.
+ * Base for integration tests. By default the server under test is the
+ * {@code apache/iggy:edge} image started via testcontainers. The tag tracks
+ * master, so refresh the local copy with {@code docker pull apache/iggy:edge}
+ * whenever the SDK's wire protocol moves ahead of it.
  *
- * <p>With {@code USE_EXTERNAL_SERVER} set, tests target an externally
- * started VSR server on localhost, running standalone (single-node) mode.
- * Start it from the repo root:
+ * <p>With {@code USE_EXTERNAL_SERVER} set, tests instead target an externally
+ * started server on localhost, running standalone (single-node) mode. Start
+ * it from the repo root:
  * <pre>{@code
  * IGGY_ROOT_USERNAME=iggy IGGY_ROOT_PASSWORD=iggy cargo run --bin iggy-server
  * }</pre>
- *
- * <p>Otherwise a server container is started via testcontainers. This works
- * once the published image ships a VSR-capable server; until then the
- * external-server mode is the only one that can pass.
  */
 @Testcontainers
 public abstract class BaseIntegrationTest {
 
     protected static GenericContainer<?> iggyServer;
+    private static final DockerImageName IGGY_IMAGE = DockerImageName.parse("apache/iggy:edge");
     private static final String LOCALHOST_IP = "127.0.0.1";
     private static final int HTTP_PORT = 3000;
     private static final int TCP_PORT = 8090;
@@ -80,22 +80,20 @@ public abstract class BaseIntegrationTest {
     static void setupContainer() {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
         if (!USE_EXTERNAL_SERVER) {
-            // The published image still ships the legacy server, which does
-            // not speak the VSR wire protocol, so tests against this
-            // container fail until a VSR-capable server is released. Use
-            // USE_EXTERNAL_SERVER until then.
             log.info("Starting Iggy Server Container...");
-            iggyServer = new GenericContainer<>(DockerImageName.parse("apache/iggy:edge"))
+            iggyServer = new GenericContainer<>(IGGY_IMAGE)
                     .withExposedPorts(HTTP_PORT, TCP_PORT)
                     .withEnv("IGGY_ROOT_USERNAME", "iggy")
                     .withEnv("IGGY_ROOT_PASSWORD", "iggy")
-                    .withEnv("IGGY_TCP_ADDRESS", "0.0.0.0:8090")
-                    .withEnv("IGGY_HTTP_ADDRESS", "0.0.0.0:3000")
-                    .withEnv("IGGY_NODE_ADVERTISED_ADDRESS", "127.0.0.1")
+                    .withEnv("IGGY_TCP_ADDRESS", "0.0.0.0:" + TCP_PORT)
+                    .withEnv("IGGY_HTTP_ADDRESS", "0.0.0.0:" + HTTP_PORT)
+                    .withEnv("IGGY_NODE_ADVERTISED_ADDRESS", LOCALHOST_IP)
+                    .withEnv("IGGY_SYSTEM_SHARDING_CPU_ALLOCATION", "all")
                     .withCreateContainerCmdModifier(cmd -> cmd.getHostConfig()
                             .withCapAdd(Capability.SYS_NICE)
                             .withSecurityOpts(List.of("seccomp:unconfined"))
                             .withUlimits(List.of(new Ulimit("memlock", -1L, -1L))))
+                    .waitingFor(Wait.forHttp("/ping").forPort(HTTP_PORT))
                     .withLogConsumer(frame -> System.out.print(frame.getUtf8String()));
             iggyServer.start();
         } else {


### PR DESCRIPTION
The Pinot suite could not start the current apache/iggy:edge image:
the server now refuses a wildcard bind without an advertised address
(#3923) and the suite never set one. It also re-pulled the image on
every run, which made it far slower than the SDK suite, and its
readiness probe accepted any HTTP status below 500 from /. The SDK
suite in turn still claimed the published image shipped the legacy
server and only waited for the ports to open.

Both suites now configure the container the same way: advertise an
address clients can dial, let the server use every core, and gate on
/ping before running tests. The Pinot suite reuses the locally cached
image like the SDK suite does.
