### PR TITLE
feat(server): generic external auth callout

### DIFF
--- a/core/common/src/types/permissions/permissions_global.rs
+++ b/core/common/src/types/permissions/permissions_global.rs
@@ -26,6 +26,7 @@ use std::fmt::Display;
 /// Global permissions are applied to all streams.
 /// Stream permissions are applied to a specific stream.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+#[serde(default)]
 pub struct Permissions {
     /// Global permissions are applied to all streams.
     pub global: GlobalPermissions,
@@ -36,6 +37,7 @@ pub struct Permissions {
 
 /// `GlobalPermissions` are applied to all streams without a need to specify them one by one in the `streams` field.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+#[serde(default)]
 pub struct GlobalPermissions {
     /// `manage_servers` permission allows to manage the servers and includes all the permissions of `read_servers`.
     pub manage_servers: bool,
@@ -104,6 +106,7 @@ pub struct GlobalPermissions {
 /// `StreamPermissions` are applied to a specific stream and its all topics. If you want to define granular permissions for each topic, use the `topics` field.
 /// These permissions do not override the global permissions, but extend them, and allow more granular control over the streams and the users that can access them.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+#[serde(default)]
 pub struct StreamPermissions {
     /// `manage_stream` permission allows to manage the stream and includes all the permissions of `read_stream`.
     /// Also, it allows to manage all the topics of a stream, thus it has all the permissions of `manage_topics`.
@@ -143,6 +146,7 @@ pub struct StreamPermissions {
 
 /// `TopicPermissions` are applied to a specific topic of a stream. This is the lowest level of permissions.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+#[serde(default)]
 pub struct TopicPermissions {
     /// `manage_topic` permission allows to manage the topic and includes all the permissions of `read_topic`.
     pub manage_topic: bool,

--- a/core/configs/src/common/defaults.rs
+++ b/core/configs/src/common/defaults.rs
@@ -25,6 +25,7 @@ use super::system::{
     EncryptionConfig, LoggingConfig, PartitionConfig, RecoveryConfig, RuntimeConfig, SegmentConfig,
     StreamConfig, SystemConfig, TopicConfig,
 };
+use crate::server_config::external_auth::ExternalAuthConfig;
 use configs::ConfigEnvMappings;
 
 static_toml::static_toml! {
@@ -323,6 +324,21 @@ impl Default for TelemetryTracesConfig {
         TelemetryTracesConfig {
             transport: SERVER_CONFIG.telemetry.traces.transport.parse().unwrap(),
             endpoint: SERVER_CONFIG.telemetry.traces.endpoint.parse().unwrap(),
+        }
+    }
+}
+
+impl Default for ExternalAuthConfig {
+    fn default() -> ExternalAuthConfig {
+        ExternalAuthConfig {
+            enabled: SERVER_CONFIG.external_auth.enabled,
+            url: SERVER_CONFIG.external_auth.url.parse().unwrap(),
+            timeout: SERVER_CONFIG.external_auth.timeout.parse().unwrap(),
+            forward_credentials: SERVER_CONFIG.external_auth.forward_credentials,
+            user_id: u32::try_from(SERVER_CONFIG.external_auth.user_id).expect(
+                "static_toml external_auth.user_id must fit in u32 (0..=4294967295); \
+                 fix core/server/config.toml",
+            ),
         }
     }
 }

--- a/core/configs/src/lib.rs
+++ b/core/configs/src/lib.rs
@@ -27,5 +27,6 @@ pub use configs_impl::{
     FileConfigProvider, RelocatedKey, TypedEnvProvider, parse_env_value_to_json,
 };
 pub use server_config::{
-    cluster, message_bus, metadata, partition, quic, server, sharding, tcp, websocket,
+    cluster, external_auth, message_bus, metadata, partition, quic, server, sharding, tcp,
+    websocket,
 };

--- a/core/configs/src/server_config/defaults.rs
+++ b/core/configs/src/server_config/defaults.rs
@@ -27,6 +27,7 @@ use super::cluster::{
     ClusterAuthConfig, ClusterConfig, ClusterCoordinatorConfig, ClusterNodeConfig,
     ClusterTlsConfig, TransportPorts,
 };
+use super::external_auth::ExternalAuthConfig;
 use super::message_bus::MessageBusConfig;
 use super::metadata::MetadataConfig;
 use super::node::NodeConfig;
@@ -66,6 +67,7 @@ impl Default for ServerConfig {
             metadata: MetadataConfig::default(),
             partition: PartitionConfig::default(),
             message_bus: MessageBusConfig::default(),
+            external_auth: ExternalAuthConfig::default(),
         }
     }
 }

--- a/core/configs/src/server_config/displays.rs
+++ b/core/configs/src/server_config/displays.rs
@@ -22,6 +22,7 @@
 //! [`ServerConfig`] formatter and the [`MessageBusConfig`] section
 //! formatter.
 
+use super::external_auth::ExternalAuthConfig;
 use super::message_bus::MessageBusConfig;
 use super::metadata::MetadataConfig;
 use super::partition::PartitionConfig;
@@ -36,7 +37,7 @@ impl Display for ServerConfig {
             f,
             "{{ consumer_group: {}, data_maintenance: {}, \
              heartbeat: {}, system: {}, quic: {}, tcp: {}, http: {}, telemetry: {}, \
-             metadata: {}, message_bus: {}, partition: {} }}",
+             metadata: {}, message_bus: {}, partition: {}, external_auth: {} }}",
             self.consumer_group,
             self.data_maintenance,
             self.heartbeat,
@@ -48,6 +49,7 @@ impl Display for ServerConfig {
             self.metadata,
             self.message_bus,
             self.partition,
+            self.external_auth,
         )
     }
 }
@@ -146,6 +148,22 @@ impl Display for QuicCertificateConfig {
             f,
             "{{ self_signed: {}, cert_file: {}, key_file: {} }}",
             self.self_signed, self.cert_file, self.key_file
+        )
+    }
+}
+
+impl Display for ExternalAuthConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let url_indicator = if self.url.is_empty() {
+            "(not set)"
+        } else {
+            "[redacted]"
+        };
+        write!(
+            f,
+            "{{ enabled: {}, url: {url_indicator}, timeout: {}, \
+             forward_credentials: {}, user_id: {} }}",
+            self.enabled, self.timeout, self.forward_credentials, self.user_id,
         )
     }
 }

--- a/core/configs/src/server_config/external_auth.rs
+++ b/core/configs/src/server_config/external_auth.rs
@@ -45,6 +45,16 @@ pub struct ExternalAuthConfig {
     /// inline grants share this single ID; the external principal string
     /// distinguishes sessions. Must not be 0 (root). The replicated
     /// state-machine gate recognizes this ID at boot.
+    ///
+    /// **Changing this value between restarts is safe.** External auth
+    /// sessions are connection-scoped and never persisted, so there is no
+    /// stale state referencing the old value. The server validates at boot
+    /// that the new value does not collide with any existing user in the
+    /// slab. Within a running process the value is immutable (set-once via
+    /// `OnceLock`); a hot-reload that attempts a different value panics.
+    /// In a cluster, all nodes should use the same value to avoid
+    /// operational confusion, though cross-node correctness is not
+    /// affected (session state is node-local).
     #[serde(default = "default_external_auth_user_id")]
     #[config_env(leaf)]
     pub user_id: u32,

--- a/core/configs/src/server_config/external_auth.rs
+++ b/core/configs/src/server_config/external_auth.rs
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use configs::ConfigEnv;
+use iggy_common::IggyDuration;
+use serde::{Deserialize, Serialize};
+use serde_with::DisplayFromStr;
+use serde_with::serde_as;
+
+/// External authentication callout configuration.
+///
+/// When enabled, login attempts that fail built-in credential verification
+/// are forwarded to an external HTTP service. The service returns a grant
+/// (with inline permissions or by mapping to an existing Iggy user) or a
+/// denial. Built-in users never hit the callout.
+#[serde_as]
+#[derive(Debug, Deserialize, Serialize, Clone, ConfigEnv)]
+pub struct ExternalAuthConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default, skip_serializing)]
+    #[config_env(secret)]
+    pub url: String,
+    #[serde_as(as = "DisplayFromStr")]
+    #[serde(default = "default_external_auth_timeout")]
+    #[config_env(leaf)]
+    pub timeout: IggyDuration,
+    #[serde(default)]
+    pub forward_credentials: bool,
+    /// Reserved user ID for inline-grant sessions. All external auth
+    /// inline grants share this single ID; the external principal string
+    /// distinguishes sessions. Must not be 0 (root). The replicated
+    /// state-machine gate recognizes this ID at boot.
+    #[serde(default = "default_external_auth_user_id")]
+    #[config_env(leaf)]
+    pub user_id: u32,
+}
+
+fn default_external_auth_timeout() -> IggyDuration {
+    "5 s".parse().expect("hardcoded timeout")
+}
+
+const fn default_external_auth_user_id() -> u32 {
+    u32::MAX
+}

--- a/core/configs/src/server_config/mod.rs
+++ b/core/configs/src/server_config/mod.rs
@@ -24,6 +24,7 @@
 pub mod cluster;
 pub mod defaults;
 pub mod displays;
+pub mod external_auth;
 pub mod message_bus;
 pub mod metadata;
 pub mod node;

--- a/core/configs/src/server_config/server.rs
+++ b/core/configs/src/server_config/server.rs
@@ -17,6 +17,7 @@
 
 use super::COMPONENT;
 use super::cluster::ClusterConfig;
+use super::external_auth::ExternalAuthConfig;
 use super::message_bus::MessageBusConfig;
 use super::metadata::MetadataConfig;
 use super::node::NodeConfig;
@@ -126,6 +127,8 @@ pub struct ServerConfig {
     pub metadata: MetadataConfig,
     pub partition: PartitionConfig,
     pub message_bus: MessageBusConfig,
+    #[serde(default)]
+    pub external_auth: ExternalAuthConfig,
 }
 
 /// One client-facing listener, as the client-facing address derivation and

--- a/core/metadata/src/impls/metadata.rs
+++ b/core/metadata/src/impls/metadata.rs
@@ -81,6 +81,10 @@ pub trait StreamsFrontend {
     fn users(&self) -> &Users;
     #[must_use]
     fn streams(&self) -> &Streams;
+    /// Reserved user ID for external auth inline-grant sessions. `None`
+    /// when external auth is disabled.
+    #[must_use]
+    fn external_auth_user_id(&self) -> Option<u32>;
 }
 
 impl StreamsFrontend for MuxStateMachine<variadic!(Users, Streams)> {
@@ -90,6 +94,10 @@ impl StreamsFrontend for MuxStateMachine<variadic!(Users, Streams)> {
 
     fn streams(&self) -> &Streams {
         &self.inner().1.0
+    }
+
+    fn external_auth_user_id(&self) -> Option<u32> {
+        self.external_auth_user_id()
     }
 }
 

--- a/core/metadata/src/stm/authz.rs
+++ b/core/metadata/src/stm/authz.rs
@@ -77,7 +77,12 @@ where
     M: StreamsFrontend
         + StateMachine<Input = Message<PrepareHeader>, Output = ApplyReply, Error = IggyError>,
 {
-    if let Some(denied) = authorize(&prepare, mux.users(), mux.streams()) {
+    if let Some(denied) = authorize(
+        &prepare,
+        mux.users(),
+        mux.streams(),
+        mux.external_auth_user_id(),
+    ) {
         return Ok(denied);
     }
     mux.update(prepare)
@@ -129,6 +134,7 @@ pub(crate) fn authorize(
     prepare: &Message<PrepareHeader>,
     users: &Users,
     streams: &Streams,
+    external_auth_user_id: Option<u32>,
 ) -> Option<ApplyReply> {
     let header = prepare.header();
     let user_id = header.user_id;
@@ -136,7 +142,30 @@ pub(crate) fn authorize(
     if user_id == ROOT_USER_ID {
         return None;
     }
+
     let body = prepare.body();
+
+    // The external auth inline-grant user may execute the replicated
+    // data-plane ops listed below. Each is also gated at dispatch time by
+    // session-scoped permissions (authorize_partition_op for SendMessages
+    // and consumer offsets; authorize_consumer_group_op for CG join/leave).
+    // Non-replicated reads (PollMessages, GetConsumerOffset) never reach
+    // the STM and are gated only at dispatch time.
+    // SYNC: if a new REPLICATED data-plane operation is added, add it
+    // here AND add a dispatch-time session-scoped permission check in
+    // dispatch/authz.rs or dispatch/mod.rs.
+    if external_auth_user_id.is_some_and(|id| user_id == id) {
+        return match header.operation {
+            Operation::Register
+            | Operation::Logout
+            | Operation::SendMessages
+            | Operation::StoreConsumerOffset
+            | Operation::DeleteConsumerOffset
+            | Operation::JoinConsumerGroup
+            | Operation::LeaveConsumerGroup => None,
+            _ => Some(ApplyReply::err(IggyError::Unauthorized.as_code())),
+        };
+    }
 
     match header.operation {
         // Streams. `create_stream` is unscoped; the rest resolve the stream id.
@@ -417,11 +446,16 @@ mod tests {
     const ROOT: u32 = 0;
     const ALICE: u32 = 1;
 
+    /// External auth user ID used by tests that exercise the inline-grant gate.
+    const EXT_AUTH_USER_ID: u32 = 99_999;
+
     fn mux() -> MuxStateMachine<variadic!(Users, Streams)> {
         let users = Users::default();
         users.ensure_root_user("iggy", "hash");
         let streams = Streams::default();
-        MuxStateMachine::new(variadic!(users, streams))
+        let m = MuxStateMachine::new(variadic!(users, streams));
+        m.set_external_auth_user_id(EXT_AUTH_USER_ID);
+        m
     }
 
     fn make_prepare(
@@ -685,7 +719,13 @@ mod tests {
         let mux = mux();
         let prepare = make_prepare(1, Operation::CompleteConsumerGroupRevocation, ROOT, &[]);
         assert!(
-            authorize(&prepare, mux.users(), mux.streams()).is_none(),
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
             "server-originated revocation must not be gated"
         );
     }
@@ -703,7 +743,13 @@ mod tests {
 
         let prepare = make_prepare(2, Operation::CreatePersonalAccessToken, ALICE, &[]);
         assert!(
-            authorize(&prepare, mux.users(), mux.streams()).is_none(),
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
             "PAT ops are self-scoped (parity: no legacy RBAC)"
         );
     }
@@ -754,5 +800,153 @@ mod tests {
         assert_eq!(primary_codes[2], UNAUTHORIZED, "alice's create is denied");
         assert_eq!(primary.streams().read(|inner| inner.items.len()), 1);
         assert_eq!(replay.streams().read(|inner| inner.items.len()), 1);
+    }
+
+    #[test]
+    fn given_external_auth_user_when_register_should_allow() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::Register, EXT_AUTH_USER_ID, &[]);
+        assert!(
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
+            "external auth user must be allowed to Register"
+        );
+    }
+
+    #[test]
+    fn given_external_auth_user_when_send_messages_should_allow() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::SendMessages, EXT_AUTH_USER_ID, &[]);
+        assert!(
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
+            "external auth user must be allowed to SendMessages"
+        );
+    }
+
+    #[test]
+    fn given_external_auth_user_when_join_consumer_group_should_allow() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::JoinConsumerGroup, EXT_AUTH_USER_ID, &[]);
+        assert!(
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
+            "external auth user must be allowed to JoinConsumerGroup"
+        );
+    }
+
+    #[test]
+    fn given_external_auth_user_when_create_stream_should_deny() {
+        let mux = mux();
+        let prepare = make_prepare(
+            1,
+            Operation::CreateStream,
+            EXT_AUTH_USER_ID,
+            &create_stream_body("s"),
+        );
+        let reply = authorize(
+            &prepare,
+            mux.users(),
+            mux.streams(),
+            mux.external_auth_user_id(),
+        );
+        assert!(
+            reply.is_some(),
+            "external auth user must not create streams"
+        );
+        assert_eq!(reply.unwrap().code, UNAUTHORIZED);
+    }
+
+    #[test]
+    fn given_external_auth_user_when_create_user_should_deny() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::CreateUser, EXT_AUTH_USER_ID, &[]);
+        let reply = authorize(
+            &prepare,
+            mux.users(),
+            mux.streams(),
+            mux.external_auth_user_id(),
+        );
+        assert!(reply.is_some(), "external auth user must not create users");
+        assert_eq!(reply.unwrap().code, UNAUTHORIZED);
+    }
+
+    #[test]
+    fn given_external_auth_user_when_logout_should_allow() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::Logout, EXT_AUTH_USER_ID, &[]);
+        assert!(
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
+            "external auth user must be allowed to Logout"
+        );
+    }
+
+    #[test]
+    fn given_external_auth_user_when_store_consumer_offset_should_allow() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::StoreConsumerOffset, EXT_AUTH_USER_ID, &[]);
+        assert!(
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
+            "external auth user must be allowed to StoreConsumerOffset"
+        );
+    }
+
+    #[test]
+    fn given_external_auth_user_when_delete_consumer_offset_should_allow() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::DeleteConsumerOffset, EXT_AUTH_USER_ID, &[]);
+        assert!(
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
+            "external auth user must be allowed to DeleteConsumerOffset"
+        );
+    }
+
+    #[test]
+    fn given_external_auth_user_when_leave_consumer_group_should_allow() {
+        let mux = mux();
+        let prepare = make_prepare(1, Operation::LeaveConsumerGroup, EXT_AUTH_USER_ID, &[]);
+        assert!(
+            authorize(
+                &prepare,
+                mux.users(),
+                mux.streams(),
+                mux.external_auth_user_id()
+            )
+            .is_none(),
+            "external auth user must be allowed to LeaveConsumerGroup"
+        );
     }
 }

--- a/core/metadata/src/stm/mux.rs
+++ b/core/metadata/src/stm/mux.rs
@@ -73,6 +73,13 @@ where
     T: StateMachine,
 {
     inner: T,
+    /// Reserved user ID for external auth inline-grant sessions. The
+    /// in-apply authorization gate uses this to recognize the single
+    /// external-auth user without depending on config at replay time.
+    /// Set once at boot via [`Self::set_external_auth_user_id`]; `None`
+    /// means external auth is disabled. `OnceLock` (not `OnceCell`) so
+    /// the type stays sound if `MuxStateMachine` is ever made `Sync`.
+    external_auth_user_id: std::sync::OnceLock<u32>,
 }
 
 impl<T> MuxStateMachine<T>
@@ -81,12 +88,44 @@ where
 {
     #[must_use]
     pub const fn new(inner: T) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            external_auth_user_id: std::sync::OnceLock::new(),
+        }
     }
 
     #[must_use]
     pub const fn inner(&self) -> &T {
         &self.inner
+    }
+
+    /// Set the reserved external auth user ID. Called in the
+    /// `seed_baseline` callback before WAL replay (owner shard) or
+    /// after `from_factory_bundle` (peer shards). Config-derived and
+    /// immutable for the process lifetime.
+    ///
+    /// Idempotent for the same value (safe to call from both the Owner
+    /// `seed_baseline` and the post-recovery guard).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the caller tries to change the value after it is set:
+    /// that would silently split the authz gate between shards.
+    pub fn set_external_auth_user_id(&self, user_id: u32) {
+        if self.external_auth_user_id.set(user_id).is_err() {
+            // OnceCell::set failed, so a value is already present. Accept
+            // an idempotent re-set of the same value; reject a change.
+            let existing = self.external_auth_user_id.get().copied().unwrap_or(0);
+            assert_eq!(
+                existing, user_id,
+                "external_auth_user_id cannot change at runtime: was {existing}, attempted {user_id}"
+            );
+        }
+    }
+
+    #[must_use]
+    pub fn external_auth_user_id(&self) -> Option<u32> {
+        self.external_auth_user_id.get().copied()
     }
 }
 
