### PR TITLE
test(integration): cleanup & drop the doris nextest test-group

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,21 +27,6 @@ nextest-version = { required = "0.9.77" }
 filter = 'package(integration) and test(cli::system::test_cli_session_scenario::should_be_successful)'
 threads-required = "num-cpus"
 
-# Doris tests are serialized among themselves, but no longer monopolize the
-# whole runner. The all-in-one image's BE advertises 127.0.0.1:8040 for the
-# FE→BE 307 redirect, so only one Doris container per process can bind
-# host:8040. Within a nextest binary the fixture caches one shared container in
-# `SHARED_DORIS` so the first doris test pays the ~40s boot and the rest reuse
-# it; `max-threads = 1` keeps a second nextest binary (or a re-run) from
-# racing the same host port, while still letting unrelated light tests fill
-# the rest of the runner.
-[test-groups.doris]
-max-threads = 1
-
-[[profile.default.overrides]]
-filter = 'package(integration) and test(/connectors::doris::/)'
-test-group = "doris"
-
 # Elasticsearch tests share one reusable container (fixed name
 # `iggy-test-elasticsearch`, ReuseDirective::Always). Serializing the group
 # lets the first test create it and the rest attach by name, instead of racing

--- a/.github/config/components.yml
+++ b/.github/config/components.yml
@@ -23,6 +23,7 @@ components:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".cargo/**"
+      - ".config/**" # nextest + cargo-rail config gate every Rust test job
 
   # crates.io publish chain verification. Runs scripts/verify-crates-publish.sh,
   # which spins up cargo-http-registry as a local alt-registry and chain-publishes


### PR DESCRIPTION
## Which issue does this PR address?

Closes #3371

## Rationale

The doris test-group serializes against a race the fixture no longer has, and its comment references a `SHARED_DORIS` cache that never landed.

## What changed?

The doris fixture shares one fixed-name container (`ReuseDirective::Always`) across nextest processes with a per-test database, so nothing races host:8040 anymore. In CI each partition pays the ~65s boot once and later doris tests take 3-7s, well inside the 5-minute slow-timeout. This drops the group and its override.

A change under `.config/` matched no CI component, so the first run of this PR skipped the whole Rust matrix. `rust-workspace` now also watches `.config/**` (like `.cargo/**`), which is what lets this PR run the doris tests at all.

Result on this PR: all doris tests pass with no retries. The partition with four doris tests finished them in 37-50s each (they now share the boot wait) instead of 67s + 3s + 3s + 7s in sequence.

## Local Execution

- Passed: `taplo fmt --check`, `taplo lint`, `typos`, `cargo nextest show-config version`.
- Not run: doris integration tests (fixture is Linux-only). CI validates the parallel run.
- Pre-commit hooks ran partially (bash-based hooks need bash >= 4.2, unavailable on this Mac).

## AI Usage

- Claude Code.
- Issue triage, the config edit, this description.
- Read the fixture's reuse path and doris timings from a recent Pre-merge run; CI checks the parallel behaviour.
- Yes.
