### PR TITLE
feat(python): add partition management methods

### DIFF
--- a/foreign/python/apache_iggy.pyi
+++ b/foreign/python/apache_iggy.pyi
@@ -1347,6 +1347,50 @@ class IggyClient:
             ValueError: If `message_expiry` or `max_topic_size` is out of range.
             PyRuntimeError: If another argument is invalid or the request fails.
         """
+    def create_partitions(
+        self,
+        stream_id: builtins.str | builtins.int,
+        topic_id: builtins.str | builtins.int,
+        partitions_count: builtins.int,
+    ) -> collections.abc.Awaitable[None]:
+        r"""
+        Add partitions to a topic.
+
+        New partitions are appended after the topic's existing partitions.
+
+        Args:
+            stream_id: Stream identifier as `str | int`.
+            topic_id: Topic identifier as `str | int`.
+            partitions_count: Number of partitions to add as `int`.
+
+        Returns:
+            An awaitable that resolves to `None` when the partitions are created.
+
+        Raises:
+            RuntimeError: If an identifier or count is invalid, or the request
+                fails.
+        """
+    def delete_partitions(
+        self,
+        stream_id: builtins.str | builtins.int,
+        topic_id: builtins.str | builtins.int,
+        partitions_count: builtins.int,
+    ) -> collections.abc.Awaitable[None]:
+        r"""
+        Remove the last partitions from a topic.
+
+        Args:
+            stream_id: Stream identifier as `str | int`.
+            topic_id: Topic identifier as `str | int`.
+            partitions_count: Number of partitions to remove as `int`.
+
+        Returns:
+            An awaitable that resolves to `None` when the partitions are deleted.
+
+        Raises:
+            RuntimeError: If an identifier or count is invalid, or the request
+                fails.
+        """
     def get_topic(
         self,
         stream_id: builtins.str | builtins.int,

--- a/foreign/python/src/client.rs
+++ b/foreign/python/src/client.rs
@@ -789,6 +789,76 @@ impl IggyClient {
         })
     }
 
+    /// Add partitions to a topic.
+    ///
+    /// New partitions are appended after the topic's existing partitions.
+    ///
+    /// Args:
+    ///     stream_id: Stream identifier as `str | int`.
+    ///     topic_id: Topic identifier as `str | int`.
+    ///     partitions_count: Number of partitions to add as `int`.
+    ///
+    /// Returns:
+    ///     An awaitable that resolves to `None` when the partitions are created.
+    ///
+    /// Raises:
+    ///     RuntimeError: If an identifier or count is invalid, or the request
+    ///         fails.
+    #[gen_stub(override_return_type(type_repr="collections.abc.Awaitable[None]", imports=("collections.abc")))]
+    fn create_partitions<'a>(
+        &self,
+        py: Python<'a>,
+        stream_id: PyIdentifier,
+        topic_id: PyIdentifier,
+        partitions_count: u32,
+    ) -> PyResult<Bound<'a, PyAny>> {
+        let stream_id = Identifier::try_from(stream_id)?;
+        let topic_id = Identifier::try_from(topic_id)?;
+        let inner = self.inner.clone();
+
+        future_into_py(py, async move {
+            inner
+                .create_partitions(&stream_id, &topic_id, partitions_count)
+                .await
+                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    /// Remove the last partitions from a topic.
+    ///
+    /// Args:
+    ///     stream_id: Stream identifier as `str | int`.
+    ///     topic_id: Topic identifier as `str | int`.
+    ///     partitions_count: Number of partitions to remove as `int`.
+    ///
+    /// Returns:
+    ///     An awaitable that resolves to `None` when the partitions are deleted.
+    ///
+    /// Raises:
+    ///     RuntimeError: If an identifier or count is invalid, or the request
+    ///         fails.
+    #[gen_stub(override_return_type(type_repr="collections.abc.Awaitable[None]", imports=("collections.abc")))]
+    fn delete_partitions<'a>(
+        &self,
+        py: Python<'a>,
+        stream_id: PyIdentifier,
+        topic_id: PyIdentifier,
+        partitions_count: u32,
+    ) -> PyResult<Bound<'a, PyAny>> {
+        let stream_id = Identifier::try_from(stream_id)?;
+        let topic_id = Identifier::try_from(topic_id)?;
+        let inner = self.inner.clone();
+
+        future_into_py(py, async move {
+            inner
+                .delete_partitions(&stream_id, &topic_id, partitions_count)
+                .await
+                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+            Ok(())
+        })
+    }
+
     /// Gets topic by stream and id.
     /// Returns the topic details, or `None` if the topic does not exist.
     /// Raises `RuntimeError` on failure.

--- a/foreign/python/tests/test_topic.py
+++ b/foreign/python/tests/test_topic.py
@@ -512,6 +512,53 @@ class TestCreateTopic:
             )
 
 
+class TestPartitions:
+    """Test adding and removing topic partitions."""
+
+    @pytest.mark.asyncio
+    async def test_create_partitions_adds_partitions(
+        self, iggy_client: IggyClient, unique_name
+    ):
+        """Test create_partitions appends to the topic partition count."""
+        stream_name = unique_name()
+        topic_name = unique_name()
+
+        await iggy_client.create_stream(stream_name)
+        await iggy_client.create_topic(
+            stream=stream_name, name=topic_name, partitions_count=2
+        )
+        await iggy_client.create_partitions(stream_name, topic_name, 3)
+
+        topic = await iggy_client.get_topic(stream_name, topic_name)
+        assert topic is not None
+        assert topic.partitions_count == 5
+        assert len(topic.partitions) == 5
+
+    @pytest.mark.asyncio
+    async def test_delete_partitions_removes_last_partitions_by_numeric_ids(
+        self, iggy_client: IggyClient, unique_name
+    ):
+        """Test delete_partitions accepts numeric identifiers and updates the count."""
+        stream_name = unique_name()
+        topic_name = unique_name()
+
+        await iggy_client.create_stream(stream_name)
+        await iggy_client.create_topic(
+            stream=stream_name, name=topic_name, partitions_count=5
+        )
+        stream = await iggy_client.get_stream(stream_name)
+        topic = await iggy_client.get_topic(stream_name, topic_name)
+        assert stream is not None
+        assert topic is not None
+
+        await iggy_client.delete_partitions(stream.id, topic.id, 2)
+
+        updated_topic = await iggy_client.get_topic(stream.id, topic.id)
+        assert updated_topic is not None
+        assert updated_topic.partitions_count == 3
+        assert len(updated_topic.partitions) == 3
+
+
 class TestGetTopic:
     """Test topic retrieval via get_topic."""
 


### PR DESCRIPTION
## Summary
- expose `create_partitions` in the Python SDK
- expose `delete_partitions` in the Python SDK
- update generated Python type stubs and add integration coverage for string and numeric identifiers

Closes #4014

## Validation
- `uv run --no-sync --locked --extra testing python -m pytest tests/test_topic.py::TestPartitions -v` — 2 passed
- `uv run --no-sync --locked --extra testing python -m pytest tests/test_topic.py -v` — 134 passed
- `cargo fmt --all -- --check`
- `git diff --check`