### PR TITLE
fix(connectors): meilisearch_sink URL scheme check is case-sensitive

### DIFF
--- a/core/connectors/sinks/meilisearch_sink/src/lib.rs
+++ b/core/connectors/sinks/meilisearch_sink/src/lib.rs
@@ -985,10 +985,23 @@ fn normalize_host(raw: &str) -> Result<String, Error> {
         ));
     }
 
-    let with_scheme = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
-        trimmed.to_string()
-    } else {
-        format!("http://{trimmed}")
+    // `://` (rather than a plain colon) is the marker of an explicit scheme,
+    // since a bare `host:port` also contains a colon. Detected
+    // case-insensitively so `HTTPS://host` isn't missed and mistaken for a
+    // schemeless host, which would otherwise get `http://` prepended and
+    // send the request to a bogus host built from the original string.
+    let with_scheme = match trimmed.split_once("://") {
+        Some((scheme, _))
+            if scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https") =>
+        {
+            trimmed.to_string()
+        }
+        Some((scheme, _)) => {
+            return Err(Error::Connection(format!(
+                "Invalid Meilisearch URL: unsupported scheme '{scheme}', expected http or https"
+            )));
+        }
+        None => format!("http://{trimmed}"),
     };
     let url = Url::parse(&with_scheme)
         .map_err(|error| Error::Connection(format!("Invalid Meilisearch URL: {error}")))?;
@@ -1000,6 +1013,15 @@ fn normalize_host(raw: &str) -> Result<String, Error> {
     base_url.set_query(None);
     base_url.set_fragment(None);
     Ok(base_url.as_str().trim_end_matches('/').to_string())
+}
+
+// Case-insensitive for the same reason as `normalize_host`'s scheme check:
+// `HTTP://host` is an explicit scheme, just not a lowercase one.
+fn explicit_http_scheme_hint(raw: &str) -> &'static str {
+    match raw.trim().split_once("://") {
+        Some((scheme, _)) if scheme.eq_ignore_ascii_case("http") => "explicit http://",
+        _ => "implicit http://",
+    }
 }
 
 fn warn_if_api_key_uses_insecure_http(raw: &str, normalized: &str, has_api_key: bool) {
@@ -1020,11 +1042,7 @@ fn warn_if_api_key_uses_insecure_http(raw: &str, normalized: &str, has_api_key: 
         return;
     }
 
-    let scheme_hint = if raw.trim().starts_with("http://") {
-        "explicit http://"
-    } else {
-        "implicit http://"
-    };
+    let scheme_hint = explicit_http_scheme_hint(raw);
     warn!(
         "Meilisearch API key is configured with {scheme_hint} for non-loopback host '{host}'. Credentials will be sent without TLS; use https:// unless this is intentional."
     );
@@ -1365,6 +1383,39 @@ mod tests {
             normalize_host("https://localhost:7700/path?foo=bar#section").expect("normalize host");
 
         assert_eq!(url, "https://localhost:7700");
+    }
+
+    #[test]
+    fn normalize_host_should_accept_uppercase_https_scheme() {
+        // Regression: a case-sensitive `starts_with("https://")` check fell
+        // through to the schemeless branch and produced
+        // `http://HTTPS://realhost:9200`, which `Url::parse` accepted with
+        // scheme=http, host="https" — silently dropping TLS and connecting
+        // to the wrong host.
+        let url = normalize_host("HTTPS://realhost:9200").expect("normalize host");
+
+        assert_eq!(url, "https://realhost:9200");
+    }
+
+    #[test]
+    fn normalize_host_should_accept_mixed_case_http_scheme() {
+        let url = normalize_host("HtTp://realhost:7700").expect("normalize host");
+
+        assert_eq!(url, "http://realhost:7700");
+    }
+
+    #[test]
+    fn normalize_host_should_reject_unsupported_scheme() {
+        let error = normalize_host("ftp://realhost:7700").expect_err("unsupported scheme");
+
+        assert!(matches!(error, Error::Connection(_)));
+    }
+
+    #[test]
+    fn explicit_http_scheme_hint_should_be_case_insensitive() {
+        assert_eq!(explicit_http_scheme_hint("HTTP://host"), "explicit http://");
+        assert_eq!(explicit_http_scheme_hint("http://host"), "explicit http://");
+        assert_eq!(explicit_http_scheme_hint("host"), "implicit http://");
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR address?

Closes #4157

## What changed?

`normalize_host` detected the URL scheme via a literal `starts_with("http://")`/`starts_with("https://")` check. An uppercase or mixed-case scheme like `HTTPS://host` matched neither literal, fell through to the "no scheme" branch, and got `http://` prepended, producing `http://HTTPS://host`, which parses as `scheme="http"`, `host="https"`, silently connecting to the wrong host over plaintext.

Scheme detection is now case-insensitive (`eq_ignore_ascii_case` on the split-off scheme), matching `opensearch_sink`'s existing pattern. An unsupported scheme (e.g. `ftp://`) is now also rejected outright instead of being silently mangled the same way.

## Local Execution

- Passed
- Pre-commit hooks ran

## AI Usage

Claude was used in creating this PR.
