### PR TITLE
fix(go): align MaxPayloadSize with core (64 MB)

### DIFF
--- a/foreign/go/contracts/messages.go
+++ b/foreign/go/contracts/messages.go
@@ -30,8 +30,8 @@ const (
 	//
 	//  Constraints
 	//  - Minimum payload size: 1 byte (empty payloads are not allowed)
-	//  - Maximum payload size: 10 MB
-	MaxPayloadSize = 10 * 1000 * 1000
+	//  - Maximum payload size: 64 MB
+	MaxPayloadSize = 64 * 1000 * 1000
 
 	// MaxUserHeadersSize is maximum allowed size in bytes for user-defined headers.
 	//


### PR DESCRIPTION
## Summary

Aligns the Go SDK's `MaxPayloadSize` constant with the core server's `MAX_PAYLOAD_SIZE` (64 MB), which was raised from 10 MB to 64 MB in PR #2341 but never reflected in the Go SDK. This caused the Go client to reject payloads that the server accepts, while Node/C#/Java SDKs enforce no limit at all.

- Update `MaxPayloadSize` from `10 * 1000 * 1000` to `64 * 1000 * 1000` in `foreign/go/contracts/messages.go`
- Update the doc comment from "10 MB" to "64 MB"

## Files changed

- `foreign/go/contracts/messages.go` (2 lines: constant + doc comment)

## Test plan

- [x] `go build ./contracts/` — passes
- [x] `go test ./...` across all Go SDK packages — all pass (no existing tests assert the old 10 MB value)
- [ ] CI green on PR

Fixes #4078
