### PR TITLE
fix(connectors): use DLL_EXTENSION for plugin path suffix

### DIFF
--- a/core/connectors/runtime/src/main.rs
+++ b/core/connectors/runtime/src/main.rs
@@ -354,12 +354,7 @@ pub(crate) fn resolve_plugin_path(path: &str) -> Result<String, RuntimeError> {
     let with_extension = if ALLOWED_PLUGIN_EXTENSIONS.contains(&extension) {
         path.to_string()
     } else {
-        let os_extension = match std::env::consts::OS {
-            "macos" => "dylib",
-            "windows" => "dll",
-            _ => "so",
-        };
-        format!("{path}.{os_extension}")
+        format!("{path}.{}", std::env::consts::DLL_EXTENSION)
     };
 
     let candidate = std::path::Path::new(&with_extension);
@@ -548,10 +543,7 @@ mod tests {
     fn path_without_extension_gets_os_suffix() {
         let result = resolve_plugin_path("/tmp/nonexistent_test_plugin");
         let err = result.unwrap_err().to_string();
-        let expected_ext = match std::env::consts::OS {
-            "macos" => "dylib",
-            _ => "so",
-        };
+        let expected_ext = std::env::consts::DLL_EXTENSION;
         assert!(
             err.contains(&format!("nonexistent_test_plugin.{expected_ext}")),
             "Error should mention OS-specific extension, got: {err}"


### PR DESCRIPTION
Fixes #4111 

## Rationale

Simplifies extension logic to use compile time constant, which fixes a test failure that happened when the duplicated logic in production code and test code got out of sync.

## AI Usage

Diagnosis and suggested fix was guided with Opus 4.8. I understand and can explain all changed lines. 