### PR TITLE
docs: add AI assistance expectations to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,23 @@ These require design discussion in the issue before coding:
 
 Authors of PRs must run the code locally. "Relying on CI" is not acceptable.
 
+### AI Assistance
+
+You are responsible for the code you submit, even if a tool wrote it.
+
+Using an AI assistant to help you code is fine. Submitting code you don't understand is
+not. Before you open a PR you must be able to explain what every part of the change does
+and why, answer review questions about it yourself, and defend the design without going
+back to the tool for an answer. If you can't, the PR isn't ready.
+
+While you're new to the project, please keep to **one open PR at a time**. Review takes
+longer than writing, so a queue of changes from one contributor holds up everyone else's.
+
+Maintainers may close a PR at first review if it reads as a relay between the reviewer and
+a model, rather than a change the author understands and takes responsibility for. That is
+a judgment about the submission, not about you, and it does not bar you from contributing
+again if you come back with a change you can take responsibility for.
+
 ### Green CI
 
 Maintainers will not start reviewing a PR while its CI is failing. Get the


### PR DESCRIPTION
## Which issue does this PR address?

N/A

## Rationale

CONTRIBUTING says nothing about AI assistants, but the Close Policy already lets a maintainer close a PR that reads as a relay to an LLM. This states the expectation up front so that this can happen ealier.

## What changed?

CONTRIBUTING covers running the code locally, green CI and single purpose, but says nothing about AI assistants, so contributors have no stated expectation to meet and maintainers only raise it once review is under way. A new AI Assistance subsection under Run It Locally sets out responsibility for the code, being able to explain and defend it without the tool, one open PR at a time while new, and that a maintainer may close early if a PR reads as a relay.

## Local Execution

Pre-commit hooks ran

## AI Usage

Yes but reviewed by a human.