@@ -218,6 +257,13 @@ where
     T: StateMachine + RestoreSnapshotInPlace<SnapshotData>,
 {
     fn restore_snapshot_in_place(&self, snapshot: &SnapshotData) -> Result<(), SnapshotError> {
+        // Replaces the inner state machines (Users, Streams) in place.
+        // `external_auth_user_id` is intentionally NOT reset here: it is a
+        // config-derived value set at boot and immutable for the process
+        // lifetime. A state transfer replaces replicated state, not local
+        // config. If a future change makes this value cluster-negotiated
+        // rather than config-pinned, it must be included in the snapshot
+        // format (MetadataSnapshot) and restored here.
         self.inner.restore_snapshot_in_place(snapshot)
     }
 
@@ -350,5 +396,24 @@ mod tests {
         mux.fill_snapshot(&mut verify_snapshot).unwrap();
         assert!(verify_snapshot.users.is_some());
         assert!(verify_snapshot.streams.is_some());
+    }
+
+    #[test]
+    fn set_external_auth_user_id_is_idempotent_for_same_value() {
+        type MuxTuple = (Users, (Streams, ()));
+        let mux = MuxStateMachine::<MuxTuple>::default();
+        mux.set_external_auth_user_id(42);
+        // Idempotent: same value does not panic.
+        mux.set_external_auth_user_id(42);
+        assert_eq!(mux.external_auth_user_id(), Some(42));
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot change at runtime")]
+    fn set_external_auth_user_id_panics_on_different_value() {
+        type MuxTuple = (Users, (Streams, ()));
+        let mux = MuxStateMachine::<MuxTuple>::default();
+        mux.set_external_auth_user_id(42);
+        mux.set_external_auth_user_id(99);
     }
 }

--- a/core/server/config.toml
+++ b/core/server/config.toml
@@ -1159,3 +1159,44 @@ close_grace = "2 s"
 # connecting.await + accept_bi.await) so a slowloris peer cannot pin
 # per-conn channels + registry slot + spawned task indefinitely.
 handshake_grace = "10 s"
+
+# External authentication callout. When enabled, login attempts that fail
+# built-in credential verification are forwarded to an external HTTP service.
+# The service receives a JSON POST with credential_type, credential (when
+# forward_credentials is true), username, transport, and client_address.
+# client_address is the raw TCP peer socket, not a forwarded-for address;
+# behind a reverse proxy it reports the proxy, not the end-user.
+#
+# The service responds with one of three decisions:
+#   - "iggy_user":     map the login to an existing Iggy user by user_id.
+#                      The user must exist, be active, and not be root (ID 0).
+#   - "inline_grant":  create a session-scoped identity with explicit permissions
+#                      and an optional expires_at (unix seconds). The session is
+#                      restricted to data-plane ops (send/poll messages, consumer
+#                      offsets, consumer group join/leave). Token refresh is not
+#                      available; the client must re-authenticate when the token
+#                      expires. The permissions object uses Iggy's numeric stream
+#                      and topic IDs as map keys for per-stream/topic grants:
+#                        "streams": { "1": { "poll_messages": true } }
+#   - "deny":          reject the login with an optional reason (logged
+#                      server-side only, never forwarded to the client).
+#
+# Built-in credentials are checked first; the external auth callout runs
+# only when built-in rejects. A callout failure (timeout, network error,
+# non-2xx, malformed response) denies the login (fail-closed).
+#
+# The url must start with http:// or https://. Plain HTTP logs a warning at
+# startup since credentials may be sent in cleartext. The response body is
+# capped at 1 MiB.
+[external_auth]
+enabled = false
+url = ""
+timeout = "5 s"
+forward_credentials = false
+# Reserved user ID for inline-grant sessions. All external auth inline
+# grants share this single ID; the external principal string from the
+# auth service distinguishes sessions. Must not be 0 (root).
+# Safe to change between restarts (sessions are never persisted); the
+# server checks at boot that it does not collide with an existing user.
+# Immutable within a running process. All cluster nodes should agree.
+user_id = 4294967295

--- a/core/server/src/boot/listeners.rs
+++ b/core/server/src/boot/listeners.rs
@@ -65,6 +65,7 @@ pub(in crate::boot) async fn start_tcp_runtime(
     dialed_replica: DialedReplicaFn,
     accepted_clients: LocalClientAcceptFns,
     shard_metrics_all: &[ShardMetrics],
+    external_auth: Arc<configs::external_auth::ExternalAuthConfig>,
 ) -> Result<(), ServerError> {
     // HTTP is served over TCP but sits outside the replica_io / manual client
     // reactor, so it binds on its own. Config first, so a bad `[http.*]`
@@ -155,6 +156,7 @@ pub(in crate::boot) async fn start_tcp_runtime(
             Arc::clone(&config.system),
             roster,
             shard_metrics_all,
+            external_auth,
         )?;
     }
 

--- a/core/server/src/boot/mod.rs
+++ b/core/server/src/boot/mod.rs
@@ -107,6 +107,7 @@ pub fn wire_shell_handlers<B, MJ, S, SB>(
     shard_handle: &ShellShardHandle<B, MJ, S, SB>,
     system_config: Arc<ServerSystemConfig>,
     max_tokens_per_user: u32,
+    external_auth: Arc<configs::external_auth::ExternalAuthConfig>,
 ) -> ShellHandlers
 where
     B: ShellBus,
@@ -124,6 +125,7 @@ where
             &sessions,
             system_config,
             max_tokens_per_user,
+            external_auth,
         ),
         on_metadata_submit: make_metadata_submit_handler(shard_handle),
         on_list_clients: make_list_clients_handler(&sessions),
