### PR TITLE
perf(node, csharp, java, go): generate message ids from random bytes instead of via UUIDs 

### DIFF
--- a/foreign/csharp/Iggy_SDK/Contracts/Tcp/TcpContracts.cs
+++ b/foreign/csharp/Iggy_SDK/Contracts/Tcp/TcpContracts.cs
@@ -344,12 +344,17 @@ internal static class TcpContracts
         position += 4;
 
         // The producer owns message ids: a zero id is minted before the frame checksum covers it.
+        // A zero id is filled with random bytes directly (fast, non-crypto): the id is opaque,
+        // not keyed on, and 128 bits keeps collisions far below the birthday bound. The scratch
+        // buffer is hoisted out of the loop so the stackalloc runs once (CA2014).
         var originTimestamp = ulong.MaxValue;
+        Span<byte> idBytes = stackalloc byte[16];
         foreach (var message in messages)
         {
             if (message.Header.Id == 0)
             {
-                message.Header = message.Header with { Id = Guid.NewGuid().ToUInt128() };
+                Random.Shared.NextBytes(idBytes);
+                message.Header = message.Header with { Id = BinaryPrimitives.ReadUInt128LittleEndian(idBytes) };
             }
 
             originTimestamp = Math.Min(originTimestamp, message.Header.OriginTimestamp);

--- a/foreign/csharp/Iggy_SDK/Contracts/Tcp/TcpContracts.cs
+++ b/foreign/csharp/Iggy_SDK/Contracts/Tcp/TcpContracts.cs
@@ -344,9 +344,6 @@ internal static class TcpContracts
         position += 4;
 
         // The producer owns message ids: a zero id is minted before the frame checksum covers it.
-        // A zero id is filled with random bytes directly (fast, non-crypto): the id is opaque,
-        // not keyed on, and 128 bits keeps collisions far below the birthday bound. The scratch
-        // buffer is hoisted out of the loop so the stackalloc runs once (CA2014).
         var originTimestamp = ulong.MaxValue;
         Span<byte> idBytes = stackalloc byte[16];
         foreach (var message in messages)
@@ -356,7 +353,6 @@ internal static class TcpContracts
                 Random.Shared.NextBytes(idBytes);
                 message.Header = message.Header with { Id = BinaryPrimitives.ReadUInt128LittleEndian(idBytes) };
             }
-
             originTimestamp = Math.Min(originTimestamp, message.Header.OriginTimestamp);
         }
 

--- a/foreign/go/internal/command/message.go
+++ b/foreign/go/internal/command/message.go
@@ -22,10 +22,10 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand/v2"
 
 	"github.com/apache/iggy/foreign/go/contracts"
 	"github.com/apache/iggy/foreign/go/internal/batch"
-	"github.com/google/uuid"
 	"github.com/klauspost/compress/s2"
 	"github.com/zeebo/xxh3"
 )
