### PR TITLE
fix(shard): widen partition repair when a view-adopted suffix is missing bodies

### DIFF
--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -8316,12 +8316,18 @@ where
         }
         let nonce = iggy_common::random_id::get_uuid();
         let from_op = consensus.commit_min() + 1;
-        // The widening is for the replica that is LEVEL with the commit
-        // frontier and short of bodies above it. Widening while a commit lag
-        // stands would ask for `(commit_min, head]` -- the whole committed
-        // prefix this replica already holds, refetched -- and the suffix is
-        // reached anyway once the lag closes, on the arm after it.
-        let fetch_to_op = if commit_lag { commit_to_op } else { head };
+        // Capping at `commit_to_op` while a commit lag stands avoids
+        // re-asking for `(commit_min, commit_to_op]`, the committed prefix
+        // this replica already holds. But a restarted node has a commit lag
+        // by construction, and if it also adopted a StartView suffix, the
+        // missing bodies sit above `commit_to_op`, not within it -- so the
+        // cap only holds when no suffix is missing; otherwise it must widen
+        // to `head` to ever reach those bodies.
+        let fetch_to_op = if commit_lag && !missing_suffix {
+            commit_to_op
+        } else {
+            head
+        };
         let cluster = consensus.cluster();
         let self_id = consensus.replica();
         let namespace = consensus.group();


### PR DESCRIPTION
## Closes

#4075

## Rationale

A partition group can wedge permanently and stop committing after a view change lands while a node is mid-restart, hanging every producer to that partition until its read timeout expires.

## What changed?

After a view change, a backup that adopts a `StartView` suffix advances its sequencer to the new head immediately, but repair only fetched bodies up to the commit point when the replica also had a commit lag, which a just-restarted node always does. The adopted op's body was never fetched. Once any later op advanced the sequencer past it, the backup's replication gap check rejected every retransmission of the missing op as a stale duplicate, permanently, and commit could never advance past it.

Widens the repair fetch window using `missing_suffix`, already computed for this but not consulted in this branch, so the first repair pass covers the adopted suffix before anything else can move the sequencer past it.

Fixes `cluster::fast_primary_rejoin::given_a_quic_producer_when_its_first_roster_hop_is_down_should_reach_the_partition_primary`, failing ~70-90% of local runs and on all 4 CI attempts.

## Local Execution

- Passed. Fixed test: 12/12 runs. WebSocket sibling: 5/5. Full `fast_primary_rejoin.rs` (8 tests), full `cluster::` integration suite (61 tests), and `consensus`/`partitions`/`shard` unit suites (462 tests): all pass, no regressions.
- Pre-commit hooks: not run through this session; `cargo fmt`, `cargo sort --no-format`, and `cargo clippy` were run manually.

## AI Usage

Claude was used in the generation of this.