### PR TITLE
docs: say where a closed PR's findings go, and fix the stale timing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,19 @@ PRs may be closed if:
 - Code not ran and tested locally
 - Mixed purposes or purposes not clear
 - Can't answer questions about the change
-- Inactivity for longer than 7 days
+- Inactivity, see [Stale PRs](#stale-prs) below
+
+Whoever closes leaves a comment saying why. If the thread holds a finding
+that outlives the change, open an issue for it and link it from that
+comment. The closed thread is the first place someone looks to find out
+whether anything fell through.
+
+### Stale PRs
+
+A bot labels a PR `S-stale` after 7 days without activity and closes it 7
+days after that. A push, comment, review, reopen, or ready-for-review
+clears the label. Drafts and PRs labeled `pinned` are exempt. Issues are
+never labeled or closed by it. A closed PR can be reopened.
 
 ## Questions?
 


### PR DESCRIPTION
Closes #3982. Wording is @hubcio's from [this comment](https://github.com/apache/iggy/issues/3982#issuecomment-5546601424), applied verbatim, scoped as @justinmclean suggested: keep the forwarding comment, drop the "name every finding before closing" bullet.

Two changes to `## Close Policy`:

**Where findings go.** Whoever closes leaves a comment saying why, and a finding that outlives the change gets its own issue linked from that comment. #3795 to #3981 is the worked example: the close was correct once #3855 removed the premise, but the surviving half sat in a closed thread for days and only surfaced because someone asked whether anything had been dropped.

**The stale timing.** The old line read "Inactivity for longer than 7 days". It now points at a new `### Stale PRs` subsection.

I checked each claim in that subsection against `.github/workflows/` rather than taking the numbers on trust:

| Claim | Where it comes from |
| --- | --- |
| 7 days to label, 7 more to close | `days-before-pr-stale: 7`, `days-before-pr-close: 7` in `stale-prs.yml`; the close message itself says "inactive for 14 days" |
| Push, comment, review, reopen, ready-for-review clear it | `stale-prs-unmark.yml` on `[synchronize, reopened, ready_for_review]`, and `stale-prs-unmark-on-activity.yml` via `pr-triage-collect.yml` on `issue_comment: created` / `pull_request_review: submitted` |
| The bot does not clear its own label | `remove-stale-when-updated: false` |
| Drafts and `pinned` exempt | `exempt-draft-pr: true`, `exempt-pr-labels: "pinned"` |
| Issues never labeled or closed | `days-before-issue-stale: -1`, `days-before-issue-close: -1`, and the job grants only `pull-requests: write` |

Deliberately left out, per @hubcio: the `exempt-pr-labels: pinned,S-waiting-on-review` idea and the `/pin` command. Both are workflow changes and belong in their own PR.

`markdownlint` passes on `CONTRIBUTING.md` and repo-wide with the script's own invocation.
