### PR TITLE
fix(repo): include gateways so the source release tarball builds

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -60,6 +60,7 @@ RELEASE_PATHS=(
   "core"
   "examples"
   "foreign"
+  "gateways"
   "helm"
   "scripts"
   "web"


### PR DESCRIPTION
The Kafka gateway crates joined the workspace in #3519, but
`scripts/prepare-release.sh` copies an explicit path list that has no
`gateways/`. The source tarball cut from master then fails to load:

```text
error: failed to load manifest for workspace member `.../iggy-0.9.0-edge.7-src/gateways/kafka`
```

With `gateways` in the list, the tarball carries the 38 gateway files.
The extracted tree passes `cargo metadata --locked --offline` and
`cargo check --workspace --all-targets --locked`. This blocks the 0.9.0
source release.
