### PR TITLE
feat(bench): add poll measurements and comparison tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6864,6 +6864,7 @@ dependencies = [
  "rand 0.10.2",
  "rayon",
  "serde",
+ "serde_json",
  "sysinfo 0.39.6",
  "tokio",
  "tracing",

--- a/core/bench/Cargo.toml
+++ b/core/bench/Cargo.toml
@@ -49,6 +49,7 @@ nonzero_lit = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 sysinfo = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/core/bench/README.md
+++ b/core/bench/README.md
@@ -5,3 +5,56 @@ The interactive Bench CLI allows you to perform various benchmarking on the Apac
 Iggy Bench CLI can be installed with `cargo install iggy-bench` and then simply accessed by typing `iggy-bench` in your terminal.
 
 ![CLI](../../assets/bench.png)
+
+## Poll measurements
+
+The low level consumer API supports two optional global selectors:
+
+| Selector | Values | Effect |
+| --- | --- | --- |
+| `--polling-kind` | `offset`, `next` | Explicit offsets disable automatic commit; Next enables it. |
+| `--latency-kind` | `poll`, `origin-timestamp` | Time the SDK poll call or the age of the first returned message. |
+
+Without these selectors, pinned consumers use explicit offsets, groups use Next,
+consumer benchmarks measure the poll call, and benchmarks with concurrent producers
+measure message age. Consumer rate amplification remains independent of the latency
+selector. Explicit selectors require the low level API and a benchmark with consumers.
+
+For example, after populating `bench-stream-1` and `topic-1`:
+
+```sh
+cargo run --release --bin iggy-bench -- \
+  --messages-per-batch 1 --message-batches 10000 --warmup-time 0s \
+  --polling-kind next --latency-kind poll \
+  pinned-consumer --streams 1 --consumers 1 tcp --nodelay \
+  output --output-dir performance_results
+```
+
+When output is enabled, three additional files appear beside `bench.log`:
+
+- `polls.csv` retains every SDK poll call after warmup, including empty responses,
+  errors, structured SDK timeouts, and an interrupted call. Columns are `actor_id`,
+  `sequence`, `elapsed_us`, `poll_latency_us`, `origin_latency_us`, `partition_id`,
+  `messages`, `payload_bytes`, `outcome`, and `error_code`. Missing values are empty
+  CSV fields. Outcomes are `messages`, `empty`, `error`, `timeout`, and `cancelled`.
+- `run-manifest.json` records resolved selectors, workload options, run status,
+  outcome counters, and actor measurement start times in Unix microseconds. Actor
+  durations and CSV elapsed times use a monotonic clock relative to that actor's
+  measurement start. Authentication secrets are omitted.
+- `producer-samples.csv` retains cumulative producer counters about every 100 ms
+  after successful sends, plus initial and final samples. Its columns are `actor_id`,
+  `elapsed_us`, `completed_batches`, `completed_messages`, and `payload_bytes`.
+  Producer start times and final counters also appear in the manifest, including
+  when a background producer is interrupted.
+
+Poll samples are buffered in each actor and written after measurement. Capturing
+samples adds memory use proportional to the number of polls, including empty polls.
+Ctrl-C stops and joins actors before exporting partial results. Failed and interrupted
+runs retain their artifacts. Explicit selector values distinguish output directory
+names and report identifiers; the report JSON schema is unchanged.
+
+Poll timings include the SDK and transport, including retries inside the SDK call.
+They exclude later benchmark accounting. These options do not force a resident or
+disk read path; prepare the fixture and verify its read path separately. Aggregate
+report percentiles still average actor percentiles. Pool `polls.csv` observations
+before calculating percentiles when a combined distribution is required.

--- a/core/bench/report/src/prints.rs
+++ b/core/bench/report/src/prints.rs
@@ -73,9 +73,12 @@ impl BenchmarkReport {
 
         info!("{}", params_print);
 
-        self.group_metrics
-            .iter()
-            .for_each(|s| println!("\n{}", s.formatted_string(pretty)));
+        for group in &self.group_metrics {
+            println!(
+                "\n{}",
+                group.formatted_string_with_duration(pretty, self.group_duration(group))
+            );
+        }
     }
 
     pub fn total_messages(&self) -> u64 {
@@ -137,23 +140,57 @@ impl BenchmarkReport {
             batches
         }
     }
+    fn group_duration(&self, group: &BenchmarkGroupMetrics) -> f64 {
+        self.individual_metrics
+            .iter()
+            .filter(|metrics| match group.summary.kind {
+                GroupMetricsKind::Producers => metrics.summary.actor_kind == ActorKind::Producer,
+                GroupMetricsKind::Consumers => metrics.summary.actor_kind == ActorKind::Consumer,
+                GroupMetricsKind::ProducingConsumers => {
+                    metrics.summary.actor_kind == ActorKind::ProducingConsumer
+                }
+                GroupMetricsKind::ProducersAndConsumers => {
+                    metrics.summary.actor_kind != ActorKind::ProducingConsumer
+                }
+            })
+            .map(|metrics| metrics.summary.total_time_secs)
+            .reduce(f64::max)
+            .unwrap_or_else(|| group.time_series_duration())
+    }
 }
 
 impl BenchmarkGroupMetrics {
     pub fn formatted_string(&self, pretty: bool) -> String {
+        self.formatted_string_with_duration(pretty, self.time_series_duration())
+    }
+
+    fn formatted_string_with_duration(&self, pretty: bool, duration: f64) -> String {
         if pretty {
             let width = get_terminal_width();
             if width >= WIDE_LAYOUT_THRESHOLD {
-                self.format_wide_layout()
+                self.format_wide_layout(duration)
             } else {
-                self.format_narrow_layout()
+                self.format_narrow_layout(duration)
             }
         } else {
-            self.format_original()
+            self.format_original(duration)
         }
     }
 
-    fn format_original(&self) -> String {
+    fn time_series_duration(&self) -> f64 {
+        [
+            &self.avg_throughput_mb_ts,
+            &self.avg_throughput_msg_ts,
+            &self.avg_latency_ts,
+        ]
+        .into_iter()
+        .filter_map(|series| series.points.last())
+        .map(|point| point.time_s)
+        .reduce(f64::max)
+        .unwrap_or(0.0)
+    }
+
+    fn format_original(&self, duration: f64) -> String {
         let (prefix, color) = match self.summary.kind {
             GroupMetricsKind::Producers => ("Producers Results", Color::Green),
             GroupMetricsKind::Consumers => ("Consumers Results", Color::Green),
@@ -178,10 +215,7 @@ impl BenchmarkGroupMetrics {
         let min = format!("{:.2}", self.summary.min_latency_ms);
         let max = format!("{:.2}", self.summary.max_latency_ms);
         let std_dev = format!("{:.2}", self.summary.std_dev_latency_ms);
-        let total_test_time = format!(
-            "{:.2}",
-            self.avg_throughput_mb_ts.points.last().unwrap().time_s
-        );
+        let total_test_time = format!("{:.2}", duration);
 
         format!(
         "{prefix}: Total throughput: {total_mb} MB/s, {total_msg} messages/s, average throughput per {actor}: {avg_mb} MB/s, \
@@ -193,7 +227,7 @@ impl BenchmarkGroupMetrics {
     .to_string()
     }
 
-    fn format_wide_layout(&self) -> String {
+    fn format_wide_layout(&self, duration: f64) -> String {
         let prefix = match self.summary.kind {
             GroupMetricsKind::Producers => "Producers Results",
             GroupMetricsKind::Consumers => "Consumers Results",
@@ -209,10 +243,7 @@ impl BenchmarkGroupMetrics {
 
         summary_table.add_row(vec![
             prefix.to_string(),
-            format!(
-                "{:.2} s",
-                self.avg_throughput_mb_ts.points.last().unwrap().time_s
-            ),
+            format!("{:.2} s", duration),
             format!(
                 "{:.2} MB/s",
                 self.summary.total_throughput_megabytes_per_second
@@ -254,7 +285,7 @@ impl BenchmarkGroupMetrics {
         format!("\n{}\n{}", summary_table, latency_table)
     }
 
-    fn format_narrow_layout(&self) -> String {
+    fn format_narrow_layout(&self, duration: f64) -> String {
         let prefix = match self.summary.kind {
             GroupMetricsKind::Producers => "Producers Results",
             GroupMetricsKind::Consumers => "Consumers Results",
@@ -272,13 +303,7 @@ impl BenchmarkGroupMetrics {
         table.add_row(vec![prefix.to_string(), String::new()]);
 
         table.add_row(vec!["Summary", ""]);
-        table.add_row(vec![
-            "Total Time".to_string(),
-            format!(
-                "{:.2} s",
-                self.avg_throughput_mb_ts.points.last().unwrap().time_s
-            ),
-        ]);
+        table.add_row(vec!["Total Time".to_string(), format!("{:.2} s", duration)]);
 
         table.add_row(vec!["Throughput", ""]);
         table.add_row(vec![
@@ -344,5 +369,121 @@ impl BenchmarkGroupMetrics {
         ]);
 
         format!("\n{}", table)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::{
+        actor_kind::ActorKind, create_latency_chart, create_latency_distribution_chart,
+        create_throughput_chart, group_metrics::BenchmarkGroupMetrics,
+        individual_metrics::BenchmarkIndividualMetrics, report::BenchmarkReport,
+    };
+
+    #[test]
+    fn empty_time_series_format_in_every_layout() {
+        let group = group_without_time_series();
+        assert!(group.formatted_string(false).contains("total time: 0.00 s"));
+        assert!(
+            group
+                .format_wide_layout(group.time_series_duration())
+                .contains("0.00 s")
+        );
+        assert!(
+            group
+                .format_narrow_layout(group.time_series_duration())
+                .contains("0.00 s")
+        );
+    }
+
+    #[test]
+    fn report_duration_uses_matching_actors_when_time_series_are_empty() {
+        let group = group_without_time_series();
+        let mut consumer = individual_without_time_series();
+        consumer.summary.actor_kind = ActorKind::Consumer;
+        consumer.summary.total_time_secs = 9.0;
+        let report = BenchmarkReport {
+            group_metrics: vec![group.clone()],
+            individual_metrics: vec![individual_without_time_series(), consumer],
+            ..BenchmarkReport::default()
+        };
+        assert_eq!(report.group_duration(&group), 0.125);
+        assert!(
+            group
+                .formatted_string_with_duration(false, report.group_duration(&group))
+                .contains("total time: 0.12 s")
+        );
+        report.print_summary(false);
+    }
+
+    #[test]
+    fn charts_accept_short_run_with_empty_time_series() {
+        let report = BenchmarkReport {
+            group_metrics: vec![group_without_time_series()],
+            individual_metrics: vec![individual_without_time_series()],
+            ..BenchmarkReport::default()
+        };
+        for chart in [
+            create_throughput_chart(&report, false, false),
+            create_latency_chart(&report, false, false),
+            create_latency_distribution_chart(&report, false, false),
+        ] {
+            assert!(serde_json::to_value(chart).unwrap().is_object());
+        }
+    }
+
+    fn group_without_time_series() -> BenchmarkGroupMetrics {
+        serde_json::from_value(json!({
+            "summary": {
+                "kind": "producers",
+                "total_throughput_megabytes_per_second": 1.0,
+                "total_throughput_messages_per_second": 1.0,
+                "average_throughput_megabytes_per_second": 1.0,
+                "average_throughput_messages_per_second": 1.0,
+                "average_p50_latency_ms": 1.0,
+                "average_p90_latency_ms": 1.0,
+                "average_p95_latency_ms": 1.0,
+                "average_p99_latency_ms": 1.0,
+                "average_p999_latency_ms": 1.0,
+                "average_p9999_latency_ms": 1.0,
+                "average_latency_ms": 1.0,
+                "average_median_latency_ms": 1.0
+            },
+            "avg_throughput_mb_ts": { "points": [] },
+            "avg_throughput_msg_ts": { "points": [] },
+            "avg_latency_ts": { "points": [] }
+        }))
+        .unwrap()
+    }
+
+    fn individual_without_time_series() -> BenchmarkIndividualMetrics {
+        serde_json::from_value(json!({
+            "summary": {
+                "benchmark_kind": "pinned_producer",
+                "actor_kind": "producer",
+                "actor_id": 1,
+                "total_time_secs": 0.125,
+                "total_user_data_bytes": 256,
+                "total_bytes": 320,
+                "total_messages": 1,
+                "total_message_batches": 1,
+                "throughput_megabytes_per_second": 1.0,
+                "throughput_messages_per_second": 1.0,
+                "p50_latency_ms": 1.0,
+                "p90_latency_ms": 1.0,
+                "p95_latency_ms": 1.0,
+                "p99_latency_ms": 1.0,
+                "p999_latency_ms": 1.0,
+                "p9999_latency_ms": 1.0,
+                "avg_latency_ms": 1.0,
+                "median_latency_ms": 1.0
+            },
+            "throughput_mb_ts": { "points": [] },
+            "throughput_msg_ts": { "points": [] },
+            "latency_ts": { "points": [] }
+        }))
+        .unwrap()
     }
 }

--- a/core/bench/src/actors/consumer/benchmark_consumer.rs
+++ b/core/bench/src/actors/consumer/benchmark_consumer.rs
@@ -15,12 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::actors::consumer::client::BenchmarkConsumerClient;
-use crate::actors::consumer::client::interface::BenchmarkConsumerConfig;
-use crate::analytics::metrics::individual::from_records;
-use crate::analytics::record::BenchmarkRecord;
-use crate::utils::finish_condition::BenchmarkFinishCondition;
-use crate::utils::rate_limiter::BenchmarkRateLimiter;
+use std::sync::Arc;
+use std::time::Duration;
+
 use bench_report::actor_kind::ActorKind;
 use bench_report::benchmark_kind::BenchmarkKind;
 use bench_report::individual_metrics::BenchmarkIndividualMetrics;
@@ -30,10 +27,15 @@ use comfy_table::presets::UTF8_FULL;
 use comfy_table::{ContentArrangement, Table};
 use human_repr::HumanCount;
 use iggy::prelude::*;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::time::Instant;
 use tracing::info;
+
+use crate::actors::consumer::client::BenchmarkConsumerClient;
+use crate::actors::consumer::client::interface::BenchmarkConsumerConfig;
+use crate::analytics::metrics::individual::from_records;
+use crate::analytics::record::BenchmarkRecord;
+use crate::utils::finish_condition::BenchmarkFinishCondition;
+use crate::utils::rate_limiter::BenchmarkRateLimiter;
 
 pub struct BenchmarkConsumer<C: BenchmarkConsumerClient> {
     pub client: C,
@@ -83,6 +85,7 @@ impl<C: BenchmarkConsumerClient> BenchmarkConsumer<C> {
 
         let max_capacity = self.finish_condition.max_capacity();
         let mut records = Vec::with_capacity(max_capacity);
+        self.client.start_measurement(max_capacity);
         let mut messages_processed = 0;
         let mut batches_processed = 0;
         let mut bytes_processed = 0;

--- a/core/bench/src/actors/consumer/client/interface.rs
+++ b/core/bench/src/actors/consumer/client/interface.rs
@@ -15,10 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use bench_report::numeric_parameter::BenchmarkNumericParameter;
 use iggy::prelude::*;
 
 use crate::actors::{ApiLabel, BatchMetrics, BenchmarkInit};
+use crate::poll_artifacts::PollArtifacts;
 
 #[derive(Debug, Clone)]
 pub struct BenchmarkConsumerConfig {
@@ -29,10 +32,13 @@ pub struct BenchmarkConsumerConfig {
     pub warmup_time: IggyDuration,
     pub polling_kind: PollingKind,
     pub origin_timestamp_latency_calculation: bool,
+    pub poll_artifacts: Option<Arc<PollArtifacts>>,
     pub pretty: bool,
 }
 
 pub trait ConsumerClient: Send + Sync {
+    fn start_measurement(&mut self, _capacity: usize) {}
+
     async fn consume_batch(&mut self) -> Result<Option<BatchMetrics>, IggyError>;
 }
 pub trait BenchmarkConsumerClient: ConsumerClient + BenchmarkInit + ApiLabel + Send + Sync {}

--- a/core/bench/src/actors/consumer/client/low_level.rs
+++ b/core/bench/src/actors/consumer/client/low_level.rs
@@ -15,17 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use iggy::prelude::*;
+use tokio::time::Instant;
+
 use crate::actors::consumer::client::BenchmarkConsumerClient;
 use crate::actors::consumer::client::interface::{BenchmarkConsumerConfig, ConsumerClient};
 use crate::actors::{ApiLabel, BatchMetrics, BenchmarkInit};
 use crate::benchmarks::common::create_consumer;
+use crate::poll_artifacts::ActorPollRecorder;
 use crate::utils::ClientFactory;
 use crate::utils::{batch_total_size_bytes, batch_user_size_bytes};
-use iggy::prelude::*;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::time::Instant;
 
 pub struct LowLevelConsumerClient {
     client_factory: Arc<dyn ClientFactory>,
@@ -40,6 +43,7 @@ pub struct LowLevelConsumerClient {
     /// Where offset polling continues in each partition. A group member polls its partitions
     /// round-robin, so one shared cursor would skip the start of every partition but the first.
     next_offsets: HashMap<u32, u64>,
+    poll_recorder: Option<ActorPollRecorder>,
 }
 
 impl LowLevelConsumerClient {
@@ -55,11 +59,18 @@ impl LowLevelConsumerClient {
             polling_strategy: PollingStrategy::next(),
             auto_commit: true,
             next_offsets: HashMap::new(),
+            poll_recorder: None,
         }
     }
 }
 
 impl ConsumerClient for LowLevelConsumerClient {
+    fn start_measurement(&mut self, capacity: usize) {
+        self.poll_recorder = self.config.poll_artifacts.as_ref().map(|artifacts| {
+            ActorPollRecorder::new(self.config.consumer_id, artifacts.clone(), capacity)
+        });
+    }
+
     async fn consume_batch(&mut self) -> Result<Option<BatchMetrics>, IggyError> {
         let client = self.client.as_ref().expect("client not initialized");
         let consumer = self.consumer.as_ref().expect("consumer not initialized");
@@ -72,6 +83,9 @@ impl ConsumerClient for LowLevelConsumerClient {
                 .get(&partition_id)
                 .map_or(polling_strategy, |offset| PollingStrategy::offset(*offset))
         };
+        if let Some(recorder) = &mut self.poll_recorder {
+            recorder.begin_poll();
+        }
         let before_poll = Instant::now();
         let polled = client
             .poll_messages_with_strategy_for(
@@ -85,9 +99,14 @@ impl ConsumerClient for LowLevelConsumerClient {
             )
             .await;
 
+        let poll_latency = before_poll.elapsed();
+        let poll_latency_us = u64::try_from(poll_latency.as_micros()).unwrap_or(u64::MAX);
         let polled = match polled {
             Ok(p) => p,
             Err(e) => {
+                if let Some(recorder) = &mut self.poll_recorder {
+                    recorder.fail_poll(&e, poll_latency_us);
+                }
                 if matches!(e, IggyError::TopicIdNotFound(_, _)) {
                     return Ok(None);
                 }
@@ -95,19 +114,31 @@ impl ConsumerClient for LowLevelConsumerClient {
             }
         };
 
+        let origin_latency_us = polled.messages.first().map(|message| {
+            IggyTimestamp::now()
+                .as_micros()
+                .saturating_sub(message.header.origin_timestamp)
+        });
+        let messages_count = u32::try_from(polled.messages.len()).unwrap_or(u32::MAX);
+        let user_bytes = batch_user_size_bytes(&polled);
+        let total_bytes = batch_total_size_bytes(&polled);
+        if let Some(recorder) = &mut self.poll_recorder {
+            recorder.complete_poll(
+                poll_latency_us,
+                origin_latency_us,
+                polled.partition_id,
+                messages_count,
+                user_bytes,
+            );
+        }
         if polled.messages.is_empty() {
             return Ok(None);
         }
-        let messages_count = polled.messages.len() as u64;
         let latency = if self.config.origin_timestamp_latency_calculation {
-            let now = IggyTimestamp::now().as_micros();
-            Duration::from_micros(now - polled.messages[0].header.origin_timestamp)
+            Duration::from_micros(origin_latency_us.unwrap_or_default())
         } else {
-            before_poll.elapsed()
+            poll_latency
         };
-
-        let user_bytes = batch_user_size_bytes(&polled);
-        let total_bytes = batch_total_size_bytes(&polled);
 
         if self.polling_strategy.kind == PollingKind::Offset
             && let Some(last) = polled.messages.last()
@@ -117,7 +148,7 @@ impl ConsumerClient for LowLevelConsumerClient {
         }
 
         Ok(Some(BatchMetrics {
-            messages: messages_count.try_into().unwrap(),
+            messages: messages_count,
             user_data_bytes: user_bytes,
             total_bytes,
             latency,

--- a/core/bench/src/actors/consumer/typed_benchmark_consumer.rs
+++ b/core/bench/src/actors/consumer/typed_benchmark_consumer.rs
@@ -17,6 +17,13 @@
 
 use std::sync::Arc;
 
+use bench_report::{
+    benchmark_kind::BenchmarkKind, individual_metrics::BenchmarkIndividualMetrics,
+    numeric_parameter::BenchmarkNumericParameter,
+};
+use iggy::prelude::*;
+
+use crate::poll_artifacts::PollArtifacts;
 use crate::utils::ClientFactory;
 use crate::{
     actors::consumer::{
@@ -28,11 +35,6 @@ use crate::{
     },
     utils::finish_condition::BenchmarkFinishCondition,
 };
-use bench_report::{
-    benchmark_kind::BenchmarkKind, individual_metrics::BenchmarkIndividualMetrics,
-    numeric_parameter::BenchmarkNumericParameter,
-};
-use iggy::prelude::*;
 
 pub enum TypedBenchmarkConsumer {
     High(Box<BenchmarkConsumer<HighLevelConsumerClient>>),
@@ -56,6 +58,7 @@ impl TypedBenchmarkConsumer {
         polling_kind: PollingKind,
         limit_bytes_per_second: Option<IggyByteSize>,
         origin_timestamp_latency_calculation: bool,
+        poll_artifacts: Option<Arc<PollArtifacts>>,
         pretty: bool,
     ) -> Self {
         let config = BenchmarkConsumerConfig {
@@ -66,6 +69,7 @@ impl TypedBenchmarkConsumer {
             warmup_time,
             polling_kind,
             origin_timestamp_latency_calculation,
+            poll_artifacts,
             pretty,
         };
 

--- a/core/bench/src/actors/producer/benchmark_producer.rs
+++ b/core/bench/src/actors/producer/benchmark_producer.rs
@@ -15,14 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    actors::producer::client::{BenchmarkProducerClient, interface::BenchmarkProducerConfig},
-    analytics::{metrics::individual::from_records, record::BenchmarkRecord},
-    utils::{
-        batch_generator::BenchmarkBatchGenerator, finish_condition::BenchmarkFinishCondition,
-        rate_limiter::BenchmarkRateLimiter,
-    },
-};
+use std::{sync::Arc, time::Duration};
+
 use bench_report::benchmark_kind::BenchmarkKind;
 use bench_report::individual_metrics::BenchmarkIndividualMetrics;
 use bench_report::numeric_parameter::BenchmarkNumericParameter;
@@ -33,9 +27,18 @@ use bench_report::{
 use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL};
 use human_repr::HumanCount;
 use iggy::prelude::*;
-use std::{sync::Arc, time::Duration};
 use tokio::time::Instant;
 use tracing::info;
+
+use crate::poll_artifacts::ProducerRecorder;
+use crate::{
+    actors::producer::client::{BenchmarkProducerClient, interface::BenchmarkProducerConfig},
+    analytics::{metrics::individual::from_records, record::BenchmarkRecord},
+    utils::{
+        batch_generator::BenchmarkBatchGenerator, finish_condition::BenchmarkFinishCondition,
+        rate_limiter::BenchmarkRateLimiter,
+    },
+};
 
 pub struct BenchmarkProducer<P: BenchmarkProducerClient> {
     pub client: P,
@@ -105,6 +108,11 @@ impl<P: BenchmarkProducerClient> BenchmarkProducer<P> {
         let mut total_bytes_processed = 0;
 
         let rate_limiter = self.limit_bytes_per_second.map(BenchmarkRateLimiter::new);
+        let mut producer_recorder = self
+            .config
+            .poll_artifacts
+            .as_ref()
+            .map(|artifacts| ProducerRecorder::new(self.config.producer_id, artifacts.clone()));
         let start_timestamp = Instant::now();
 
         while !self.finish_condition.is_done() {
@@ -114,6 +122,9 @@ impl<P: BenchmarkProducerClient> BenchmarkProducer<P> {
                 continue;
             };
 
+            if let Some(recorder) = &mut producer_recorder {
+                recorder.record_batch(&batch);
+            }
             messages_processed += u64::from(batch.messages);
             batches_processed += 1;
             user_data_bytes_processed += batch.user_data_bytes;
@@ -152,6 +163,7 @@ impl<P: BenchmarkProducerClient> BenchmarkProducer<P> {
             }
         }
 
+        drop(producer_recorder);
         let metrics = from_records(
             &records,
             self.benchmark_kind,

--- a/core/bench/src/actors/producer/client/interface.rs
+++ b/core/bench/src/actors/producer/client/interface.rs
@@ -15,12 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
+use bench_report::numeric_parameter::BenchmarkNumericParameter;
+use iggy::prelude::*;
+
+use crate::poll_artifacts::PollArtifacts;
 use crate::{
     actors::{ApiLabel, BatchMetrics, BenchmarkInit},
     utils::batch_generator::BenchmarkBatchGenerator,
 };
-use bench_report::numeric_parameter::BenchmarkNumericParameter;
-use iggy::prelude::*;
 
 #[derive(Debug, Clone)]
 pub struct BenchmarkProducerConfig {
@@ -30,6 +34,7 @@ pub struct BenchmarkProducerConfig {
     pub messages_per_batch: BenchmarkNumericParameter,
     pub message_size: BenchmarkNumericParameter,
     pub warmup_time: IggyDuration,
+    pub poll_artifacts: Option<Arc<PollArtifacts>>,
     pub pretty: bool,
 }
 

--- a/core/bench/src/actors/producer/typed_benchmark_producer.rs
+++ b/core/bench/src/actors/producer/typed_benchmark_producer.rs
@@ -15,6 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
+use bench_report::{
+    benchmark_kind::BenchmarkKind, individual_metrics::BenchmarkIndividualMetrics,
+    numeric_parameter::BenchmarkNumericParameter,
+};
+use iggy::prelude::*;
+
+use crate::poll_artifacts::PollArtifacts;
 use crate::utils::ClientFactory;
 use crate::{
     actors::producer::{
@@ -26,12 +35,6 @@ use crate::{
     },
     utils::finish_condition::BenchmarkFinishCondition,
 };
-use bench_report::{
-    benchmark_kind::BenchmarkKind, individual_metrics::BenchmarkIndividualMetrics,
-    numeric_parameter::BenchmarkNumericParameter,
-};
-use iggy::prelude::*;
-use std::sync::Arc;
 
 pub enum TypedBenchmarkProducer {
     High(BenchmarkProducer<HighLevelProducerClient>),
@@ -54,6 +57,7 @@ impl TypedBenchmarkProducer {
         sampling_time: IggyDuration,
         moving_average_window: u32,
         limit_bytes_per_second: Option<IggyByteSize>,
+        poll_artifacts: Option<Arc<PollArtifacts>>,
         pretty: bool,
     ) -> Self {
         let config = BenchmarkProducerConfig {
@@ -63,6 +67,7 @@ impl TypedBenchmarkProducer {
             messages_per_batch,
             message_size,
             warmup_time,
+            poll_artifacts,
             pretty,
         };
 

--- a/core/bench/src/actors/producing_consumer/benchmark_producing_consumer.rs
+++ b/core/bench/src/actors/producing_consumer/benchmark_producing_consumer.rs
@@ -17,17 +17,6 @@
 
 use std::{sync::Arc, time::Duration};
 
-use crate::{
-    actors::{
-        consumer::client::{BenchmarkConsumerClient, interface::BenchmarkConsumerConfig},
-        producer::client::{BenchmarkProducerClient, interface::BenchmarkProducerConfig},
-    },
-    analytics::{metrics::individual::from_records, record::BenchmarkRecord},
-    utils::{
-        batch_generator::BenchmarkBatchGenerator, finish_condition::BenchmarkFinishCondition,
-        rate_limiter::BenchmarkRateLimiter,
-    },
-};
 use bench_report::{
     actor_kind::ActorKind,
     benchmark_kind::BenchmarkKind,
@@ -40,6 +29,19 @@ use human_repr::HumanCount;
 use iggy::prelude::*;
 use tokio::time::Instant;
 use tracing::info;
+
+use crate::poll_artifacts::ProducerRecorder;
+use crate::{
+    actors::{
+        consumer::client::{BenchmarkConsumerClient, interface::BenchmarkConsumerConfig},
+        producer::client::{BenchmarkProducerClient, interface::BenchmarkProducerConfig},
+    },
+    analytics::{metrics::individual::from_records, record::BenchmarkRecord},
+    utils::{
+        batch_generator::BenchmarkBatchGenerator, finish_condition::BenchmarkFinishCondition,
+        rate_limiter::BenchmarkRateLimiter,
+    },
+};
 
 pub struct BenchmarkProducingConsumer<P, C>
 where
@@ -124,6 +126,7 @@ where
             .max_capacity()
             .max(self.poll_finish_condition.max_capacity());
         let mut records = Vec::with_capacity(max_capacity);
+        self.consumer.start_measurement(max_capacity);
 
         let mut rl_value = 0;
         let mut sent_user_bytes = 0;
@@ -143,6 +146,14 @@ where
             is_producer && is_consumer && self.consumer_config.consumer_group_id.is_none();
         let mut awaiting_reply = false;
 
+        let mut producer_recorder = self
+            .producer_config
+            .poll_artifacts
+            .as_ref()
+            .filter(|_| is_producer)
+            .map(|artifacts| {
+                ProducerRecorder::new(self.producer_config.producer_id, artifacts.clone())
+            });
         let start = Instant::now();
 
         while !(self.send_finish_condition.is_done() && self.poll_finish_condition.is_done()) {
@@ -151,6 +162,9 @@ where
                 && (!require_reply || !awaiting_reply)
                 && let Some(batch) = self.producer.produce_batch(&mut batch_generator).await?
             {
+                if let Some(recorder) = &mut producer_recorder {
+                    recorder.record_batch(&batch);
+                }
                 rl_value += batch.user_data_bytes;
                 sent_user_bytes += batch.user_data_bytes;
                 sent_total_bytes += batch.total_bytes;
@@ -210,6 +224,7 @@ where
             }
         }
 
+        drop(producer_recorder);
         let metrics = from_records(
             &records,
             self.benchmark_kind,

--- a/core/bench/src/actors/producing_consumer/typed_benchmark_producing_consumer.rs
+++ b/core/bench/src/actors/producing_consumer/typed_benchmark_producing_consumer.rs
@@ -17,6 +17,13 @@
 
 use std::sync::Arc;
 
+use bench_report::{
+    benchmark_kind::BenchmarkKind, individual_metrics::BenchmarkIndividualMetrics,
+    numeric_parameter::BenchmarkNumericParameter,
+};
+use iggy::prelude::*;
+
+use crate::poll_artifacts::PollArtifacts;
 use crate::utils::ClientFactory;
 use crate::{
     actors::{
@@ -32,12 +39,6 @@ use crate::{
     },
     utils::finish_condition::BenchmarkFinishCondition,
 };
-use bench_report::{
-    benchmark_kind::BenchmarkKind, individual_metrics::BenchmarkIndividualMetrics,
-    numeric_parameter::BenchmarkNumericParameter,
-};
-
-use iggy::prelude::*;
 
 pub enum TypedBenchmarkProducingConsumer {
     High(BenchmarkProducingConsumer<HighLevelProducerClient, HighLevelConsumerClient>),
@@ -63,6 +64,7 @@ impl TypedBenchmarkProducingConsumer {
         limit_bytes_per_second: Option<IggyByteSize>,
         polling_kind: PollingKind,
         origin_timestamp_latency_calculation: bool,
+        poll_artifacts: Option<Arc<PollArtifacts>>,
         pretty: bool,
     ) -> Self {
         let producer_config = BenchmarkProducerConfig {
@@ -72,6 +74,7 @@ impl TypedBenchmarkProducingConsumer {
             messages_per_batch,
             message_size,
             warmup_time,
+            poll_artifacts: poll_artifacts.clone(),
             pretty,
         };
 
@@ -83,6 +86,7 @@ impl TypedBenchmarkProducingConsumer {
             warmup_time,
             polling_kind,
             origin_timestamp_latency_calculation,
+            poll_artifacts,
             pretty,
         };
 

--- a/core/bench/src/args/common.rs
+++ b/core/bench/src/args/common.rs
@@ -15,16 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::kind::BenchmarkKindCommand;
-use super::output::BenchmarkOutputCommand;
-use super::props::{BenchmarkKindProps, BenchmarkTransportProps};
-use super::{
-    defaults::{
-        DEFAULT_MESSAGE_BATCHES, DEFAULT_MESSAGE_SIZE, DEFAULT_MESSAGES_PER_BATCH,
-        DEFAULT_MOVING_AVERAGE_WINDOW, DEFAULT_SAMPLING_TIME, DEFAULT_WARMUP_TIME,
-    },
-    transport::BenchmarkTransportCommand,
-};
+use std::num::NonZeroU32;
+use std::str::FromStr;
+use std::sync::Arc;
+
 use bench_report::benchmark_kind::BenchmarkKind;
 use bench_report::numeric_parameter::BenchmarkNumericParameter;
 use clap::error::ErrorKind;
@@ -33,8 +27,19 @@ use iggy::prelude::{
     DEFAULT_ROOT_PASSWORD, DEFAULT_ROOT_USERNAME, IggyByteSize, IggyDuration, IggyExpiry,
     TransportProtocol,
 };
-use std::num::NonZeroU32;
-use std::str::FromStr;
+
+use super::kind::BenchmarkKindCommand;
+use super::output::BenchmarkOutputCommand;
+use super::polling::{LatencyKind, PollingMode};
+use super::props::{BenchmarkKindProps, BenchmarkTransportProps};
+use super::{
+    defaults::{
+        DEFAULT_MESSAGE_BATCHES, DEFAULT_MESSAGE_SIZE, DEFAULT_MESSAGES_PER_BATCH,
+        DEFAULT_MOVING_AVERAGE_WINDOW, DEFAULT_SAMPLING_TIME, DEFAULT_WARMUP_TIME,
+    },
+    transport::BenchmarkTransportCommand,
+};
+use crate::poll_artifacts::PollArtifacts;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -78,6 +83,17 @@ pub struct IggyBenchArgs {
     /// Window size for moving average calculations in time series data
     #[arg(long, short = 'W', default_value_t = DEFAULT_MOVING_AVERAGE_WINDOW)]
     pub moving_average_window: u32,
+
+    /// Polling strategy. Next enables automatic offset commit; offset disables it.
+    #[arg(long, global = true, value_enum)]
+    pub polling_kind: Option<PollingMode>,
+
+    /// Consumer latency measurement, either the poll request or message origin timestamp.
+    #[arg(long, global = true, value_enum)]
+    pub latency_kind: Option<LatencyKind>,
+
+    #[arg(skip)]
+    pub poll_artifacts: Option<Arc<PollArtifacts>>,
 
     /// Use high-level API for actors
     #[arg(long, short = 'H', default_value_t = false)]
@@ -173,6 +189,12 @@ impl IggyBenchArgs {
                     ErrorKind::ArgumentConflict,
                     "High-level consumer API (--high-level-api) requires fixed batch size, but random batch size was specified. Use a single value instead of a range for --messages-per-batch.",
                 )
+                .exit();
+        }
+
+        if let Err(message) = self.validate_poll_selectors() {
+            Self::command()
+                .error(ErrorKind::ArgumentConflict, message)
                 .exit();
         }
 
@@ -422,7 +444,7 @@ impl IggyBenchArgs {
             parts.push(identifier.clone());
         }
 
-        parts.join("_")
+        format!("{}{}", parts.join("_"), self.poll_selector_suffix())
     }
 
     /// Generates a human-readable pretty name for the benchmark

--- a/core/bench/src/args/mod.rs
+++ b/core/bench/src/args/mod.rs
@@ -19,6 +19,7 @@ pub mod common;
 pub mod defaults;
 pub mod kind;
 pub mod kinds;
+pub mod polling;
 pub mod transport;
 
 mod examples;

--- a/core/bench/src/args/polling.rs
+++ b/core/bench/src/args/polling.rs
@@ -1,0 +1,211 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::{Display, Formatter, Write};
+
+use bench_report::benchmark_kind::BenchmarkKind;
+use clap::ValueEnum;
+use iggy::prelude::PollingKind;
+use serde::Serialize;
+
+use super::common::IggyBenchArgs;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PollingMode {
+    Offset,
+    Next,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LatencyKind {
+    Poll,
+    OriginTimestamp,
+}
+
+impl Display for PollingMode {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Offset => "offset",
+            Self::Next => "next",
+        })
+    }
+}
+
+impl Display for LatencyKind {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Poll => "poll",
+            Self::OriginTimestamp => "origin-timestamp",
+        })
+    }
+}
+
+impl From<PollingMode> for PollingKind {
+    fn from(value: PollingMode) -> Self {
+        match value {
+            PollingMode::Offset => Self::Offset,
+            PollingMode::Next => Self::Next,
+        }
+    }
+}
+
+impl IggyBenchArgs {
+    pub fn resolved_polling_kind(&self) -> PollingMode {
+        self.polling_kind.unwrap_or_else(|| {
+            if self.number_of_consumer_groups() > 0 {
+                PollingMode::Next
+            } else {
+                PollingMode::Offset
+            }
+        })
+    }
+
+    pub fn resolved_latency_kind(&self) -> LatencyKind {
+        self.latency_kind.unwrap_or_else(|| match self.kind() {
+            BenchmarkKind::PinnedConsumer | BenchmarkKind::BalancedConsumerGroup => {
+                LatencyKind::Poll
+            }
+            _ => LatencyKind::OriginTimestamp,
+        })
+    }
+
+    pub fn poll_selector_suffix(&self) -> String {
+        let mut suffix = String::new();
+        if let Some(polling) = self.polling_kind {
+            let _ = write!(suffix, "_polling-{polling}");
+        }
+        if let Some(latency) = self.latency_kind {
+            let _ = write!(suffix, "_latency-{latency}");
+        }
+        suffix
+    }
+
+    pub fn validate_poll_selectors(&self) -> Result<(), &'static str> {
+        if self.polling_kind.is_none() && self.latency_kind.is_none() {
+            return Ok(());
+        }
+        if self.high_level_api {
+            return Err(
+                "--polling-kind and --latency-kind require the low-level API; omit --high-level-api",
+            );
+        }
+        if matches!(
+            self.kind(),
+            BenchmarkKind::PinnedProducer | BenchmarkKind::BalancedProducer
+        ) {
+            return Err("--polling-kind and --latency-kind require a benchmark with consumers");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{LatencyKind, PollingMode};
+    use crate::args::common::IggyBenchArgs;
+
+    #[test]
+    fn selectors_preserve_mode_defaults_and_accept_global_overrides() {
+        for (mode, polling, latency) in [
+            ("pinned-consumer", PollingMode::Offset, LatencyKind::Poll),
+            (
+                "balanced-consumer-group",
+                PollingMode::Next,
+                LatencyKind::Poll,
+            ),
+            (
+                "pinned-producer-and-consumer",
+                PollingMode::Offset,
+                LatencyKind::OriginTimestamp,
+            ),
+            (
+                "balanced-producer-and-consumer-group",
+                PollingMode::Next,
+                LatencyKind::OriginTimestamp,
+            ),
+            (
+                "end-to-end-producing-consumer",
+                PollingMode::Offset,
+                LatencyKind::OriginTimestamp,
+            ),
+            (
+                "end-to-end-producing-consumer-group",
+                PollingMode::Next,
+                LatencyKind::OriginTimestamp,
+            ),
+        ] {
+            let args = IggyBenchArgs::try_parse_from(["iggy-bench", mode, "tcp"]).unwrap();
+            assert_eq!(args.resolved_polling_kind(), polling);
+            assert_eq!(args.resolved_latency_kind(), latency);
+            let args = IggyBenchArgs::try_parse_from([
+                "iggy-bench",
+                mode,
+                "tcp",
+                "--polling-kind",
+                "next",
+                "--latency-kind",
+                "poll",
+            ])
+            .unwrap();
+            assert!(args.validate_poll_selectors().is_ok());
+            assert_eq!(args.resolved_polling_kind(), PollingMode::Next);
+            assert_eq!(args.resolved_latency_kind(), LatencyKind::Poll);
+        }
+    }
+
+    #[test]
+    fn unsupported_api_and_producer_selectors_are_rejected() {
+        let args = IggyBenchArgs::try_parse_from([
+            "iggy-bench",
+            "--high-level-api",
+            "--polling-kind",
+            "next",
+            "pinned-consumer",
+            "tcp",
+        ])
+        .unwrap();
+        assert!(args.validate_poll_selectors().is_err());
+        let args = IggyBenchArgs::try_parse_from([
+            "iggy-bench",
+            "--latency-kind",
+            "poll",
+            "pinned-producer",
+            "tcp",
+        ])
+        .unwrap();
+        assert!(args.validate_poll_selectors().is_err());
+    }
+
+    #[test]
+    fn poll_latency_override_preserves_read_amplification() {
+        let args = IggyBenchArgs::try_parse_from([
+            "iggy-bench",
+            "--latency-kind",
+            "poll",
+            "balanced-producer-and-consumer-group",
+            "--read-amplification",
+            "1.25",
+            "tcp",
+        ])
+        .unwrap();
+        assert_eq!(args.read_amplification(), Some(1.25));
+    }
+}

--- a/core/bench/src/benchmarks/common.rs
+++ b/core/bench/src/benchmarks/common.rs
@@ -15,6 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::{future::Future, sync::Arc};
+
+use bench_report::individual_metrics::BenchmarkIndividualMetrics;
+use iggy::prelude::*;
+use tracing::{error, info};
+
 use super::{CONSUMER_GROUP_BASE_ID, CONSUMER_GROUP_NAME_PREFIX};
 use crate::utils::ClientFactory;
 use crate::{
@@ -23,13 +29,9 @@ use crate::{
         producer::typed_benchmark_producer::TypedBenchmarkProducer,
         producing_consumer::typed_benchmark_producing_consumer::TypedBenchmarkProducingConsumer,
     },
-    args::common::IggyBenchArgs,
+    args::{common::IggyBenchArgs, polling::LatencyKind},
     utils::finish_condition::{BenchmarkFinishCondition, BenchmarkFinishConditionMode},
 };
-use bench_report::{benchmark_kind::BenchmarkKind, individual_metrics::BenchmarkIndividualMetrics};
-use iggy::prelude::*;
-use std::{future::Future, sync::Arc};
-use tracing::{error, info};
 
 pub async fn create_consumer(
     client: &IggyClient,
@@ -131,6 +133,7 @@ pub fn build_producer_futures(
             let stream_idx = 1 + ((producer_id - 1) % streams);
             let stream_id = format!("bench-stream-{stream_idx}");
 
+            let poll_artifacts = args.poll_artifacts.clone();
             async move {
                 let producer = TypedBenchmarkProducer::new(
                     use_high_level_api,
@@ -146,6 +149,7 @@ pub fn build_producer_futures(
                     sampling_time,
                     moving_average_window,
                     rate_limit,
+                    poll_artifacts,
                     pretty,
                 );
                 producer.run().await
@@ -167,25 +171,17 @@ pub fn build_consumer_futures(
     let moving_average_window = args.moving_average_window();
     let kind = args.kind();
     let pretty = args.pretty;
-    let polling_kind = if cg_count > 0 {
-        PollingKind::Next
-    } else {
-        PollingKind::Offset
-    };
-    let origin_timestamp_latency_calculation = match args.kind() {
-        BenchmarkKind::PinnedConsumer | BenchmarkKind::BalancedConsumerGroup => false,
-        BenchmarkKind::PinnedProducerAndConsumer
-        | BenchmarkKind::BalancedProducerAndConsumerGroup => true,
-        _ => unreachable!(),
-    };
+    let polling_kind = args.resolved_polling_kind().into();
+    let origin_timestamp_latency_calculation =
+        args.resolved_latency_kind() == LatencyKind::OriginTimestamp;
+    let poll_artifacts = args.poll_artifacts.clone();
 
     let global_finish_condition =
         BenchmarkFinishCondition::new(args, BenchmarkFinishConditionMode::Shared);
-    // When measuring true E2E latency, apply read_amplification multiplier to consumer rate
-    // to ensure they can keep up with producers and not inflate latency due to queue buildup
+    // Keep consumer capacity independent of the selected latency measurement.
     let read_amplification = args.read_amplification().unwrap_or(1.0);
     let rate_limit = rate_limit_per_actor(args.rate_limit(), actors).map(|rl| {
-        if origin_timestamp_latency_calculation {
+        if args.read_amplification().is_some() {
             #[allow(
                 clippy::cast_sign_loss,
                 clippy::cast_possible_truncation,
@@ -221,6 +217,7 @@ pub fn build_consumer_futures(
                 None
             };
 
+            let poll_artifacts = poll_artifacts.clone();
             async move {
                 let consumer = TypedBenchmarkConsumer::new(
                     use_high_level_api,
@@ -237,6 +234,7 @@ pub fn build_consumer_futures(
                     polling_kind,
                     rate_limit,
                     origin_timestamp_latency_calculation,
+                    poll_artifacts,
                     pretty,
                 );
                 consumer.run().await
@@ -256,7 +254,7 @@ pub fn build_producing_consumers_futures(
     let warmup_time = args.warmup_time();
     let messages_per_batch = args.messages_per_batch();
     let message_size = args.message_size();
-    let polling_kind = PollingKind::Offset;
+    let polling_kind = args.resolved_polling_kind().into();
 
     (1..=producing_consumers)
         .map(|actor_id| {
@@ -273,7 +271,8 @@ pub fn build_producing_consumers_futures(
                 &args,
                 BenchmarkFinishConditionMode::PerProducingConsumer,
             );
-            let origin_timestamp_latency_calculation = true;
+            let origin_timestamp_latency_calculation =
+                args.resolved_latency_kind() == LatencyKind::OriginTimestamp;
             let use_high_level_api = args.high_level_api();
             let rate_limit = rate_limit_per_actor(args.rate_limit(), producing_consumers);
 
@@ -300,6 +299,7 @@ pub fn build_producing_consumers_futures(
                     rate_limit,
                     polling_kind,
                     origin_timestamp_latency_calculation,
+                    args_clone.poll_artifacts.clone(),
                     args_clone.pretty,
                 );
                 actor.run().await
@@ -322,7 +322,7 @@ pub fn build_producing_consumer_groups_futures(
     let messages_per_batch = args.messages_per_batch();
     let message_size = args.message_size();
     let start_consumer_group_id = CONSUMER_GROUP_BASE_ID;
-    let polling_kind = PollingKind::Next;
+    let polling_kind = args.resolved_polling_kind().into();
     let use_high_level_api = args.high_level_api();
     let shared_send_finish_condition =
         BenchmarkFinishCondition::new(&args, BenchmarkFinishConditionMode::SharedHalf);
@@ -364,7 +364,8 @@ pub fn build_producing_consumer_groups_futures(
             } else {
                 None
             };
-            let origin_timestamp_latency_calculation = true;
+            let origin_timestamp_latency_calculation =
+                args.resolved_latency_kind() == LatencyKind::OriginTimestamp;
 
             async move {
                 let actor_type = match (should_produce, should_consume) {
@@ -403,6 +404,7 @@ pub fn build_producing_consumer_groups_futures(
                     rate_limit,
                     polling_kind,
                     origin_timestamp_latency_calculation,
+                    args_clone.poll_artifacts.clone(),
                     args_clone.pretty,
                 );
 

--- a/core/bench/src/main.rs
+++ b/core/bench/src/main.rs
@@ -20,17 +20,22 @@ mod analytics;
 mod args;
 mod benchmarks;
 mod plot;
+mod poll_artifacts;
 mod runner;
 mod utils;
 
-use crate::{args::common::IggyBenchArgs, runner::BenchmarkRunner};
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
 use clap::Parser;
 use figlet_rs::FIGlet;
 use iggy::prelude::IggyError;
-use std::fs;
-use std::path::Path;
 use tracing::{error, info};
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+use crate::{args::common::IggyBenchArgs, runner::BenchmarkRunner};
+use poll_artifacts::{PollArtifacts, RunStatus};
 use utils::cpu_name::append_cpu_name_lowercase;
 
 /// Which SDK framing this binary speaks, printed in the always-on banner so a
@@ -83,30 +88,34 @@ async fn main() -> Result<(), IggyError> {
             .init();
     }
 
-    let benchmark_runner = BenchmarkRunner::new(args);
-
-    info!("Starting the benchmarks...");
-    let ctrl_c = tokio::signal::ctrl_c();
-    let benchmark_future = benchmark_runner.run();
-
-    tokio::select! {
-        _ = ctrl_c => {
-            info!("Received Ctrl-C, exiting...");
-            // Clean up unfinished benchmark directory on manual interruption
-            if let Some(ref benchmark_dir) = benchmark_dir {
-                info!("Cleaning up unfinished benchmark directory...");
-                if let Err(e) = std::fs::remove_dir_all(benchmark_dir) {
-                    error!("Failed to clean up benchmark directory: {}", e);
-                }
-            }
-        }
-        result = benchmark_future => {
-            if let Err(e) = result {
-                error!("Benchmark failed with error: {:?}", e);
-                return Err(e);
-            }
-        }
+    let poll_artifacts = benchmark_dir
+        .as_ref()
+        .map(|_| Arc::new(PollArtifacts::new(&args)));
+    args.poll_artifacts = poll_artifacts.clone();
+    if let (Some(directory), Some(artifacts)) = (&benchmark_dir, &poll_artifacts) {
+        artifacts
+            .write(directory, RunStatus::Running)
+            .map_err(|error| {
+                error!("Failed to initialize poll artifacts: {error}");
+                IggyError::CannotWriteToFile
+            })?;
     }
-
-    Ok(())
+    let benchmark_runner = BenchmarkRunner::new(args);
+    info!("Starting the benchmarks...");
+    let result = benchmark_runner.run().await;
+    let status = match &result {
+        Ok(status) => *status,
+        Err(error) => {
+            error!("Benchmark failed with error: {error:?}");
+            RunStatus::Failed
+        }
+    };
+    if let (Some(directory), Some(artifacts)) = (&benchmark_dir, &poll_artifacts) {
+        artifacts.write(directory, status).map_err(|error| {
+            error!("Failed to write poll artifacts: {error}");
+            IggyError::CannotWriteToFile
+        })?;
+        info!("Preserved benchmark artifacts in {}", directory.display());
+    }
+    result.map(|_| ())
 }

--- a/core/bench/src/poll_artifacts.rs
+++ b/core/bench/src/poll_artifacts.rs
@@ -1,0 +1,576 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    fs::{self, File},
+    io::{self, BufWriter, Write},
+    path::Path,
+    sync::{Arc, Mutex, PoisonError},
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
+
+use iggy::prelude::IggyError;
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use crate::{
+    actors::BatchMetrics,
+    args::{common::IggyBenchArgs, polling::PollingMode},
+};
+
+const CSV_HEADER: &str = "actor_id,sequence,elapsed_us,poll_latency_us,origin_latency_us,partition_id,messages,payload_bytes,outcome,error_code";
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    Running,
+    Completed,
+    Failed,
+    Interrupted,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum PollOutcome {
+    Messages,
+    Empty,
+    Error,
+    Timeout,
+    Cancelled,
+}
+
+#[derive(Debug)]
+pub struct PollRecord {
+    elapsed_us: u64,
+    poll_latency_us: u64,
+    origin_latency_us: Option<u64>,
+    partition_id: Option<u32>,
+    messages: u32,
+    payload_bytes: u64,
+    outcome: PollOutcome,
+    error_code: Option<u32>,
+}
+
+#[derive(Debug)]
+pub struct PollArtifacts {
+    manifest: Value,
+    actors: Mutex<Vec<ActorPollRecords>>,
+    producers: Mutex<Vec<ProducerSamples>>,
+}
+
+#[derive(Debug)]
+struct ActorPollRecords {
+    actor_id: u32,
+    measurement_started_at_unix_us: u64,
+    records: Vec<PollRecord>,
+}
+
+#[derive(Debug)]
+pub struct ActorPollRecorder {
+    actor_id: u32,
+    artifacts: Arc<PollArtifacts>,
+    start: Instant,
+    measurement_started_at_unix_us: u64,
+    pending: Option<Instant>,
+    records: Vec<PollRecord>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ProducerSample {
+    elapsed_us: u64,
+    completed_batches: u64,
+    completed_messages: u64,
+    payload_bytes: u64,
+}
+
+#[derive(Debug)]
+struct ProducerSamples {
+    actor_id: u32,
+    measurement_started_at_unix_us: u64,
+    last_completion_us: u64,
+    samples: Vec<ProducerSample>,
+}
+
+pub struct ProducerRecorder {
+    artifacts: Arc<PollArtifacts>,
+    start: Instant,
+    actor: ProducerSamples,
+    latest: ProducerSample,
+}
+
+impl PollArtifacts {
+    pub fn new(args: &IggyBenchArgs) -> Self {
+        Self {
+            manifest: json!({
+                "schema_version": 1,
+                "benchmark_version": env!("CARGO_PKG_VERSION"),
+                "started_at": chrono::Utc::now().to_rfc3339(),
+                "benchmark_kind": args.kind(),
+                "transport": args.transport_command(),
+                "server_address": args.server_address(),
+                "high_level_api": args.high_level_api,
+                "requested_polling_kind": args.polling_kind,
+                "requested_latency_kind": args.latency_kind,
+                "resolved_polling_kind": args.resolved_polling_kind(),
+                "resolved_latency_kind": if args.high_level_api {
+                    json!("sdk-batch")
+                } else {
+                    json!(args.resolved_latency_kind())
+                },
+                "auto_commit": args.resolved_polling_kind() == PollingMode::Next,
+                "raw_poll_capture": !args.high_level_api,
+                "raw_poll_file": "polls.csv",
+                "latency_unit": "microseconds",
+                "elapsed_time_origin": "actor measurement start, after warmup",
+                "measurement_boundary": "SDK poll call, including SDK retries and transport",
+                "message_size": args.message_size().to_string(),
+                "messages_per_batch": args.messages_per_batch().to_string(),
+                "message_batches": args.message_batches.map(std::num::NonZeroU32::get),
+                "total_data_bytes": args.total_data.map(|size| size.as_bytes_u64()),
+                "rate_limit_bytes_per_second": args.rate_limit.map(|size| size.as_bytes_u64()),
+                "read_amplification": args.read_amplification(),
+                "warmup_time": args.warmup_time.to_string(),
+                "producers": args.producers(),
+                "consumers": args.consumers(),
+                "streams": args.streams(),
+                "partitions": args.number_of_partitions(),
+                "consumer_groups": args.number_of_consumer_groups(),
+                "reuse_streams": args.reuse_streams,
+                "enforce_fsync": args.enforce_fsync,
+                "messages_required_to_save": args.messages_required_to_save.map(std::num::NonZeroU32::get),
+                "gitref_label": args.gitref(),
+                "identifier": args.identifier(),
+                "remark": args.remark(),
+            }),
+            actors: Mutex::new(Vec::new()),
+            producers: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn write(&self, directory: &Path, status: RunStatus) -> io::Result<()> {
+        fs::create_dir_all(directory)?;
+        let actors = self.actors.lock().unwrap_or_else(PoisonError::into_inner);
+        let mut output = BufWriter::new(File::create(directory.join("polls.csv"))?);
+        writeln!(output, "{CSV_HEADER}")?;
+        let mut counts = [0_u64; 5];
+        let mut actor_counts = Vec::with_capacity(actors.len());
+        for actor in actors.iter() {
+            let actor_id = actor.actor_id;
+            let records = &actor.records;
+            let mut actor_outcomes = [0_u64; 5];
+            for (sequence, record) in records.iter().enumerate() {
+                write_record(&mut output, actor_id, sequence + 1, record)?;
+                let index = match record.outcome {
+                    PollOutcome::Messages => 0,
+                    PollOutcome::Empty => 1,
+                    PollOutcome::Error => 2,
+                    PollOutcome::Timeout => 3,
+                    PollOutcome::Cancelled => 4,
+                };
+                counts[index] += 1;
+                actor_outcomes[index] += 1;
+            }
+            actor_counts.push(json!({
+                "actor_id": actor_id,
+                "measurement_started_at_unix_us": actor.measurement_started_at_unix_us,
+                "measurement_duration_us": records.iter().map(|record| record.elapsed_us).max().unwrap_or(0),
+                "outcomes": outcome_counts(actor_outcomes),
+            }));
+        }
+        drop(actors);
+        output.flush()?;
+        let mut manifest = self.manifest.clone();
+        manifest["status"] = json!(status);
+        manifest["updated_at"] = json!(chrono::Utc::now().to_rfc3339());
+        manifest["poll_outcomes"] = outcome_counts(counts);
+        manifest["actors"] = json!(actor_counts);
+        manifest["producers"] = self.write_producer_samples(directory)?;
+        manifest["producer_samples_file"] = json!("producer-samples.csv");
+        let mut output = BufWriter::new(File::create(directory.join("run-manifest.json"))?);
+        serde_json::to_writer_pretty(&mut output, &manifest)?;
+        writeln!(output)?;
+        output.flush()
+    }
+
+    fn write_producer_samples(&self, directory: &Path) -> io::Result<Value> {
+        let producers = self
+            .producers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let mut output = BufWriter::new(File::create(directory.join("producer-samples.csv"))?);
+        writeln!(
+            output,
+            "actor_id,elapsed_us,completed_batches,completed_messages,payload_bytes"
+        )?;
+        let mut summaries = Vec::with_capacity(producers.len());
+        for producer in producers.iter() {
+            for sample in &producer.samples {
+                writeln!(
+                    output,
+                    "{},{},{},{},{}",
+                    producer.actor_id,
+                    sample.elapsed_us,
+                    sample.completed_batches,
+                    sample.completed_messages,
+                    sample.payload_bytes
+                )?;
+            }
+            let last = producer.samples.last().copied().unwrap_or_default();
+            summaries.push(json!({
+                "actor_id": producer.actor_id,
+                "measurement_started_at_unix_us": producer.measurement_started_at_unix_us,
+                "measurement_duration_us": last.elapsed_us,
+                "last_completion_us": producer.last_completion_us,
+                "completed_batches": last.completed_batches,
+                "completed_messages": last.completed_messages,
+                "payload_bytes": last.payload_bytes,
+            }));
+        }
+        drop(producers);
+        output.flush()?;
+        Ok(json!(summaries))
+    }
+}
+
+impl ProducerRecorder {
+    pub fn new(actor_id: u32, artifacts: Arc<PollArtifacts>) -> Self {
+        Self {
+            artifacts,
+            start: Instant::now(),
+            actor: ProducerSamples {
+                actor_id,
+                measurement_started_at_unix_us: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_or(0, micros),
+                last_completion_us: 0,
+                samples: vec![ProducerSample::default()],
+            },
+            latest: ProducerSample::default(),
+        }
+    }
+
+    pub fn record_batch(&mut self, batch: &BatchMetrics) {
+        self.latest.elapsed_us = micros(self.start.elapsed());
+        self.latest.completed_batches += 1;
+        self.latest.completed_messages += u64::from(batch.messages);
+        self.latest.payload_bytes += batch.user_data_bytes;
+        self.actor.last_completion_us = self.latest.elapsed_us;
+        if self.latest.elapsed_us.saturating_sub(
+            self.actor
+                .samples
+                .last()
+                .map_or(0, |sample| sample.elapsed_us),
+        ) >= 100_000
+        {
+            self.actor.samples.push(self.latest);
+        }
+    }
+}
+
+impl Drop for ProducerRecorder {
+    fn drop(&mut self) {
+        self.latest.elapsed_us = micros(self.start.elapsed());
+        self.actor.samples.push(self.latest);
+        self.artifacts
+            .producers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(ProducerSamples {
+                actor_id: self.actor.actor_id,
+                measurement_started_at_unix_us: self.actor.measurement_started_at_unix_us,
+                last_completion_us: self.actor.last_completion_us,
+                samples: std::mem::take(&mut self.actor.samples),
+            });
+    }
+}
+
+impl ActorPollRecorder {
+    pub fn new(actor_id: u32, artifacts: Arc<PollArtifacts>, capacity: usize) -> Self {
+        Self {
+            actor_id,
+            artifacts,
+            start: Instant::now(),
+            measurement_started_at_unix_us: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, micros),
+            pending: None,
+            records: Vec::with_capacity(capacity.min(1_000_000)),
+        }
+    }
+
+    pub fn begin_poll(&mut self) {
+        self.pending = Some(Instant::now());
+    }
+
+    pub fn complete_poll(
+        &mut self,
+        poll_latency_us: u64,
+        origin_latency_us: Option<u64>,
+        partition_id: u32,
+        messages: u32,
+        payload_bytes: u64,
+    ) {
+        self.pending = None;
+        self.records.push(PollRecord {
+            elapsed_us: micros(self.start.elapsed()),
+            poll_latency_us,
+            origin_latency_us,
+            partition_id: Some(partition_id),
+            messages,
+            payload_bytes,
+            outcome: if messages == 0 {
+                PollOutcome::Empty
+            } else {
+                PollOutcome::Messages
+            },
+            error_code: None,
+        });
+    }
+
+    pub fn fail_poll(&mut self, error: &IggyError, poll_latency_us: u64) {
+        self.pending = None;
+        self.records.push(PollRecord {
+            elapsed_us: micros(self.start.elapsed()),
+            poll_latency_us,
+            origin_latency_us: None,
+            partition_id: None,
+            messages: 0,
+            payload_bytes: 0,
+            outcome: if matches!(
+                error,
+                IggyError::TaskTimeout | IggyError::BackgroundSendTimeout
+            ) {
+                PollOutcome::Timeout
+            } else {
+                PollOutcome::Error
+            },
+            error_code: Some(error.as_code()),
+        });
+    }
+}
+
+impl Drop for ActorPollRecorder {
+    fn drop(&mut self) {
+        if let Some(start) = self.pending.take() {
+            self.records.push(PollRecord {
+                elapsed_us: micros(self.start.elapsed()),
+                poll_latency_us: micros(start.elapsed()),
+                origin_latency_us: None,
+                partition_id: None,
+                messages: 0,
+                payload_bytes: 0,
+                outcome: PollOutcome::Cancelled,
+                error_code: None,
+            });
+        }
+        self.artifacts
+            .actors
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(ActorPollRecords {
+                actor_id: self.actor_id,
+                measurement_started_at_unix_us: self.measurement_started_at_unix_us,
+                records: std::mem::take(&mut self.records),
+            });
+    }
+}
+
+fn write_record(
+    output: &mut impl Write,
+    actor_id: u32,
+    sequence: usize,
+    record: &PollRecord,
+) -> io::Result<()> {
+    let outcome = match record.outcome {
+        PollOutcome::Messages => "messages",
+        PollOutcome::Empty => "empty",
+        PollOutcome::Error => "error",
+        PollOutcome::Timeout => "timeout",
+        PollOutcome::Cancelled => "cancelled",
+    };
+    writeln!(
+        output,
+        "{actor_id},{sequence},{},{},{},{},{},{},{outcome},{}",
+        record.elapsed_us,
+        record.poll_latency_us,
+        record
+            .origin_latency_us
+            .map_or_else(String::new, |value| value.to_string()),
+        record
+            .partition_id
+            .map_or_else(String::new, |value| value.to_string()),
+        record.messages,
+        record.payload_bytes,
+        record
+            .error_code
+            .map_or_else(String::new, |value| value.to_string())
+    )
+}
+
+fn outcome_counts(counts: [u64; 5]) -> Value {
+    json!({
+        "messages": counts[0], "empty": counts[1], "errors": counts[2],
+        "timeouts": counts[3], "cancelled": counts[4],
+    })
+}
+
+fn micros(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, future::pending, sync::Arc, time::Duration};
+
+    use tokio::{sync::oneshot, task::JoinSet};
+
+    use clap::Parser;
+    use iggy::prelude::IggyError;
+    use serde_json::Value;
+
+    use super::{ActorPollRecorder, PollArtifacts, ProducerRecorder, RunStatus};
+    use crate::actors::BatchMetrics;
+    use crate::args::common::IggyBenchArgs;
+
+    #[test]
+    fn raw_output_retains_outcomes_and_cancelled_poll() {
+        let args = IggyBenchArgs::try_parse_from([
+            "iggy-bench",
+            "--polling-kind",
+            "next",
+            "--latency-kind",
+            "poll",
+            "pinned-consumer",
+            "tcp",
+        ])
+        .unwrap();
+        let artifacts = Arc::new(PollArtifacts::new(&args));
+        let directory =
+            std::env::temp_dir().join(format!("iggy-poll-artifacts-{}", uuid::Uuid::new_v4()));
+        artifacts.write(&directory, RunStatus::Running).unwrap();
+        {
+            let mut recorder = ActorPollRecorder::new(7, artifacts.clone(), 5);
+            recorder.begin_poll();
+            recorder.complete_poll(12, Some(34), 0, 2, 128);
+            recorder.begin_poll();
+            recorder.complete_poll(5, None, 0, 0, 0);
+            recorder.begin_poll();
+            recorder.fail_poll(&IggyError::CannotReadFile, 8);
+            recorder.begin_poll();
+            recorder.fail_poll(&IggyError::TaskTimeout, 20);
+            recorder.begin_poll();
+        }
+        artifacts.write(&directory, RunStatus::Interrupted).unwrap();
+        let csv = fs::read_to_string(directory.join("polls.csv")).unwrap();
+        let rows: Vec<_> = csv.lines().collect();
+        assert_eq!(rows.len(), 6);
+        assert!(rows[1].contains(",12,34,0,2,128,messages,"));
+        assert!(rows[2].contains(",5,,0,0,0,empty,"));
+        assert!(rows[3].contains(",error,"));
+        assert!(rows[4].contains(",timeout,"));
+        assert!(rows[5].contains(",cancelled,"));
+        let manifest: Value =
+            serde_json::from_str(&fs::read_to_string(directory.join("run-manifest.json")).unwrap())
+                .unwrap();
+        assert_eq!(manifest["status"], "interrupted");
+        assert_eq!(manifest["resolved_polling_kind"], "next");
+        assert_eq!(manifest["resolved_latency_kind"], "poll");
+        assert_eq!(manifest["auto_commit"], true);
+        assert!(
+            manifest["actors"][0]["measurement_started_at_unix_us"]
+                .as_u64()
+                .unwrap()
+                > 0
+        );
+        assert!(manifest["actors"][0]["measurement_duration_us"].is_u64());
+        for key in ["messages", "empty", "errors", "timeouts", "cancelled"] {
+            assert_eq!(manifest["poll_outcomes"][key], 1);
+        }
+        assert!(manifest.get("password").is_none());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn actor_shutdown_preserves_samples_and_inflight_poll() {
+        let args = IggyBenchArgs::try_parse_from(["iggy-bench", "pinned-consumer", "tcp"]).unwrap();
+        let artifacts = Arc::new(PollArtifacts::new(&args));
+        let actor_artifacts = artifacts.clone();
+        let (ready_sender, ready_receiver) = oneshot::channel();
+        let mut actors = JoinSet::new();
+        actors.spawn(async move {
+            let mut recorder = ActorPollRecorder::new(3, actor_artifacts, 2);
+            recorder.begin_poll();
+            recorder.complete_poll(11, None, 0, 1, 64);
+            recorder.begin_poll();
+            ready_sender.send(()).unwrap();
+            pending::<()>().await;
+            drop(recorder);
+        });
+        ready_receiver.await.unwrap();
+        actors.shutdown().await;
+        let recorded = artifacts.actors.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].actor_id, 3);
+        assert_eq!(recorded[0].records.len(), 2);
+        assert!(matches!(
+            recorded[0].records[0].outcome,
+            super::PollOutcome::Messages
+        ));
+        assert!(matches!(
+            recorded[0].records[1].outcome,
+            super::PollOutcome::Cancelled
+        ));
+        drop(recorded);
+    }
+
+    #[test]
+    fn producer_samples_survive_interruption_with_completed_counters() {
+        let args = IggyBenchArgs::try_parse_from(["iggy-bench", "pinned-producer", "tcp"]).unwrap();
+        let artifacts = Arc::new(PollArtifacts::new(&args));
+        {
+            let mut recorder = ProducerRecorder::new(2, artifacts.clone());
+            let batch = BatchMetrics {
+                messages: 3,
+                user_data_bytes: 192,
+                total_bytes: 288,
+                latency: Duration::from_micros(50),
+            };
+            recorder.record_batch(&batch);
+            recorder.record_batch(&batch);
+        }
+        let directory =
+            std::env::temp_dir().join(format!("iggy-producer-artifacts-{}", uuid::Uuid::new_v4()));
+        artifacts.write(&directory, RunStatus::Interrupted).unwrap();
+        let manifest: Value =
+            serde_json::from_str(&fs::read_to_string(directory.join("run-manifest.json")).unwrap())
+                .unwrap();
+        assert_eq!(manifest["status"], "interrupted");
+        let producer = &manifest["producers"][0];
+        assert_eq!(producer["actor_id"], 2);
+        assert_eq!(producer["completed_batches"], 2);
+        assert_eq!(producer["completed_messages"], 6);
+        assert_eq!(producer["payload_bytes"], 384);
+        assert!(producer["measurement_started_at_unix_us"].as_u64().unwrap() > 0);
+        assert!(
+            producer["measurement_duration_us"].as_u64().unwrap()
+                >= producer["last_completion_us"].as_u64().unwrap()
+        );
+        let samples = fs::read_to_string(directory.join("producer-samples.csv")).unwrap();
+        assert!(samples.lines().nth(1).unwrap().ends_with(",0,0,0,0"));
+        assert!(samples.lines().last().unwrap().ends_with(",2,6,384"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/core/bench/src/runner.rs
+++ b/core/bench/src/runner.rs
@@ -15,18 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bench_report::{hardware::BenchmarkHardware, individual_metrics::BenchmarkIndividualMetrics};
+use iggy::prelude::IggyError;
+use tokio::time::sleep;
+use tracing::{error, info};
+
 use crate::analytics::report_builder::{BenchmarkReportBuilder, cluster_suffix};
 use crate::args::common::IggyBenchArgs;
 use crate::benchmarks::benchmark::Benchmarkable;
 use crate::plot::{ChartType, plot_chart};
+use crate::poll_artifacts::RunStatus;
 use crate::utils::cpu_name::append_cpu_name_lowercase;
-use crate::utils::{collect_server_logs_and_save_to_file, params_from_args_and_metrics};
-use bench_report::hardware::BenchmarkHardware;
-use iggy::prelude::IggyError;
-use std::path::Path;
-use std::time::Duration;
-use tokio::time::sleep;
-use tracing::{error, info};
+use crate::utils::{
+    ClientFactory, collect_server_logs_and_save_to_file, params_from_args_and_metrics,
+};
 
 pub struct BenchmarkRunner {
     args: Option<IggyBenchArgs>,
@@ -38,7 +44,7 @@ impl BenchmarkRunner {
     }
 
     #[allow(clippy::cognitive_complexity)]
-    pub async fn run(mut self) -> Result<(), IggyError> {
+    pub async fn run(mut self) -> Result<RunStatus, IggyError> {
         let args = self.args.take().unwrap();
         let pretty = args.pretty;
         let should_open_charts = args.open_charts();
@@ -49,32 +55,80 @@ impl BenchmarkRunner {
 
         let mut benchmark: Box<dyn Benchmarkable> = args.into();
         benchmark.print_info();
-        let mut join_handles = benchmark.run().await?;
+        let interrupt = tokio::signal::ctrl_c();
+        tokio::pin!(interrupt);
+        let mut join_handles = tokio::select! {
+            result = benchmark.run() => result?,
+            _ = &mut interrupt => return Ok(RunStatus::Interrupted),
+        };
 
         let mut individual_metrics = Vec::new();
 
-        while let Some(individual_metric) = join_handles.join_next().await {
-            let individual_metric = individual_metric.expect("Failed to join actor!");
+        loop {
+            let joined = tokio::select! {
+                result = join_handles.join_next() => result,
+                _ = &mut interrupt => {
+                    info!("Received Ctrl-C, stopping actors and preserving artifacts...");
+                    join_handles.shutdown().await;
+                    return Ok(RunStatus::Interrupted);
+                }
+            };
+            let Some(individual_metric) = joined else {
+                break;
+            };
             match individual_metric {
-                Ok(individual_metric) => individual_metrics.push(individual_metric),
-                Err(e) => return Err(e),
+                Ok(Ok(individual_metric)) => individual_metrics.push(individual_metric),
+                Ok(Err(error)) => {
+                    join_handles.shutdown().await;
+                    return Err(error);
+                }
+                Err(error) => {
+                    error!("Benchmark actor failed: {error}");
+                    join_handles.shutdown().await;
+                    return Err(IggyError::Error);
+                }
             }
         }
 
         info!("All actors joined!");
 
-        let client_factory = benchmark.client_factory();
+        if let (Some(artifacts), Some(output_dir)) = (
+            &benchmark.args().poll_artifacts,
+            benchmark.args().output_dir(),
+        ) {
+            let mut dir_name = benchmark.args().generate_dir_name();
+            append_cpu_name_lowercase(&mut dir_name);
+            artifacts
+                .write(&Path::new(&output_dir).join(dir_name), RunStatus::Running)
+                .map_err(|error| {
+                    error!("Failed to write poll artifacts: {error}");
+                    IggyError::CannotWriteToFile
+                })?;
+        }
+        tokio::select! {
+            result = Self::report(benchmark.args(), benchmark.client_factory(), individual_metrics, pretty, should_open_charts) => result?,
+            _ = &mut interrupt => return Ok(RunStatus::Interrupted),
+        }
+        Ok(RunStatus::Completed)
+    }
+
+    async fn report(
+        args: &IggyBenchArgs,
+        client_factory: &Arc<dyn ClientFactory>,
+        individual_metrics: Vec<BenchmarkIndividualMetrics>,
+        pretty: bool,
+        should_open_charts: bool,
+    ) -> Result<(), IggyError> {
         let admin_client = client_factory.create_authenticated_client().await?;
 
-        let hardware =
-            BenchmarkHardware::get_system_info_with_identifier(benchmark.args().identifier());
-        let params = params_from_args_and_metrics(benchmark.args(), &individual_metrics);
+        let hardware = BenchmarkHardware::get_system_info_with_identifier(args.identifier());
+        let params = params_from_args_and_metrics(args, &individual_metrics);
 
         let report = BenchmarkReportBuilder::build(
             hardware,
             params,
             individual_metrics,
-            benchmark.args().moving_average_window(),
+            args.moving_average_window(),
             &admin_client,
         )
         .await;
@@ -84,9 +138,9 @@ impl BenchmarkRunner {
 
         report.print_summary(pretty);
 
-        if let Some(output_dir) = benchmark.args().output_dir() {
+        if let Some(output_dir) = args.output_dir() {
             // Generate the full output path using the directory name generator
-            let mut dir_name = benchmark.args().generate_dir_name();
+            let mut dir_name = args.generate_dir_name();
             append_cpu_name_lowercase(&mut dir_name);
             // Cluster runs share params (and thus the dir name) with single-node
             // runs; suffix keeps them from overwriting each other's results.

--- a/core/bench/src/utils/mod.rs
+++ b/core/bench/src/utils/mod.rs
@@ -15,13 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::{fs, path::Path};
+
 use bench_report::{
     benchmark_kind::BenchmarkKind, individual_metrics::BenchmarkIndividualMetrics,
     numeric_parameter::BenchmarkNumericParameter, params::BenchmarkParams,
     transport::BenchmarkTransport,
 };
 use iggy::prelude::*;
-use std::{fs, path::Path};
 use tracing::{error, info};
 
 use crate::args::{
@@ -140,7 +141,11 @@ pub fn params_from_args_and_metrics(
         consumer_groups.to_string(),
     ];
 
-    let params_identifier = params_identifier.join("_");
+    let params_identifier = format!(
+        "{}{}",
+        params_identifier.join("_"),
+        args.poll_selector_suffix()
+    );
 
     BenchmarkParams {
         benchmark_kind,
@@ -172,6 +177,12 @@ fn recreate_bench_command(args: &IggyBenchArgs) -> String {
     parts.push("iggy-bench".to_string());
 
     add_basic_arguments(&mut parts, args);
+    if let Some(polling) = args.polling_kind {
+        parts.push(format!("--polling-kind {polling}"));
+    }
+    if let Some(latency) = args.latency_kind {
+        parts.push(format!("--latency-kind {latency}"));
+    }
     add_benchmark_kind_arguments(&mut parts, args);
     add_infrastructure_arguments(&mut parts, args);
     add_output_arguments(&mut parts, args);

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -1,9 +1,9 @@
 # Poll completion experiments
 
-`poll_completion.py` compares the current poll path with completion owned by the
-partition. It runs one consumer against one shard over TCP, retains raw poll
-observations, and compares independent pairs of complete runs. It does not test
-the purge correctness contract; run the regression tests separately.
+`poll_completion.py` compares polling performance between two server builds. It
+runs one consumer against one shard over TCP, retains raw poll observations, and
+compares independent pairs of complete runs. Run correctness regression tests
+separately from these measurements.
 
 ## Build and environment
 
@@ -22,12 +22,15 @@ rust@sha256:82150a52ec202c1b14d7817e14516c392bb7f5cfebd88f1ed531cb37ebd39922
 Build dependencies include `libhwloc-dev` and `libudev-dev`; the runner needs Python 3
 and `taskset`. Put sources used for builds, binaries, results, and fixture data in a
 Docker named volume. A bind mount of the repository is useful for copying source,
-but keep the measured fixture on the volume. Example container setup from the repo:
+but keep the measured fixture on the volume. Set `POLL_SECCOMP_PROFILE` to the
+absolute path of a seccomp profile for your Docker environment that permits
+`io_uring_setup`, `io_uring_enter`, and `io_uring_register`. Example container setup
+from the repository:
 
 ```sh
 docker volume create iggy-poll-lab
 docker run --name iggy-poll-lab --cpuset-cpus=0-3 --memory=8g \
-  --security-opt "seccomp=$PWD/performance_results/owner-poll-20260909/environment/io-uring-seccomp.json" \
+  --security-opt "seccomp=${POLL_SECCOMP_PROFILE:?Set the path to your io_uring seccomp profile}" \
   --mount type=volume,source=iggy-poll-lab,target=/work \
   --mount "type=bind,source=$PWD,target=/source,readonly" \
   -it rust@sha256:82150a52ec202c1b14d7817e14516c392bb7f5cfebd88f1ed531cb37ebd39922 bash
@@ -36,9 +39,9 @@ docker run --name iggy-poll-lab --cpuset-cpus=0-3 --memory=8g \
 Retain the actual seccomp profile with environment records. This profile permits the
 required `io_uring` operations; replacing it with unrestricted seccomp changes the
 recorded setup. The runner pins the Linux server to guest CPU 0 and clients to CPUs
-1 and 2. The container permits CPUs 0 through 3 and has an 8 GiB ceiling. In this
-session Docker's VM has 10 guest CPUs and approximately 8 GiB shared memory; the
-container limit does not reserve that memory or dedicate host CPUs to the experiment.
+1 and 2. The container permits CPUs 0 through 3 and has an 8 GiB ceiling. Record the
+Docker VM's CPU count and available memory. The container limit does not reserve
+that memory or dedicate host CPUs to the experiment.
 
 For macOS, use native builds and a separate local results directory. The runner
 uses one shard and two Tokio worker threads without CPU affinity. It reads process
@@ -153,11 +156,13 @@ the analysis does not silently impose a new threshold for this guardrail.
 
 ## Diagnostics and retained evidence
 
-Build a separate diagnostic server with `--features poll-diagnostics`, and run it
-with `RUST_LOG=iggy.shard.poll_diagnostics=debug`. Logs identify resident and disk
-dispatch and the time disk completion waited for the shard. Use this to confirm the
-mechanism and fixture routing. Disable the feature and diagnostic logging for the
-performance comparison so tracing does not become part of the measured cost.
+Verify fixture routing with the diagnostics available in each server revision.
+When a revision provides the `poll-diagnostics` feature, build a separate diagnostic
+server with that feature and run it with `RUST_LOG=iggy.shard.poll_diagnostics=debug`.
+Those logs identify resident and disk dispatch and the time disk completion waited
+for the shard. The runner does not require this optional server feature. Disable
+diagnostic features and logging for the performance comparison so tracing does not
+become part of the measured cost.
 
 Each run retains commands, binary hashes, server logs, `polls.csv`,
 `run-manifest.json`, producer samples, process samples, and a summary. CPU counters

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -1,0 +1,175 @@
+# Poll completion experiments
+
+`poll_completion.py` compares the current poll path with completion owned by the
+partition. It runs one consumer against one shard over TCP, retains raw poll
+observations, and compares independent pairs of complete runs. It does not test
+the purge correctness contract; run the regression tests separately.
+
+## Build and environment
+
+Build baseline and candidate servers with the same Rust 1.98.0 toolchain, lockfile,
+release profile, and features. Record source revisions and any compatibility patches.
+Build one `iggy-bench` binary and one `iggy` CLI binary from the harness revision for
+each platform. Reuse those exact client binaries against both servers. The runner
+records binary hashes; keep Linux and native macOS results and comparisons separate.
+
+The Linux experiment uses this pinned image:
+
+```text
+rust@sha256:82150a52ec202c1b14d7817e14516c392bb7f5cfebd88f1ed531cb37ebd39922
+```
+
+Build dependencies include `libhwloc-dev` and `libudev-dev`; the runner needs Python 3
+and `taskset`. Put sources used for builds, binaries, results, and fixture data in a
+Docker named volume. A bind mount of the repository is useful for copying source,
+but keep the measured fixture on the volume. Example container setup from the repo:
+
+```sh
+docker volume create iggy-poll-lab
+docker run --name iggy-poll-lab --cpuset-cpus=0-3 --memory=8g \
+  --security-opt "seccomp=$PWD/performance_results/owner-poll-20260909/environment/io-uring-seccomp.json" \
+  --mount type=volume,source=iggy-poll-lab,target=/work \
+  --mount "type=bind,source=$PWD,target=/source,readonly" \
+  -it rust@sha256:82150a52ec202c1b14d7817e14516c392bb7f5cfebd88f1ed531cb37ebd39922 bash
+```
+
+Retain the actual seccomp profile with environment records. This profile permits the
+required `io_uring` operations; replacing it with unrestricted seccomp changes the
+recorded setup. The runner pins the Linux server to guest CPU 0 and clients to CPUs
+1 and 2. The container permits CPUs 0 through 3 and has an 8 GiB ceiling. In this
+session Docker's VM has 10 guest CPUs and approximately 8 GiB shared memory; the
+container limit does not reserve that memory or dedicate host CPUs to the experiment.
+
+For macOS, use native builds and a separate local results directory. The runner
+uses one shard and two Tokio worker threads without CPU affinity. It reads process
+CPU and RSS through `libproc`; Linux uses `/proc`. Native macOS exercises its native
+I/O backend, so its results are not measurements of Linux `io_uring`.
+
+## Workloads and pilots
+
+| Case | Messages per poll | Polling | Additional work |
+| --- | ---: | --- | --- |
+| `resident` | 1 | Next | Journal remains resident |
+| `disk-offset` | 1 | Offset | No automatic commit |
+| `disk-next` | 1 | Next | Automatic commit |
+| `disk-batch` | 100 | Next | Automatic commit |
+| `disk-group` | 100 | Next | One consumer group |
+| `disk-writes` | 100 | Next | Concurrent producer at a fixed target rate |
+| `disk-fsync` | 100 | Next | Concurrent producer with fsync enforced |
+
+Every message has a 256 byte payload. The runner warms the path on a separate
+fixture, deletes it, and creates the measured fixture. The benchmark's own warmup
+is disabled so it does not consume measured messages. Disk cases flush each produced batch through the topic's count threshold of one.
+The server stays running, retaining the read indexes built during preload;
+the OS file cache may remain hot. These cases establish use of the disk read
+path, not physical storage latency. Verify routing with a separate diagnostic run.
+
+Use absolute binary and result paths because child processes run from a fixture
+directory. For example, inside the Linux container:
+
+```sh
+POLL_BIN_DIR=/work/bin/linux
+POLL_RESULTS=/work/results/linux
+mkdir -p "$POLL_RESULTS"
+python3 /work/source/scripts/benchmarks/poll_completion.py run \
+  --server "$POLL_BIN_DIR/baseline-server" \
+  --client "$POLL_BIN_DIR/iggy-bench" --cli "$POLL_BIN_DIR/iggy" \
+  --case disk-next --polls 10000 --label baseline \
+  --output "$POLL_RESULTS/pilot-disk-next"
+```
+
+The example poll count is a starting point, not a calibrated duration. Use pilots
+to check completion counts, empty responses, runtime, cache routing, and resource
+headroom. Choose enough work to resolve the effects of interest and make the 50 ms
+CPU sampling and 100 ms producer sampling useful. Repeat the baseline against itself
+with the paired procedure below to estimate the noise floor before interpreting
+small changes. Keep builds and unrelated workloads out of measured runs.
+
+Calibrate the baseline producer separately for both background cases:
+
+```sh
+python3 /work/source/scripts/benchmarks/poll_completion.py run \
+  --server "$POLL_BIN_DIR/baseline-server" \
+  --client "$POLL_BIN_DIR/iggy-bench" --cli "$POLL_BIN_DIR/iggy" \
+  --case disk-writes --calibrate-producer --polls 10000 --label baseline \
+  --output "$POLL_RESULTS/calibration-disk-writes"
+```
+
+Repeat with `disk-fsync`. Choose and record the target rate from those observations;
+use the same target for both versions within each case. An individual mixed pilot
+also requires `--background-rate` in payload bytes per second.
+
+## Freeze and compare
+
+Freeze one workload JSON file per platform after the pilots. Keys are case names;
+each value has `polls` and, for background cases, `background_rate`. This is a minimal
+example for two cases, not the complete calibrated workload:
+
+```json
+{
+  "resident": {"polls": 10000},
+  "disk-next": {"polls": 10000}
+}
+```
+
+For the full suite include all seven case keys and their calibrated counts and
+rates. Keep the frozen file with results. `schedule` creates counterbalanced order
+within each case; `matrix` executes it serially and refuses existing run directories.
+For the two cases above:
+
+```sh
+python3 /work/source/scripts/benchmarks/poll_completion.py schedule \
+  --cases resident disk-next --pairs 10 --seed 20260909 \
+  --output "$POLL_RESULTS/schedule.json"
+python3 /work/source/scripts/benchmarks/poll_completion.py matrix \
+  --baseline "$POLL_BIN_DIR/baseline-server" \
+  --candidate "$POLL_BIN_DIR/candidate-server" \
+  --client "$POLL_BIN_DIR/iggy-bench" --cli "$POLL_BIN_DIR/iggy" \
+  --schedule "$POLL_RESULTS/schedule.json" --workload "$POLL_RESULTS/workload.json" \
+  --results "$POLL_RESULTS/runs"
+python3 /work/source/scripts/benchmarks/poll_completion.py compare \
+  --schedule "$POLL_RESULTS/schedule.json" --results "$POLL_RESULTS/runs" \
+  --output "$POLL_RESULTS/comparison.json"
+```
+
+For the baseline comparison with itself, pass the baseline server as both server
+arguments and use separate result directories. For macOS, repeat this workflow with
+native binaries, native paths, and its own frozen workload and schedule.
+
+The analysis pools successful nonempty raw polls before calculating each run's
+percentiles. It bootstraps independent paired run ratios, not individual polls.
+Throughput ratios are candidate divided by baseline, with higher values better;
+latency ratios use the same direction, with lower values better. The current
+comparison checks a throughput ratio of at least 0.97 and a p99 ratio of at most
+1.05 with one-sided 95% bootstrap bounds and at least ten pairs. Report absolute
+values, intervals, and the noise pilot alongside those conditional labels.
+
+Background throughput is a separate workload guardrail. Report the frozen target,
+achieved payload bytes per second for each version over the consumer window, and
+the candidate to baseline ratio. If changed producer work could explain a poll
+improvement, leave that conclusion inconclusive. Any numeric tolerance needs to be
+chosen before confirmation from baseline variation and the intended workload;
+the analysis does not silently impose a new threshold for this guardrail.
+
+## Diagnostics and retained evidence
+
+Build a separate diagnostic server with `--features poll-diagnostics`, and run it
+with `RUST_LOG=iggy.shard.poll_diagnostics=debug`. Logs identify resident and disk
+dispatch and the time disk completion waited for the shard. Use this to confirm the
+mechanism and fixture routing. Disable the feature and diagnostic logging for the
+performance comparison so tracing does not become part of the measured cost.
+
+Each run retains commands, binary hashes, server logs, `polls.csv`,
+`run-manifest.json`, producer samples, process samples, and a summary. CPU counters
+are interpolated from 50 ms samples to the consumer measurement window. Producer
+counters use approximately 100 ms samples over that same window. Those are coarse
+resource guardrails; neither interpolation creates finer measurement precision.
+Failed and interrupted runs retain their evidence. Fixture data is removed by
+default; use `run --keep-fixture` when diagnosing a failure. Keep failed runs and
+any exclusions visible rather than replacing them in place.
+
+Validate analysis without running a server:
+
+```sh
+python3 -B -m unittest discover -s scripts/benchmarks -p test_poll_completion.py
+```

--- a/scripts/benchmarks/poll_completion.py
+++ b/scripts/benchmarks/poll_completion.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Run isolated poll experiments on Linux or macOS and compare paired samples."""
+
+import argparse
+import collections
+import csv
+import ctypes
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import random
+import shutil
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import threading
+import time
+
+
+CASES = {
+    "resident": (1, "next", False, False, False),
+    "disk-offset": (1, "offset", False, True, False),
+    "disk-next": (1, "next", False, True, False),
+    "disk-batch": (100, "next", False, True, False),
+    "disk-group": (100, "next", True, True, False),
+    "disk-writes": (100, "next", False, True, True),
+    "disk-fsync": (100, "next", False, True, True),
+}
+
+
+def save(path, value):
+    Path(path).write_text(json.dumps(value, indent=2) + "\n")
+
+
+def digest(path):
+    hasher = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            hasher.update(block)
+    return hasher.hexdigest()
+
+
+def cpu_prefix(cpus):
+    return ["taskset", "-c", cpus] if sys.platform == "linux" else []
+
+
+def stop(process):
+    if process and process.poll() is None:
+        process.send_signal(signal.SIGINT)
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+def execute(command, cwd, log, deadline=60, env=None):
+    with open(log, "w") as output:
+        process = subprocess.Popen(command, cwd=cwd, env=env, stdout=output, stderr=output)
+        try:
+            code = process.wait(timeout=deadline)
+        except subprocess.TimeoutExpired:
+            stop(process)
+            raise RuntimeError(f"External deadline exceeded: {command}; see {log}") from None
+        if code:
+            raise RuntimeError(f"Command exited {code}: {command}; see {log}")
+
+
+def process_sample(pid):
+    if sys.platform == "darwin":
+        # RUSAGE_INFO_V0 from the macOS SDK's sys/resource.h.
+        class RusageInfo(ctypes.Structure):
+            _fields_ = [("uuid", ctypes.c_uint8 * 16), ("values", ctypes.c_uint64 * 10)]
+
+        usage = RusageInfo()
+        library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        if library.proc_pid_rusage(pid, 0, ctypes.byref(usage)) != 0:
+            raise OSError(ctypes.get_errno(), "proc_pid_rusage failed")
+        class TimebaseInfo(ctypes.Structure):
+            _fields_ = [("numer", ctypes.c_uint32), ("denom", ctypes.c_uint32)]
+
+        timebase = TimebaseInfo()
+        system = ctypes.CDLL("/usr/lib/libSystem.B.dylib")
+        if system.mach_timebase_info(ctypes.byref(timebase)) != 0 or not timebase.denom:
+            raise RuntimeError("Cannot convert native CPU clock ticks")
+        return {
+            "time": time.monotonic(), "unix_us": time.time_ns() // 1000,
+            "cpu_seconds": (usage.values[0] + usage.values[1]) * timebase.numer / timebase.denom / 1e9,
+            "rss_bytes": usage.values[6],
+        }
+    fields = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()
+    return {
+        "time": time.monotonic(),
+        "unix_us": time.time_ns() // 1000,
+        "cpu_seconds": (int(fields[11]) + int(fields[12])) / os.sysconf("SC_CLK_TCK"),
+        "rss_bytes": int(fields[21]) * os.sysconf("SC_PAGE_SIZE"),
+    }
+
+
+def percentile(values, quantile):
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def interpolate(samples, timestamp, clock_key, value_key):
+    for left, right in zip(samples, samples[1:]):
+        if left[clock_key] <= timestamp <= right[clock_key]:
+            span = right[clock_key] - left[clock_key]
+            fraction = (timestamp - left[clock_key]) / span if span else 0
+            return left[value_key] + fraction * (right[value_key] - left[value_key])
+    raise RuntimeError(f"Measurement window is not bracketed by {value_key} samples")
+
+
+def poll_summary(path):
+    with open(path, newline="") as source:
+        rows = list(csv.DictReader(source))
+    outcomes = collections.Counter(row["outcome"] for row in rows)
+    completed = [row for row in rows if row["outcome"] == "messages"]
+    if not completed:
+        raise RuntimeError(f"No completed polls in {path}")
+    actors = {row["actor_id"] for row in rows}
+    if len(actors) != 1:
+        raise RuntimeError("This runner requires one consumer; actor clocks are not synchronized")
+    duration = max(int(row["elapsed_us"]) for row in rows) / 1e6
+    latencies = [int(row["poll_latency_us"]) for row in completed]
+    messages = sum(int(row["messages"]) for row in completed)
+    return {
+        "completed_polls": len(completed),
+        "completed_messages": messages,
+        "measurement_seconds": duration,
+        "polls_per_second": len(completed) / duration,
+        "messages_per_second": messages / duration,
+        "p50_poll_us": percentile(latencies, 0.50),
+        "p99_poll_us": percentile(latencies, 0.99),
+        "outcomes": dict(outcomes),
+        "percentile_population": "all successful nonempty polls, pooled before quantiles",
+    }
+
+
+class Experiment:
+    def __init__(self, args):
+        self.args = args
+        maximum = 2_000_000 if args.case == "resident" else 8_000_000
+        if not 0 < args.polls * CASES[args.case][0] <= maximum:
+            raise ValueError(f"Fixture must contain 1 to {maximum:,} messages")
+        self.directory = Path(args.output).resolve()
+        self.directory.mkdir(parents=True, exist_ok=False)
+        self.fixture = self.directory / "fixture"
+        self.fixture.mkdir()
+        self.batch, self.kind, self.group, self.disk, self.background = CASES[args.case]
+        if args.calibrate_producer:
+            self.background = False
+        self.commands = []
+        self.sequence = 0
+        with socket.socket() as listener:
+            listener.bind(("127.0.0.1", 0))
+            self.port = listener.getsockname()[1]
+        self.address = f"127.0.0.1:{self.port}"
+
+    def command(self, command, label, deadline=120):
+        self.commands.append({"label": label, "argv": command})
+        save(self.directory / "commands.json", self.commands)
+        self.sequence += 1
+        execute(command, self.fixture, self.directory / f"{self.sequence:02}-{label}.log", deadline)
+
+    def cli(self, *arguments):
+        self.command(cpu_prefix("1-2") + [self.args.cli, "--transport", "tcp", "--tcp-server-address", self.address, "--username", "iggy", "--password", "iggy", *arguments], arguments[0] + "-" + arguments[1])
+
+    def bench(self, label, batches, batch, producer=False, rate=None):
+        command = cpu_prefix("1-2") + [self.args.client, "--message-size", "256", "--messages-per-batch", str(batch), "--message-batches", str(batches), "--warmup-time", "0s", "--reuse-streams"]
+        if rate:
+            command += ["--rate-limit", str(rate)]
+        if producer:
+            command += ["pinned-producer", "--streams", "1", "--producers", "1"]
+        else:
+            command += ["--polling-kind", self.kind, "--latency-kind", "poll"]
+            command += ["balanced-consumer-group" if self.group else "pinned-consumer", "--streams", "1", "--consumers", "1"]
+            if self.group:
+                command += ["--consumer-groups", "1"]
+        return command + ["tcp", "--server-address", self.address, "--nodelay", "output", "--output-dir", str(self.directory / label), "--gitref", self.args.label, "--remark", self.args.case]
+
+    def fixture_create(self, messages, label):
+        self.cli("stream", "create", "bench-stream-1")
+        options = {
+            "segment_size": "16MiB" if self.disk else "1GiB",
+            "messages_required_to_save": "1" if self.disk else "16777216",
+            "size_of_messages_required_to_save": "1GiB",
+            "preallocate_segments": "false",
+            "enforce_fsync": "true" if self.args.case == "disk-fsync" else "false",
+        }
+        command = ["topic", "create", "bench-stream-1", "topic-1", "1", "none", "unlimited", "--max-topic-size", "unlimited"]
+        for key, value in options.items():
+            command += ["--set", f"{key}={value}"]
+        self.cli(*command)
+        self.command(self.bench(label + "-produce", math.ceil(messages / 1000), 1000, producer=True), label + "-produce", deadline=180)
+        self.cli("topic", "get", "bench-stream-1", "topic-1")
+
+    def start_server(self, env):
+        with open(self.directory / "server.log", "a") as output:
+            server = subprocess.Popen(cpu_prefix("0") + [self.args.server, "--with-default-root-credentials"], cwd=self.fixture, env=env, stdout=output, stderr=output)
+        try:
+            for _ in range(300):
+                if server.poll() is not None:
+                    raise RuntimeError("Server exited before readiness; inspect server.log")
+                try:
+                    with socket.create_connection(("127.0.0.1", self.port), timeout=0.1):
+                        return server
+                except OSError:
+                    time.sleep(0.1)
+            raise RuntimeError("Server readiness deadline exceeded")
+        except BaseException:
+            stop(server)
+            raise
+
+    def run(self):
+        server = background = None
+        samples = []
+        done = threading.Event()
+        env = {key: value for key, value in os.environ.items() if not key.startswith("IGGY_")}
+        env.update({"IGGY_SYSTEM_SHARDING_CPU_ALLOCATION": "1", "IGGY_SYSTEM_SHARDING_PIN_CORES": "true" if sys.platform == "linux" else "false"})
+        env.update({"IGGY_TCP_ADDRESS": self.address, "IGGY_HTTP_ENABLED": "false", "IGGY_QUIC_ENABLED": "false", "IGGY_WEBSOCKET_ENABLED": "false"})
+        env["IGGY_SYSTEM_PATH"] = str(self.fixture / "local_data")
+        metadata = {
+            "case": self.args.case, "label": self.args.label,
+            "polls": self.args.polls, "batch": self.batch,
+            "background_rate_bytes_per_second": self.args.background_rate,
+            "server_sha256": digest(self.args.server), "client_sha256": digest(self.args.client),
+            "cli_sha256": digest(self.args.cli),
+            "server_environment": {key: value for key, value in env.items() if key.startswith("IGGY_")},
+            "platform": sys.platform,
+            "server_cpu": "0" if sys.platform == "linux" else "OS scheduled, one shard",
+            "client_cpus": "1-2" if sys.platform == "linux" else "OS scheduled, two Tokio worker threads",
+            "deadline_seconds": self.args.deadline,
+            "status": "running", "started_at_unix": time.time(),
+        }
+        save(self.directory / "experiment.json", metadata)
+        try:
+            server = self.start_server(env)
+            self.fixture_create(max(1000, 100 * self.batch), "warm")
+            self.command(self.bench("warm-consume", 100, self.batch), "warm-consume", self.args.deadline)
+            self.cli("stream", "delete", "bench-stream-1")
+            self.fixture_create(1000 if self.args.calibrate_producer else self.args.polls * self.batch, "fixture")
+            if self.args.calibrate_producer:
+                self.command(self.bench("producer-calibration", self.args.polls, self.batch, producer=True), "producer-calibration", self.args.deadline)
+                manifests = list((self.directory / "producer-calibration").rglob("run-manifest.json"))
+                if len(manifests) != 1:
+                    raise RuntimeError("Missing producer calibration manifest")
+                manifest = json.loads(manifests[0].read_text())
+                producer = manifest["producers"][0]
+                if manifest["status"] != "completed":
+                    raise RuntimeError("Producer calibration did not complete")
+                save(self.directory / "summary.json", {
+                    "payload_bytes_per_second": producer["payload_bytes"] * 1e6 / producer["measurement_duration_us"],
+                    "measurement_seconds": producer["measurement_duration_us"] / 1e6,
+                    "completed_batches": producer["completed_batches"],
+                    "completed_messages": producer["completed_messages"],
+                })
+                metadata["status"] = "completed"
+                return
+            if self.background:
+                if not self.args.background_rate:
+                    raise RuntimeError("Background cases require a rate calibrated on the baseline")
+                # Bound background data even when a consumer fails to finish.
+                batches = math.ceil(self.args.background_rate * (self.args.deadline + 5) / (256 * 100))
+                command = self.bench("background", batches, 100, producer=True, rate=self.args.background_rate)
+                self.commands.append({"label": "background", "argv": command})
+                with open(self.directory / "background.log", "w") as output:
+                    background = subprocess.Popen(command, cwd=self.fixture, stdout=output, stderr=output)
+                time.sleep(1)
+                if background.poll() is not None:
+                    raise RuntimeError("Background producer exited before measurement")
+
+            def sample():
+                while not done.is_set():
+                    try:
+                        samples.append(process_sample(server.pid))
+                    except (OSError, ValueError):
+                        break
+                    done.wait(0.05)
+
+            monitor = threading.Thread(target=sample, daemon=True)
+            monitor.start()
+            try:
+                self.command(self.bench("measured", self.args.polls, self.batch), "measured", self.args.deadline)
+            finally:
+                done.set()
+                monitor.join()
+                samples.append(process_sample(server.pid))
+            if background and background.poll() is not None:
+                raise RuntimeError("Background producer exited during measurement")
+            raw = list((self.directory / "measured").rglob("polls.csv"))
+            if len(raw) != 1:
+                raise RuntimeError(f"Expected one poll CSV, found {len(raw)}")
+            summary = poll_summary(raw[0])
+            manifest = json.loads(raw[0].with_name("run-manifest.json").read_text())
+            if manifest["status"] != "completed" or len(manifest["actors"]) != 1:
+                raise RuntimeError("Measured consumer did not complete with exactly one actor")
+            started = manifest["actors"][0]["measurement_started_at_unix_us"]
+            ended = started + round(summary["measurement_seconds"] * 1e6)
+            expected = self.args.polls * self.batch
+            if summary["completed_messages"] != expected:
+                raise RuntimeError(f"Completed {summary['completed_messages']} messages, expected {expected}")
+            summary.update({
+                "server_cpu_seconds": interpolate(samples, ended, "unix_us", "cpu_seconds") - interpolate(samples, started, "unix_us", "cpu_seconds"),
+                "peak_server_rss_bytes": max(point["rss_bytes"] for point in samples if started - 50000 <= point["unix_us"] <= ended + 50000),
+                "cpu_window_seconds": (ended - started) / 1e6,
+                "cpu_window": "consumer measurement; CPU counters interpolated from 50 ms samples",
+            })
+            stop(background)
+            if background:
+                manifests = list((self.directory / "background").rglob("run-manifest.json"))
+                if len(manifests) != 1:
+                    raise RuntimeError("Missing background producer manifest")
+                producer = json.loads(manifests[0].read_text())["producers"][0]
+                with open(manifests[0].with_name("producer-samples.csv"), newline="") as source:
+                    points = [{key: int(value) for key, value in row.items()} for row in csv.DictReader(source)]
+                origin = producer["measurement_started_at_unix_us"]
+                produced = interpolate(points, ended - origin, "elapsed_us", "payload_bytes") - interpolate(points, started - origin, "elapsed_us", "payload_bytes")
+                summary["background_payload_bytes_per_second"] = produced / summary["measurement_seconds"]
+                summary["background_counter_resolution"] = "approximately 100 ms; interpolated over consumer window"
+            summary["server_cpu_seconds_per_completed_poll"] = summary["server_cpu_seconds"] / summary["completed_polls"]
+            save(self.directory / "summary.json", summary)
+            save(self.directory / "server-samples.json", samples)
+            metadata["status"] = "completed"
+        except BaseException as error:
+            metadata["status"] = "failed"
+            metadata["failure"] = str(error)
+            raise
+        finally:
+            stop(background)
+            stop(server)
+            save(self.directory / "server-samples.json", samples)
+            save(self.directory / "experiment.json", metadata)
+            if not self.args.keep_fixture:
+                shutil.rmtree(self.fixture)
+
+
+def compare(args):
+    schedule = json.loads(Path(args.schedule).read_text())
+    rows = collections.defaultdict(list)
+    clients = set()
+    platforms = set()
+    servers = collections.defaultdict(set)
+    for pair in schedule["pairs"]:
+        runs = []
+        for version in ("baseline", "candidate"):
+            directory = Path(args.results) / pair[version]
+            experiment = json.loads((directory / "experiment.json").read_text())
+            summary = json.loads((directory / "summary.json").read_text())
+            if experiment["status"] != "completed":
+                raise RuntimeError(f"Incomplete run: {directory}")
+            if experiment["case"] != pair["case"]:
+                raise RuntimeError(f"Run does not match scheduled case: {directory}")
+            clients.add(experiment["client_sha256"])
+            platforms.add(experiment["platform"])
+            servers[version].add(experiment["server_sha256"])
+            if any(summary["outcomes"].get(kind, 0) for kind in ("empty", "error", "timeout", "cancelled")):
+                raise RuntimeError(f"Unexpected poll outcomes: {directory}")
+            runs.append((experiment, summary))
+        if runs[0][0]["client_sha256"] != runs[1][0]["client_sha256"]:
+            raise RuntimeError("Baseline and candidate used different clients")
+        for key in ("platform", "case", "polls", "batch", "background_rate_bytes_per_second"):
+            if runs[0][0][key] != runs[1][0][key]:
+                raise RuntimeError(f"Paired workloads differ: {key}")
+        rows[pair["case"]].append({
+            "pair": pair["pair"],
+            "throughput_ratio": runs[1][1]["polls_per_second"] / runs[0][1]["polls_per_second"],
+            "p99_ratio": runs[1][1]["p99_poll_us"] / runs[0][1]["p99_poll_us"],
+            "background_payload_ratio": (runs[1][1]["background_payload_bytes_per_second"] / runs[0][1]["background_payload_bytes_per_second"]) if CASES[pair["case"]][4] else None,
+        })
+    if len(clients) != 1 or len(platforms) != 1 or any(len(hashes) != 1 for hashes in servers.values()):
+        raise RuntimeError("Platform or binary changed within the comparison")
+    randomizer = random.Random(args.seed)
+    result = {"method": "paired bootstrap of geometric mean ratios, one-sided 95% bounds; independent runs are the sampling units", "seed": args.seed, "resamples": args.resamples, "cases": {}}
+    for case, pairs in rows.items():
+        count = len(pairs)
+        bounds = {}
+        for metric, quantile in (("throughput_ratio", 0.05), ("p99_ratio", 0.95)):
+            logs = [math.log(pair[metric]) for pair in pairs]
+            bootstrap = [math.exp(statistics.mean(randomizer.choices(logs, k=count))) for _ in range(args.resamples)]
+            bounds[metric] = {"geometric_mean": math.exp(statistics.mean(logs)), "one_sided_95_bound": percentile(bootstrap, quantile), "lower_95_bound": percentile(bootstrap, 0.05), "upper_95_bound": percentile(bootstrap, 0.95)}
+        passes = count >= 10 and bounds["throughput_ratio"]["one_sided_95_bound"] >= 0.97 and bounds["p99_ratio"]["one_sided_95_bound"] <= 1.05
+        regression = count >= 10 and (bounds["throughput_ratio"]["upper_95_bound"] < 0.97 or bounds["p99_ratio"]["lower_95_bound"] > 1.05)
+        result["cases"][case] = {"pairs": pairs, "bounds": bounds, "decision": "preliminary compliance" if passes else "confirmed regression" if regression else "inconclusive"}
+    save(args.output, result)
+
+
+def schedule(args):
+    randomizer = random.Random(args.seed)
+    pairs = []
+    for case in args.cases:
+        orders = [["baseline", "candidate"], ["candidate", "baseline"]] * math.ceil(args.pairs / 2)
+        randomizer.shuffle(orders)
+        for index, order in enumerate(orders[:args.pairs]):
+            names = {version: f"{case}/{index:02}-{version}" for version in order}
+            pairs.append({"case": case, "pair": index, "order": order, **names})
+    save(args.output, {"seed": args.seed, "pairs": pairs})
+
+
+def matrix(args):
+    workload = json.loads(Path(args.workload).read_text())
+    plan = json.loads(Path(args.schedule).read_text())
+    for pair in plan["pairs"]:
+        for version in pair["order"]:
+            directory = Path(args.results).resolve() / pair[version]
+            settings = workload[pair["case"]]
+            run = argparse.Namespace(
+                server=getattr(args, version), client=args.client, cli=args.cli,
+                output=str(directory), label=version, case=pair["case"],
+                polls=settings["polls"], deadline=args.deadline,
+                background_rate=settings.get("background_rate", 0),
+                keep_fixture=False, calibrate_producer=False,
+            )
+            if directory.exists():
+                raise RuntimeError(f"Run directory already exists: {directory}; preserve results and use a new schedule")
+            Experiment(run).run()
+            result = json.loads((directory / "summary.json").read_text())
+            print(json.dumps({"case": pair["case"], "pair": pair["pair"], "version": version, "summary": result}), flush=True)
+
+
+def main():
+    os.environ["TOKIO_WORKER_THREADS"] = "2"
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    run = commands.add_parser("run")
+    for flag in ("server", "client", "cli", "output", "label"):
+        run.add_argument("--" + flag, required=True)
+    run.add_argument("--case", choices=CASES, required=True)
+    run.add_argument("--polls", type=int, required=True)
+    run.add_argument("--deadline", type=int, default=40)
+    run.add_argument("--background-rate", type=int, default=0)
+    run.add_argument("--keep-fixture", action="store_true")
+    run.add_argument("--calibrate-producer", action="store_true")
+    plan = commands.add_parser("schedule")
+    plan.add_argument("--cases", nargs="+", choices=CASES, default=list(CASES))
+    plan.add_argument("--pairs", type=int, default=10)
+    plan.add_argument("--seed", type=int, default=20260909)
+    plan.add_argument("--output", required=True)
+    analysis = commands.add_parser("compare")
+    analysis.add_argument("--schedule", required=True)
+    analysis.add_argument("--results", required=True)
+    analysis.add_argument("--output", required=True)
+    analysis.add_argument("--seed", type=int, default=20260909)
+    analysis.add_argument("--resamples", type=int, default=10000)
+    series = commands.add_parser("matrix")
+    for flag in ("baseline", "candidate", "client", "cli", "schedule", "workload", "results"):
+        series.add_argument("--" + flag, required=True)
+    series.add_argument("--deadline", type=int, default=40)
+    args = parser.parse_args()
+    if args.command == "run":
+        maximum = 2_000_000 if args.case == "resident" else 8_000_000
+        if args.polls <= 0 or args.polls * CASES[args.case][0] > maximum:
+            parser.error(f"Fixture must contain 1 to {maximum:,} messages")
+        Experiment(args).run()
+    elif args.command == "schedule":
+        schedule(args)
+    elif args.command == "matrix":
+        matrix(args)
+    else:
+        compare(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/poll_completion.py
+++ b/scripts/benchmarks/poll_completion.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 # Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements. See the NOTICE file
+# or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership. The ASF licenses this file
+# regarding copyright ownership.  The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
+# with the License.  You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied. See the License for the
+# KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
 
@@ -98,15 +98,15 @@ def process_sample(pid):
         if library.proc_pid_rusage(pid, 0, ctypes.byref(usage)) != 0:
             raise OSError(ctypes.get_errno(), "proc_pid_rusage failed")
         class TimebaseInfo(ctypes.Structure):
-            _fields_ = [("numer", ctypes.c_uint32), ("denom", ctypes.c_uint32)]
+            _fields_ = [("numerator", ctypes.c_uint32), ("denominator", ctypes.c_uint32)]
 
         timebase = TimebaseInfo()
         system = ctypes.CDLL("/usr/lib/libSystem.B.dylib")
-        if system.mach_timebase_info(ctypes.byref(timebase)) != 0 or not timebase.denom:
+        if system.mach_timebase_info(ctypes.byref(timebase)) != 0 or not timebase.denominator:
             raise RuntimeError("Cannot convert native CPU clock ticks")
         return {
             "time": time.monotonic(), "unix_us": time.time_ns() // 1000,
-            "cpu_seconds": (usage.values[0] + usage.values[1]) * timebase.numer / timebase.denom / 1e9,
+            "cpu_seconds": (usage.values[0] + usage.values[1]) * timebase.numerator / timebase.denominator / 1e9,
             "rss_bytes": usage.values[6],
         }
     fields = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()

--- a/scripts/benchmarks/test_poll_completion.py
+++ b/scripts/benchmarks/test_poll_completion.py
@@ -1,17 +1,17 @@
 # Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements. See the NOTICE file
+# or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership. The ASF licenses this file
+# regarding copyright ownership.  The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
+# with the License.  You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied. See the License for the
+# KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
 

--- a/scripts/benchmarks/test_poll_completion.py
+++ b/scripts/benchmarks/test_poll_completion.py
@@ -1,0 +1,197 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Validate analysis with synthetic observations; no server is started."""
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+import tempfile
+import unittest
+
+import poll_completion as runner
+
+
+class PollAnalysisTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="iggy-poll-analysis-")
+        self.addCleanup(temporary.cleanup)
+        self.directory = Path(temporary.name)
+
+    def write_polls(self, rows):
+        path = self.directory / "polls.csv"
+        with path.open("w", newline="") as output:
+            writer = csv.DictWriter(output, fieldnames=[
+                "actor_id", "elapsed_us", "poll_latency_us", "messages", "outcome",
+            ])
+            writer.writeheader()
+            writer.writerows(rows)
+        return path
+
+    def comparison(self, ratios, candidate_latency=1.0):
+        pairs = []
+        for index, ratio in enumerate(ratios):
+            pair = {"case": "disk-next", "pair": index}
+            for version in ("baseline", "candidate"):
+                name = f"{index}-{version}"
+                pair[version] = name
+                directory = self.directory / name
+                directory.mkdir()
+                runner.save(directory / "experiment.json", {
+                    "status": "completed", "platform": "linux", "case": "disk-next",
+                    "client_sha256": "same-client", "server_sha256": f"{version}-server", "polls": 100, "batch": 1,
+                    "background_rate_bytes_per_second": 0,
+                })
+                baseline_rate = 100 if index % 2 == 0 else 1000
+                runner.save(directory / "summary.json", {
+                    "outcomes": {"messages": 100},
+                    "polls_per_second": baseline_rate * (ratio if version == "candidate" else 1),
+                    "p99_poll_us": 100 * (candidate_latency if version == "candidate" else 1),
+                })
+            pairs.append(pair)
+        schedule = self.directory / "schedule.json"
+        runner.save(schedule, {"pairs": pairs})
+        return argparse.Namespace(
+            schedule=str(schedule), results=str(self.directory),
+            output=str(self.directory / "comparison.json"), seed=42, resamples=500,
+        )
+
+    def test_raw_quantiles_exclude_failed_polls_but_elapsed_work_does_not(self):
+        path = self.write_polls([
+            {"actor_id": 1, "elapsed_us": 250000, "poll_latency_us": 10, "messages": 1, "outcome": "messages"},
+            {"actor_id": 1, "elapsed_us": 500000, "poll_latency_us": 100, "messages": 2, "outcome": "messages"},
+            {"actor_id": 1, "elapsed_us": 750000, "poll_latency_us": 20, "messages": 3, "outcome": "messages"},
+            {"actor_id": 1, "elapsed_us": 1000000, "poll_latency_us": 999999, "messages": 0, "outcome": "empty"},
+            {"actor_id": 1, "elapsed_us": 2000000, "poll_latency_us": 999999, "messages": 0, "outcome": "error"},
+        ])
+        summary = runner.poll_summary(path)
+        self.assertEqual(summary["completed_polls"], 3)
+        self.assertEqual(summary["completed_messages"], 6)
+        self.assertEqual(summary["measurement_seconds"], 2)
+        self.assertEqual(summary["polls_per_second"], 1.5)
+        self.assertEqual(summary["messages_per_second"], 3)
+        self.assertEqual(summary["p50_poll_us"], 20)
+        self.assertAlmostEqual(summary["p99_poll_us"], 98.4)
+        self.assertEqual(summary["outcomes"], {"messages": 3, "empty": 1, "error": 1})
+
+    def test_poll_summary_rejects_empty_and_unsynchronized_actor_data(self):
+        empty = {"actor_id": 1, "elapsed_us": 10, "poll_latency_us": 10, "messages": 0, "outcome": "empty"}
+        with self.assertRaisesRegex(RuntimeError, "No completed polls"):
+            runner.poll_summary(self.write_polls([empty]))
+        message = dict(empty, messages=1, outcome="messages")
+        with self.assertRaisesRegex(RuntimeError, "one consumer"):
+            runner.poll_summary(self.write_polls([message, dict(message, actor_id=2)]))
+
+    def test_cpu_crop_uses_only_bracketed_measurement_window(self):
+        samples = [
+            {"unix_us": 10, "cpu_seconds": 100},
+            {"unix_us": 20, "cpu_seconds": 102},
+            {"unix_us": 40, "cpu_seconds": 108},
+        ]
+        before = runner.interpolate(samples, 15, "unix_us", "cpu_seconds")
+        after = runner.interpolate(samples, 35, "unix_us", "cpu_seconds")
+        self.assertEqual(after - before, 5.5)
+        for timestamp in (9, 41):
+            with self.assertRaisesRegex(RuntimeError, "not bracketed"):
+                runner.interpolate(samples, timestamp, "unix_us", "cpu_seconds")
+
+    def test_producer_crop_translates_consumer_wall_clock_to_actor_elapsed(self):
+        producer_started = 1000000
+        consumer_started, consumer_ended = 1050000, 1150000
+        samples = [
+            {"elapsed_us": 0, "payload_bytes": 0},
+            {"elapsed_us": 100000, "payload_bytes": 1000},
+            {"elapsed_us": 200000, "payload_bytes": 5000},
+        ]
+        before = runner.interpolate(samples, consumer_started - producer_started, "elapsed_us", "payload_bytes")
+        after = runner.interpolate(samples, consumer_ended - producer_started, "elapsed_us", "payload_bytes")
+        self.assertEqual((after - before) * 1e6 / (consumer_ended - consumer_started), 25000)
+
+    def test_schedule_preserves_counterbalanced_order_and_seed(self):
+        args = argparse.Namespace(cases=["resident", "disk-next"], pairs=10, seed=43, output=str(self.directory / "schedule.json"))
+        runner.schedule(args)
+        first = Path(args.output).read_text()
+        runner.schedule(args)
+        self.assertEqual(first, Path(args.output).read_text())
+        pairs = json.loads(first)["pairs"]
+        for case in args.cases:
+            matching = [pair for pair in pairs if pair["case"] == case]
+            self.assertEqual(len(matching), 10)
+            self.assertEqual(sum(pair["order"][0] == "baseline" for pair in matching), 5)
+            self.assertEqual(len({pair[version] for pair in matching for version in ("baseline", "candidate")}), 20)
+
+    def test_bootstrap_uses_independent_pair_ratios_and_is_reproducible(self):
+        args = self.comparison([2, 0.5] * 5)
+        runner.compare(args)
+        first = Path(args.output).read_text()
+        runner.compare(args)
+        self.assertEqual(first, Path(args.output).read_text())
+        result = json.loads(first)["cases"]["disk-next"]
+        self.assertAlmostEqual(result["bounds"]["throughput_ratio"]["geometric_mean"], 1)
+        self.assertNotAlmostEqual(result["bounds"]["throughput_ratio"]["geometric_mean"], 700 / 1100)
+        self.assertEqual(len(result["pairs"]), 10)
+        self.assertTrue(math.isfinite(result["bounds"]["throughput_ratio"]["one_sided_95_bound"]))
+
+    def test_constant_regression_and_insufficient_replication_are_distinct(self):
+        args = self.comparison([0.9] * 10, candidate_latency=1.2)
+        runner.compare(args)
+        result = json.loads(Path(args.output).read_text())["cases"]["disk-next"]
+        self.assertEqual(result["decision"], "confirmed regression")
+        plan = json.loads(Path(args.schedule).read_text())
+        plan["pairs"].pop()
+        runner.save(args.schedule, plan)
+        runner.compare(args)
+        result = json.loads(Path(args.output).read_text())["cases"]["disk-next"]
+        self.assertEqual(result["decision"], "inconclusive")
+
+    def test_comparison_rejects_client_mismatch_and_incomplete_work(self):
+        args = self.comparison([1] * 10)
+        path = self.directory / "0-candidate" / "experiment.json"
+        original = json.loads(path.read_text())
+        runner.save(path, dict(original, client_sha256="different-client"))
+        with self.assertRaisesRegex(RuntimeError, "different clients"):
+            runner.compare(args)
+        runner.save(path, original)
+        path = self.directory / "0-candidate" / "summary.json"
+        summary = json.loads(path.read_text())
+        summary["outcomes"]["cancelled"] = 1
+        runner.save(path, summary)
+        with self.assertRaisesRegex(RuntimeError, "Unexpected poll outcomes"):
+            runner.compare(args)
+
+
+    def test_comparison_rejects_schedule_mismatch_and_binary_changes_between_pairs(self):
+        args = self.comparison([1] * 10)
+        path = self.directory / "0-candidate" / "experiment.json"
+        original = json.loads(path.read_text())
+        runner.save(path, dict(original, case="resident"))
+        with self.assertRaisesRegex(RuntimeError, "scheduled case"):
+            runner.compare(args)
+        runner.save(path, original)
+        for version in ("baseline", "candidate"):
+            path = self.directory / f"1-{version}" / "experiment.json"
+            experiment = json.loads(path.read_text())
+            experiment["client_sha256"] = "another-client-for-this-pair"
+            runner.save(path, experiment)
+        with self.assertRaisesRegex(RuntimeError, "binary changed"):
+            runner.compare(args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Which issue does this PR address?

Relates to #4117. The benchmark tooling was extracted from #4119 so it can be reviewed independently of the poll completion fix.

## Rationale

Comparing changes to polling needs explicit control over polling behavior and latency measurement, together with raw observations and a repeatable workload setup.

## What changed?

The benchmark client adds optional polling and latency selectors, raw poll observations, run manifests, and producer samples. Failed and interrupted runs retain their artifacts, and reports handle short runs with empty time series. Existing selector defaults and the report JSON schema are preserved.

A Python runner prepares workloads, records binary hashes and process samples, schedules paired runs, and compares results. The tooling builds against current master and does not require the server changes in #4119. The documentation describes measurement limits and treats server diagnostics as optional.

## Local Execution

- Passed `cargo test --locked -p iggy-bench -p bench-report`: 42 tests.
- Passed all nine Python campaign tests.
- Passed Clippy for both benchmark crates with all features, all targets, and warnings denied.
- Passed a local macOS smoke run against a server without the poll fix: 100 completed polls, with artifacts retained and no empty responses or errors. This checks execution, not performance.
- Passed workspace formatting and dependency sort checks, changed TOML formatting, Markdown lint, spelling, license headers, whitespace, and trailing newline checks.
- Pre-commit hooks are not installed in this checkout; the checks above were run directly.

No new performance comparison is claimed by this extraction. The previously recorded measurements remain in #4119.

## AI Usage

Codex was used for the extraction, dependency review, standalone documentation adjustments, and local verification listed above. This PR is a draft for further review.