@@ -96,11 +96,11 @@ func (s *SendMessages) AppendBinary(b []byte) ([]byte, error) {
 		// The id sits under the frame checksum, so it must exist before the
 		// frame is hashed; the server never mints ids.
 		if message.Header.Id == (iggcon.MessageID{}) {
-			id, err := uuid.NewRandom()
-			if err != nil {
-				return b, err
-			}
-			message.Header.Id = iggcon.MessageID(id)
+			// A zero id is filled with random bytes directly (fast, non-crypto):
+			// the id is opaque, not keyed on, and 128 bits keeps collisions far
+			// below the birthday bound at any realistic message rate.
+			binary.LittleEndian.PutUint64(message.Header.Id[0:8], rand.Uint64())
+			binary.LittleEndian.PutUint64(message.Header.Id[8:16], rand.Uint64())
 		}
 		// The header lengths and the appended slices must agree, or every
 		// message boundary after a mismatch mis-frames; deriving both from

--- a/foreign/go/internal/command/message.go
+++ b/foreign/go/internal/command/message.go
@@ -96,9 +96,6 @@ func (s *SendMessages) AppendBinary(b []byte) ([]byte, error) {
 		// The id sits under the frame checksum, so it must exist before the
 		// frame is hashed; the server never mints ids.
 		if message.Header.Id == (iggcon.MessageID{}) {
-			// A zero id is filled with random bytes directly (fast, non-crypto):
-			// the id is opaque, not keyed on, and 128 bits keeps collisions far
-			// below the birthday bound at any realistic message rate.
 			binary.LittleEndian.PutUint64(message.Header.Id[0:8], rand.Uint64())
 			binary.LittleEndian.PutUint64(message.Header.Id[8:16], rand.Uint64())
 		}

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/serde/BytesSerializer.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/serde/BytesSerializer.java
@@ -33,7 +33,6 @@ import org.apache.iggy.message.MessageHeader;
 import org.apache.iggy.message.MessageId;
 import org.apache.iggy.message.Partitioning;
 import org.apache.iggy.message.PollingStrategy;
-import org.apache.iggy.message.UuidMessageId;
 import org.apache.iggy.user.GlobalPermissions;
 import org.apache.iggy.user.Permissions;
 import org.apache.iggy.user.StreamPermissions;
@@ -45,7 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Unified serializer for both blocking and async clients.
@@ -340,7 +339,12 @@ public final class BytesSerializer {
      */
     private static byte[] encodedMessageId(MessageId id) {
         if (id.toBigInteger().signum() == 0) {
-            return readAllBytes(new UuidMessageId(UUID.randomUUID()).toBytes());
+            // A zero id is filled with random bytes directly (fast, non-crypto):
+            // the id is opaque, not keyed on, and 128 bits keeps collisions far
+            // below the birthday bound at any realistic message rate.
+            byte[] minted = new byte[16];
+            ThreadLocalRandom.current().nextBytes(minted);
+            return minted;
         }
         return readAllBytes(id.toBytes());
     }

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/serde/BytesSerializer.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/serde/BytesSerializer.java
@@ -339,9 +339,6 @@ public final class BytesSerializer {
      */
     private static byte[] encodedMessageId(MessageId id) {
         if (id.toBigInteger().signum() == 0) {
-            // A zero id is filled with random bytes directly (fast, non-crypto):
-            // the id is opaque, not keyed on, and 128 bits keeps collisions far
-            // below the birthday bound at any realistic message rate.
             byte[] minted = new byte[16];
             ThreadLocalRandom.current().nextBytes(minted);
             return minted;

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/serde/BytesSerializer.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/serde/BytesSerializer.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Unified serializer for both blocking and async clients.
@@ -339,9 +338,7 @@ public final class BytesSerializer {
      */
     private static byte[] encodedMessageId(MessageId id) {
         if (id.toBigInteger().signum() == 0) {
-            byte[] minted = new byte[16];
-            ThreadLocalRandom.current().nextBytes(minted);
-            return minted;
+            return MessageIdGenerator.mint();
         }
         return readAllBytes(id.toBytes());
     }

--- a/foreign/java/java-sdk/src/main/java/org/apache/iggy/serde/MessageIdGenerator.java
+++ b/foreign/java/java-sdk/src/main/java/org/apache/iggy/serde/MessageIdGenerator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iggy.serde;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+
+/**
+ * Mints the opaque 16-byte id stamped on a message whose caller passed a zero id.
+ *
+ * <p>Each thread runs its own AES-CTR keystream: a random 128-bit key and IV are drawn once from
+ * {@link SecureRandom} and never reused or decrypted, so the counter blocks are cryptographically
+ * strong random bytes. The id therefore has 128-bit collision resistance backed by 256 bits of
+ * independent per-thread seed, and each mint is a single AES-NI block. This is a randomness source,
+ * not a security primitive: the id is opaque, is not keyed on, and need not stay secret, so the
+ * keystream is never reseeded.
+ */
+final class MessageIdGenerator {
+
+    /** Constant plaintext encrypted to read a block of keystream; never mutated. */
+    private static final byte[] PLAINTEXT = new byte[16];
+
+    /** Draws each thread's key and IV once, from a cryptographic source. */
+    private static final SecureRandom SEEDER = new SecureRandom();
+
+    private static final ThreadLocal<Cipher> KEYSTREAM = ThreadLocal.withInitial(MessageIdGenerator::newKeystream);
+
+    private MessageIdGenerator() {}
+
+    /** Returns a fresh 16-byte id from the calling thread's keystream. */
+    static byte[] mint() {
+        byte[] minted = new byte[16];
+        try {
+            KEYSTREAM.get().update(PLAINTEXT, 0, 16, minted);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("failed to mint a message id", e);
+        }
+        return minted;
+    }
+
+    private static Cipher newKeystream() {
+        byte[] key = new byte[16];
+        byte[] iv = new byte[16];
+        SEEDER.nextBytes(key);
+        SEEDER.nextBytes(iv);
+        try {
+            Cipher keystream = Cipher.getInstance("AES/CTR/NoPadding");
+            keystream.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+            return keystream;
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("failed to initialise the message-id keystream", e);
+        }
+    }
+}

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/serde/MessageIdGeneratorTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/serde/MessageIdGeneratorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iggy.serde;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The zero-id mint: ids fill the full 16 bytes, never repeat within a thread (the AES-CTR counter
+ * always advances), and never collide across threads (each thread seeds an independent keystream).
+ */
+class MessageIdGeneratorTest {
+
+    @Test
+    void shouldMintSixteenBytes() {
+        assertThat(MessageIdGenerator.mint()).hasSize(16);
+    }
+
+    @Test
+    void shouldMintDistinctIdsWithinAThread() {
+        var count = 100_000;
+        Set<BigInteger> ids = new HashSet<>(count * 2);
+        for (var i = 0; i < count; i++) {
+            ids.add(new BigInteger(1, MessageIdGenerator.mint()));
+        }
+        assertThat(ids).hasSize(count);
+    }
+
+    @Test
+    void shouldMintDistinctIdsAcrossThreads() throws InterruptedException {
+        var threads = 4;
+        var perThread = 25_000;
+        List<List<BigInteger>> perThreadIds = new ArrayList<>();
+        List<Thread> workers = new ArrayList<>();
+        for (var t = 0; t < threads; t++) {
+            List<BigInteger> mine = new ArrayList<>(perThread);
+            perThreadIds.add(mine);
+            var worker = new Thread(() -> {
+                for (var i = 0; i < perThread; i++) {
+                    mine.add(new BigInteger(1, MessageIdGenerator.mint()));
+                }
+            });
+            workers.add(worker);
+            worker.start();
+        }
+        for (var worker : workers) {
+            worker.join();
+        }
+
+        Set<BigInteger> all = new HashSet<>(threads * perThread * 2);
+        for (var ids : perThreadIds) {
+            all.addAll(ids);
+        }
+        assertThat(all).hasSize(threads * perThread);
+    }
+}

--- a/foreign/node/src/wire/message/message.utils.test.ts
+++ b/foreign/node/src/wire/message/message.utils.test.ts
@@ -74,7 +74,7 @@ describe("serializeMessageId", () => {
     assert.throws(() => serializeMessageId(-1n), />= 0/);
   });
 
-  it("rejects an unparseable string", () => {
+  it("rejects an unparsable string", () => {
     assert.throws(() => serializeMessageId("not-a-uuid"), /invalid message id/);
   });
 

--- a/foreign/node/src/wire/message/message.utils.test.ts
+++ b/foreign/node/src/wire/message/message.utils.test.ts
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { u128ToBuf } from "../number.utils.js";
+import {
+  isValidMessageId,
+  serializeMessageId,
+  resolveMessageId,
+  mintMessageId,
+} from "./message.utils.js";
+
+const MESSAGE_ID_SIZE = 16;
+const MAX_U128 = (1n << 128n) - 1n;
+const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+const isZero = (b: Buffer) => b.every((byte) => byte === 0);
+
+describe("isValidMessageId", () => {
+  it("accepts undefined, string, number, and bigint", () => {
+    assert.ok(isValidMessageId(undefined));
+    assert.ok(isValidMessageId("id"));
+    assert.ok(isValidMessageId(7));
+    assert.ok(isValidMessageId(7n));
+  });
+
+  it("rejects other types", () => {
+    assert.ok(!isValidMessageId(null));
+    assert.ok(!isValidMessageId({}));
+  });
+});
+
+describe("serializeMessageId", () => {
+  it("serializes undefined to a zero u128", () => {
+    assert.deepEqual(serializeMessageId(), Buffer.alloc(MESSAGE_ID_SIZE, 0));
+  });
+
+  it("serializes a number as little-endian u128", () => {
+    assert.deepEqual(serializeMessageId(7), u128ToBuf(7n));
+  });
+
+  it("serializes a bigint as little-endian u128", () => {
+    assert.deepEqual(serializeMessageId(8n), u128ToBuf(8n));
+  });
+
+  it("serializes a UUID string to the same bytes as its numeric value", () => {
+    const uuid = "00000000-0000-0000-0000-000000000007";
+    assert.deepEqual(serializeMessageId(uuid), u128ToBuf(7n));
+  });
+
+  it("accepts the largest u128", () => {
+    assert.deepEqual(serializeMessageId(MAX_U128), u128ToBuf(MAX_U128));
+  });
+
+  it("rejects a numeric id at or above 2^128", () => {
+    assert.throws(() => serializeMessageId(1n << 128n), /2\^128/);
+  });
+
+  it("rejects a negative numeric id", () => {
+    assert.throws(() => serializeMessageId(-1n), />= 0/);
+  });
+
+  it("rejects an unparseable string", () => {
+    assert.throws(() => serializeMessageId("not-a-uuid"), /invalid message id/);
+  });
+
+  it("rejects an invalid type", () => {
+    assert.throws(() => serializeMessageId({}), /invalid message id/);
+  });
+});
+
+describe("resolveMessageId", () => {
+  it("mints a non-zero id for undefined, 0, and 0n", () => {
+    for (const id of [undefined, 0, 0n]) {
+      const b = resolveMessageId(id);
+      assert.equal(b.length, MESSAGE_ID_SIZE);
+      assert.ok(!isZero(b));
+    }
+  });
+
+  it("mints for the all-zero nil UUID string", () => {
+    assert.ok(!isZero(resolveMessageId(NIL_UUID)));
+  });
+
+  it("passes a provided non-zero id through unchanged", () => {
+    assert.deepEqual(resolveMessageId(7n), serializeMessageId(7n));
+  });
+});
+
+describe("mintMessageId", () => {
+  it("returns a non-zero 16-byte buffer", () => {
+    const b = mintMessageId();
+    assert.equal(b.length, MESSAGE_ID_SIZE);
+    assert.ok(!isZero(b));
+  });
+
+  it("produces unique, non-zero ids across pool refills", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 10_000; i++) {
+      const hex = mintMessageId().toString("hex");
+      assert.notEqual(hex, "0".repeat(MESSAGE_ID_SIZE * 2));
+      seen.add(hex);
+    }
+    assert.equal(seen.size, 10_000);
+  });
+
+  it("returns owned bytes that survive a later refill", () => {
+    const first = mintMessageId().toString("hex");
+    const held = mintMessageId();
+    const snapshot = held.toString("hex");
+    for (let i = 0; i < 10_000; i++) mintMessageId();
+    assert.equal(held.toString("hex"), snapshot);
+    assert.notEqual(snapshot, first);
+  });
+});

--- a/foreign/node/src/wire/message/message.utils.ts
+++ b/foreign/node/src/wire/message/message.utils.ts
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { uuidv4 } from 'uuidv7';
 import { uint32ToBuf, u128ToBuf, uint8ToBuf } from '../number.utils.js';
 import { serializeHeaders, type Headers } from './header.utils.js';
 import { serializeIdentifier, type Id } from '../identifier.utils.js';
@@ -31,6 +30,9 @@ import {
 
 /** Size of the message ID in bytes (u128) */
 const MESSAGE_ID_SIZE = 16;
+
+/** Exclusive upper bound for a numeric message ID: a u128 must be < 2^128. */
+const MESSAGE_ID_UPPER_BOUND = 1n << 128n;
 
 /** Largest representable frame timestamp delta (u32, microseconds) */
 const MAX_TIMESTAMP_DELTA = 0xFFFF_FFFFn;
@@ -99,6 +101,8 @@ export const serializeMessageId = (id?: unknown) => {
       throw new Error(`invalid message id: '${id}' (numeric id must be >= 0)`)
 
     const idValue = 'number' === typeof id ? BigInt(id) : id;
+    if (idValue >= MESSAGE_ID_UPPER_BOUND)
+      throw new Error(`invalid message id: '${id}' (numeric id must be < 2^128)`)
     return u128ToBuf(idValue);
   }
 
@@ -115,16 +119,43 @@ export const serializeMessageId = (id?: unknown) => {
 }
 
 /**
- * Serializes a message ID, minting a random UUID when the ID is
- * absent or zero.
+ * Mints a random 16-byte message ID.
+ *
+ * Fills the buffer with four little-endian 32-bit draws from `Math.random`
+ * (V8 xorshift128+) — no UUID string, no hex round-trip, no BigInt (issue
+ * #4066). The id is opaque, not keyed on, and need not be secret, so a
+ * non-cryptographic PRNG is appropriate; 128 bits keeps collisions far below
+ * the birthday bound at any realistic message rate. The all-zero result has
+ * probability 2^-128, so the "non-zero" intent holds without a per-message
+ * retry.
+ *
+ * @returns 16-byte buffer of random bytes
+ */
+const mintMessageId = (): Buffer => {
+  const b = Buffer.allocUnsafe(MESSAGE_ID_SIZE);
+  b.writeUInt32LE((Math.random() * 0x1_0000_0000) >>> 0, 0);
+  b.writeUInt32LE((Math.random() * 0x1_0000_0000) >>> 0, 4);
+  b.writeUInt32LE((Math.random() * 0x1_0000_0000) >>> 0, 8);
+  b.writeUInt32LE((Math.random() * 0x1_0000_0000) >>> 0, 12);
+  return b;
+};
+
+/**
+ * Resolves a message ID to a 16-byte little-endian buffer, minting a random
+ * one when the ID is absent or zero.
  *
  * @param id - Optional message ID
  * @returns 16-byte little-endian buffer containing a non-zero ID
  */
 const resolveMessageId = (id?: MessageIdKind): Buffer => {
+  // Hot path: an absent or explicit-zero id mints straight from the CSPRNG,
+  // skipping serialization and the all-zero byte scan entirely.
+  if (id === undefined || id === 0 || id === 0n)
+    return mintMessageId();
   const bId = serializeMessageId(id);
-  return bId.every((byte) => byte === 0)
-    ? u128ToBuf(BigInt(`0x${uuidv4().replaceAll('-', '')}`))
+  // A caller can still pass the all-zero nil UUID string; keep "zero id -> mint".
+  return 'string' === typeof id && bId.every((byte) => byte === 0)
+    ? mintMessageId()
     : bId;
 };
 

--- a/foreign/node/src/wire/message/message.utils.ts
+++ b/foreign/node/src/wire/message/message.utils.ts
@@ -32,7 +32,7 @@ import {
 /** Size of the message ID in bytes (u128) */
 const MESSAGE_ID_SIZE = 16;
 
-/** Exclusive upper bound for a numeric message ID: it must be < 2^(size*8). */
+/** Exclusive upper bound for a numeric message ID: it must be < 2^128 */
 const MESSAGE_ID_UPPER_BOUND = 1n << BigInt((MESSAGE_ID_SIZE * 8));
 
 /** Largest representable frame timestamp delta (u32, microseconds) */

--- a/foreign/node/src/wire/message/message.utils.ts
+++ b/foreign/node/src/wire/message/message.utils.ts
@@ -119,26 +119,15 @@ export const serializeMessageId = (id?: unknown) => {
 
 }
 
-/** Number of ids drawn per CSPRNG refill. One randomFillSync fills the whole
- *  pool; ids are handed out from it until drained, amortizing the per-call
- *  crypto overhead (~2us) across this many mints. */
+/** Number of ids drawn from the pool per CSPRNG refill */
 const ID_POOL_COUNT = 4096;
 
-/** Pooled random bytes and a cursor into them. Filled lazily on first mint. */
+/** Pooled random bytes and a cursor into them, filled lazily on first mint */
 const idPool = Buffer.allocUnsafe(ID_POOL_COUNT * MESSAGE_ID_SIZE);
 let idPoolCursor = idPool.length; // past the end -> refill on first use
 
 /**
- * Mints a random 16-byte message ID from a pooled CSPRNG buffer.
- *
- * One randomFillSync fills the whole pool; each mint copies the next 16 bytes
- * into a freshly owned buffer and advances the cursor, refilling when drained.
- * Amortizing the per-call crypto cost across ID_POOL_COUNT ids makes this both
- * faster than a per-id draw and stronger than a non-cryptographic PRNG. The id
- * is opaque and not keyed on, so its only requirements are uniqueness and a
- * non-zero value; 128 bits keeps collisions far below the birthday bound, and
- * the all-zero result has probability 2^-128, so "non-zero" holds without a
- * retry. The bytes are copied out, so the id stays valid across a later refill.
+ * Mints a random 16-byte message ID from the pool, refilling when drained.
  *
  * @returns 16-byte buffer of random bytes owned by the caller
  */
@@ -161,12 +150,11 @@ const mintMessageId = (): Buffer => {
  * @returns 16-byte little-endian buffer containing a non-zero ID
  */
 const resolveMessageId = (id?: MessageIdKind): Buffer => {
-  // Hot path: an absent or explicit-zero id mints straight from the CSPRNG,
-  // skipping serialization and the all-zero byte scan entirely.
+  // An absent or zero id mints a random one.
   if (id === undefined || id === 0 || id === 0n)
     return mintMessageId();
   const bId = serializeMessageId(id);
-  // A caller can still pass the all-zero nil UUID string; keep "zero id -> mint".
+  // A string id can still be the all-zero nil UUID; mint in that case too.
   return 'string' === typeof id && bId.every((byte) => byte === 0)
     ? mintMessageId()
     : bId;

--- a/foreign/node/src/wire/message/message.utils.ts
+++ b/foreign/node/src/wire/message/message.utils.ts
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { randomFillSync } from 'node:crypto';
 import { uint32ToBuf, u128ToBuf, uint8ToBuf } from '../number.utils.js';
 import { serializeHeaders, type Headers } from './header.utils.js';
 import { serializeIdentifier, type Id } from '../identifier.utils.js';
@@ -31,8 +32,8 @@ import {
 /** Size of the message ID in bytes (u128) */
 const MESSAGE_ID_SIZE = 16;
 
-/** Exclusive upper bound for a numeric message ID: a u128 must be < 2^128. */
-const MESSAGE_ID_UPPER_BOUND = 1n << 128n;
+/** Exclusive upper bound for a numeric message ID: it must be < 2^(size*8). */
+const MESSAGE_ID_UPPER_BOUND = 1n << BigInt((MESSAGE_ID_SIZE * 8));
 
 /** Largest representable frame timestamp delta (u32, microseconds) */
 const MAX_TIMESTAMP_DELTA = 0xFFFF_FFFFn;
@@ -102,7 +103,7 @@ export const serializeMessageId = (id?: unknown) => {
 
     const idValue = 'number' === typeof id ? BigInt(id) : id;
     if (idValue >= MESSAGE_ID_UPPER_BOUND)
-      throw new Error(`invalid message id: '${id}' (numeric id must be < 2^128)`)
+      throw new Error(`invalid message id: '${id}' (numeric id must be < 2^${MESSAGE_ID_SIZE * 8})`)
     return u128ToBuf(idValue);
   }
 
@@ -118,26 +119,38 @@ export const serializeMessageId = (id?: unknown) => {
 
 }
 
+/** Number of ids drawn per CSPRNG refill. One randomFillSync fills the whole
+ *  pool; ids are handed out from it until drained, amortizing the per-call
+ *  crypto overhead (~2us) across this many mints. */
+const ID_POOL_COUNT = 4096;
+
+/** Pooled random bytes and a cursor into them. Filled lazily on first mint. */
+const idPool = Buffer.allocUnsafe(ID_POOL_COUNT * MESSAGE_ID_SIZE);
+let idPoolCursor = idPool.length; // past the end -> refill on first use
+
 /**
- * Mints a random 16-byte message ID.
+ * Mints a random 16-byte message ID from a pooled CSPRNG buffer.
  *
- * Fills the buffer with four little-endian 32-bit draws from `Math.random`
- * (V8 xorshift128+) — no UUID string, no hex round-trip, no BigInt (issue
- * #4066). The id is opaque, not keyed on, and need not be secret, so a
- * non-cryptographic PRNG is appropriate; 128 bits keeps collisions far below
- * the birthday bound at any realistic message rate. The all-zero result has
- * probability 2^-128, so the "non-zero" intent holds without a per-message
- * retry.
+ * One randomFillSync fills the whole pool; each mint copies the next 16 bytes
+ * into a freshly owned buffer and advances the cursor, refilling when drained.
+ * Amortizing the per-call crypto cost across ID_POOL_COUNT ids makes this both
+ * faster than a per-id draw and stronger than a non-cryptographic PRNG. The id
+ * is opaque and not keyed on, so its only requirements are uniqueness and a
+ * non-zero value; 128 bits keeps collisions far below the birthday bound, and
+ * the all-zero result has probability 2^-128, so "non-zero" holds without a
+ * retry. The bytes are copied out, so the id stays valid across a later refill.
  *
- * @returns 16-byte buffer of random bytes
+ * @returns 16-byte buffer of random bytes owned by the caller
  */
 const mintMessageId = (): Buffer => {
-  const b = Buffer.allocUnsafe(MESSAGE_ID_SIZE);
-  b.writeUInt32LE((Math.random() * 0x1_0000_0000) >>> 0, 0);
-  b.writeUInt32LE((Math.random() * 0x1_0000_0000) >>> 0, 4);
-  b.writeUInt32LE((Math.random() * 0x1_0000_0000) >>> 0, 8);
-  b.writeUInt32LE((Math.random() * 0x1_0000_0000) >>> 0, 12);
-  return b;
+  if (idPoolCursor + MESSAGE_ID_SIZE > idPool.length) {
+    randomFillSync(idPool);
+    idPoolCursor = 0;
+  }
+  const id = Buffer.allocUnsafe(MESSAGE_ID_SIZE);
+  idPool.copy(id, 0, idPoolCursor, idPoolCursor + MESSAGE_ID_SIZE);
+  idPoolCursor += MESSAGE_ID_SIZE;
+  return id;
 };
 
 /**

--- a/foreign/node/src/wire/message/message.utils.ts
+++ b/foreign/node/src/wire/message/message.utils.ts
@@ -131,7 +131,7 @@ let idPoolCursor = idPool.length; // past the end -> refill on first use
  *
  * @returns 16-byte buffer of random bytes owned by the caller
  */
-const mintMessageId = (): Buffer => {
+export const mintMessageId = (): Buffer => {
   if (idPoolCursor + MESSAGE_ID_SIZE > idPool.length) {
     randomFillSync(idPool);
     idPoolCursor = 0;
@@ -149,7 +149,7 @@ const mintMessageId = (): Buffer => {
  * @param id - Optional message ID
  * @returns 16-byte little-endian buffer containing a non-zero ID
  */
-const resolveMessageId = (id?: MessageIdKind): Buffer => {
+export const resolveMessageId = (id?: MessageIdKind): Buffer => {
   // An absent or zero id mints a random one.
   if (id === undefined || id === 0 || id === 0n)
     return mintMessageId();

--- a/foreign/node/src/wire/number.utils.test.ts
+++ b/foreign/node/src/wire/number.utils.test.ts
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { u128ToBuf } from "./number.utils.js";
+
+const MAX_U128 = (1n << 128n) - 1n;
+const hex = (v: bigint) => u128ToBuf(v).toString("hex");
+
+describe("u128ToBuf", () => {
+  it("encodes zero as 16 zero bytes", () => {
+    assert.equal(hex(0n), "0".repeat(32));
+  });
+
+  it("encodes a small value little-endian", () => {
+    assert.equal(hex(7n), "07" + "0".repeat(30));
+  });
+
+  it("orders all 16 bytes little-endian", () => {
+    // Distinct bytes so a byte-order slip is visible.
+    assert.equal(
+      hex(0x0102030405060708090a0b0c0d0e0f10n),
+      "100f0e0d0c0b0a090807060504030201",
+    );
+  });
+
+  it("spans the 64-bit half boundary", () => {
+    assert.equal(hex((1n << 64n) - 1n), "ff".repeat(8) + "00".repeat(8));
+    assert.equal(hex(1n << 64n), "00".repeat(8) + "01" + "00".repeat(7));
+  });
+
+  it("encodes the largest u128 as all ones", () => {
+    assert.equal(hex(MAX_U128), "ff".repeat(16));
+  });
+
+  it("round-trips through readBigUInt64LE halves", () => {
+    for (const v of [0n, 1n, 42n, 1n << 64n, MAX_U128]) {
+      const b = u128ToBuf(v);
+      const low = b.readBigUInt64LE(0);
+      const high = b.readBigUInt64LE(8);
+      assert.equal((high << 64n) | low, v);
+    }
+  });
+
+  it("throws for a value at or above 2^128", () => {
+    assert.throws(() => u128ToBuf(1n << 128n));
+  });
+
+  it("throws for a negative value", () => {
+    assert.throws(() => u128ToBuf(-1n));
+  });
+});

--- a/foreign/node/src/wire/number.utils.ts
+++ b/foreign/node/src/wire/number.utils.ts
@@ -147,17 +147,26 @@ export const doubleToBuf = (v: number) => {
   return b;
 }
 
+/** Mask selecting the low 64 bits of a u128, for little-endian half-writes. */
+const U64_MASK = 0xFFFF_FFFF_FFFF_FFFFn;
+
 /**
- * Converts a BigInt to a 128-bit unsigned integer Buffer in little-endian format.
+ * Converts a u128 value to a 16-byte unsigned integer Buffer in little-endian
+ * format.
  *
- * @param num - BigInt value to convert
- * @param width - Width in bytes (default: 16)
- * @returns Buffer containing the value in little-endian byte order
+ * Writes the two 64-bit halves directly rather than round-tripping through a hex
+ * string. `value` must be a non-negative integer below 2^128; anything outside
+ * that range throws (a `RangeError` from the underlying write), which is
+ * preferable to silently truncating a message id.
+ *
+ * @param value - u128 value (0 <= value < 2^128)
+ * @returns 16-byte buffer containing the value in little-endian byte order
  */
-export function u128ToBuf(num: bigint, width = 16): Buffer {
-  const hex = num.toString(16);
-  const b = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');
-  return b.reverse();
+export function u128ToBuf(value: bigint): Buffer {
+  const b = Buffer.allocUnsafe(16);
+  b.writeBigUInt64LE(value & U64_MASK, 0);
+  b.writeBigUInt64LE(value >> 64n, 8);
+  return b;
 }
 
 /**


### PR DESCRIPTION
Closes #4066

## Rationale

Profiling the small-message hot path showed a large amount of time spent in generating message IDs. This was most noticeable in the Node SDK where it was impacting throughput severely.

## What changed?

The SDKs were minting Ids by constructing UUIDv4 values and then transforming them to extract the 16 bytes the message IDs needed.  The message IDs are opaque bytes which do not need to match a UUID format, nor are they cryptographically sensitive.

This updates the SDKs to generate bytes directly from faster random sources where available. 

For Node, to achieve a fast throughput required a new random pool, which was fastest to fill from the CSPRNG, because the non-CSPRNG doesn't have any way to get a byte array from it. Other SDKs have PRNGs which are fast without the complexity of managing a pool.

The Node path now throws on a numeric id ≥ 2¹²⁸ (via a new bound check in serializeMessageId), where the old hex round-trip silently truncated to a garbage value. This is in line with other SDKs. 

### Producer throughput — small (~6 B) messages

`id=0` mint path, measured with my harness (`MODE=producer
MSG_ID=uuid REPEAT=10 BITS=42`, TCP_NODELAY on, server + producer co-located).
Mean messages/sec over 10 runs (stddev %).

| SDK     | master (before)  | branch (after)   |            change |
| :------ | ---------------: | ---------------: | ----------------: |
| Node    |   196,809 (1.6%) |   528,076 (2.4%) | **+168% (2.68×)** |
| Java    | 1,027,080 (6.5%) | 1,375,820 (9.1%) |        **+34.0%** |
| C#\*    | 1,870,353 (5.5%) | 2,201,070 (9.8%) |        **+17.7%** |
| Go      | 1,630,751 (8.2%) | 1,915,466 (9.4%) |        **+17.5%** |
| Rust\*\*| 1,785,892 (6.7%) | 1,824,243 (8.3%) |      +2.1% (within noise)  |

\* C# Compiled with .NET 11 AOT, which emits warnings against the SDK's HTTP transport, which is unused. Both master and branch are compiled in the same way.

\*\* Rust is a control: its mint path is unchanged, so the tie (within noise)
confirms the harness attributes the other deltas to the code, not the machine.

### Producer throughput — ~1 KB messages

Same test at a realistic payload (`pack=167` → 1,002-byte messages). Mean
messages/sec over 10 runs (stddev %); the mint runs once per message, so its
benefit shrinks as payloads grow.

| SDK  | master (before) | branch (after)  |          change |
| :--- | --------------: | --------------: | --------------: |
| Node |   75,565 (3.4%) |  107,641 (2.2%) |    **+42.4%**   |
| Java |  172,647 (5.1%) |  203,600 (4.1%) |    **+17.9%**   |
| Go   |  368,275 (5.1%) |  384,620 (6.5%) |  +4.4% (noise)  |
| C#   |  394,541 (4.5%) |  407,785 (4.0%) |  +3.4% (noise)  |
| Rust\*  |  323,347 (7.4%) |  324,836 (10.1%)|   +0.5% (tie)   |

The C# and Go results collapse to technically within noise, but given the single-message improvements is likely to be a real effect that I can't prove statistically without ~50 repeated runs for each branch.

The Java and Node results are well above the noise floor.

\* Rust is a control, unchanged between master and branch.

Please do not try to compare languages, absolute throughput is not comparable across SDKs, each producer is different and are not comparable, the benchmarks are tuned for comparing differences across builds of the same SDK, not between languages or SDKs.

## AI Usage

Claude Opus 4.8 was used extensively both for writing code, analysis of ideas, in benchmarking and in verification of results.
Every line has been hand-reviewed and I fully understand the changes, the choices made and the rationale for those choices.

Verification was mostly through end-to-end benchmarking tests which also verify correctness. Additional correctness tests and micro-benchmarks were scaffolded during development to check assumptions, some of which were out of scope of this PR and have been excluded. 