@@ -255,6 +257,22 @@ pub fn bootstrap(
     // run this bootstrap; after this line those are no-ops.
     install_default_crypto_provider();
     validate_root_credentials_env(&config)?;
+    crate::external_auth::validate_config(&config.external_auth)?;
+    if config.external_auth.enabled {
+        for issuer in config.http.jwt.trusted_issuers.iter().flatten() {
+            if issuer.user_id == config.external_auth.user_id {
+                return Err(
+                    crate::server_error::ServerError::InvalidExternalAuthConfig {
+                        reason: format!(
+                            "trusted issuer '{}' user_id {} collides with external_auth.user_id",
+                            issuer.issuer, issuer.user_id
+                        ),
+                    },
+                );
+            }
+        }
+    }
+    crate::external_auth::warn_insecure_url(&config.external_auth);
     warm_dummy_password_hash();
     // The sync GetStats read path has no access to server config, so capture
     // the data directory here for its disk-usage reporting.
@@ -531,6 +549,9 @@ async fn shard_main(
                 config.metadata.clients_table_max,
                 |mux_stm| {
                     ensure_default_root_user(mux_stm);
+                    if config.external_auth.enabled {
+                        mux_stm.set_external_auth_user_id(config.external_auth.user_id);
+                    }
                 },
                 |mux_stm, client, stamp| {
                     mux_stm
@@ -627,6 +648,29 @@ async fn shard_main(
     } else {
         (None, None, None, None, (0, 0), None)
     };
+    // Peer shards (Waiter path) and snapshot-restored mux_stm need the
+    // external auth user_id too. The Owner path sets it in seed_baseline
+    // (before WAL replay); the Waiter path gets it here after the bundle.
+    // set_external_auth_user_id is idempotent for the same value, so the
+    // Owner path's earlier set is a no-op here.
+    if config.external_auth.enabled {
+        mux_stm.set_external_auth_user_id(config.external_auth.user_id);
+        // The reserved user_id must not collide with a real user, or the
+        // authz gate would block that user from all metadata operations.
+        let uid = config.external_auth.user_id;
+        let collides = mux_stm
+            .users()
+            .read(|users| users.items.contains(uid as usize));
+        if collides {
+            return Err(ServerError::InvalidExternalAuthConfig {
+                reason: format!(
+                    "external_auth.user_id {uid} collides with an existing user in the slab; \
+                     pick a user_id that is not assigned to any Iggy user (default: {})",
+                    u32::MAX
+                ),
+            });
+        }
+    }
     let metadata = ServerMetadata::new(
         metadata_consensus,
         journal_for_metadata,
@@ -668,6 +712,7 @@ async fn shard_main(
     // Heap-pin like `run_shard_thread` pins `shard_main`: the builder future
     // carries the whole shard construction state machine and outgrew clippy's
     // `large_futures` cap; one allocation per shard startup.
+    let external_auth_config = Arc::new(config.external_auth.clone());
     let ShardBuild {
         shard,
         sessions,
@@ -685,6 +730,7 @@ async fn shard_main(
         reply_inbox,
         shard_metrics,
         &roster_cells,
+        Arc::clone(&external_auth_config),
     ))
     .await?;
 
@@ -964,6 +1010,7 @@ async fn shard_main(
             dialed_replica,
             accepted_client,
             &shard_metrics_all,
+            external_auth_config,
         )
         .await
         {

--- a/core/server/src/boot/recovery.rs
+++ b/core/server/src/boot/recovery.rs
@@ -79,6 +79,7 @@ pub(in crate::boot) async fn build_shard_for_thread(
     reply_inbox: ShardReceiver<ShardFrame>,
     metrics: ShardMetrics,
     roster_cells: &RosterCells,
+    external_auth: Arc<configs::external_auth::ExternalAuthConfig>,
 ) -> Result<ShardBuild, ServerError> {
     let shard_local_id = ShardId::new(shard_id);
     let total_partitions = metadata.mux_stm.streams().read(|inner| {
@@ -244,6 +245,7 @@ pub(in crate::boot) async fn build_shard_for_thread(
         &shard_handle,
         Arc::clone(&config.system),
         config.personal_access_token.max_tokens_per_user,
+        external_auth,
     );
     sessions
         .borrow_mut()

--- a/core/server/src/dispatch/authz.rs
+++ b/core/server/src/dispatch/authz.rs
@@ -35,13 +35,14 @@ use iggy_binary_protocol::codes::{
     GET_USER_CODE, GET_USERS_CODE,
 };
 use iggy_binary_protocol::requests::consumer_groups::{
-    GetConsumerGroupRequest, GetConsumerGroupsRequest,
+    GetConsumerGroupRequest, GetConsumerGroupsRequest, JoinConsumerGroupRequest,
+    LeaveConsumerGroupRequest,
 };
 use iggy_binary_protocol::requests::streams::GetStreamRequest;
 use iggy_binary_protocol::requests::topics::{GetTopicRequest, GetTopicsRequest};
 use iggy_binary_protocol::requests::users::GetUserRequest;
 use iggy_binary_protocol::{Operation, PrepareHeader, WireDecode, WireIdentifier, lookup_command};
-use iggy_common::IggyError;
+use iggy_common::{IggyError, Permissions};
 use journal::superblock::SuperblockStore;
 use journal::{Journal, JournalHandle};
 use metadata::impls::metadata::StreamsFrontend;
@@ -51,17 +52,143 @@ use server_common::Message;
 use crate::responses::{resolve_stream_id, resolve_topic_id};
 use crate::shell::{ShellBus, ShellShard};
 
+/// Check session-scoped permissions for an external auth inline-grant user.
+/// Returns `Some(Ok(()))` if permitted, `Some(Err(Unauthorized))` if denied,
+/// or `None` if `session_perms` is absent (the caller is a regular user and
+/// falls through to the Permissioner).
+pub(super) fn check_session_permission(
+    session_perms: Option<&Permissions>,
+    check: impl FnOnce(&Permissions) -> bool,
+) -> Option<Result<(), IggyError>> {
+    match session_perms {
+        Some(perms) if check(perms) => Some(Ok(())),
+        Some(_) => Some(Err(IggyError::Unauthorized)),
+        None => None,
+    }
+}
+
+/// Check if inline permissions allow sending messages to (stream, topic),
+/// mirroring the `Permissioner::append_messages` inheritance chain.
+// SYNC: keep in lockstep with Permissioner::append_messages
+pub fn can_send_messages(perms: &Permissions, stream_id: usize, topic_id: usize) -> bool {
+    let g = &perms.global;
+    if g.send_messages || g.manage_streams || g.manage_topics {
+        return true;
+    }
+    if let Some(sp) = perms.streams.as_ref().and_then(|s| s.get(&stream_id)) {
+        if sp.send_messages || sp.manage_stream || sp.manage_topics {
+            return true;
+        }
+        if sp
+            .topics
+            .as_ref()
+            .and_then(|t| t.get(&topic_id))
+            .is_some_and(|tp| tp.send_messages || tp.manage_topic)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if inline permissions allow polling messages from (stream, topic),
+/// mirroring the `Permissioner::poll_messages` inheritance chain.
+// SYNC: keep in lockstep with Permissioner::poll_messages
+pub fn can_poll_messages(perms: &Permissions, stream_id: usize, topic_id: usize) -> bool {
+    let g = &perms.global;
+    if g.poll_messages || g.read_topics || g.manage_topics || g.read_streams || g.manage_streams {
+        return true;
+    }
+    if let Some(sp) = perms.streams.as_ref().and_then(|s| s.get(&stream_id)) {
+        if sp.poll_messages
+            || sp.read_topics
+            || sp.manage_topics
+            || sp.read_stream
+            || sp.manage_stream
+        {
+            return true;
+        }
+        if sp
+            .topics
+            .as_ref()
+            .and_then(|t| t.get(&topic_id))
+            .is_some_and(|tp| tp.poll_messages || tp.read_topic || tp.manage_topic)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if inline permissions allow reading a specific stream.
+// SYNC: keep in lockstep with Permissioner::get_stream
+pub fn can_read_stream(perms: &Permissions, stream_id: usize) -> bool {
+    let g = &perms.global;
+    if g.manage_streams || g.read_streams {
+        return true;
+    }
+    perms
+        .streams
+        .as_ref()
+        .and_then(|s| s.get(&stream_id))
+        .is_some_and(|sp| sp.manage_stream || sp.read_stream)
+}
+
+/// Check if inline permissions allow listing topics in a specific stream.
+/// Mirrors `Permissioner::get_topics`: stream-level read OR topic-level
+/// read/manage grants are sufficient (no per-topic ID needed).
+// SYNC: keep in lockstep with Permissioner::get_topics
+pub fn can_list_topics(perms: &Permissions, stream_id: usize) -> bool {
+    let g = &perms.global;
+    if g.read_streams || g.manage_streams || g.manage_topics || g.read_topics {
+        return true;
+    }
+    perms
+        .streams
+        .as_ref()
+        .and_then(|s| s.get(&stream_id))
+        .is_some_and(|sp| sp.manage_stream || sp.read_stream || sp.manage_topics || sp.read_topics)
+}
+
+/// Check if inline permissions allow reading a specific topic.
+// SYNC: keep in lockstep with Permissioner::get_topic
+pub fn can_read_topic(perms: &Permissions, stream_id: usize, topic_id: usize) -> bool {
+    let g = &perms.global;
+    if g.read_streams || g.manage_streams || g.manage_topics || g.read_topics {
+        return true;
+    }
+    if let Some(sp) = perms.streams.as_ref().and_then(|s| s.get(&stream_id)) {
+        if sp.manage_stream || sp.read_stream || sp.manage_topics || sp.read_topics {
+            return true;
+        }
+        if sp
+            .topics
+            .as_ref()
+            .and_then(|t| t.get(&topic_id))
+            .is_some_and(|tp| tp.manage_topic || tp.read_topic)
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Authorize a partition-plane op on its resolved (stream, topic) for the
 /// acting user, returning the deny status code or `None` to proceed. The
 /// namespace already resolved, so the entity exists; a `None` user id (which
 /// the bound-session gate should preclude) fails closed with `Unauthenticated`
 /// rather than allow an unattributed write.
+///
+/// When `session_perms` is provided and the user is synthetic (external auth
+/// inline-grant), checks the inline permissions directly instead of the
+/// Permissioner.
 pub(in crate::dispatch) fn authorize_partition_op<B, MJ, S, SB>(
     shard: &Rc<ShellShard<B, MJ, S, SB>>,
     operation: Operation,
     user_id: Option<u32>,
     stream_id: usize,
     topic_id: usize,
+    session_perms: Option<&Permissions>,
 ) -> Option<u32>
 where
     B: ShellBus,
@@ -73,6 +200,15 @@ where
     let Some(user_id) = user_id else {
         return Some(IggyError::Unauthenticated.as_code());
     };
+    if let Some(result) = check_session_permission(session_perms, |perms| match operation {
+        Operation::SendMessages => can_send_messages(perms, stream_id, topic_id),
+        Operation::StoreConsumerOffset | Operation::DeleteConsumerOffset => {
+            can_poll_messages(perms, stream_id, topic_id)
+        }
+        _ => false,
+    }) {
+        return result.err().map(|e| e.as_code());
+    }
     let decision =
         shard
             .plane
@@ -128,12 +264,60 @@ where
     decision.err().map(|error| error.as_code())
 }
 
+/// Pre-submit check for external auth users on CG join/leave. The STM
+/// allow-list passes these ops (it has no session-scoped permissions), so
+/// this is the only topic-level gate on the binary transport. Returns
+/// `Some(status_code)` to deny, `None` to proceed.
+pub(in crate::dispatch) fn authorize_consumer_group_op<B, MJ, S, SB>(
+    shard: &Rc<ShellShard<B, MJ, S, SB>>,
+    operation: Operation,
+    body: &[u8],
+    session_perms: Option<&Permissions>,
+) -> Option<u32>
+where
+    B: ShellBus,
+    MJ: JournalHandle + 'static,
+    MJ::Target: Journal<Entry = Message<PrepareHeader>, Header = PrepareHeader>,
+    S: 'static,
+    SB: SuperblockStore + 'static,
+{
+    let Some(perms) = session_perms else {
+        return Some(IggyError::Unauthorized.as_code());
+    };
+    let (stream_id, topic_id) = match operation {
+        Operation::JoinConsumerGroup => {
+            let Ok(req) = JoinConsumerGroupRequest::decode_from(body) else {
+                return None;
+            };
+            (req.stream_id, req.topic_id)
+        }
+        Operation::LeaveConsumerGroup => {
+            let Ok(req) = LeaveConsumerGroupRequest::decode_from(body) else {
+                return None;
+            };
+            (req.stream_id, req.topic_id)
+        }
+        _ => return None,
+    };
+    let (sid, tid) = resolve_topic_scope(shard, &stream_id, &topic_id)?;
+    if can_poll_messages(perms, sid, tid) {
+        None
+    } else {
+        Some(IggyError::Unauthorized.as_code())
+    }
+}
+
 /// Run an unscoped non-replicated-read rule for the acting user. A `None` user
 /// id (only the pre-auth path, which serves ungated codes) fails closed.
+///
+/// When `session_perms` is provided and the user is synthetic, runs
+/// `session_check` against the inline permissions instead of the Permissioner.
 pub(in crate::dispatch) fn authorize_uid<B, MJ, S, SB>(
     shard: &Rc<ShellShard<B, MJ, S, SB>>,
     user_id: Option<u32>,
     rule: impl FnOnce(&Permissioner, u32) -> Result<(), IggyError>,
+    session_perms: Option<&Permissions>,
+    session_check: impl FnOnce(&Permissions) -> bool,
 ) -> Result<(), IggyError>
 where
     B: ShellBus,
@@ -143,6 +327,9 @@ where
     SB: SuperblockStore + 'static,
 {
     let user_id = user_id.ok_or(IggyError::Unauthenticated)?;
+    if let Some(result) = check_session_permission(session_perms, session_check) {
+        return result;
+    }
     shard
         .plane
         .metadata()
@@ -155,12 +342,16 @@ where
 /// (stream, topic). `None` proceeds (allowed, or a resolution miss the caller's
 /// own not-found path handles); `Some(status)` denies. A `None` user id fails
 /// closed.
+///
+/// When `session_perms` is provided and the user is synthetic, checks the
+/// inline permissions directly (`poll_messages` inheritance chain).
 pub(in crate::dispatch) fn authorize_partition_read<B, MJ, S, SB>(
     shard: &Rc<ShellShard<B, MJ, S, SB>>,
     stream_id: &WireIdentifier,
     topic_id: &WireIdentifier,
     user_id: Option<u32>,
     rule: impl FnOnce(&Permissioner, u32, usize, usize) -> Result<(), IggyError>,
+    session_perms: Option<&Permissions>,
 ) -> Option<u32>
 where
     B: ShellBus,
@@ -172,7 +363,18 @@ where
     let Some(user_id) = user_id else {
         return Some(IggyError::Unauthenticated.as_code());
     };
-    let (stream_id, topic_id) = resolve_topic_scope(shard, stream_id, topic_id)?;
+    let Some((stream_id, topic_id)) = resolve_topic_scope(shard, stream_id, topic_id) else {
+        // Regular users: fall through to the builder's not-found reply.
+        // External auth users: fail closed (session-scoped check is the only gate).
+        return session_perms
+            .is_some()
+            .then(|| IggyError::Unauthorized.as_code());
+    };
+    if let Some(result) = check_session_permission(session_perms, |perms| {
+        can_poll_messages(perms, stream_id, topic_id)
+    }) {
+        return result.err().map(|e| e.as_code());
+    }
     shard
         .plane
         .metadata()
@@ -196,11 +398,15 @@ where
 /// serves has a named arm, and the tail refuses everything else (a replicated
 /// code inside a `NonReplicated` header, a table-listed code with no arm, an
 /// unknown code) instead of deferring it to the builder's catch-all.
+///
+/// When `session_perms` is provided and the user is synthetic, checks inline
+/// permissions instead of the Permissioner.
 pub(in crate::dispatch) fn authorize_default_read<B, MJ, S, SB>(
     shard: &Rc<ShellShard<B, MJ, S, SB>>,
     code: u32,
     body: &[u8],
     user_id: Option<u32>,
+    session_perms: Option<&Permissions>,
 ) -> Result<(), IggyError>
 where
     B: ShellBus,
@@ -212,9 +418,21 @@ where
     // A `u32` match cannot be exhaustive, so totality is by construction:
     // every code with a decision is named, and the tail refuses the rest.
     match code {
-        GET_STATS_CODE => authorize_uid(shard, user_id, Permissioner::get_stats),
-        GET_USERS_CODE => authorize_uid(shard, user_id, Permissioner::get_users),
-        GET_USER_CODE => gate_user_scoped(shard, user_id, body),
+        GET_STATS_CODE => authorize_uid(
+            shard,
+            user_id,
+            Permissioner::get_stats,
+            session_perms,
+            |p| p.global.manage_servers || p.global.read_servers,
+        ),
+        GET_USERS_CODE => authorize_uid(
+            shard,
+            user_id,
+            Permissioner::get_users,
+            session_perms,
+            |p| p.global.manage_users || p.global.read_users,
+        ),
+        GET_USER_CODE => gate_user_scoped(shard, user_id, body, session_perms),
         // Self-scoped: lists only the caller's own tokens, so there is no
         // permissioner rule to run (legacy runs none either).
         GET_PERSONAL_ACCESS_TOKENS_CODE => user_id.map(|_| ()).ok_or(IggyError::Unauthenticated),
@@ -225,13 +443,21 @@ where
         // transport with an `Unauthenticated` Reply before it reaches the
         // builder, so this arm only ever fires if that gate is bypassed.
         GET_CLUSTER_METADATA_CODE => user_id.map(|_| ()).ok_or(IggyError::Unauthenticated),
-        GET_STREAMS_CODE => authorize_uid(shard, user_id, Permissioner::get_streams),
+        GET_STREAMS_CODE => authorize_uid(
+            shard,
+            user_id,
+            Permissioner::get_streams,
+            session_perms,
+            |p| p.global.manage_streams || p.global.read_streams,
+        ),
         GET_STREAM_CODE => gate_stream_scoped::<GetStreamRequest, _, _, _, _>(
             shard,
             user_id,
             body,
             |request| &request.stream_id,
             Permissioner::get_stream,
+            session_perms,
+            can_read_stream,
         ),
         GET_TOPICS_CODE => gate_stream_scoped::<GetTopicsRequest, _, _, _, _>(
             shard,
@@ -239,6 +465,8 @@ where
             body,
             |request| &request.stream_id,
             Permissioner::get_topics,
+            session_perms,
+            can_list_topics,
         ),
         GET_TOPIC_CODE => gate_topic_scoped::<GetTopicRequest, _, _, _, _>(
             shard,
@@ -246,6 +474,7 @@ where
             body,
             |request| (&request.stream_id, &request.topic_id),
             Permissioner::get_topic,
+            session_perms,
         ),
         GET_CONSUMER_GROUP_CODE => gate_topic_scoped::<GetConsumerGroupRequest, _, _, _, _>(
             shard,
@@ -253,6 +482,7 @@ where
             body,
             |request| (&request.stream_id, &request.topic_id),
             Permissioner::get_consumer_group,
+            session_perms,
         ),
         GET_CONSUMER_GROUPS_CODE => gate_topic_scoped::<GetConsumerGroupsRequest, _, _, _, _>(
             shard,
@@ -260,6 +490,7 @@ where
             body,
             |request| (&request.stream_id, &request.topic_id),
             Permissioner::get_consumer_groups,
+            session_perms,
         ),
         // No on-demand flush primitive exists, and flush has no HTTP route, so
         // this arm is the only thing answering `FeatureUnavailable` for it.
@@ -286,6 +517,7 @@ fn gate_user_scoped<B, MJ, S, SB>(
     shard: &Rc<ShellShard<B, MJ, S, SB>>,
     user_id: Option<u32>,
     body: &[u8],
+    session_perms: Option<&Permissions>,
 ) -> Result<(), IggyError>
 where
     B: ShellBus,
@@ -304,12 +536,21 @@ where
         .users()
         .read(|users| users.resolve_user_id(&request.user_id))
     else {
+        // For external auth inline-grant users, deny on unresolvable
+        // target instead of falling through to the builder's NotFound.
+        // This matches the HTTP handler, which runs the predicate
+        // regardless.
+        if session_perms.is_some() {
+            return Err(IggyError::Unauthorized);
+        }
         return Ok(());
     };
     if user_id.is_some_and(|caller_id| caller_id as usize == target_id) {
         return Ok(());
     }
-    authorize_uid(shard, user_id, Permissioner::get_user)
+    authorize_uid(shard, user_id, Permissioner::get_user, session_perms, |p| {
+        p.global.manage_users || p.global.read_users
+    })
 }
 
 /// Gate a stream-scoped read: decode the request, project its wire stream id,
@@ -322,6 +563,8 @@ fn gate_stream_scoped<T: WireDecode, B, MJ, S, SB>(
     body: &[u8],
     stream_id: impl FnOnce(&T) -> &WireIdentifier,
     rule: impl FnOnce(&Permissioner, u32, usize) -> Result<(), IggyError>,
+    session_perms: Option<&Permissions>,
+    session_rule: impl FnOnce(&Permissions, usize) -> bool,
 ) -> Result<(), IggyError>
 where
     B: ShellBus,
@@ -331,26 +574,41 @@ where
     SB: SuperblockStore + 'static,
 {
     let Ok(request) = T::decode_from(body) else {
+        // Malformed body: regular users fall through to the builder's own
+        // decode error; ext-auth users fail closed (session-scoped check is
+        // the only gate).
+        if session_perms.is_some() {
+            return Err(IggyError::Unauthorized);
+        }
         return Ok(());
     };
     let Some(stream_id) = resolve_stream_scope(shard, stream_id(&request)) else {
+        if session_perms.is_some() {
+            return Err(IggyError::Unauthorized);
+        }
         return Ok(());
     };
-    authorize_uid(shard, user_id, |permissioner, uid| {
-        rule(permissioner, uid, stream_id)
-    })
+    authorize_uid(
+        shard,
+        user_id,
+        |permissioner, uid| rule(permissioner, uid, stream_id),
+        session_perms,
+        |p| session_rule(p, stream_id),
+    )
 }
 
 /// Gate a topic-scoped read: decode the request, project its wire (stream,
 /// topic) pair, resolve both to committed slab ids, then run `rule`. A malformed
 /// body or a resolution miss on either returns `Ok(())` so the builder's own
 /// error / not-found reply holds (decode-and-notfound-before-permission).
+/// External auth users fail closed: the session-scoped check is the only gate.
 fn gate_topic_scoped<T: WireDecode, B, MJ, S, SB>(
     shard: &Rc<ShellShard<B, MJ, S, SB>>,
     user_id: Option<u32>,
     body: &[u8],
     ids: impl FnOnce(&T) -> (&WireIdentifier, &WireIdentifier),
     rule: impl FnOnce(&Permissioner, u32, usize, usize) -> Result<(), IggyError>,
+    session_perms: Option<&Permissions>,
 ) -> Result<(), IggyError>
 where
     B: ShellBus,
@@ -360,15 +618,25 @@ where
     SB: SuperblockStore + 'static,
 {
     let Ok(request) = T::decode_from(body) else {
+        if session_perms.is_some() {
+            return Err(IggyError::Unauthorized);
+        }
         return Ok(());
     };
     let (stream_id, topic_id) = ids(&request);
     let Some((stream_id, topic_id)) = resolve_topic_scope(shard, stream_id, topic_id) else {
+        if session_perms.is_some() {
+            return Err(IggyError::Unauthorized);
+        }
         return Ok(());
     };
-    authorize_uid(shard, user_id, |permissioner, uid| {
-        rule(permissioner, uid, stream_id, topic_id)
-    })
+    authorize_uid(
+        shard,
+        user_id,
+        |permissioner, uid| rule(permissioner, uid, stream_id, topic_id),
+        session_perms,
+        |p| can_read_topic(p, stream_id, topic_id),
+    )
 }
 
 /// Resolve a wire stream identifier to its committed slab id, or `None` on a
@@ -453,7 +721,7 @@ mod tests {
 
     /// Gate a header-only frame (`body = &[]`) for `user_id`.
     fn gate(shard: &Rc<TestShard>, code: u32, user_id: Option<u32>) -> Verdict {
-        match authorize_default_read(shard, code, &[], user_id) {
+        match authorize_default_read(shard, code, &[], user_id, None) {
             Ok(()) => Verdict::Allow,
             Err(error) => Verdict::Deny(error.as_code()),
         }

--- a/core/server/src/dispatch/failure.rs
+++ b/core/server/src/dispatch/failure.rs
@@ -612,11 +612,13 @@ mod tests {
         )
         .into_generic();
 
+        let external_auth = Arc::new(configs::external_auth::ExternalAuthConfig::default());
         handle_client_request(
             &shard,
             &sessions,
             &system_config,
             1,
+            &external_auth,
             TRANSPORT,
             request.into_generic(),
         )

--- a/core/server/src/dispatch/login_error.rs
+++ b/core/server/src/dispatch/login_error.rs
@@ -34,6 +34,14 @@ pub enum LoginRegisterError {
     InvalidCredentials,
     InvalidToken,
     UserInactive,
+    /// The username matched a local user but the password was wrong (or the
+    /// account is inactive). Surfaced to the client identically to
+    /// `InvalidCredentials` so we don't leak which field failed, but
+    /// excluded from `is_invalid_credentials` so the external auth
+    /// fallback is never attempted for known local users.
+    LocalUserRejected,
+    /// Denied by an external authentication service.
+    ExternalAuthDenied(String),
     Session(SessionError),
     /// Recoverable consensus failure. The connection stays `Connected`; the
     /// SDK read-timeout replays.
@@ -41,6 +49,15 @@ pub enum LoginRegisterError {
 }
 
 impl LoginRegisterError {
+    /// `true` when the credential did not match any local user and an
+    /// external auth callout should be attempted as a fallback.
+    /// `LocalUserRejected` is intentionally excluded: the user exists
+    /// locally so the external path must not override local credentials.
+    #[must_use]
+    pub const fn is_invalid_credentials(&self) -> bool {
+        matches!(self, Self::InvalidCredentials | Self::InvalidToken)
+    }
+
     /// `true` for a terminal failure the client cannot fix by retrying (bad
     /// credentials / token / inactive user / session error); `false` for a
     /// transient consensus failure the SDK replays. The handler fast-fails
@@ -61,9 +78,12 @@ impl LoginRegisterError {
 impl std::fmt::Display for LoginRegisterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidCredentials => write!(f, "invalid username or password"),
+            Self::InvalidCredentials | Self::LocalUserRejected => {
+                write!(f, "invalid username or password")
+            }
             Self::InvalidToken => write!(f, "invalid or expired personal access token"),
             Self::UserInactive => write!(f, "user account is inactive"),
+            Self::ExternalAuthDenied(reason) => write!(f, "external auth denied: {reason}"),
             Self::Session(e) => write!(f, "session error: {e}"),
             Self::Transient(e) => write!(f, "transient consensus failure: {e}"),
         }

--- a/core/server/src/dispatch/mod.rs
+++ b/core/server/src/dispatch/mod.rs
@@ -31,7 +31,7 @@
 //! HTTP spine keeps its own equivalent gates (see `crate::http`) because its
 //! error contract (404-before-403) is pinned client-visible behavior.
 
-mod authz;
+pub mod authz;
 mod failure;
 pub mod login_error;
 pub mod partition;
@@ -56,8 +56,9 @@ use crate::responses::build_raw_pat_reply;
 use crate::rewrite::{RewriteDeny, RewriteStage, tcp_chain};
 use crate::session_manager::{ConnectionContext, SessionManager};
 use crate::shell::{ShellBus, ShellShard, ShellShardHandle};
-use crate::wire::verify_request_checksum;
+use crate::wire::{request_body, verify_request_checksum};
 use ahash::{AHashMap, AHashSet};
+use configs::external_auth::ExternalAuthConfig;
 use configs::server::ServerSystemConfig;
 use iggy_binary_protocol::PrepareHeader;
 use iggy_binary_protocol::codes::{
@@ -142,6 +143,7 @@ pub fn make_deferred_client_request_handler<B, MJ, S, SB>(
     sessions: &Rc<RefCell<SessionManager>>,
     system_config: Arc<ServerSystemConfig>,
     max_tokens_per_user: u32,
+    external_auth: Arc<ExternalAuthConfig>,
 ) -> RequestHandler
 where
     B: ShellBus,
@@ -196,6 +198,7 @@ where
             &sessions,
             &system_config,
             max_tokens_per_user,
+            &external_auth,
             &queues,
             &active,
             client_id,
@@ -249,6 +252,7 @@ fn enqueue_client_request<B, MJ, S, SB>(
     sessions: &Rc<RefCell<SessionManager>>,
     system_config: &Arc<ServerSystemConfig>,
     max_tokens_per_user: u32,
+    external_auth: &Arc<ExternalAuthConfig>,
     queues: &ClientRequestQueues,
     active: &ActiveClientRequests,
     client_id: u128,
@@ -279,6 +283,7 @@ fn enqueue_client_request<B, MJ, S, SB>(
     let shard_handle = Rc::clone(shard_handle);
     let sessions = Rc::clone(sessions);
     let system_config = Arc::clone(system_config);
+    let external_auth = Arc::clone(external_auth);
     let queues = Rc::clone(queues);
     let active = Rc::clone(active);
     bus.spawn(async move {
@@ -294,6 +299,7 @@ fn enqueue_client_request<B, MJ, S, SB>(
             sessions,
             system_config,
             max_tokens_per_user,
+            external_auth,
             queues,
             client_id,
         )
@@ -376,12 +382,13 @@ impl Drop for ActiveDrainSlot {
     }
 }
 
-#[allow(clippy::future_not_send)]
+#[allow(clippy::future_not_send, clippy::too_many_arguments)]
 async fn drain_client_requests<B, MJ, S, SB>(
     shard: Rc<ShellShard<B, MJ, S, SB>>,
     sessions: Rc<RefCell<SessionManager>>,
     system_config: Arc<ServerSystemConfig>,
     max_tokens_per_user: u32,
+    external_auth: Arc<ExternalAuthConfig>,
     queues: ClientRequestQueues,
     client_id: u128,
 ) where
@@ -400,6 +407,7 @@ async fn drain_client_requests<B, MJ, S, SB>(
             &sessions,
             &system_config,
             max_tokens_per_user,
+            &external_auth,
             client_id,
             message,
         )
@@ -521,6 +529,7 @@ async fn handle_client_request<B, MJ, S, SB>(
     sessions: &Rc<RefCell<SessionManager>>,
     system_config: &Arc<ServerSystemConfig>,
     max_tokens_per_user: u32,
+    external_auth: &Arc<ExternalAuthConfig>,
     transport_client_id: u128,
     message: Message<iggy_binary_protocol::GenericHeader>,
 ) where
@@ -654,6 +663,7 @@ async fn handle_client_request<B, MJ, S, SB>(
                 shard,
                 sessions,
                 system_config,
+                external_auth,
                 transport_client_id,
                 request,
                 (user_id, client_address, metadata_watermark),
@@ -661,7 +671,14 @@ async fn handle_client_request<B, MJ, S, SB>(
             .await;
         }
         RequestClass::LoginRegister => {
-            handle_login_register_request(shard, sessions, transport_client_id, request).await;
+            handle_login_register_request(
+                shard,
+                sessions,
+                transport_client_id,
+                request,
+                external_auth,
+            )
+            .await;
         }
         RequestClass::Logout => {
             handle_logout_request(shard, sessions, transport_client_id, request).await;
@@ -712,6 +729,15 @@ async fn handle_client_request<B, MJ, S, SB>(
             // The acting user comes from the prologue's lookup. A bound
             // transport always has one, but the gate below fails closed on
             // `None` rather than trust that.
+            let session_perms = user_id
+                .filter(|&uid| external_auth.enabled && uid == external_auth.user_id)
+                .and_then(|_| {
+                    let now_secs =
+                        iggy_common::IggyTimestamp::from(shard.bus.realtime_micros()).to_secs();
+                    sessions
+                        .borrow_mut()
+                        .session_permissions_for_connection(transport_client_id, now_secs)
+                });
             dispatch_partition_request(
                 shard,
                 request,
@@ -719,6 +745,7 @@ async fn handle_client_request<B, MJ, S, SB>(
                 bound_session,
                 transport_client_id,
                 user_id,
+                session_perms.as_deref(),
             )
             .await;
         }
@@ -740,6 +767,33 @@ async fn handle_client_request<B, MJ, S, SB>(
                         new_header.session = bound_session;
                     }
                 });
+            // Pre-submit authorization for external auth users on CG
+            // join/leave. The STM allow-list lets these through (it has no
+            // session-scoped permissions), so the dispatch-time check is the
+            // only topic-level gate. Regular users are checked by the STM's
+            // Permissioner.
+            if external_auth.enabled
+                && matches!(
+                    request.header().operation,
+                    Operation::JoinConsumerGroup | Operation::LeaveConsumerGroup
+                )
+                && user_id.is_some_and(|uid| uid == external_auth.user_id)
+            {
+                let now_secs =
+                    iggy_common::IggyTimestamp::from(shard.bus.realtime_micros()).to_secs();
+                let session_perms = sessions
+                    .borrow_mut()
+                    .session_permissions_for_connection(transport_client_id, now_secs);
+                if let Some(deny_code) = authz::authorize_consumer_group_op(
+                    shard,
+                    request.header().operation,
+                    request_body(&request),
+                    session_perms.as_deref(),
+                ) {
+                    send_deny_reply(shard, transport_client_id, request.header(), deny_code).await;
+                    return;
+                }
+            }
             let (request, raw_pat_token) = match tcp_chain(
                 shard,
                 sessions,
@@ -1081,6 +1135,7 @@ mod tests {
         let shard = Rc::new(test_shard(&bus, 0, 1, FIRST_BOOT));
         let sessions = Rc::new(RefCell::new(SessionManager::new()));
         let system_config = Arc::new(ServerSystemConfig::default());
+        let external_auth = Arc::new(ExternalAuthConfig::default());
 
         let multi_node = Rc::new(ClusterRoster {
             enabled: true,
@@ -1109,6 +1164,7 @@ mod tests {
                 &sessions,
                 &system_config,
                 1,
+                &external_auth,
                 TRANSPORT,
                 metadata_read(),
             )
@@ -1353,6 +1409,7 @@ mod tests {
         let shard = Rc::new(test_shard(&bus, 0, 1, FIRST_BOOT));
         let sessions = Rc::new(RefCell::new(SessionManager::new()));
         let system_config = Arc::new(ServerSystemConfig::default());
+        let external_auth = Arc::new(ExternalAuthConfig::default());
 
         for code in [LOGIN_USER_CODE, LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE] {
             handle_client_request(
@@ -1360,6 +1417,7 @@ mod tests {
                 &sessions,
                 &system_config,
                 1,
+                &external_auth,
                 TRANSPORT,
                 non_replicated_request(TRANSPORT, code),
             )
@@ -1394,12 +1452,14 @@ mod tests {
         let shard = Rc::new(test_shard(&bus, 0, 1, FIRST_BOOT));
         let sessions = Rc::new(RefCell::new(SessionManager::new()));
         let system_config = Arc::new(ServerSystemConfig::default());
+        let external_auth = Arc::new(ExternalAuthConfig::default());
 
         handle_client_request(
             &shard,
             &sessions,
             &system_config,
             1,
+            &external_auth,
             TRANSPORT,
             wire_request(Operation::CreateStream, TRANSPORT, 1, 1, &[]).into_generic(),
         )
@@ -1429,12 +1489,14 @@ mod tests {
         let shard = Rc::new(test_shard(&bus, 0, 1, FIRST_BOOT));
         let sessions = Rc::new(RefCell::new(SessionManager::new()));
         let system_config = Arc::new(ServerSystemConfig::default());
+        let external_auth = Arc::new(ExternalAuthConfig::default());
 
         handle_client_request(
             &shard,
             &sessions,
             &system_config,
             1,
+            &external_auth,
             TRANSPORT,
             non_replicated_request(TRANSPORT, PING_CODE),
         )
@@ -1462,6 +1524,7 @@ mod tests {
         let shard = Rc::new(test_shard(&bus, 0, 1, FIRST_BOOT));
         let sessions = Rc::new(RefCell::new(SessionManager::new()));
         let system_config = Arc::new(ServerSystemConfig::default());
+        let external_auth = Arc::new(ExternalAuthConfig::default());
 
         let mut message = wire_request(Operation::CreateStream, TRANSPORT, 1, 1, BODY);
         {
@@ -1478,6 +1541,7 @@ mod tests {
             &sessions,
             &system_config,
             1,
+            &external_auth,
             TRANSPORT,
             message.into_generic(),
         )
@@ -1521,6 +1585,7 @@ mod tests {
             &Rc::new(RefCell::new(SessionManager::new())),
             Arc::new(ServerSystemConfig::default()),
             1,
+            Arc::new(ExternalAuthConfig::default()),
         );
         assert_eq!(
             bus.connection_lost_hooks.get(),
@@ -1545,6 +1610,7 @@ mod tests {
             &Rc::new(RefCell::new(SessionManager::new())),
             Arc::new(ServerSystemConfig::default()),
             1,
+            Arc::new(ExternalAuthConfig::default()),
         );
 
         handler(TRANSPORT, non_replicated_request(TRANSPORT, PING_CODE));

--- a/core/server/src/dispatch/partition.rs
+++ b/core/server/src/dispatch/partition.rs
@@ -59,7 +59,9 @@ use iggy_binary_protocol::{
     AckLevel, Command, KIND_CONSUMER_GROUP, Operation, RoutedRequestHeader, WireDecode, WireEncode,
     WireIdentifier,
 };
-use iggy_common::{ConsumerKind, IggyError, PollingStrategy, RESYNC_REQUIRED_PARTITION_SENTINEL};
+use iggy_common::{
+    ConsumerKind, IggyError, Permissions, PollingStrategy, RESYNC_REQUIRED_PARTITION_SENTINEL,
+};
 use journal::superblock::SuperblockStore;
 use journal::{Journal, JournalHandle};
 use message_bus::{AUTO_COMMIT_CLIENT_ID, BusMessage};
@@ -427,6 +429,7 @@ pub async fn dispatch_partition_request<B, MJ, S, SB>(
     bound_session: u64,
     transport_client_id: u128,
     acting_user_id: Option<u32>,
+    session_perms: Option<&Permissions>,
 ) where
     B: ShellBus,
     MJ: JournalHandle + 'static,
@@ -489,6 +492,7 @@ pub async fn dispatch_partition_request<B, MJ, S, SB>(
         acting_user_id,
         scope.stream_id(),
         scope.topic_id(),
+        session_perms,
     ) {
         warn!(
             transport_client_id,
@@ -682,6 +686,7 @@ pub(in crate::dispatch) async fn handle_poll_messages<B, MJ, S, SB>(
     transport_client_id: u128,
     request: &Message<RoutedRequestHeader>,
     user_id: Option<u32>,
+    session_perms: Option<&Permissions>,
 ) where
     B: ShellBus,
     MJ: JournalHandle + 'static,
@@ -715,6 +720,7 @@ pub(in crate::dispatch) async fn handle_poll_messages<B, MJ, S, SB>(
         |permissioner, uid, stream_id, topic_id| {
             permissioner.poll_messages(uid, stream_id, topic_id)
         },
+        session_perms,
     ) {
         send_non_replicated_deny(shard, request, transport_client_id, status).await;
         return;
@@ -868,6 +874,7 @@ pub(in crate::dispatch) async fn handle_get_consumer_offset<B, MJ, S, SB>(
     transport_client_id: u128,
     request: &Message<RoutedRequestHeader>,
     user_id: Option<u32>,
+    session_perms: Option<&Permissions>,
 ) where
     B: ShellBus,
     MJ: JournalHandle + 'static,
@@ -897,6 +904,7 @@ pub(in crate::dispatch) async fn handle_get_consumer_offset<B, MJ, S, SB>(
         |permissioner, uid, stream_id, topic_id| {
             permissioner.get_consumer_offset(uid, stream_id, topic_id)
         },
+        session_perms,
     ) {
         send_non_replicated_deny(shard, request, transport_client_id, status).await;
         return;
@@ -1542,7 +1550,8 @@ mod tests {
         ));
         for (index, (operation, body, expected)) in cases.into_iter().enumerate() {
             let request = request_message(operation, 1, 1, index as u64 + 1, &body);
-            dispatch_partition_request(&shard, request, 1, 1, 91, Some(DEFAULT_ROOT_USER_ID)).await;
+            dispatch_partition_request(&shard, request, 1, 1, 91, Some(DEFAULT_ROOT_USER_ID), None)
+                .await;
             let replies = bus.client_replies.borrow();
             assert_eq!(
                 replies.len(),
@@ -1582,7 +1591,7 @@ mod tests {
             1,
             TRUNCATED_BODY,
         );
-        handle_poll_messages(&shard, TRANSPORT, &poll, Some(DEFAULT_ROOT_USER_ID)).await;
+        handle_poll_messages(&shard, TRANSPORT, &poll, Some(DEFAULT_ROOT_USER_ID), None).await;
 
         let offset = request_message(
             Operation::NonReplicated,
@@ -1591,7 +1600,8 @@ mod tests {
             2,
             TRUNCATED_BODY,
         );
-        handle_get_consumer_offset(&shard, TRANSPORT, &offset, Some(DEFAULT_ROOT_USER_ID)).await;
+        handle_get_consumer_offset(&shard, TRANSPORT, &offset, Some(DEFAULT_ROOT_USER_ID), None)
+            .await;
 
         let delete = request_message(
             Operation::DeleteSegments,
@@ -1653,7 +1663,7 @@ mod tests {
         }
         .to_bytes();
         let poll = request_message(Operation::NonReplicated, VSR_CLIENT, SESSION, 1, &poll_body);
-        handle_poll_messages(&shard, TRANSPORT, &poll, Some(DEFAULT_ROOT_USER_ID)).await;
+        handle_poll_messages(&shard, TRANSPORT, &poll, Some(DEFAULT_ROOT_USER_ID), None).await;
 
         let offset_body = GetConsumerOffsetRequest {
             consumer: WireConsumer::consumer(WireIdentifier::Numeric(1)),
@@ -1669,7 +1679,8 @@ mod tests {
             2,
             &offset_body,
         );
-        handle_get_consumer_offset(&shard, TRANSPORT, &offset, Some(DEFAULT_ROOT_USER_ID)).await;
+        handle_get_consumer_offset(&shard, TRANSPORT, &offset, Some(DEFAULT_ROOT_USER_ID), None)
+            .await;
 
         let replies = bus.client_replies.borrow();
         assert_eq!(
@@ -1805,6 +1816,7 @@ mod tests {
             SESSION,
             TRANSPORT,
             Some(DEFAULT_ROOT_USER_ID),
+            None,
         )
         .await;
 

--- a/core/server/src/dispatch/reads.rs
+++ b/core/server/src/dispatch/reads.rs
@@ -59,7 +59,7 @@ use iggy_binary_protocol::responses::clients::get_clients::GetClientsResponse;
 use iggy_binary_protocol::responses::consumer_groups::SyncConsumerGroupResponse;
 use iggy_binary_protocol::responses::system::get_snapshot::GetSnapshotResponse;
 use iggy_binary_protocol::{HEADER_SIZE, RoutedRequestHeader, WireDecode, WireEncode};
-use iggy_common::{IggyError, SnapshotCompression, SystemSnapshotType};
+use iggy_common::{IggyError, Permissions, SnapshotCompression, SystemSnapshotType};
 use journal::superblock::SuperblockStore;
 use journal::{Journal, JournalHandle};
 use message_bus::framing::MAX_MESSAGE_SIZE;
@@ -342,6 +342,7 @@ pub(in crate::dispatch) async fn handle_non_replicated_request<B, MJ, S, SB>(
     shard: &Rc<ShellShard<B, MJ, S, SB>>,
     sessions: &Rc<RefCell<SessionManager>>,
     system_config: &Arc<ServerSystemConfig>,
+    external_auth: &Arc<configs::external_auth::ExternalAuthConfig>,
     transport_client_id: u128,
     request: Message<RoutedRequestHeader>,
     // Acting user, peer address and read-your-writes floor for the read gates
@@ -360,6 +361,14 @@ pub(in crate::dispatch) async fn handle_non_replicated_request<B, MJ, S, SB>(
 {
     const CODE_RANGE: std::ops::Range<usize> = 0..4;
     let code = u32::from_le_bytes(request.header().reserved[CODE_RANGE].try_into().unwrap());
+    let session_perms = user_id
+        .filter(|&uid| external_auth.enabled && uid == external_auth.user_id)
+        .and_then(|_| {
+            let now_secs = iggy_common::IggyTimestamp::from(shard.bus.realtime_micros()).to_secs();
+            sessions
+                .borrow_mut()
+                .session_permissions_for_connection(transport_client_id, now_secs)
+        });
     match code {
         PING_CODE => {
             // No `record_heartbeat` here: the funnel records one for EVERY
@@ -401,7 +410,13 @@ pub(in crate::dispatch) async fn handle_non_replicated_request<B, MJ, S, SB>(
         }
         GET_CLIENTS_CODE => {
             if let Err(error) = authorize_and_hold_read(shard, code, watermark, || {
-                authorize_uid(shard, user_id, Permissioner::get_clients)
+                authorize_uid(
+                    shard,
+                    user_id,
+                    Permissioner::get_clients,
+                    session_perms.as_deref(),
+                    |p| p.global.manage_servers || p.global.read_servers,
+                )
             })
             .await
             {
@@ -430,7 +445,13 @@ pub(in crate::dispatch) async fn handle_non_replicated_request<B, MJ, S, SB>(
         }
         GET_CLIENT_CODE => {
             if let Err(error) = authorize_and_hold_read(shard, code, watermark, || {
-                authorize_uid(shard, user_id, Permissioner::get_client)
+                authorize_uid(
+                    shard,
+                    user_id,
+                    Permissioner::get_client,
+                    session_perms.as_deref(),
+                    |p| p.global.manage_servers || p.global.read_servers,
+                )
             })
             .await
             {
@@ -483,13 +504,35 @@ pub(in crate::dispatch) async fn handle_non_replicated_request<B, MJ, S, SB>(
             .await;
         }
         GET_SNAPSHOT_FILE_CODE => {
-            handle_get_snapshot(shard, system_config, transport_client_id, &request, user_id).await;
+            handle_get_snapshot(
+                shard,
+                system_config,
+                transport_client_id,
+                &request,
+                user_id,
+                session_perms.as_deref(),
+            )
+            .await;
         }
         POLL_MESSAGES_CODE => {
-            handle_poll_messages(shard, transport_client_id, &request, user_id).await;
+            handle_poll_messages(
+                shard,
+                transport_client_id,
+                &request,
+                user_id,
+                session_perms.as_deref(),
+            )
+            .await;
         }
         GET_CONSUMER_OFFSET_CODE => {
-            handle_get_consumer_offset(shard, transport_client_id, &request, user_id).await;
+            handle_get_consumer_offset(
+                shard,
+                transport_client_id,
+                &request,
+                user_id,
+                session_perms.as_deref(),
+            )
+            .await;
         }
         SYNC_CONSUMER_GROUP_CODE => {
             // Self-scoped: serves the caller's own assignment keyed by the
@@ -521,6 +564,7 @@ pub(in crate::dispatch) async fn handle_non_replicated_request<B, MJ, S, SB>(
                 watermark,
                 &roster,
                 client_ip,
+                session_perms.as_deref(),
             )
             .await;
         }
@@ -537,6 +581,7 @@ async fn handle_default_non_replicated<B, MJ, S, SB>(
     watermark: u64,
     roster: &ClusterRoster,
     client_ip: Option<IpAddr>,
+    session_perms: Option<&Permissions>,
 ) where
     B: ShellBus,
     MJ: JournalHandle + 'static,
@@ -550,7 +595,7 @@ async fn handle_default_non_replicated<B, MJ, S, SB>(
     // read-your-writes hold sits INSIDE the same call, behind that denial: an
     // unauthorized read must fail now, not after the whole poll budget.
     if let Err(error) = authorize_and_hold_read(shard, code, watermark, || {
-        authorize_default_read(shard, code, request_body(request), user_id)
+        authorize_default_read(shard, code, request_body(request), user_id, session_perms)
     })
     .await
     {
@@ -638,6 +683,7 @@ async fn handle_get_snapshot<B, MJ, S, SB>(
     transport_client_id: u128,
     request: &Message<RoutedRequestHeader>,
     user_id: Option<u32>,
+    session_perms: Option<&Permissions>,
 ) where
     B: ShellBus,
     MJ: JournalHandle + 'static,
@@ -645,7 +691,13 @@ async fn handle_get_snapshot<B, MJ, S, SB>(
     S: 'static,
     SB: SuperblockStore + 'static,
 {
-    if let Err(error) = authorize_uid(shard, user_id, Permissioner::get_snapshot) {
+    if let Err(error) = authorize_uid(
+        shard,
+        user_id,
+        Permissioner::get_snapshot,
+        session_perms,
+        |p| p.global.manage_servers || p.global.read_servers,
+    ) {
         send_non_replicated_deny(shard, request, transport_client_id, error.as_code()).await;
         return;
     }

--- a/core/server/src/dispatch/session_ops.rs
+++ b/core/server/src/dispatch/session_ops.rs
@@ -64,7 +64,7 @@ use server_common::Message;
 use server_common::crypto;
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use tracing::warn;
 
@@ -119,14 +119,13 @@ where
             let _ = crypto::verify_password(password, DUMMY_PASSWORD_HASH.as_str());
             return Err(LoginRegisterError::InvalidCredentials);
         };
-        // Verify before the status check and collapse inactive to
-        // InvalidCredentials: an inactive account must answer exactly like a
-        // wrong password (same error, same Argon2 cost), or login could probe
-        // which accounts exist but are disabled.
+        // The user exists locally. Wrong password or inactive account is
+        // `LocalUserRejected` (not `InvalidCredentials`) so the external
+        // auth fallback is never attempted for known local users.
         if !crypto::verify_password(password, user.password_hash.as_ref())
             || user.status != UserStatus::Active
         {
-            return Err(LoginRegisterError::InvalidCredentials);
+            return Err(LoginRegisterError::LocalUserRejected);
         }
         Ok(user.id)
     })
@@ -383,7 +382,9 @@ const fn transient_login_code(error: &LoginRegisterError) -> IggyError {
 /// `SessionError`; the SDK maps it to `Unauthenticated`.
 const fn eviction_reason_for(error: &LoginRegisterError) -> EvictionReason {
     match error {
-        LoginRegisterError::InvalidCredentials => EvictionReason::InvalidCredentials,
+        LoginRegisterError::InvalidCredentials
+        | LoginRegisterError::LocalUserRejected
+        | LoginRegisterError::ExternalAuthDenied(_) => EvictionReason::InvalidCredentials,
         LoginRegisterError::InvalidToken => EvictionReason::InvalidToken,
         LoginRegisterError::UserInactive => EvictionReason::UserInactive,
         _ => EvictionReason::SessionError,
@@ -1159,6 +1160,7 @@ pub(in crate::dispatch) async fn handle_login_register_request<B, MJ, S, SB>(
     sessions: &Rc<RefCell<SessionManager>>,
     transport_client_id: u128,
     request: Message<RoutedRequestHeader>,
+    external_auth: &Arc<configs::external_auth::ExternalAuthConfig>,
 ) where
     B: ShellBus,
     MJ: JournalHandle + 'static,
@@ -1211,10 +1213,21 @@ pub(in crate::dispatch) async fn handle_login_register_request<B, MJ, S, SB>(
     }
 
     let body_tail = &body[prefix_len..];
+
+    // Built-in credentials first so known users never hit the external
+    // auth callout. External auth runs only when built-in rejects.
+    //
+    // The external auth block (below the built-in check) needs the
+    // decoded wire request to build the callout payload. Decode once
+    // here and reuse.
+    let password_decode =
+        LoginRegisterRequest::decode_after_prefix(version_info.clone(), body_tail).ok();
+    let pat_decode =
+        LoginRegisterWithPatRequest::decode_after_prefix(version_info.clone(), body_tail).ok();
+
+    // --- built-in credential check ---
     let mut credentials_rejected = false;
-    if let Ok((wire_request, _)) =
-        LoginRegisterRequest::decode_after_prefix(version_info.clone(), body_tail)
-    {
+    if let Some((ref wire_request, _)) = password_decode {
         match verify_login_credentials(
             shard,
             wire_request.username.as_str(),
@@ -1254,9 +1267,7 @@ pub(in crate::dispatch) async fn handle_login_register_request<B, MJ, S, SB>(
         }
     }
 
-    if let Ok((wire_request, _)) =
-        LoginRegisterWithPatRequest::decode_after_prefix(version_info, body_tail)
-    {
+    if let Some((ref wire_request, _)) = pat_decode {
         match verify_pat_credentials(shard, wire_request.token.expose_secret()) {
             Ok(user_id) => {
                 if let Err(error) = complete_login_register(
@@ -1270,53 +1281,268 @@ pub(in crate::dispatch) async fn handle_login_register_request<B, MJ, S, SB>(
                 )
                 .await
                 {
-                    warn!(
-                        transport_client_id,
-                        error = %error,
-                        "login/register with PAT failed"
-                    );
+                    warn!(transport_client_id, error = %error, "login/register with PAT failed");
                     surface_login_failure(shard, transport_client_id, request.header(), &error)
                         .await;
                 }
                 return;
             }
             Err(error) => {
+                if error.is_invalid_credentials() {
+                    credentials_rejected = true;
+                } else {
+                    warn!(transport_client_id, error = %error, "login/register with PAT failed");
+                    surface_login_failure(shard, transport_client_id, request.header(), &error)
+                        .await;
+                    return;
+                }
+            }
+        }
+    }
+
+    // --- external auth fallback (only on credential rejection) ---
+    if credentials_rejected && external_auth.enabled {
+        let transport_name = {
+            use message_bus::installer::conn_info::ClientTransportKind;
+            let mgr = sessions.borrow();
+            match mgr.connection_transport(transport_client_id) {
+                Some(ClientTransportKind::Tcp | ClientTransportKind::TcpTls) => "tcp",
+                Some(ClientTransportKind::Quic) => "quic",
+                Some(ClientTransportKind::Ws | ClientTransportKind::Wss) => "websocket",
+                Some(_) | None => "binary",
+            }
+        };
+        let ext_request = if let Some((ref wire_request, _)) = password_decode {
+            crate::external_auth::ExternalAuthRequest {
+                credential_type: crate::external_auth::CredentialType::Password,
+                credential: if external_auth.forward_credentials {
+                    Some(wire_request.password.expose_secret().to_owned())
+                } else {
+                    None
+                },
+                username: wire_request.username.to_string(),
+                transport: transport_name.to_owned(),
+                client_address: sessions
+                    .borrow()
+                    .connection_address(transport_client_id)
+                    .map_or_else(String::new, |a| a.to_string()),
+            }
+        } else if let Some((ref wire_request, _)) = pat_decode {
+            crate::external_auth::ExternalAuthRequest {
+                credential_type: crate::external_auth::CredentialType::PersonalAccessToken,
+                credential: if external_auth.forward_credentials {
+                    Some(wire_request.token.expose_secret().to_owned())
+                } else {
+                    None
+                },
+                username: String::new(),
+                transport: transport_name.to_owned(),
+                client_address: sessions
+                    .borrow()
+                    .connection_address(transport_client_id)
+                    .map_or_else(String::new, |a| a.to_string()),
+            }
+        } else {
+            warn!(
+                transport_client_id,
+                "rejecting register request with unsupported payload shape"
+            );
+            send_eviction(
+                shard,
+                transport_client_id,
+                vsr_client_id,
+                EvictionReason::MalformedLogin,
+                "login_rejection",
+            )
+            .await;
+            return;
+        };
+
+        match crate::external_auth::try_external_auth(external_auth, ext_request).await {
+            Ok(crate::external_auth::ExternalAuthDecision::IggyUser { user_id }) => {
+                if user_id == 0 {
+                    warn!(
+                        transport_client_id,
+                        "external auth attempted to map login to root user"
+                    );
+                    send_eviction(
+                        shard,
+                        transport_client_id,
+                        vsr_client_id,
+                        EvictionReason::InvalidCredentials,
+                        "login_rejection",
+                    )
+                    .await;
+                    return;
+                }
+                if user_id == external_auth.user_id {
+                    warn!(
+                        transport_client_id,
+                        user_id, "external auth returned the reserved user_id; rejecting"
+                    );
+                    send_eviction(
+                        shard,
+                        transport_client_id,
+                        vsr_client_id,
+                        EvictionReason::InvalidCredentials,
+                        "login_rejection",
+                    )
+                    .await;
+                    return;
+                }
+                let user_valid = shard.plane.metadata().mux_stm.users().read(|users| {
+                    users
+                        .items
+                        .get(user_id as usize)
+                        .is_some_and(|u| u.status == UserStatus::Active)
+                });
+                if !user_valid {
+                    warn!(
+                        transport_client_id,
+                        user_id, "external auth mapped to non-existent or inactive user"
+                    );
+                    send_eviction(
+                        shard,
+                        transport_client_id,
+                        vsr_client_id,
+                        EvictionReason::InvalidCredentials,
+                        "login_rejection",
+                    )
+                    .await;
+                    return;
+                }
+                if let Err(error) = complete_login_register(
+                    shard,
+                    sessions,
+                    transport_client_id,
+                    vsr_client_id,
+                    request.header(),
+                    user_id,
+                    &version_info,
+                )
+                .await
+                {
+                    warn!(transport_client_id, error = %error, "external auth login failed");
+                    surface_login_failure(shard, transport_client_id, request.header(), &error)
+                        .await;
+                }
+                return;
+            }
+            Ok(crate::external_auth::ExternalAuthDecision::InlineGrant {
+                principal,
+                permissions,
+                expires_at,
+            }) => {
+                // Use the bus clock for consistency with PAT expiry.
+                // Under the deterministic simulator IggyTimestamp::now() diverges
+                // from the bus clock, which would cause replica disagreement on
+                // whether an inline grant is expired.
+                let now_secs = IggyTimestamp::from(shard.bus.realtime_micros()).to_secs();
+                if expires_at <= now_secs {
+                    warn!(
+                        transport_client_id,
+                        expires_at, now_secs, "external auth inline grant already expired"
+                    );
+                    surface_login_failure(
+                        shard,
+                        transport_client_id,
+                        request.header(),
+                        &LoginRegisterError::ExternalAuthDenied(
+                            "inline grant already expired".to_owned(),
+                        ),
+                    )
+                    .await;
+                    return;
+                }
+                let reserved_uid = external_auth.user_id;
+                // Set permissions BEFORE binding the session so that any
+                // request arriving immediately after bind already sees the
+                // grants. On bind failure we roll back.
+                sessions.borrow_mut().set_session_permissions(
+                    transport_client_id,
+                    crate::external_auth::SessionPermissions {
+                        principal,
+                        permissions: std::sync::Arc::new(permissions),
+                        expires_at,
+                    },
+                );
+                if let Err(error) = complete_login_register(
+                    shard,
+                    sessions,
+                    transport_client_id,
+                    vsr_client_id,
+                    request.header(),
+                    reserved_uid,
+                    &version_info,
+                )
+                .await
+                {
+                    warn!(transport_client_id, error = %error, "external auth inline grant login failed");
+                    sessions
+                        .borrow_mut()
+                        .clear_session_permissions(transport_client_id);
+                    surface_login_failure(shard, transport_client_id, request.header(), &error)
+                        .await;
+                }
+                return;
+            }
+            Ok(crate::external_auth::ExternalAuthDecision::Deny { reason }) => {
+                warn!(
+                    transport_client_id,
+                    reason = reason,
+                    "external auth denied login"
+                );
+                surface_login_failure(
+                    shard,
+                    transport_client_id,
+                    request.header(),
+                    &LoginRegisterError::ExternalAuthDenied(reason),
+                )
+                .await;
+                return;
+            }
+            Err(error) => {
                 warn!(
                     transport_client_id,
                     error = %error,
-                    "login/register with PAT failed"
+                    "external auth callout failed"
                 );
-                surface_login_failure(shard, transport_client_id, request.header(), &error).await;
+                surface_login_failure(
+                    shard,
+                    transport_client_id,
+                    request.header(),
+                    &LoginRegisterError::ExternalAuthDenied(error.to_string()),
+                )
+                .await;
                 return;
             }
         }
     }
 
-    if credentials_rejected {
+    if !credentials_rejected {
         warn!(
             transport_client_id,
-            "rejecting register request: invalid credentials"
+            "rejecting register request with unsupported payload shape"
         );
         send_eviction(
             shard,
             transport_client_id,
             request.header().client,
-            EvictionReason::InvalidCredentials,
+            EvictionReason::MalformedLogin,
             "login_rejection",
         )
         .await;
         return;
     }
-
     warn!(
         transport_client_id,
-        "rejecting register request with unsupported payload shape"
+        "rejecting register request: invalid credentials"
     );
     send_eviction(
         shard,
         transport_client_id,
         request.header().client,
-        EvictionReason::MalformedLogin,
+        EvictionReason::InvalidCredentials,
         "login_rejection",
     )
     .await;

--- a/core/server/src/external_auth.rs
+++ b/core/server/src/external_auth.rs
@@ -1,0 +1,743 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! External authentication callout.
+//!
+//! When enabled, the server POSTs credential and connection metadata to an
+//! external HTTP service during login. The service decides whether to grant
+//! access (with inline permissions or by mapping to an existing Iggy user)
+//! or deny it. This module owns the request/response types, the HTTP
+//! callout, and the session-scoped permission carrier.
+//!
+//! Known limitation: there is no per-client rate limit on callout attempts.
+//! Every failed built-in login triggers a callout, so a brute-force attack
+//! can amplify traffic to the external service. The shard reactor's
+//! single-threaded model bounds binary-transport concurrency, but the HTTP
+//! transport is concurrent. Operators should rate-limit at the network
+//! layer or inside the external auth service itself.
+
+use std::fmt;
+
+use configs::external_auth::ExternalAuthConfig;
+use iggy_common::Permissions;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+const MAX_RESPONSE_BODY_BYTES: usize = 1_048_576;
+
+/// Reject credentials longer than this before serializing them into the
+/// callout body. A multi-MB PAT passes the built-in hash check (mismatch)
+/// and would otherwise be forwarded verbatim to the external service.
+const MAX_CREDENTIAL_BYTES: usize = 8_192;
+
+thread_local! {
+    static HTTP_CLIENT: cyper::Client =
+        cyper::Client::builder()
+            .redirect(cyper::redirect::Policy::none())
+            .build()
+            .expect("failed to build cyper HTTP client for external auth");
+}
+
+fn get_http_client() -> cyper::Client {
+    HTTP_CLIENT.with(cyper::Client::clone)
+}
+
+/// Credential metadata sent to the external auth service.
+///
+/// For `PersonalAccessToken` logins, `username` is empty (PATs are not
+/// associated with a username on the wire). The auth service should use
+/// the `credential` value to identify the caller.
+///
+/// Manual `Debug` redacts the `credential` field so passwords and tokens
+/// never appear in log output.
+#[derive(Serialize)]
+pub struct ExternalAuthRequest {
+    pub credential_type: CredentialType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential: Option<String>,
+    pub username: String,
+    pub transport: String,
+    pub client_address: String,
+}
+
+impl fmt::Debug for ExternalAuthRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExternalAuthRequest")
+            .field("credential_type", &self.credential_type)
+            .field(
+                "credential",
+                &self.credential.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("username", &self.username)
+            .field("transport", &self.transport)
+            .field("client_address", &self.client_address)
+            .finish()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialType {
+    Password,
+    PersonalAccessToken,
+}
+
+/// JSON response from the external auth service.
+#[derive(Debug, Deserialize)]
+struct ExternalAuthResponse {
+    decision: DecisionTag,
+    user_id: Option<u32>,
+    principal: Option<String>,
+    permissions: Option<Permissions>,
+    expires_at: Option<u64>,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum DecisionTag {
+    IggyUser,
+    InlineGrant,
+    Deny,
+}
+
+/// Parsed decision from the external auth service.
+#[derive(Debug)]
+pub enum ExternalAuthDecision {
+    IggyUser {
+        user_id: u32,
+    },
+    InlineGrant {
+        principal: String,
+        permissions: Permissions,
+        expires_at: u64,
+    },
+    Deny {
+        reason: String,
+    },
+}
+
+/// Callout failure (network, timeout, bad response, or rejected request).
+#[derive(Debug)]
+pub enum ExternalAuthError {
+    HttpError(String),
+    Timeout,
+    BadResponse(String),
+    /// The request was rejected before the callout was made (e.g. credential
+    /// too large). Distinguished from `BadResponse` so callers/logs can tell
+    /// which side was at fault.
+    BadRequest(String),
+}
+
+impl fmt::Display for ExternalAuthError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HttpError(msg) => write!(f, "external auth HTTP error: {msg}"),
+            Self::Timeout => write!(f, "external auth callout timed out"),
+            Self::BadResponse(msg) => write!(f, "external auth bad response: {msg}"),
+            Self::BadRequest(msg) => write!(f, "external auth bad request: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ExternalAuthError {}
+
+/// # Errors
+///
+/// Returns [`ServerError::InvalidExternalAuthConfig`](crate::server_error::ServerError::InvalidExternalAuthConfig)
+/// when the URL is empty or uses an unsupported scheme.
+pub fn validate_config(
+    config: &ExternalAuthConfig,
+) -> Result<(), crate::server_error::ServerError> {
+    if !config.enabled {
+        return Ok(());
+    }
+    if config.url.is_empty() {
+        return Err(
+            crate::server_error::ServerError::InvalidExternalAuthConfig {
+                reason: "external_auth.url must be set when external_auth.enabled = true"
+                    .to_owned(),
+            },
+        );
+    }
+    if !config.url.starts_with("http://") && !config.url.starts_with("https://") {
+        return Err(
+            crate::server_error::ServerError::InvalidExternalAuthConfig {
+                reason: format!(
+                    "external_auth.url must start with http:// or https://, got: {}",
+                    config.url
+                ),
+            },
+        );
+    }
+    // Catch bare schemes ("http://") with no host at boot instead of on
+    // first callout. The scheme prefix check above already guarantees the
+    // split will succeed.
+    let after_scheme = config.url.split_once("://").map_or("", |(_, rest)| rest);
+    if after_scheme.is_empty() || after_scheme.starts_with('/') {
+        return Err(
+            crate::server_error::ServerError::InvalidExternalAuthConfig {
+                reason: format!("external_auth.url has no host: {}", config.url),
+            },
+        );
+    }
+    if config.timeout.get_duration().is_zero() {
+        return Err(
+            crate::server_error::ServerError::InvalidExternalAuthConfig {
+                reason: "external_auth.timeout must be greater than zero".to_owned(),
+            },
+        );
+    }
+    // The callout runs inline on the single-threaded shard reactor; a very
+    // large timeout blocks the entire shard for its duration. Warn above 30 s.
+    if config.timeout.get_duration().as_secs() > 30 {
+        tracing::warn!(
+            timeout = %config.timeout,
+            "external_auth.timeout is unusually large (> 30 s); \
+             the callout blocks the shard reactor for its full duration"
+        );
+    }
+    if config.user_id == 0 {
+        return Err(
+            crate::server_error::ServerError::InvalidExternalAuthConfig {
+                reason: "external_auth.user_id must not be 0 (reserved for root)".to_owned(),
+            },
+        );
+    }
+    // The slab allocator assigns user IDs sequentially from 0 (root).
+    // A low user_id will collide with a real user once enough are created,
+    // silently restricting that user to data-plane ops. The default
+    // (u32::MAX) avoids this; warn if the operator picked a low value.
+    if config.user_id < 1_000_000 {
+        tracing::warn!(
+            user_id = config.user_id,
+            "external_auth.user_id is low; it may collide with a future Iggy user ID. \
+             Consider using a large value (the default is u32::MAX)."
+        );
+    }
+    Ok(())
+}
+
+pub fn warn_insecure_url(config: &ExternalAuthConfig) {
+    if config.enabled && config.url.starts_with("http://") {
+        tracing::warn!(
+            url = config.url,
+            "external auth URL uses plain HTTP; credentials will be sent in cleartext"
+        );
+    }
+}
+
+/// Session-scoped permissions from an external auth inline grant.
+/// Carried on the connection/session, never persisted. The permissions
+/// are `Arc`-wrapped so dispatch-time lookups share rather than clone
+/// the full `BTreeMap` tree on every request.
+#[derive(Debug, Clone)]
+pub struct SessionPermissions {
+    pub principal: String,
+    pub permissions: std::sync::Arc<Permissions>,
+    pub expires_at: u64,
+}
+
+/// Call the external auth service and parse the response.
+///
+/// # Errors
+///
+/// Returns [`ExternalAuthError`] on network/timeout/parse failure.
+/// Fail-closed: every error variant denies the login.
+pub async fn callout_external_auth(
+    config: &ExternalAuthConfig,
+    request: ExternalAuthRequest,
+) -> Result<ExternalAuthDecision, ExternalAuthError> {
+    use futures::StreamExt;
+
+    if let Some(ref cred) = request.credential
+        && cred.len() > MAX_CREDENTIAL_BYTES
+    {
+        return Err(ExternalAuthError::BadRequest(format!(
+            "credential too large ({} bytes, limit {MAX_CREDENTIAL_BYTES})",
+            cred.len()
+        )));
+    }
+
+    let client = get_http_client();
+    let timeout = config.timeout.get_duration();
+
+    let body = serde_json::to_vec(&request)
+        .map_err(|e| ExternalAuthError::BadResponse(format!("failed to serialize request: {e}")))?;
+
+    // Single timeout wrapping the entire round-trip (connect + headers +
+    // body read) so a slow-drip body cannot extend the window to 2x.
+    let round_trip = async {
+        let request_builder = client
+            .post(&config.url)
+            .map_err(|e| ExternalAuthError::HttpError(format!("failed to build request: {e}")))?
+            .header("content-type", "application/json")
+            .map_err(|e| ExternalAuthError::HttpError(format!("failed to set header: {e}")))?
+            .body(body);
+
+        let response = request_builder
+            .send()
+            .await
+            .map_err(|e| ExternalAuthError::HttpError(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(ExternalAuthError::HttpError(format!(
+                "non-success status: {status}"
+            )));
+        }
+
+        if let Some(len) = response
+            .headers()
+            .get("content-length")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<usize>().ok())
+            && len > MAX_RESPONSE_BODY_BYTES
+        {
+            return Err(ExternalAuthError::BadResponse(
+                "response body too large".to_owned(),
+            ));
+        }
+
+        // Stream the body with a running cap so a length-less response cannot
+        // OOM the server. Matches the forward.rs pattern.
+        let mut buf = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk =
+                chunk.map_err(|e| ExternalAuthError::HttpError(format!("body read: {e}")))?;
+            if buf.len() + chunk.len() > MAX_RESPONSE_BODY_BYTES {
+                return Err(ExternalAuthError::BadResponse(
+                    "response body too large".to_owned(),
+                ));
+            }
+            buf.extend_from_slice(&chunk);
+        }
+        Ok(buf)
+    };
+    let bytes = compio::time::timeout(timeout, round_trip)
+        .await
+        .map_err(|_| ExternalAuthError::Timeout)??;
+
+    let resp: ExternalAuthResponse = serde_json::from_slice(&bytes)
+        .map_err(|e| ExternalAuthError::BadResponse(format!("invalid JSON: {e}")))?;
+
+    parse_decision(resp)
+}
+
+/// Map a deserialized response to a decision. Extracted so tests can
+/// exercise the mapping without an HTTP round-trip.
+fn parse_decision(resp: ExternalAuthResponse) -> Result<ExternalAuthDecision, ExternalAuthError> {
+    match resp.decision {
+        DecisionTag::IggyUser => {
+            let user_id = resp.user_id.ok_or_else(|| {
+                ExternalAuthError::BadResponse("iggy_user decision missing user_id".to_owned())
+            })?;
+            Ok(ExternalAuthDecision::IggyUser { user_id })
+        }
+        DecisionTag::InlineGrant => {
+            let principal = resp.principal.ok_or_else(|| {
+                ExternalAuthError::BadResponse("inline_grant decision missing principal".to_owned())
+            })?;
+            let permissions = resp.permissions.ok_or_else(|| {
+                ExternalAuthError::BadResponse(
+                    "inline_grant decision missing permissions".to_owned(),
+                )
+            })?;
+            // When the external auth service omits expires_at, the grant
+            // logically never expires. On the HTTP path, generate_capped
+            // caps the JWT at the server's configured token expiry. On the
+            // binary transport, the raw u64::MAX rides on the connection
+            // and expires_at is only checked against the bus clock at
+            // dispatch time.
+            let expires_at = resp.expires_at.unwrap_or(u64::MAX);
+            Ok(ExternalAuthDecision::InlineGrant {
+                principal,
+                permissions,
+                expires_at,
+            })
+        }
+        DecisionTag::Deny => {
+            let reason = resp
+                .reason
+                .unwrap_or_else(|| "denied by external auth".to_owned());
+            Ok(ExternalAuthDecision::Deny { reason })
+        }
+    }
+}
+
+/// Try external auth and map the result to a decision the login flow
+/// can act on. Fail-closed: a callout failure (timeout, network error,
+/// bad response) denies the login.
+///
+/// # Errors
+///
+/// Returns [`ExternalAuthError`] when the callout itself failed.
+pub async fn try_external_auth(
+    config: &ExternalAuthConfig,
+    request: ExternalAuthRequest,
+) -> Result<ExternalAuthDecision, ExternalAuthError> {
+    match callout_external_auth(config, request).await {
+        Ok(decision) => Ok(decision),
+        Err(error) => {
+            warn!(error = %error, "external auth callout failed");
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deserialize JSON and run the same decision-mapping logic that
+    /// `callout_external_auth` uses after receiving the HTTP body.
+    fn parse_response(json: &str) -> Result<ExternalAuthDecision, ExternalAuthError> {
+        let resp: ExternalAuthResponse = serde_json::from_str(json)
+            .map_err(|e| ExternalAuthError::BadResponse(format!("invalid JSON: {e}")))?;
+        parse_decision(resp)
+    }
+
+    // ── request serialization (full schema) ─────────────────────────
+
+    #[test]
+    fn request_password_round_trip() {
+        let req = ExternalAuthRequest {
+            credential_type: CredentialType::Password,
+            credential: Some("s3cret".to_owned()),
+            username: "alice".to_owned(),
+            transport: "tcp".to_owned(),
+            client_address: "10.0.0.1:5000".to_owned(),
+        };
+        let val: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(val["credential_type"], "password");
+        assert_eq!(val["credential"], "s3cret");
+        assert_eq!(val["username"], "alice");
+        assert_eq!(val["transport"], "tcp");
+        assert_eq!(val["client_address"], "10.0.0.1:5000");
+        assert_eq!(val.as_object().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn request_pat_omits_credential_when_none() {
+        let req = ExternalAuthRequest {
+            credential_type: CredentialType::PersonalAccessToken,
+            credential: None,
+            username: String::new(),
+            transport: "http".to_owned(),
+            client_address: "10.0.0.1:443".to_owned(),
+        };
+        let val: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(val["credential_type"], "personal_access_token");
+        assert!(
+            val.get("credential").is_none(),
+            "credential must be omitted"
+        );
+        assert_eq!(val["username"], "");
+        assert_eq!(val.as_object().unwrap().len(), 4);
+    }
+
+    // ── response deserialization: iggy_user ──────────────────────────
+
+    #[test]
+    fn response_iggy_user_complete() {
+        let json = r#"{"decision": "iggy_user", "user_id": 42}"#;
+        match parse_response(json).unwrap() {
+            ExternalAuthDecision::IggyUser { user_id } => assert_eq!(user_id, 42),
+            other => panic!("expected IggyUser, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn response_iggy_user_missing_user_id_should_error() {
+        let json = r#"{"decision": "iggy_user"}"#;
+        let err = parse_response(json).unwrap_err();
+        assert!(err.to_string().contains("missing user_id"));
+    }
+
+    // ── response deserialization: inline_grant ───────────────────────
+
+    #[test]
+    fn response_inline_grant_complete() {
+        let json = r#"{
+            "decision": "inline_grant",
+            "principal": "device-1234",
+            "permissions": {
+                "global": {
+                    "read_streams": true,
+                    "read_topics": true,
+                    "poll_messages": true,
+                    "send_messages": true
+                },
+                "streams": {
+                    "1": {
+                        "poll_messages": true,
+                        "send_messages": true,
+                        "topics": {
+                            "0": { "poll_messages": true }
+                        }
+                    }
+                }
+            },
+            "expires_at": 1700000000
+        }"#;
+        match parse_response(json).unwrap() {
+            ExternalAuthDecision::InlineGrant {
+                principal,
+                permissions,
+                expires_at,
+            } => {
+                assert_eq!(principal, "device-1234");
+                assert_eq!(expires_at, 1_700_000_000);
+                // global
+                assert!(permissions.global.poll_messages);
+                assert!(permissions.global.send_messages);
+                assert!(permissions.global.read_streams);
+                assert!(!permissions.global.manage_servers);
+                // per-stream
+                let stream = permissions.streams.as_ref().unwrap().get(&1).unwrap();
+                assert!(stream.poll_messages);
+                assert!(stream.send_messages);
+                assert!(!stream.manage_stream);
+                // per-topic inside stream
+                let topic = stream.topics.as_ref().unwrap().get(&0).unwrap();
+                assert!(topic.poll_messages);
+                assert!(!topic.send_messages);
+            }
+            other => panic!("expected InlineGrant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn response_inline_grant_minimal_permissions_default_all_false() {
+        let json = r#"{
+            "decision": "inline_grant",
+            "principal": "dev-1",
+            "permissions": {}
+        }"#;
+        match parse_response(json).unwrap() {
+            ExternalAuthDecision::InlineGrant {
+                permissions,
+                expires_at,
+                ..
+            } => {
+                assert!(!permissions.global.send_messages);
+                assert!(!permissions.global.poll_messages);
+                assert!(!permissions.global.manage_servers);
+                assert!(!permissions.global.read_servers);
+                assert!(!permissions.global.manage_users);
+                assert!(!permissions.global.read_users);
+                assert!(!permissions.global.manage_streams);
+                assert!(!permissions.global.read_streams);
+                assert!(!permissions.global.manage_topics);
+                assert!(!permissions.global.read_topics);
+                assert!(permissions.streams.is_none());
+                assert_eq!(expires_at, u64::MAX, "omitted expires_at defaults to MAX");
+            }
+            other => panic!("expected InlineGrant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn response_inline_grant_missing_principal_should_error() {
+        let json = r#"{
+            "decision": "inline_grant",
+            "permissions": {"global": {}},
+            "expires_at": 9999999999
+        }"#;
+        let err = parse_response(json).unwrap_err();
+        assert!(err.to_string().contains("missing principal"));
+    }
+
+    #[test]
+    fn response_inline_grant_missing_permissions_should_error() {
+        let json = r#"{
+            "decision": "inline_grant",
+            "principal": "dev-1"
+        }"#;
+        let err = parse_response(json).unwrap_err();
+        assert!(err.to_string().contains("missing permissions"));
+    }
+
+    // ── response deserialization: deny ───────────────────────────────
+
+    #[test]
+    fn response_deny_with_reason() {
+        let json = r#"{"decision": "deny", "reason": "certificate revoked"}"#;
+        match parse_response(json).unwrap() {
+            ExternalAuthDecision::Deny { reason } => {
+                assert_eq!(reason, "certificate revoked");
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn response_deny_without_reason_uses_default() {
+        let json = r#"{"decision": "deny"}"#;
+        match parse_response(json).unwrap() {
+            ExternalAuthDecision::Deny { reason } => {
+                assert_eq!(reason, "denied by external auth");
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    // ── response edge cases ─────────────────────────────────────────
+
+    #[test]
+    fn response_unknown_decision_should_fail() {
+        let json = r#"{"decision": "pass_through"}"#;
+        assert!(parse_response(json).is_err());
+    }
+
+    #[test]
+    fn response_missing_decision_should_fail() {
+        let json = r#"{"user_id": 42}"#;
+        assert!(parse_response(json).is_err());
+    }
+
+    #[test]
+    fn response_extra_fields_accepted() {
+        let json = r#"{"decision": "deny", "reason": "no", "audit_id": "abc", "trace": [1,2,3]}"#;
+        match parse_response(json).unwrap() {
+            ExternalAuthDecision::Deny { reason } => assert_eq!(reason, "no"),
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn response_empty_object_should_fail() {
+        assert!(parse_response("{}").is_err());
+    }
+
+    #[test]
+    fn given_disabled_config_when_validating_should_accept_empty_url() {
+        let config = ExternalAuthConfig {
+            enabled: false,
+            url: String::new(),
+            ..ExternalAuthConfig::default()
+        };
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn given_enabled_config_with_empty_url_when_validating_should_reject() {
+        let config = ExternalAuthConfig {
+            enabled: true,
+            url: String::new(),
+            ..ExternalAuthConfig::default()
+        };
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("external_auth.url must be set"));
+    }
+
+    #[test]
+    fn given_enabled_config_with_invalid_scheme_when_validating_should_reject() {
+        let config = ExternalAuthConfig {
+            enabled: true,
+            url: "ftp://auth.example.com".to_owned(),
+            ..ExternalAuthConfig::default()
+        };
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("must start with http://"));
+    }
+
+    #[test]
+    fn given_enabled_config_with_https_url_when_validating_should_accept() {
+        let config = ExternalAuthConfig {
+            enabled: true,
+            url: "https://auth.example.com/verify".to_owned(),
+            ..ExternalAuthConfig::default()
+        };
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn given_enabled_config_with_http_url_when_validating_should_accept() {
+        let config = ExternalAuthConfig {
+            enabled: true,
+            url: "http://localhost:8080/auth".to_owned(),
+            ..ExternalAuthConfig::default()
+        };
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn given_request_without_credential_when_serializing_should_omit_field() {
+        let req = ExternalAuthRequest {
+            credential_type: CredentialType::PersonalAccessToken,
+            credential: None,
+            username: String::new(),
+            transport: "http".to_owned(),
+            client_address: "10.0.0.1:443".to_owned(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("credential\":"));
+        // credential_type is still present
+        assert!(json.contains("\"credential_type\":\"personal_access_token\""));
+    }
+
+    #[test]
+    fn given_enabled_config_with_zero_timeout_when_validating_should_reject() {
+        let config = ExternalAuthConfig {
+            enabled: true,
+            url: "https://auth.example.com/verify".to_owned(),
+            timeout: "0 s".parse().expect("valid duration"),
+            ..ExternalAuthConfig::default()
+        };
+        let err = validate_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("timeout must be greater than zero"),
+        );
+    }
+
+    #[test]
+    fn given_enabled_config_with_bare_scheme_when_validating_should_reject() {
+        let config = ExternalAuthConfig {
+            enabled: true,
+            url: "https://".to_owned(),
+            ..ExternalAuthConfig::default()
+        };
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("has no host"));
+    }
+
+    #[test]
+    fn given_enabled_config_with_scheme_and_path_only_when_validating_should_reject() {
+        let config = ExternalAuthConfig {
+            enabled: true,
+            url: "http:///path".to_owned(),
+            ..ExternalAuthConfig::default()
+        };
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("has no host"));
+    }
+
+    #[test]
+    fn given_enabled_config_with_user_id_zero_when_validating_should_reject() {
+        let config = ExternalAuthConfig {
+            enabled: true,
+            url: "https://auth.example.com".to_owned(),
+            user_id: 0,
+            ..ExternalAuthConfig::default()
+        };
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("must not be 0"));
+    }
+}

--- a/core/server/src/http.rs
+++ b/core/server/src/http.rs
@@ -206,6 +206,7 @@ pub fn start(
     system_config: Arc<ServerSystemConfig>,
     roster: Rc<ClusterRoster>,
     shard_metrics_all: &[shard::metrics::ShardMetrics],
+    external_auth: Arc<configs::external_auth::ExternalAuthConfig>,
 ) -> Result<(), ServerError> {
     let BoundHttp {
         listener,
@@ -228,11 +229,14 @@ pub fn start(
         registrations: RegistrationBarrier::default(),
         roster,
         max_http_sessions: crate::http::session::max_http_sessions(clients_table_max),
+        max_session_grants: crate::http::session::max_http_sessions(clients_table_max),
         max_tokens_per_user,
         in_flight_writes: Cell::new(0),
         forward,
         metrics: metrics::HttpMetrics::init(shard_metrics_all),
         metadata_watermarks: Rc::default(),
+        external_auth,
+        session_grants: RefCell::new(HashMap::new()),
     }));
     let app = router(
         state,

--- a/core/server/src/http/extractor.rs
+++ b/core/server/src/http/extractor.rs
@@ -42,6 +42,35 @@ const BEARER: &str = "Bearer ";
 const JWT_KEY_PREFIX: &str = "jwt:";
 const PAT_KEY_PREFIX: &str = "pat:";
 
+/// Session table key identifying a credential. Two variants so JWTs and PATs
+/// occupy disjoint key spaces.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(in crate::http) enum SessionKey {
+    Jwt(String),
+    Pat(String),
+}
+
+impl SessionKey {
+    /// The prefixed string form used as the session table `HashMap` key.
+    pub(in crate::http) fn as_table_key(&self) -> String {
+        match self {
+            Self::Jwt(jti) => format!("{JWT_KEY_PREFIX}{jti}"),
+            Self::Pat(hash) => format!("{PAT_KEY_PREFIX}{hash}"),
+        }
+    }
+
+    /// Parse a prefixed table-key string back into a `SessionKey`.
+    /// Returns `None` if the prefix is unrecognized.
+    pub(in crate::http) fn from_table_key(key: &str) -> Option<Self> {
+        key.strip_prefix(JWT_KEY_PREFIX)
+            .map(|jti| Self::Jwt(jti.to_owned()))
+            .or_else(|| {
+                key.strip_prefix(PAT_KEY_PREFIX)
+                    .map(|hash| Self::Pat(hash.to_owned()))
+            })
+    }
+}
+
 /// Resolved caller identity for a protected write route: the shared VSR
 /// session established once per presenting credential (it carries the
 /// authenticated user id).
@@ -75,7 +104,8 @@ impl FromRequestParts<HttpState> for Authenticated {
         // critical section is synchronous), so a cooperatively-scheduled sibling
         // task on this thread never observes a borrowed session table.
         let (key, user_id, expiry) = SendWrapper::new(resolve_credential(state, bearer)).await?;
-        let session = SendWrapper::new(state.resolve_session(key, user_id, expiry)).await?;
+        let session =
+            SendWrapper::new(state.resolve_session(key.as_table_key(), user_id, expiry)).await?;
         Ok(Self {
             session: SendWrapper::new(session),
         })
@@ -94,6 +124,9 @@ impl FromRequestParts<HttpState> for Authenticated {
 /// [`resolve_credential`] chokepoint, so a JWT and a PAT are honored identically.
 pub struct Identity {
     pub user_id: u32,
+    /// Session table key. Used to look up session-scoped permissions for
+    /// external auth inline-grant sessions.
+    pub session_key: SessionKey,
     /// Original request path + query (e.g. `/streams?consistency=linearizable`),
     /// captured so a linearizable read that reaches a follower can build the
     /// `Location` for its 307 redirect to the primary. Empty only when the URI
@@ -126,7 +159,8 @@ impl FromRequestParts<HttpState> for Identity {
         // ever runs on (mirrors legacy `HttpSafeShard`). It holds no `RefCell`
         // borrow or `DashMap` guard across the `.await`, so a sibling task
         // scheduled on this thread meanwhile never observes a borrowed cell.
-        let (_key, user_id, _expiry) = SendWrapper::new(resolve_credential(state, bearer)).await?;
+        let (session_key, user_id, _expiry) =
+            SendWrapper::new(resolve_credential(state, bearer)).await?;
         let path_and_query = parts
             .uri
             .path_and_query()
@@ -144,6 +178,7 @@ impl FromRequestParts<HttpState> for Identity {
         }
         Ok(Self {
             user_id,
+            session_key,
             path_and_query,
             client_ip,
         })
@@ -177,22 +212,18 @@ pub(in crate::http) fn bearer_token(headers: &HeaderMap) -> Result<&str, IggyErr
 pub(in crate::http) async fn resolve_credential(
     state: &HttpState,
     bearer: &str,
-) -> Result<(String, u32, u64), AuthError> {
+) -> Result<(SessionKey, u32, u64), AuthError> {
     if let Ok(claims) = state.jwt.decode(bearer).await
         && let Ok(user_id) = claims.sub.parse::<u32>()
     {
-        return Ok((
-            format!("{JWT_KEY_PREFIX}{}", claims.jti),
-            user_id,
-            claims.exp,
-        ));
+        return Ok((SessionKey::Jwt(claims.jti), user_id, claims.exp));
     }
 
     let (user_id, expiry) = verify_pat_credentials_with_expiry(&state.shard, bearer)
         .map_err(|_| IggyError::Unauthenticated)?;
-    let key = format!(
-        "{PAT_KEY_PREFIX}{}",
-        PersonalAccessToken::hash_token(bearer)
-    );
-    Ok((key, user_id, expiry))
+    Ok((
+        SessionKey::Pat(PersonalAccessToken::hash_token(bearer)),
+        user_id,
+        expiry,
+    ))
 }

--- a/core/server/src/http/handlers.rs
+++ b/core/server/src/http/handlers.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use axum::Json;
 use axum::body::Body;
-use axum::extract::{Path, Query, State};
+use axum::extract::{ConnectInfo, Path, Query, State};
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use chrono::Local;
@@ -112,6 +112,7 @@ use iggy_common::{
     UserInfo, UserInfoDetails, UserUpdateOptions, Validatable, validate_preallocated_topic_bytes,
     validate_topic_segment_size,
 };
+use message_bus::MessageBus;
 use metadata::impls::metadata::StreamsFrontend;
 use metadata::permissioner::Permissioner;
 use secrecy::ExposeSecret;
@@ -119,8 +120,15 @@ use send_wrapper::SendWrapper;
 use serde::Deserialize;
 use shard::{PartitionRead, PartitionReadReply};
 
+use crate::dispatch::authz::{
+    can_list_topics, can_poll_messages, can_read_stream, can_read_topic, can_send_messages,
+};
 use crate::dispatch::partition::{resolve_consumer_offset_request, resolve_poll_request};
 use crate::dispatch::session_ops::{verify_login_credentials, verify_pat_credentials};
+use crate::external_auth::{
+    CredentialType, ExternalAuthDecision, ExternalAuthRequest, try_external_auth,
+};
+use crate::http::ClientAddr;
 use crate::http::error::{
     Consistency, ConsistencyQuery, CustomError, PartitionWriteError, ProduceAck, ProduceQuery,
     ReadError, WriteError,
@@ -128,8 +136,8 @@ use crate::http::error::{
 use crate::http::extractor::{Authenticated, Identity};
 use crate::http::metrics::gauge_value;
 use crate::http::reads::{
-    authorize_data_plane, gate_local_read, read_local, resolve_gate_stream, resolve_gate_topic,
-    resolve_gate_topic_ids, resolve_gate_user,
+    authorize_data_plane, authorize_read, gate_local_read, read_local, resolve_gate_stream,
+    resolve_gate_topic, resolve_gate_topic_ids, resolve_gate_user,
 };
 use crate::http::reply::{
     committed_payload, decode_consumer_group_details, decode_raw_pat_token, decode_stream_details,
@@ -188,6 +196,7 @@ pub(in crate::http) async fn ping(State(_state): State<HttpState>) -> &'static s
 
 pub(in crate::http) async fn login_user(
     State(state): State<HttpState>,
+    ConnectInfo(ClientAddr(peer)): ConnectInfo<ClientAddr>,
     Json(command): Json<LoginUser>,
 ) -> Result<Json<IdentityInfo>, CustomError> {
     // Credential verification is a consensus-free STM read; hold it while a
@@ -199,17 +208,32 @@ pub(in crate::http) async fn login_user(
     SendWrapper::new(crate::http::reads::await_recovery_barrier(&state.shard))
         .await
         .map_err(|_| IggyError::TransientNotCommitted)?;
-    let user_id = verify_login_credentials(
+    // Built-in credentials first so known users never hit the callout.
+    // External auth runs only when built-in rejects the credentials.
+    match verify_login_credentials(
         &state.shard,
         &command.username,
         command.password.expose_secret(),
-    )
-    .map_err(|error| login_error_to_iggy(&error))?;
-    issue_identity(&state, user_id)
+    ) {
+        Ok(user_id) => return issue_identity(&state, user_id),
+        Err(ref error) if !state.external_auth.enabled || !error.is_invalid_credentials() => {
+            return Err(login_error_to_iggy(error).into());
+        }
+        Err(_) => {}
+    }
+    SendWrapper::new(try_external_auth_http_login(
+        &state,
+        CredentialType::Password,
+        &command.username,
+        command.password.expose_secret(),
+        &peer.to_string(),
+    ))
+    .await
 }
 
 pub(in crate::http) async fn login_with_personal_access_token(
     State(state): State<HttpState>,
+    ConnectInfo(ClientAddr(peer)): ConnectInfo<ClientAddr>,
     Json(command): Json<LoginWithPersonalAccessToken>,
 ) -> Result<Json<IdentityInfo>, CustomError> {
     // Same recovery-barrier wait and retryable-503-on-expiry mapping as
@@ -217,9 +241,21 @@ pub(in crate::http) async fn login_with_personal_access_token(
     SendWrapper::new(crate::http::reads::await_recovery_barrier(&state.shard))
         .await
         .map_err(|_| IggyError::TransientNotCommitted)?;
-    let user_id = verify_pat_credentials(&state.shard, command.token.expose_secret())
-        .map_err(|error| login_error_to_iggy(&error))?;
-    issue_identity(&state, user_id)
+    match verify_pat_credentials(&state.shard, command.token.expose_secret()) {
+        Ok(user_id) => return issue_identity(&state, user_id),
+        Err(ref error) if !state.external_auth.enabled || !error.is_invalid_credentials() => {
+            return Err(login_error_to_iggy(error).into());
+        }
+        Err(_) => {}
+    }
+    SendWrapper::new(try_external_auth_http_login(
+        &state,
+        CredentialType::PersonalAccessToken,
+        "",
+        command.token.expose_secret(),
+        &peer.to_string(),
+    ))
+    .await
 }
 
 /// `POST /users/refresh-token` body. The route is unauthenticated, so the
@@ -253,6 +289,11 @@ pub(in crate::http) async fn refresh_token(
         .sub
         .parse::<u32>()
         .map_err(|_| IggyError::Unauthenticated)?;
+    // External auth inline-grant sessions must re-authenticate through
+    // their auth service; refreshing would bypass the `expires_at` cap.
+    if state.external_auth.enabled && user_id == state.external_auth.user_id {
+        return Err(IggyError::Unauthenticated.into());
+    }
     issue_identity(&state, user_id)
 }
 
@@ -291,6 +332,7 @@ pub(in crate::http) async fn describe_options(
         DESCRIBE_OPTIONS_CODE,
         &body,
         |_, _| Ok(()),
+        |_| true,
     ))
     .await?;
     let response = DescribeOptionsResponse::decode_from(&bytes)
@@ -315,6 +357,7 @@ pub(in crate::http) async fn get_streams(
         GET_STREAMS_CODE,
         &body,
         Permissioner::get_streams,
+        |p| p.global.manage_streams || p.global.read_streams,
     ))
     .await?;
     let response = GetStreamsResponse::decode_from(&bytes)
@@ -354,6 +397,10 @@ pub(in crate::http) async fn get_stream(
             resolve_gate_stream(&state, &request.stream_id)
                 .map_or(Ok(()), |stream_id| permissioner.get_stream(uid, stream_id))
         },
+        |p| {
+            resolve_gate_stream(&state, &request.stream_id)
+                .is_none_or(|sid| can_read_stream(p, sid))
+        },
     ))
     .await?;
     let response = GetStreamResponse::decode_from(&bytes)
@@ -387,6 +434,10 @@ pub(in crate::http) async fn get_topics(
         |permissioner, uid| {
             resolve_gate_stream(&state, &request.stream_id)
                 .map_or(Ok(()), |stream_id| permissioner.get_topics(uid, stream_id))
+        },
+        |p| {
+            resolve_gate_stream(&state, &request.stream_id)
+                .is_none_or(|sid| can_list_topics(p, sid))
         },
     ))
     .await?;
@@ -427,6 +478,10 @@ pub(in crate::http) async fn get_topic(
                     permissioner.get_topic(uid, stream_id, topic_id)
                 })
         },
+        |p| {
+            resolve_gate_topic(&state, &request.stream_id, &request.topic_id)
+                .is_none_or(|(sid, tid)| can_read_topic(p, sid, tid))
+        },
     ))
     .await?;
     let response = GetTopicResponse::decode_from(&bytes)
@@ -451,6 +506,7 @@ pub(in crate::http) async fn get_users(
         GET_USERS_CODE,
         &body,
         Permissioner::get_users,
+        |p| p.global.manage_users || p.global.read_users,
     ))
     .await?;
     let response = GetUsersResponse::decode_from(&bytes)
@@ -497,6 +553,11 @@ pub(in crate::http) async fn get_user(
                 permissioner.get_user(uid)
             }
         },
+        |p| {
+            let is_self_check =
+                resolve_gate_user(&state, &request.user_id) == Some(identity.user_id as usize);
+            is_self_check || p.global.manage_users || p.global.read_users
+        },
     ))
     .await?;
     let response = UserDetailsResponse::decode_from(&bytes)
@@ -535,6 +596,10 @@ pub(in crate::http) async fn get_cgs(
                 .map_or(Ok(()), |(stream_id, topic_id)| {
                     permissioner.get_consumer_groups(uid, stream_id, topic_id)
                 })
+        },
+        |p| {
+            resolve_gate_topic(&state, &request.stream_id, &request.topic_id)
+                .is_none_or(|(sid, tid)| can_read_topic(p, sid, tid))
         },
     ))
     .await?;
@@ -576,6 +641,10 @@ pub(in crate::http) async fn get_cg(
                     permissioner.get_consumer_group(uid, stream_id, topic_id)
                 })
         },
+        |p| {
+            resolve_gate_topic(&state, &request.stream_id, &request.topic_id)
+                .is_none_or(|(sid, tid)| can_read_topic(p, sid, tid))
+        },
     ))
     .await?;
     let response = ConsumerGroupDetailsResponse::decode_from(&bytes)
@@ -600,6 +669,7 @@ pub(in crate::http) async fn get_stats(
         GET_STATS_CODE,
         &body,
         Permissioner::get_stats,
+        |p| p.global.manage_servers || p.global.read_servers,
     ))
     .await?;
     let response = StatsResponse::decode_from(&bytes)
@@ -621,8 +691,20 @@ pub(in crate::http) async fn get_stats(
 /// deadline.
 pub(in crate::http) async fn get_metrics(
     State(state): State<HttpState>,
-    _identity: Identity,
-) -> String {
+    identity: Identity,
+) -> Result<String, ReadError> {
+    // Gate on the same permission as GET_STATS: server inventory data
+    // must not be served to an all-false inline grant.
+    SendWrapper::new(crate::http::reads::await_recovery_barrier(&state.shard))
+        .await
+        .map_err(|_| ReadError::Rejected(IggyError::TransientNotCommitted))?;
+    authorize_read(
+        &state,
+        &identity,
+        Consistency::default(),
+        Permissioner::get_stats,
+        |p| p.global.manage_servers || p.global.read_servers,
+    )?;
     let (streams_count, topics_count, partitions_count, segments_count, messages_count) = state
         .shard
         .plane
@@ -670,7 +752,7 @@ pub(in crate::http) async fn get_metrics(
     metrics.messages.set(gauge_value(messages_count));
     metrics.users.set(gauge_value(users_count));
     metrics.clients.set(gauge_value(clients_count));
-    metrics.formatted_output()
+    Ok(metrics.formatted_output())
 }
 
 /// `POST /snapshot`: collect a diagnostic archive and return it as a ZIP
@@ -694,6 +776,7 @@ pub(in crate::http) async fn get_snapshot(
         query.consistency,
         GET_SNAPSHOT_FILE_CODE,
         Permissioner::get_snapshot,
+        |p| p.global.manage_servers || p.global.read_servers,
     ))
     .await?;
     let archive = snapshot::collect(
@@ -755,6 +838,7 @@ pub(in crate::http) async fn get_clients(
         query.consistency,
         GET_CLIENTS_CODE,
         Permissioner::get_clients,
+        |p| p.global.manage_servers || p.global.read_servers,
     ))
     .await?;
     let infos = SendWrapper::new(state.shard.list_all_clients()).await;
@@ -787,6 +871,7 @@ pub(in crate::http) async fn get_client(
         query.consistency,
         GET_CLIENT_CODE,
         Permissioner::get_client,
+        |p| p.global.manage_servers || p.global.read_servers,
     ))
     .await?;
     let infos = SendWrapper::new(state.shard.list_all_clients()).await;
@@ -1250,6 +1335,10 @@ pub(in crate::http) async fn poll_messages(
                     permissioner.poll_messages(uid, stream_id, topic_id)
                 })
         },
+        |p| {
+            resolve_gate_topic_ids(&state, &stream_id, &topic_id)
+                .is_none_or(|(sid, tid)| can_poll_messages(p, sid, tid))
+        },
     ))
     .await?;
     let wire = poll_wire_request(&stream_id, &topic_id, &query).map_err(ReadError::Rejected)?;
@@ -1332,6 +1421,10 @@ pub(in crate::http) async fn get_consumer_offset(
                     permissioner.get_consumer_offset(uid, stream_id, topic_id)
                 })
         },
+        |p| {
+            resolve_gate_topic_ids(&state, &stream_id, &topic_id)
+                .is_none_or(|(sid, tid)| can_poll_messages(p, sid, tid))
+        },
     ))
     .await?;
     let wire =
@@ -1394,9 +1487,11 @@ pub(in crate::http) async fn send_messages(
     authorize_data_plane(
         &state,
         identity.session.user_id,
+        &identity.session.key,
         &stream_id,
         &topic_id,
         Permissioner::append_messages,
+        can_send_messages,
     )
     .map_err(PartitionWriteError::Rejected)?;
     // Rejects an oversized partitioning key and an empty or oversized batch.
@@ -1459,9 +1554,11 @@ pub(in crate::http) async fn store_consumer_offset(
     authorize_data_plane(
         &state,
         identity.session.user_id,
+        &identity.session.key,
         &stream_id,
         &topic_id,
         Permissioner::store_consumer_offset,
+        can_poll_messages,
     )
     .map_err(PartitionWriteError::Rejected)?;
     let request = store_offset_wire_request(&stream_id, &topic_id, &command)
@@ -1510,9 +1607,11 @@ pub(in crate::http) async fn delete_consumer_offset(
     authorize_data_plane(
         &state,
         identity.session.user_id,
+        &identity.session.key,
         &stream_id,
         &topic_id,
         Permissioner::delete_consumer_offset,
+        can_poll_messages,
     )
     .map_err(PartitionWriteError::Rejected)?;
     // `Consumer::new` fixes the kind to `Consumer`, exactly as the legacy
@@ -1764,6 +1863,7 @@ pub(in crate::http) async fn get_pats(
         GET_PERSONAL_ACCESS_TOKENS_CODE,
         &body,
         |_, _| Ok(()),
+        |_| true,
     ))
     .await?;
     let response = GetPersonalAccessTokensResponse::decode_from(&bytes)
@@ -1839,6 +1939,105 @@ pub(in crate::http) async fn delete_pat(
     ))
     .await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Try external auth for an HTTP login. Returns `Some(result)` when the
+/// external service responded (grant or deny) or when a callout failure
+/// produces a terminal deny. Returns `None` when the caller should fall
+/// through to built-in credential verification.
+async fn try_external_auth_http_login(
+    state: &HttpInner,
+    credential_type: CredentialType,
+    username: &str,
+    credential_value: &str,
+    client_address: &str,
+) -> Result<Json<IdentityInfo>, CustomError> {
+    let credential = state
+        .external_auth
+        .forward_credentials
+        .then(|| credential_value.to_owned());
+    let request = ExternalAuthRequest {
+        credential_type,
+        credential,
+        username: username.to_owned(),
+        transport: "http".to_owned(),
+        client_address: client_address.to_owned(),
+    };
+    let Ok(decision) = try_external_auth(&state.external_auth, request).await else {
+        return Err(IggyError::Unauthenticated.into());
+    };
+    handle_http_auth_decision(state, decision)
+}
+
+fn handle_http_auth_decision(
+    state: &HttpInner,
+    decision: ExternalAuthDecision,
+) -> Result<Json<IdentityInfo>, CustomError> {
+    match decision {
+        ExternalAuthDecision::IggyUser { user_id } => {
+            if user_id == 0 {
+                tracing::warn!("external auth attempted to map login to root user");
+                return Err(IggyError::Unauthenticated.into());
+            }
+            if state.external_auth.enabled && user_id == state.external_auth.user_id {
+                tracing::warn!(
+                    user_id,
+                    "external auth returned the reserved user_id in IggyUser response"
+                );
+                return Err(IggyError::Unauthenticated.into());
+            }
+            let user_valid = state.shard.plane.metadata().mux_stm.users().read(|users| {
+                users
+                    .items
+                    .get(user_id as usize)
+                    .is_some_and(|u| u.status == iggy_common::UserStatus::Active)
+            });
+            if !user_valid {
+                return Err(IggyError::Unauthenticated.into());
+            }
+            issue_identity(state, user_id)
+        }
+        ExternalAuthDecision::InlineGrant {
+            principal,
+            permissions,
+            expires_at,
+        } => {
+            let now_secs =
+                iggy_common::IggyTimestamp::from(state.shard.bus.realtime_micros()).to_secs();
+            if expires_at <= now_secs {
+                tracing::warn!(
+                    expires_at,
+                    now_secs,
+                    "external auth inline grant already expired"
+                );
+                return Err(IggyError::Unauthenticated.into());
+            }
+            let user_id = state.external_auth.user_id;
+            let generated = state.jwt.generate_capped(user_id, expires_at)?;
+            let session_key = crate::http::extractor::SessionKey::Jwt(generated.jti.clone());
+            if !state.insert_session_grant(
+                session_key,
+                crate::external_auth::SessionPermissions {
+                    principal,
+                    permissions: std::sync::Arc::new(permissions),
+                    expires_at,
+                },
+            ) {
+                return Err(IggyError::TransientNotCommitted.into());
+            }
+            Ok(Json(IdentityInfo {
+                user_id: generated.user_id,
+                access_token: Some(TokenInfo {
+                    token: generated.access_token,
+                    expiry: generated.access_token_expiry,
+                }),
+            }))
+        }
+        ExternalAuthDecision::Deny { reason } => {
+            tracing::info!(reason, "external auth denied HTTP login");
+            Err(IggyError::Unauthenticated.into())
+        }
+    }
 }
 
 /// Issue a fresh access token for `user_id` and wrap it in the exact

--- a/core/server/src/http/jwks.rs
+++ b/core/server/src/http/jwks.rs
@@ -47,7 +47,10 @@ thread_local! {
     // keep one client per thread. The `Rc` inner makes cloning cheap, so callers
     // take an owned handle.
     static HTTP_CLIENT: cyper::Client =
-        cyper::Client::new().expect("failed to build cyper HTTP client for JWKS");
+        cyper::Client::builder()
+            .redirect(cyper::redirect::Policy::none())
+            .build()
+            .expect("failed to build cyper HTTP client for JWKS");
 }
 
 fn get_http_client() -> cyper::Client {

--- a/core/server/src/http/jwt.rs
+++ b/core/server/src/http/jwt.rs
@@ -167,6 +167,17 @@ impl JwtManager {
     ///
     /// Returns [`IggyError::CannotGenerateJwt`] if signing fails.
     pub fn generate(&self, user_id: UserId) -> Result<GeneratedToken, IggyError> {
+        self.generate_capped(user_id, u64::MAX)
+    }
+
+    /// Generate a token whose `exp` is capped at `max_expiry_secs` (unix
+    /// seconds). Used by external auth inline-grant sessions to honor the
+    /// auth service's `expires_at`.
+    pub fn generate_capped(
+        &self,
+        user_id: UserId,
+        max_expiry_secs: u64,
+    ) -> Result<GeneratedToken, IggyError> {
         let header = Header::new(self.algorithm);
         let iat = IggyTimestamp::now().to_secs();
         let expiry_secs = match self.access_token_expiry {
@@ -174,7 +185,7 @@ impl JwtManager {
             IggyExpiry::ServerDefault => 0,
             IggyExpiry::ExpireDuration(duration) => duration.as_secs(),
         };
-        let exp = iat + u64::from(expiry_secs);
+        let exp = (iat + u64::from(expiry_secs)).min(max_expiry_secs);
         let nbf = iat + u64::from(self.not_before.as_secs());
         let claims = JwtClaims {
             jti: Uuid::now_v7().to_string(),
@@ -189,6 +200,7 @@ impl JwtManager {
             .map_err(|_| IggyError::CannotGenerateJwt)?;
         Ok(GeneratedToken {
             user_id,
+            jti: claims.jti,
             access_token,
             access_token_expiry: exp,
         })
@@ -485,6 +497,7 @@ pub(in crate::http) struct JwtClaims {
 #[derive(Debug)]
 pub(in crate::http) struct GeneratedToken {
     pub user_id: UserId,
+    pub jti: String,
     pub access_token: String,
     pub access_token_expiry: u64,
 }

--- a/core/server/src/http/reads.rs
+++ b/core/server/src/http/reads.rs
@@ -30,7 +30,7 @@ use consensus::MetadataHandle;
 use iggy_binary_protocol::WireIdentifier;
 use iggy_binary_protocol::codes::GET_STATS_CODE;
 use iggy_common::wire_conversions::identifier_to_wire;
-use iggy_common::{Identifier, IggyError};
+use iggy_common::{Identifier, IggyError, Permissions};
 use metadata::impls::metadata::StreamsFrontend;
 use metadata::permissioner::Permissioner;
 use send_wrapper::SendWrapper;
@@ -55,20 +55,30 @@ use crate::responses::{
 /// Every read route reaches this through [`gate_local_read`], which is what
 /// pairs it with the two waits a local read must serve behind. Callable on its
 /// own only for a read that is NOT served from local state.
-fn authorize_read(
+pub(in crate::http) fn authorize_read(
     state: &HttpInner,
     identity: &Identity,
     consistency: Consistency,
     rule: impl Fn(&Permissioner, u32) -> Result<(), IggyError>,
+    inline_grant_check: impl Fn(&Permissions) -> bool,
 ) -> Result<(), ReadError> {
-    state
-        .shard
-        .plane
-        .metadata()
-        .mux_stm
-        .users()
-        .authorize(|permissioner| rule(permissioner, identity.user_id))
-        .map_err(ReadError::Rejected)?;
+    if state.external_auth.enabled && identity.user_id == state.external_auth.user_id {
+        let perms = state
+            .session_grant_permissions(&identity.session_key)
+            .ok_or(ReadError::Rejected(IggyError::Unauthorized))?;
+        if !inline_grant_check(&perms) {
+            return Err(ReadError::Rejected(IggyError::Unauthorized));
+        }
+    } else {
+        state
+            .shard
+            .plane
+            .metadata()
+            .mux_stm
+            .users()
+            .authorize(|permissioner| rule(permissioner, identity.user_id))
+            .map_err(ReadError::Rejected)?;
+    }
     if consistency == Consistency::Linearizable && !state.is_metadata_primary() {
         return Err(state.not_primary_read_error(&identity.path_and_query, identity.client_ip));
     }
@@ -95,8 +105,9 @@ pub(in crate::http) async fn read_local(
     code: u32,
     body: &[u8],
     rule: impl Fn(&Permissioner, u32) -> Result<(), IggyError>,
+    inline_grant_check: impl Fn(&Permissions) -> bool,
 ) -> Result<Bytes, ReadError> {
-    gate_local_read(state, identity, consistency, code, rule).await?;
+    gate_local_read(state, identity, consistency, code, rule, inline_grant_check).await?;
     let clients_count = if code == GET_STATS_CODE {
         u32::try_from(SendWrapper::new(state.shard.list_all_clients()).await.len())
             .unwrap_or(u32::MAX)
@@ -150,13 +161,14 @@ pub(in crate::http) async fn gate_local_read(
     consistency: Consistency,
     code: u32,
     rule: impl Fn(&Permissioner, u32) -> Result<(), IggyError>,
+    inline_grant_check: impl Fn(&Permissions) -> bool,
 ) -> Result<(), ReadError> {
     await_recovery_barrier(&state.shard).await?;
-    authorize_read(state, identity, consistency, &rule)?;
+    authorize_read(state, identity, consistency, &rule, &inline_grant_check)?;
     if read_needs_metadata_frontier(code)
         && await_metadata_read_frontier(state, identity).await? == FrontierWait::CaughtUp
     {
-        authorize_read(state, identity, consistency, &rule)?;
+        authorize_read(state, identity, consistency, &rule, &inline_grant_check)?;
     }
     Ok(())
 }
@@ -383,10 +395,36 @@ pub(in crate::http) fn resolve_gate_topic_ids(
 pub(in crate::http) fn authorize_data_plane(
     state: &HttpInner,
     user_id: u32,
+    session_key: &str,
     stream_id: &Identifier,
     topic_id: &Identifier,
     rule: impl FnOnce(&Permissioner, u32, usize, usize) -> Result<(), IggyError>,
+    inline_grant_check: impl FnOnce(&Permissions, usize, usize) -> bool,
 ) -> Result<(), IggyError> {
+    if state.external_auth.enabled && user_id == state.external_auth.user_id {
+        let sk = crate::http::extractor::SessionKey::from_table_key(session_key)
+            .ok_or(IggyError::Unauthorized)?;
+        let perms = state
+            .session_grant_permissions(&sk)
+            .ok_or(IggyError::Unauthorized)?;
+        // Fail-closed: for external auth users the session-scoped check below
+        // is the only topic-level gate (the STM authz gate allows all
+        // data-plane ops by op-code). A resolution miss must deny, not fall
+        // through to the handler's own not-found path.
+        let (Ok(wire_stream), Ok(wire_topic)) =
+            (identifier_to_wire(stream_id), identifier_to_wire(topic_id))
+        else {
+            return Err(IggyError::Unauthorized);
+        };
+        let Some((sid, tid)) = resolve_gate_topic(state, &wire_stream, &wire_topic) else {
+            return Err(IggyError::Unauthorized);
+        };
+        return if inline_grant_check(&perms, sid, tid) {
+            Ok(())
+        } else {
+            Err(IggyError::Unauthorized)
+        };
+    }
     let (Ok(wire_stream), Ok(wire_topic)) =
         (identifier_to_wire(stream_id), identifier_to_wire(topic_id))
     else {

--- a/core/server/src/http/reply.rs
+++ b/core/server/src/http/reply.rs
@@ -226,7 +226,9 @@ pub(in crate::http) fn eviction_error(reply: &Message<GenericHeader>) -> IggyErr
 /// `#[non_exhaustive]` enum.
 pub(in crate::http) const fn login_error_to_iggy(error: &LoginRegisterError) -> IggyError {
     match error {
-        LoginRegisterError::InvalidCredentials => IggyError::InvalidCredentials,
+        LoginRegisterError::InvalidCredentials | LoginRegisterError::LocalUserRejected => {
+            IggyError::InvalidCredentials
+        }
         LoginRegisterError::InvalidToken => IggyError::InvalidPersonalAccessToken,
         LoginRegisterError::UserInactive => IggyError::UserInactive,
         _ => IggyError::Unauthenticated,

--- a/core/server/src/http/state.rs
+++ b/core/server/src/http/state.rs
@@ -27,11 +27,12 @@ use std::sync::Arc;
 
 use axum::http::{HeaderName, HeaderValue};
 use axum::response::Response;
+use configs::external_auth::ExternalAuthConfig;
 use configs::server::ServerSystemConfig;
 use consensus::{MetadataHandle, VsrConsensus};
 use futures::channel::oneshot;
 use iggy_common::{ClusterMetadata, IggyTimestamp};
-use message_bus::InstanceToken;
+use message_bus::{InstanceToken, MessageBus};
 use metadata::MetadataSubmitError;
 use send_wrapper::SendWrapper;
 use tokio::sync::Mutex;
@@ -175,6 +176,10 @@ pub(in crate::http) struct HttpInner {
     /// clients out of the shared VSR client table. Read by `resolve_session`
     /// when admitting a fresh session.
     pub(in crate::http) max_http_sessions: usize,
+    /// Cap on pending external auth inline-grant entries. Separate from
+    /// `max_http_sessions` (which bounds VSR session slots): a grant is
+    /// inserted at login and may outlive its session.
+    pub(in crate::http) max_session_grants: usize,
     /// Configured `[personal_access_token] max_tokens_per_user`, enforced
     /// pre-consensus by the PAT rewrite inside the write submit (the cap is
     /// config-derived, so it must never branch inside the replicated apply).
@@ -193,6 +198,14 @@ pub(in crate::http) struct HttpInner {
     /// Behind `Rc` because the write path records from a detached task that
     /// outlives its handler by design (see `submit_committed`).
     pub(in crate::http) metadata_watermarks: Rc<MetadataWatermarks>,
+    /// External authentication callout config. Shared across all handlers.
+    pub(in crate::http) external_auth: Arc<ExternalAuthConfig>,
+    /// Pending inline-grant permissions keyed by session key (`jwt:{jti}`).
+    /// Populated at login when an inline grant is issued; consumed by the
+    /// session resolution path to attach the grant to the `HttpSession`.
+    pub(in crate::http) session_grants: RefCell<
+        HashMap<crate::http::extractor::SessionKey, crate::external_auth::SessionPermissions>,
+    >,
 }
 
 impl HttpInner {
@@ -283,16 +296,21 @@ impl HttpInner {
                         let mut table = self.sessions.borrow_mut();
                         let torn = sweep_expired(&mut table, now);
                         if table.len() >= self.max_http_sessions {
-                            // Still full after dropping expired entries: too many
-                            // genuinely live sessions. Refuse rather than evict a
-                            // live one (its `fresh` client id is orphaned on the
-                            // peers until they evict it - a rare at-cap cost).
                             (None, torn)
                         } else {
                             table.insert(key.clone(), Rc::clone(&fresh));
                             (Some(fresh), torn)
                         }
                     };
+                    // Reclaim orphaned grants: either the expiry has passed
+                    // or the session table no longer holds a matching entry
+                    // (the JWT expired and was swept above).
+                    {
+                        let sessions = self.sessions.borrow();
+                        self.session_grants.borrow_mut().retain(|key, grant| {
+                            grant.expires_at > now && sessions.contains_key(&key.as_table_key())
+                        });
+                    }
                     self.teardown_reply_targets(torn);
                     return admitted.ok_or(AuthError::SessionUnavailable);
                 }
@@ -456,6 +474,45 @@ impl HttpInner {
             in_flight_writes: Cell::new(0),
         }))
     }
+    /// Insert an inline-grant permission, sweeping any expired entries first
+    /// so the map stays bounded by the number of live (non-expired) grants.
+    pub(in crate::http) fn insert_session_grant(
+        &self,
+        key: crate::http::extractor::SessionKey,
+        grant: crate::external_auth::SessionPermissions,
+    ) -> bool {
+        let now_secs = IggyTimestamp::from(self.shard.bus.realtime_micros()).to_secs();
+        let mut grants = self.session_grants.borrow_mut();
+        grants.retain(|_, g| g.expires_at > now_secs);
+        if grants.len() >= self.max_session_grants {
+            warn!(
+                live_grants = grants.len(),
+                cap = self.max_session_grants,
+                "external auth grant table full; rejecting inline grant"
+            );
+            return false;
+        }
+        grants.insert(key, grant);
+        true
+    }
+
+    /// Look up session-scoped permissions for an external auth inline grant.
+    /// Returns `None` when the session has no grant or it has expired.
+    /// Expired grants are eagerly removed so they don't linger until the
+    /// next sweep.
+    pub(in crate::http) fn session_grant_permissions(
+        &self,
+        session_key: &crate::http::extractor::SessionKey,
+    ) -> Option<std::sync::Arc<iggy_common::Permissions>> {
+        let now_secs = IggyTimestamp::from(self.shard.bus.realtime_micros()).to_secs();
+        let mut grants = self.session_grants.borrow_mut();
+        let sp = grants.get(session_key)?;
+        if sp.expires_at <= now_secs {
+            grants.remove(session_key);
+            return None;
+        }
+        Some(std::sync::Arc::clone(&sp.permissions))
+    }
 
     /// Drop the session table entry for `session`, but only if it is still the
     /// current occupant of its key (pointer-fenced, so a later re-registration
@@ -466,6 +523,9 @@ impl HttpInner {
     /// request re-register cleanly through the barrier.
     pub(in crate::http) fn forget_session(&self, session: &Rc<HttpSession>) {
         let torn = forget_if_same(&mut self.sessions.borrow_mut(), session);
+        if let Some(sk) = crate::http::extractor::SessionKey::from_table_key(&session.key) {
+            self.session_grants.borrow_mut().remove(&sk);
+        }
         self.teardown_reply_targets(torn.into_iter().collect());
     }
 

--- a/core/server/src/http/submit.rs
+++ b/core/server/src/http/submit.rs
@@ -406,6 +406,13 @@ pub(in crate::http) async fn partition_write_replicated(
             );
             PartitionWriteError::Unavailable
         })?;
+    let session_perms = (state.external_auth.enabled
+        && session.user_id == state.external_auth.user_id)
+        .then(|| {
+            let sk = crate::http::extractor::SessionKey::from_table_key(&session.key);
+            sk.and_then(|k| state.session_grant_permissions(&k))
+        })
+        .flatten();
     dispatch_partition_request(
         &state.shard,
         message,
@@ -413,6 +420,7 @@ pub(in crate::http) async fn partition_write_replicated(
         session.session,
         session.client_id,
         Some(session.user_id),
+        session_perms.as_deref(),
     )
     .await;
     drop(next_data_request_id);
@@ -462,6 +470,13 @@ pub(in crate::http) async fn produce_unacked(
         request_id,
         body,
     );
+    let session_perms = (state.external_auth.enabled
+        && session.user_id == state.external_auth.user_id)
+        .then(|| {
+            let sk = crate::http::extractor::SessionKey::from_table_key(&session.key);
+            sk.and_then(|k| state.session_grant_permissions(&k))
+        })
+        .flatten();
     dispatch_partition_request(
         &state.shard,
         message,
@@ -469,6 +484,7 @@ pub(in crate::http) async fn produce_unacked(
         session.session,
         session.client_id,
         Some(session.user_id),
+        session_perms.as_deref(),
     )
     .await;
     drop(next_data_request_id);

--- a/core/server/src/lib.rs
+++ b/core/server/src/lib.rs
@@ -43,6 +43,7 @@ pub(crate) mod shard_allocator;
 // spine: the request path - shell vocabulary, dispatch funnel, per-domain ops.
 pub(crate) mod consumer_group;
 pub(crate) mod dispatch;
+pub(crate) mod external_auth;
 pub(crate) mod pat;
 pub(crate) mod responses;
 pub(crate) mod rewrite;

--- a/core/server/src/server_error.rs
+++ b/core/server/src/server_error.rs
@@ -298,6 +298,8 @@ pub enum ServerError {
         min: usize,
         max: usize,
     },
+    #[error("invalid external_auth config: {reason}")]
+    InvalidExternalAuthConfig { reason: String },
     #[error("--fresh could not remove the system path at {path}")]
     FreshWipeFailed {
         path: PathBuf,

--- a/core/server/src/session_manager.rs
+++ b/core/server/src/session_manager.rs
@@ -26,7 +26,9 @@
 //! transport connection and the consensus-level `(client_id, session)` pair.
 
 use crate::cluster_meta::ClusterRoster;
+use crate::external_auth::SessionPermissions;
 use ahash::AHashMap;
+use iggy_common::Permissions;
 use message_bus::installer::conn_info::ClientTransportKind;
 use shard::ConnectedClientInfo;
 use std::net::SocketAddr;
@@ -114,6 +116,10 @@ pub struct Connection {
     /// THIS socket was told, and a client that reconnects re-seeds from the
     /// session it binds.
     pub metadata_watermark: u64,
+    /// Session-scoped permissions from an external auth inline grant.
+    /// Present only for connections authenticated via the external auth
+    /// callout with an `inline_grant` response.
+    pub session_permissions: Option<SessionPermissions>,
 }
 
 /// Bridges transport connections to consensus sessions.
@@ -181,6 +187,7 @@ impl SessionManager {
                 last_heartbeat: Instant::now(),
                 sdk: None,
                 metadata_watermark: 0,
+                session_permissions: None,
             });
     }
 
@@ -251,10 +258,10 @@ impl SessionManager {
     /// one, so the caller can submit a session-matched `Logout` (the committed
     /// apply releases the client-table slot cluster-wide).
     pub fn remove_connection(&mut self, connection_id: u128) -> Option<(u128, u64)> {
-        if let Some(conn) = self.connections.remove(&connection_id)
-            && let ConnectionState::Bound {
-                client_id, session, ..
-            } = conn.state
+        let conn = self.connections.remove(&connection_id)?;
+        if let ConnectionState::Bound {
+            client_id, session, ..
+        } = conn.state
         {
             self.client_to_connection.remove(&client_id);
             return Some((client_id, session));
@@ -393,6 +400,14 @@ impl SessionManager {
         }
     }
 
+    /// Transport kind (TCP, QUIC, WebSocket) of a connection.
+    #[must_use]
+    pub fn connection_transport(&self, connection_id: u128) -> Option<ClientTransportKind> {
+        self.connections
+            .get(&connection_id)
+            .map(|conn| conn.transport)
+    }
+
     /// Look up the authenticated user id for a connection.
     #[must_use]
     pub fn get_user_id(&self, connection_id: u128) -> Option<u32> {
@@ -403,6 +418,15 @@ impl SessionManager {
             }
             ConnectionState::Connected => None,
         }
+    }
+
+    /// The transport-level peer address a connection arrived from, recorded by
+    /// [`Self::ensure_connection`] for every transport.
+    #[must_use]
+    pub fn connection_address(&self, connection_id: u128) -> Option<SocketAddr> {
+        self.connections
+            .get(&connection_id)
+            .map(|conn| conn.address)
     }
 
     /// Flatten one connection into a [`ConnectedClientInfo`] for `get_me`.
@@ -424,6 +448,46 @@ impl SessionManager {
         self.connections
             .iter()
             .map(|(&id, conn)| record_from(id, conn))
+    }
+
+    /// Store session-scoped permissions on a connection.
+    pub fn set_session_permissions(&mut self, connection_id: u128, perms: SessionPermissions) {
+        if let Some(conn) = self.connections.get_mut(&connection_id) {
+            conn.session_permissions = Some(perms);
+        }
+    }
+
+    /// Remove session-scoped permissions from a connection.
+    /// Used to roll back an inline-grant when `complete_login_register`
+    /// fails.
+    pub fn clear_session_permissions(&mut self, connection_id: u128) {
+        if let Some(conn) = self.connections.get_mut(&connection_id) {
+            conn.session_permissions = None;
+        }
+    }
+
+    /// Look up session-scoped permissions by connection ID. Returns `None`
+    /// when the connection has no grant or the grant has expired. Expired
+    /// grants are cleared from the connection so they do not accumulate
+    /// over long-lived TCP sessions.
+    ///
+    /// `now_secs` is the caller's authoritative wall-clock second. Pass
+    /// `IggyTimestamp::from(shard.bus.realtime_micros()).to_secs()` on the
+    /// binary transport so the expiry check uses the same clock as the
+    /// inline-grant login path.
+    #[must_use]
+    pub fn session_permissions_for_connection(
+        &mut self,
+        connection_id: u128,
+        now_secs: u64,
+    ) -> Option<std::sync::Arc<Permissions>> {
+        let conn = self.connections.get_mut(&connection_id)?;
+        let sp = conn.session_permissions.as_ref()?;
+        if sp.expires_at <= now_secs {
+            conn.session_permissions = None;
+            return None;
+        }
+        Some(std::sync::Arc::clone(&sp.permissions))
     }
 }
 

--- a/core/simulator/src/replica.rs
+++ b/core/simulator/src/replica.rs
@@ -372,6 +372,12 @@ pub fn new_shard(
     }
     // Same seed the server bootstrap runs after its own replay.
     metadata.seed_applied_frontier_from_consensus();
+    // NOTE: The simulator uses ExternalAuthConfig::default() (enabled: false),
+    // so set_external_auth_user_id is never called. If the simulator ever
+    // enables external auth, the seed_baseline closure above must call
+    // mux_stm.set_external_auth_user_id(config.external_auth.user_id) to
+    // match the server's boot path, or the authz gate will silently skip the
+    // external auth user_id check and allow management ops it should deny.
     // Mint the peers' read-side bundle AFTER reconstruction so it reflects the
     // recovered state. Shard 0 only; peers pass it back in as `reader_bundle`.
     let metadata_bundle = (shard_idx == 0).then(|| metadata.mux_stm.factory_bundle());
@@ -419,6 +425,7 @@ pub fn new_shard(
             // Default-config PAT cap, like the system config above, so sim
             // ingress admits exactly what a default-configured server does.
             PersonalAccessTokenConfig::default().max_tokens_per_user,
+            Arc::new(configs::external_auth::ExternalAuthConfig::default()),
         )
     } else {
         ShellHandlers::noop()


### PR DESCRIPTION
## Which issue does this PR address?

Closes #3929

## Rationale

Iggy supports only built-in credentials and HTTP-only JWT verification. There is no mechanism for an external service to authenticate a client and return its effective permissions, which blocks integration with centralized identity/policy systems (like Azure AD) or automated machine fleets.

## What changed?

Login attempts on all transports (TCP, QUIC, WebSocket, HTTP) can forwarded to a configured HTTP endpoint. The service authenticates the client and returns one of three decisions: map to an existing Iggy user, grant a session-scoped identity with explicit permissions, or deny. Session-scoped identities use synthetic user IDs that are never persisted and are restricted to data-plane operations; (capacity defined as `1_000_000`). The users ids within this pool are rotated (and next avaiable free user ids would be allocated). This can be adjusted if necessary.

### Request/response contract

```json
// Request (POST to configured URL)
{
  "credential_type": "password" | "personal_access_token",
  "credential": "...",
  "username": "alice",
  "transport": "tcp" | "http" | "quic" | "websocket",
  "client_address": "10.0.0.1:5000"
}

// Response
{
  "decision": "iggy_user" | "inline_grant" | "deny",
  "user_id": 42,
  "principal": "device-1234",
  "permissions": { "global": { ... } },
  "expires_at": 1700000000,
  "reason": optional string ("certificate revoked")
}
```

### Configuration

```toml
[external_auth]
enabled = false
url = "https://auth.example.com/validate"
timeout = "5 s"
on_error = "deny"          # "deny" | "fallback"
forward_credentials = true
```

### E2E validation

Built the server and validated the full external auth flow against a mock auth service.

**Startup:** Server loaded the config and logged the expected warning:


**Test 1:  Login `ext-alice` (inline_grant):** Mock received the callout with `credential_type`, `credential` (forwarded), `username`, `transport: "http"`, `client_address`. Responded with `inline_grant` granting `read_streams`, `read_topics`, `poll_messages`, `send_messages`. Server returned HTTP 200 with a JWT for synthetic `user_id: 4294967295` (u32::MAX, first minted ID).

**Test 2:  Login `ext-deny` (deny):** Mock responded `{"decision":"deny","reason":"blocked by policy"}`. Server returned HTTP 401.

**Test 3:  GET /streams with alice's token (allowed):** HTTP 200, body `[]`. The grant's `read_streams: true` allowed the read.

**Test 4:  POST /streams with alice's token (denied):** HTTP 403. The grant's `manage_streams: false` blocked the mutation.

## Local Execution

- Passed
- Pre-commit hooks ran

## AI Usage

If AI tools were used, please answer:
1. Which tools? Claude, Github Copilot
2. Scope of usage? Research and implementation (some agents, some auto completes)
3. How did you verify the generated code works correctly? Also unit tests and validation against mock servers.
4. Can you explain every line of the code if asked? Yes
