### PR TITLE
docs(integration): say that the test harness runs prebuilt binaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,9 +188,11 @@ non-trivial change passes verification, suggest `/team-review <target>`.
 
 BDD test naming: `given_X_when_Y_should_Z` (3-part). Promote to 4-part `given_X_when_Y_then_Z_should_W` only with a distinct "then" intermediate. Be consistent inside a file.
 
-Filter a single integration test by path:
+Filter a single integration test by path. Build the binaries the harness launches first: it runs
+whatever is already in `target/`, so a stale one fails as though the change under test broke it.
 
 ```bash
+cargo build --bin iggy-server --bin iggy-connectors
 cargo test -p integration -- connectors::runtime::benchmark::given_logging_format_json
 ```
 
@@ -202,6 +204,7 @@ cargo test -p integration -- connectors::runtime::benchmark::given_logging_forma
 - **`test_logs/` grows quickly.** Wipe between major refactors.
 - **Miri only covers `binary_protocol` + `consensus`.** Cannot emulate `io_uring` syscalls. do not try to expand Miri to crates that pull `compio`.
 - **Integration crate has no `--test` target.** Filter by test path inside the single `mod.rs` binary.
+- **The integration harness runs prebuilt binaries and never builds them.** `Command::cargo_bin` only resolves a path, so a stale `iggy-server`, `iggy-connectors` or `iggy-mcp` is used silently. CI builds first (`cargo build --locked --bin iggy-server --bin iggy`); a local run does not, and a stale binary fails in ways that look like the change under test. Rebuild after anything that touches a launched binary or its config.
 
 ## Local state directories
 


### PR DESCRIPTION
Closes #4159.

The integration harness resolves the binaries it launches with `Command::cargo_bin`, which finds whatever is already in `target/` and never builds it. CI does not run into that because it builds first, in `_test_bdd.yml`, `coverage-baseline.yml` and several per-language actions. The command written in this file for running a single integration test does not, so a binary left over from an earlier checkout gets used without a word.

The cost is not the rebuild, it is the time spent reading the failure. In my case a five day old `iggy-server` failed 22 tests across two suites, the plain happy path among them, with a panic naming a config file and a derive macro that were both fine, on a commit whose CI was green. Everything about that reads as a broken change rather than a stale binary.

Two small changes. The Testing section builds before it tests, so the snippet people copy is correct on its own. Pitfalls carries the general rule, since that section already collects traps of this shape.

Documentation only, no behaviour change. #4159 also describes an optional follow-up: `TestBinaryError::StartupTimeout` is the one place that already knows the server did not come up, so including the binary's modification time there would make the message actionable without guessing. I did not do that here, since it changes shared harness code and seemed worth a maintainer's opinion first.
