### PR TITLE
chore(deps): remove Microsoft.SourceLink.GitHub package reference

### DIFF
--- a/foreign/csharp/Directory.Build.props
+++ b/foreign/csharp/Directory.Build.props
@@ -26,8 +26,5 @@ under the License.
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-  </ItemGroup>
+    
 </Project>

--- a/foreign/csharp/Directory.Build.props
+++ b/foreign/csharp/Directory.Build.props
@@ -26,5 +26,4 @@ under the License.
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-    
 </Project>

--- a/foreign/csharp/Directory.Packages.props
+++ b/foreign/csharp/Directory.Packages.props
@@ -27,7 +27,6 @@ under the License.
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.108" />
         <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
         <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="2.3.3" />
         <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />


### PR DESCRIPTION
Remove the explicit `Microsoft.SourceLink.GitHub` package reference. 
Since .NET 8 SourceLink is built into the SDK (https://github.com/dotnet/sourcelink), 
so the package is not needed.
The pinned 10.0.108 also pulled in `Microsoft.Build.Tasks.Git` 10.0.108, 
flagged by CVE-2026-62900 (GHSA-23fw-v26w-5fgq), which failed CI 
restore for `Iggy_SDK.csproj` under `TreatWarningsAsErrors`.